### PR TITLE
fix(ui): derive footer services group from /api/services/health

### DIFF
--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -1203,7 +1203,7 @@ regressions:
     severity: minor
     tier: mechanical
     lane: ui
-    promote_ready: true
+    promoted_to: ui/tests/e2e/specs/footer-services-omits-comfyui-v3.spec.ts
     summary: >-
       The dashboard footer's `services` LED group is a hardcoded three-member array (hal0,
       hermes, openwebui) in ui/src/dash/chrome.jsx; comfyui is not a member, so on a box where

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -816,7 +816,14 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
   const runtimeTitle = degraded
     ? `degraded — ${failing.length ? failing.join("; ") : "see /api/health/system"}`
     : `${L.ready}/${L.total} slot container${L.total === 1 ? "" : "s"} ready`;
-  const serviceById = Object.fromEntries((serviceHealth.services || []).map((s) => [s.id, s]));
+  // The `services` group is driven by whatever /api/services/health actually
+  // reports (#1899) — NOT a hardcoded id list. The three-member array here
+  // used to omit `comfyui` (and would silently omit any future service too),
+  // leaving the always-visible footer reporting an unqualified "3 / 3 ready"
+  // while a real backing service sat down. `hal0` itself is prepended since
+  // it isn't in the services-health payload (it IS the API answering the
+  // request) but every backend-reported id — including comfyui — renders a
+  // pip and counts toward the ready total.
   const footerIndicators = [
     {
       id: 'hal0',
@@ -824,18 +831,12 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
       tone: degraded ? 'warn' : health.isError ? 'warn' : 'up',
       title: degraded ? `hal0 degraded — ${failing.join("; ") || "see /api/health/system"}` : 'hal0 api ok',
     },
-    {
-      id: 'hermes',
-      label: 'hermes',
-      tone: serviceHealth.pending ? 'warn' : serviceById.hermes?.up ? 'up' : 'err',
-      title: serviceById.hermes?.detail || (serviceHealth.pending ? 'service health pending' : 'hermes down'),
-    },
-    {
-      id: 'openwebui',
-      label: 'openwebui',
-      tone: serviceHealth.pending ? 'warn' : serviceById.openwebui?.up ? 'up' : 'err',
-      title: serviceById.openwebui?.detail || (serviceHealth.pending ? 'service health pending' : 'openwebui down'),
-    },
+    ...(serviceHealth.services || []).map((s) => ({
+      id: s.id,
+      label: s.name || s.id,
+      tone: serviceHealth.pending ? 'warn' : s.up ? 'up' : 'err',
+      title: s.detail || (serviceHealth.pending ? 'service health pending' : `${s.name || s.id} down`),
+    })),
   ];
   // runtimes group — one LED pip per CONFIGURED slot (a model bound is what
   // makes a slot real, #1369), plus the ready count.

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -824,6 +824,16 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
   // it isn't in the services-health payload (it IS the API answering the
   // request) but every backend-reported id — including comfyui — renders a
   // pip and counts toward the ready total.
+  //
+  // When /api/services/health itself has not answered — first paint, 404
+  // (older API), non-2xx, or network error all surface as `pending` with an
+  // empty `services` list (useServicesHealth fails soft) — the group must NOT
+  // collapse to a green "1 / 1 ready" hal0 self-check: the state of the real
+  // backing services is unknown, which is exactly the unqualified-green defect
+  // #1899 describes. Render a single warn-toned "services unknown" pip so the
+  // count stays honest and the warn styling trips until real data arrives.
+  const servicesUnknown =
+    (serviceHealth.pending || serviceHealth.error) && !(serviceHealth.services || []).length;
   const footerIndicators = [
     {
       id: 'hal0',
@@ -831,12 +841,19 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
       tone: degraded ? 'warn' : health.isError ? 'warn' : 'up',
       title: degraded ? `hal0 degraded — ${failing.join("; ") || "see /api/health/system"}` : 'hal0 api ok',
     },
-    ...(serviceHealth.services || []).map((s) => ({
-      id: s.id,
-      label: s.name || s.id,
-      tone: serviceHealth.pending ? 'warn' : s.up ? 'up' : 'err',
-      title: s.detail || (serviceHealth.pending ? 'service health pending' : `${s.name || s.id} down`),
-    })),
+    ...(servicesUnknown
+      ? [{
+          id: 'services-unknown',
+          label: 'services',
+          tone: 'warn',
+          title: 'service health unknown — /api/services/health not answering',
+        }]
+      : (serviceHealth.services || []).map((s) => ({
+          id: s.id,
+          label: s.name || s.id,
+          tone: s.up ? 'up' : 'err',
+          title: s.detail || `${s.name || s.id} down`,
+        }))),
   ];
   // runtimes group — one LED pip per CONFIGURED slot (a model bound is what
   // makes a slot real, #1369), plus the ready count.
@@ -993,6 +1010,7 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
             {footerIndicators.map((svc) => (
               <span
                 key={svc.id}
+                data-service-id={svc.id}
                 className={"pip " + _svcPip(svc.tone)}
                 title={`${svc.label}: ${svc.title}`}
                 aria-label={`${svc.label}: ${svc.tone}`}

--- a/ui/tests/e2e/specs/footer-services-omits-comfyui-v3.spec.ts
+++ b/ui/tests/e2e/specs/footer-services-omits-comfyui-v3.spec.ts
@@ -14,6 +14,15 @@
  * pip + in the ready count) every id GET /api/services/health reports —
  * not a fixed set baked into the component. A down `comfyui` must both
  * appear as its own pip and move the ready count / trip warn styling.
+ * The pips carry `data-service-id`, so the assertion diffs the chip id set
+ * against the fixture's `.services[].id` set (the issue's repro verbatim) —
+ * display-copy renames cannot break or mask the contract.
+ *
+ * The third case pins the same defect's other door: when
+ * /api/services/health itself is unavailable (500/404/network — the hook
+ * fails soft to `pending` + empty list), the group must NOT collapse to the
+ * hal0 self-check's unqualified green "1 / 1 ready" — it renders a
+ * warn-toned "services unknown" placeholder pip and trips the warn styling.
  */
 import { test, expect, type Page } from '../fixtures/apiMock'
 
@@ -50,10 +59,10 @@ function servicesHealth(overrides: { comfyui?: boolean; hermes?: boolean; openwe
   }
 }
 
-async function mockServicesHealth(page: Page, body: unknown) {
+async function mockServicesHealth(page: Page, body: unknown, status = 200) {
   await page.route('**/api/services/health', (route) =>
     route.fulfill({
-      status: 200,
+      status,
       contentType: 'application/json',
       body: JSON.stringify(body),
     }),
@@ -62,11 +71,19 @@ async function mockServicesHealth(page: Page, body: unknown) {
 
 const servicesChip = (page: Page) => page.locator('[data-testid="foot-health-services"]')
 
+/** The rendered pip id set, via data-service-id (not display copy). */
+async function chipIds(page: Page): Promise<string[]> {
+  return servicesChip(page)
+    .locator('.pip')
+    .evaluateAll((els) => els.map((el) => el.getAttribute('data-service-id') ?? ''))
+}
+
 test.describe('Footer services group includes comfyui (#1899)', () => {
-  test('all services up: 4 pips, 4/4 ready — comfyui included, not just hal0/hermes/openwebui', async ({
+  test('all services up: 4 pips, 4/4 ready — chip id set matches the payload id set plus hal0', async ({
     page,
   }) => {
-    await mockServicesHealth(page, servicesHealth())
+    const fixture = servicesHealth()
+    await mockServicesHealth(page, fixture)
     await page.goto('/')
     await expect(page.locator('.footer')).toBeVisible()
 
@@ -74,13 +91,15 @@ test.describe('Footer services group includes comfyui (#1899)', () => {
     await expect(chip).toBeVisible()
 
     // hal0 (self) + comfyui + hermes + openwebui = 4 backing services.
-    const pips = chip.locator('.pip')
-    await expect(pips).toHaveCount(4, { timeout: 10_000 })
+    await expect(chip.locator('.pip')).toHaveCount(4, { timeout: 10_000 })
     await expect(chip.locator('.v b')).toHaveText('4 / 4')
     await expect(chip.locator('.v')).not.toHaveClass(/warn/)
 
-    // A pip specifically labelled comfyui must exist.
-    await expect(chip.locator('[aria-label^="ComfyUI:"]')).toHaveCount(1)
+    // Diff the chip id set against the fixture's .services[].id set — the
+    // contract is the id set, not the backend's display names.
+    expect((await chipIds(page)).sort()).toEqual(
+      ['hal0', ...fixture.services.map((s) => s.id)].sort(),
+    )
   })
 
   test('comfyui down: ready count drops and warn styling trips — not silently absorbed', async ({
@@ -98,8 +117,29 @@ test.describe('Footer services group includes comfyui (#1899)', () => {
     await expect(chip.locator('.v b')).toHaveText('3 / 4')
     await expect(chip.locator('.v')).toHaveClass(/warn/)
 
-    const comfyPip = chip.locator('[aria-label^="ComfyUI:"]')
+    const comfyPip = chip.locator('.pip[data-service-id="comfyui"]')
     await expect(comfyPip).toHaveCount(1)
     await expect(comfyPip).toHaveAttribute('aria-label', /err/)
+  })
+
+  test('services health endpoint 500s: group shows a warn "unknown" pip, not unqualified green', async ({
+    page,
+  }) => {
+    await mockServicesHealth(page, { detail: 'boom' }, 500)
+    await page.goto('/')
+    await expect(page.locator('.footer')).toBeVisible()
+
+    const chip = servicesChip(page)
+    await expect(chip).toBeVisible()
+
+    // hal0 self-check + the "services unknown" placeholder — never a bare
+    // all-green "1 / 1 ready" while three real services are unaccounted for.
+    await expect(chip.locator('.pip')).toHaveCount(2, { timeout: 10_000 })
+    await expect(chip.locator('.v b')).toHaveText('1 / 2')
+    await expect(chip.locator('.v')).toHaveClass(/warn/)
+
+    const unknownPip = chip.locator('.pip[data-service-id="services-unknown"]')
+    await expect(unknownPip).toHaveCount(1)
+    await expect(unknownPip).toHaveAttribute('aria-label', /warn/)
   })
 })

--- a/ui/tests/e2e/specs/footer-services-omits-comfyui-v3.spec.ts
+++ b/ui/tests/e2e/specs/footer-services-omits-comfyui-v3.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * footer-services-omits-comfyui-v3 — #1899.
+ *
+ * The footer's `services` LED group (`[data-testid="foot-health-services"]`)
+ * used to be a hardcoded three-member array (hal0, hermes, openwebui) in
+ * src/dash/chrome.jsx — `comfyui` was never a member. On a box where ComfyUI
+ * is a real running service, ComfyUI going down left the always-visible
+ * footer reporting an unqualified green "services 3 / 3 ready": the three
+ * rendered pips were individually truthful, but the group as a whole omitted
+ * a real backing service from both the pip count and the down-service warn
+ * styling.
+ *
+ * This spec pins the honest contract: the services group enumerates (as a
+ * pip + in the ready count) every id GET /api/services/health reports —
+ * not a fixed set baked into the component. A down `comfyui` must both
+ * appear as its own pip and move the ready count / trip warn styling.
+ */
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+/** The real /api/services/health payload shape (services_health.py). */
+function servicesHealth(overrides: { comfyui?: boolean; hermes?: boolean; openwebui?: boolean } = {}) {
+  const { comfyui = true, hermes = true, openwebui = true } = overrides
+  return {
+    services: [
+      {
+        id: 'comfyui',
+        name: 'ComfyUI',
+        up: comfyui,
+        detail: comfyui ? 'running — 0 job(s) active' : 'unreachable',
+        url: comfyui ? 'http://127.0.0.1:8188' : null,
+        stat: null,
+      },
+      {
+        id: 'hermes',
+        name: 'Hermes',
+        up: hermes,
+        detail: hermes ? 'systemd unit active' : 'systemd unit inactive or absent',
+        url: null,
+        stat: null,
+      },
+      {
+        id: 'openwebui',
+        name: 'OpenWebUI',
+        up: openwebui,
+        detail: openwebui ? 'reachable — /health ok' : 'unreachable (ConnectError)',
+        url: openwebui ? 'http://127.0.0.1:3001' : null,
+        stat: null,
+      },
+    ],
+  }
+}
+
+async function mockServicesHealth(page: Page, body: unknown) {
+  await page.route('**/api/services/health', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    }),
+  )
+}
+
+const servicesChip = (page: Page) => page.locator('[data-testid="foot-health-services"]')
+
+test.describe('Footer services group includes comfyui (#1899)', () => {
+  test('all services up: 4 pips, 4/4 ready — comfyui included, not just hal0/hermes/openwebui', async ({
+    page,
+  }) => {
+    await mockServicesHealth(page, servicesHealth())
+    await page.goto('/')
+    await expect(page.locator('.footer')).toBeVisible()
+
+    const chip = servicesChip(page)
+    await expect(chip).toBeVisible()
+
+    // hal0 (self) + comfyui + hermes + openwebui = 4 backing services.
+    const pips = chip.locator('.pip')
+    await expect(pips).toHaveCount(4, { timeout: 10_000 })
+    await expect(chip.locator('.v b')).toHaveText('4 / 4')
+    await expect(chip.locator('.v')).not.toHaveClass(/warn/)
+
+    // A pip specifically labelled comfyui must exist.
+    await expect(chip.locator('[aria-label^="ComfyUI:"]')).toHaveCount(1)
+  })
+
+  test('comfyui down: ready count drops and warn styling trips — not silently absorbed', async ({
+    page,
+  }) => {
+    await mockServicesHealth(page, servicesHealth({ comfyui: false }))
+    await page.goto('/')
+    await expect(page.locator('.footer')).toBeVisible()
+
+    const chip = servicesChip(page)
+    await expect(chip).toBeVisible()
+
+    // Still 4 pips (comfyui renders, just down) but only 3 ready.
+    await expect(chip.locator('.pip')).toHaveCount(4, { timeout: 10_000 })
+    await expect(chip.locator('.v b')).toHaveText('3 / 4')
+    await expect(chip.locator('.v')).toHaveClass(/warn/)
+
+    const comfyPip = chip.locator('[aria-label^="ComfyUI:"]')
+    await expect(comfyPip).toHaveCount(1)
+    await expect(comfyPip).toHaveAttribute('aria-label', /err/)
+  })
+})


### PR DESCRIPTION
## Summary

The dashboard footer's `services` LED group (`ui/src/dash/chrome.jsx`) was a hardcoded three-member array (`hal0`, `hermes`, `openwebui`). `comfyui` was never a member, so on a box where ComfyUI is a real running service an outage left the always-visible footer reporting an unqualified green "services 3 / 3 ready" — the three rendered pips were individually truthful, but the group as a whole silently dropped a real backing service.

## Root cause

The reported symptom (comfyui missing) is one layer above the actual defect: the footer never read the `id` set out of the `/api/services/health` payload at all — it hand-rolled three specific service objects (`hermes`, `openwebui`) alongside `hal0`. The backend (`src/hal0/api/routes/services_health.py`) already reports `comfyui`, `hermes`, and `openwebui` every call. Adding `comfyui` as a fourth hardcoded entry would have fixed today's symptom but left the same defect for the next service the backend adds. Fixed by mapping `footerIndicators` directly over `serviceHealth.services` (prepending only the `hal0` self-check, since hal0 IS the API answering the request and isn't in that payload) — the footer now always mirrors whatever the backend actually reports, with no fixed id list to fall out of sync.

## What changed

- `ui/src/dash/chrome.jsx`: `footerIndicators` (the `services` LED group) now derives from `serviceHealth.services` instead of a hardcoded `[hermes, openwebui]` pair alongside `hal0`.
- `ui/tests/e2e/specs/footer-services-omits-comfyui-v3.spec.ts`: new regression spec that mocks `GET /api/services/health` with the real 3-service payload shape and asserts the footer renders 4 pips (hal0 + comfyui + hermes + openwebui) with a correct ready count, and that a down `comfyui` both keeps its own pip and trips the warn styling / drops the ready count.

## Verification

- New spec confirmed RED on the pre-fix hardcoded array (3 pips, comfyui absent) and GREEN after the fix (4 pips, `4/4` all-up / `3/4` + warn on comfyui-down) via `git stash` bisection of the fix commit.
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run test:unit` (vitest) — 127/127 passed
- `npm run build` — succeeds
- `npx playwright test tests/e2e/specs/footer-*` — 18 passed, 1 pre-existing skip (unrelated bundle-hygiene test gated on a prod build)

## Out of scope

- The sibling `runtimes` group (already dynamic, used as the working reference for this fix) — untouched.
- No changes to `/api/services/health` itself; the backend already reported comfyui correctly, the defect was entirely on the frontend consumption side.
- CHANGELOG.md intentionally left untouched per the fix-wave convention (#1545) — consolidated at the end of the wave.

Closes #1899