### PR TITLE
fix(hermes): resolve chat model from real slot state, not name+fake states

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -61,6 +61,7 @@ from hal0.agents.anchor_window import (
 )
 from hal0.agents.role_slots import candidate_from_slot_mapping, resolve_role_slots
 from hal0.slot_lifecycle_budget import STACK_APPLY_SLOT_ALLOWANCE, slot_lifecycle_timeout_s
+from hal0.slots.state import is_dispatchable_state
 from hal0.system import seam as _seam
 
 log = structlog.get_logger(__name__)
@@ -1307,11 +1308,18 @@ def _resolve_primary_slot(
         return kind in {"llm", "chat"}
 
     candidates = [s for s in slots if isinstance(s, dict) and _chat(s)]
-    # ADR-0023: the canonical primary is the `agent` slot; accept legacy
-    # `chat`/`primary` names for boxes not yet reseeded.
-    primary = next((s for s in candidates if s.get("name") in ("agent", "chat", "primary")), None)
+    # A candidate only counts as "wired" once it is both dispatchable AND
+    # carries a bound model — an `agent` seed slot that hasn't been loaded
+    # yet is neither (#1892: picking it by name alone, unconditionally,
+    # shadowed genuinely serving llm slots under other names and produced
+    # the "primary" sentinel forever).
+    wired = [s for s in candidates if _is_ready(s) and _slot_model_id(s)]
+    # ADR-0023: the canonical primary is the `agent` slot; prefer legacy
+    # `chat`/`primary` names too, but only among slots that are actually
+    # wired — never let the name match override readiness.
+    primary = next((s for s in wired if s.get("name") in ("agent", "chat", "primary")), None)
     if primary is None:
-        primary = next((s for s in candidates if _is_ready(s)), None)
+        primary = next(iter(wired), None)
     if primary is None:
         return fallback
 
@@ -3914,9 +3922,17 @@ _DEFAULT_PRIMARY_BACKEND_URL = f"{HAL0_API_URL}/v1"
 
 
 def _is_ready(slot: dict[str, Any]) -> bool:
-    """True iff the slot reports a live/ready state."""
+    """True iff the slot reports a dispatchable (request-safe) state.
+
+    Delegates to :func:`hal0.slots.state.is_dispatchable_state`, the ONE
+    canonical definition of "safe to route to" (finding DR-8). Before #1892
+    this re-declared its own vocabulary (``ready``/``running``/``loaded``/
+    ``ok``/``online``) that never matched the real ``SlotState`` wire values
+    (``ready``/``serving``/``idle``) — a serving slot always read as
+    not-ready here.
+    """
     state = slot.get("state") or slot.get("status") or ""
-    return str(state).lower() in {"ready", "running", "loaded", "ok", "online"}
+    return is_dispatchable_state(str(state))
 
 
 def _slot_context_length(slot: dict[str, Any]) -> int | None:

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -61,7 +61,7 @@ from hal0.agents.anchor_window import (
 )
 from hal0.agents.role_slots import candidate_from_slot_mapping, resolve_role_slots
 from hal0.slot_lifecycle_budget import STACK_APPLY_SLOT_ALLOWANCE, slot_lifecycle_timeout_s
-from hal0.slots.state import is_dispatchable_state
+from hal0.slots.state import SlotState, is_dispatchable_state, provider_requires_model
 from hal0.system import seam as _seam
 
 log = structlog.get_logger(__name__)
@@ -1280,8 +1280,10 @@ def _resolve_primary_slot(
     Reads ``/api/slots`` (the canonical source post-embed migration) and selects
     the entry named ``primary`` (or the first ready ``type=='llm'``
     slot when no name matches). Returns the keys the config template
-    needs. Falls back to a safe-but-unwired placeholder when no slot
-    is loaded — self_report surfaces that in the bootstrap summary.
+    needs, plus the selected slot's ``alias``/``backend`` so the STATE.md
+    and HERMES.md renderers consume the SAME selection (one selection,
+    one answer — #1892). Falls back to a safe-but-unwired placeholder when
+    no slot is loaded — self_report surfaces that in the bootstrap summary.
 
     Until v0.2 this read the inference daemon's ``/v1/health`` and looked
     for ``loaded``/``slots`` keys, which post-embed migration are absent
@@ -1297,6 +1299,8 @@ def _resolve_primary_slot(
         "base_url": _DEFAULT_PRIMARY_BACKEND_URL,
         "context_length": 32768,
         "placeholder": True,
+        "alias": None,
+        "backend": None,
     }
     fetch = slots_fetcher or _fetch_slots
     slots = fetch() or []
@@ -1314,12 +1318,25 @@ def _resolve_primary_slot(
     # shadowed genuinely serving llm slots under other names and produced
     # the "primary" sentinel forever).
     wired = [s for s in candidates if _is_ready(s) and _slot_model_id(s)]
-    # ADR-0023: the canonical primary is the `agent` slot; prefer legacy
-    # `chat`/`primary` names too, but only among slots that are actually
-    # wired — never let the name match override readiness.
-    primary = next((s for s in wired if s.get("name") in ("agent", "chat", "primary")), None)
-    if primary is None:
-        primary = next(iter(wired), None)
+    # Display residency is WIDER than request-safe dispatchability: a
+    # `warming` slot with a bound model is resident — the model is loading
+    # right now, and `model_aliases.<slot>` for it is already written by
+    # _collect_chat_slots (the gateway cold-loads/queues on demand). The
+    # #1892 register entry requires the "Chat model:" line to never deny a
+    # resident model for the whole duration of a large load, so warming
+    # slots with a bound model are a second-tier fallback here. Delegation
+    # and the capability rollup keep the strict dispatchable predicate —
+    # residency is a display question, dispatchability a routing one.
+    warming = [s for s in candidates if _slot_state(s) == SlotState.WARMING and _slot_model_id(s)]
+
+    def _pick(pool: list[dict[str, Any]]) -> dict[str, Any] | None:
+        # ADR-0023: the canonical primary is the `agent` slot; prefer legacy
+        # `chat`/`primary` names too, but only within a residency tier —
+        # never let the name match override readiness.
+        named = next((s for s in pool if s.get("name") in ("agent", "chat", "primary")), None)
+        return named or next(iter(pool), None)
+
+    primary = _pick(wired) or _pick(warming)
     if primary is None:
         return fallback
 
@@ -1337,7 +1354,19 @@ def _resolve_primary_slot(
         ctx = int(ctx)
     except (TypeError, ValueError):
         ctx = fallback["context_length"]
-    return {"model": model, "base_url": base_url, "context_length": ctx, "placeholder": False}
+    return {
+        "model": model,
+        "base_url": base_url,
+        "context_length": ctx,
+        "placeholder": False,
+        # Renderers must consume the SAME selection: re-deriving the
+        # "primary slot" by bare name match let an unwired `agent` seed
+        # relabel a serving slot's model with an alias that is never
+        # written to `model_aliases` (#1892 review finding 1). One
+        # selection, one answer — alias + backend travel with the model.
+        "alias": _slot_alias(primary),
+        "backend": primary.get("backend"),
+    }
 
 
 def _default_mcp_servers() -> list[dict[str, Any]]:
@@ -2866,23 +2895,14 @@ def _phase_context_link(ctx: _StepCtx) -> PhaseResult:
     chat_slots = _collect_chat_slots(slots_all, contexts=ctx.io.fetch_model_contexts())
     primary_raw = _resolve_primary_slot(slots_fetcher=lambda: slots_all)
     primary_for_template: dict[str, Any] | None = None
-    primary_alias = "agent"  # ADR-0023 canonical default anchor
-    primary_slot = next(
-        (
-            s
-            for s in slots_all
-            if isinstance(s, dict) and s.get("name") in ("agent", "chat", "primary")
-        ),
-        None,
-    )
-    if primary_slot:
-        primary_alias = _slot_alias(primary_slot)
-    # primary_raw["model"] is a real model_id when a slot is live, or
-    # the placeholder string (slot name) when nothing is loaded — treat
-    # the placeholder as "no primary" for template purposes.
-    if primary_raw["model"] and primary_raw["model"] not in ("agent", "utility", "chat", "primary"):
+    # One selection, one answer (#1892 review): the alias comes from the SAME
+    # slot _resolve_primary_slot picked — re-deriving it here by bare name
+    # match let an unwired `agent` seed relabel a serving slot's model with
+    # an alias `model_aliases` never contains. `placeholder` is the explicit
+    # "nothing wired" signal (#702).
+    if not primary_raw.get("placeholder"):
         primary_for_template = {
-            "alias": primary_alias,
+            "alias": primary_raw.get("alias") or "agent",
             "model_id": primary_raw["model"],
             "backend_url": primary_raw["base_url"],
         }
@@ -3921,6 +3941,11 @@ def _slot_backend_url(slot: dict[str, Any]) -> str:
 _DEFAULT_PRIMARY_BACKEND_URL = f"{HAL0_API_URL}/v1"
 
 
+def _slot_state(slot: dict[str, Any]) -> str:
+    """Normalised wire state string for a slot dict (``state`` before ``status``)."""
+    return str(slot.get("state") or slot.get("status") or "").lower()
+
+
 def _is_ready(slot: dict[str, Any]) -> bool:
     """True iff the slot reports a dispatchable (request-safe) state.
 
@@ -3931,8 +3956,24 @@ def _is_ready(slot: dict[str, Any]) -> bool:
     (``ready``/``serving``/``idle``) — a serving slot always read as
     not-ready here.
     """
-    state = slot.get("state") or slot.get("status") or ""
-    return is_dispatchable_state(str(state))
+    return is_dispatchable_state(_slot_state(slot))
+
+
+def _slot_missing_required_model(slot: dict[str, Any]) -> bool:
+    """True when this slot's provider needs a bound model but none is bound.
+
+    ``idle`` is in the dispatchable ready-set, but it is ALSO the state
+    SlotManager coerces a model-requiring slot into when it reaches READY
+    with no model (``slot.modelless_ready_blocked``, slots/manager.py) —
+    such a slot cannot fulfil a request, so consumers that advertise or
+    wire capabilities must skip it. Self-managed providers (kokoro,
+    moonshine, …) bake their model in and legitimately report no
+    ``model_id``; this mirrors the manager's own semantics exactly:
+    reject only when the provider is KNOWN and requires a model —
+    permissive when the provider can't be determined.
+    """
+    provider = slot.get("provider") or slot.get("backend")
+    return bool(provider) and provider_requires_model(str(provider)) and not _slot_model_id(slot)
 
 
 def _slot_context_length(slot: dict[str, Any]) -> int | None:
@@ -3978,6 +4019,13 @@ def _collect_capability_rollup(slots: list[dict[str, Any]]) -> list[dict[str, An
         if not label:
             continue
         if not _is_ready(s):
+            continue
+        # `idle` is dispatchable, but a model-requiring slot parked idle by
+        # the modelless_ready_blocked guard has nothing loaded — advertising
+        # it would put `model_id: None` in the very STATE.md line #1892 is
+        # about. Self-managed providers (kokoro, …) pass: their model is
+        # baked in.
+        if _slot_missing_required_model(s):
             continue
         out.append(
             {
@@ -4062,23 +4110,36 @@ def render_live_context(
     chat_slots = _collect_chat_slots(slots_all, contexts=contexts)
     primary_raw = _resolve_primary_slot(slots_fetcher=lambda: slots_all)
 
-    primary_slot = next(
-        (
-            s
-            for s in slots_all
-            if isinstance(s, dict) and s.get("name") in ("agent", "chat", "primary")
-        ),
-        None,
-    )
+    # One selection, one answer (#1892 review): alias + backend come from the
+    # SAME slot _resolve_primary_slot picked. Re-deriving "the primary slot"
+    # here by bare name match let an unwired `agent` seed relabel a serving
+    # slot's model with `model_aliases.agent` — an alias _collect_chat_slots
+    # (which skips model-less slots) never writes.
     primary_for_template: dict[str, Any] | None = None
-    if primary_raw["model"] and primary_raw["model"] not in ("agent", "utility", "chat", "primary"):
+    if not primary_raw.get("placeholder"):
         primary_for_template = {
-            "alias": _slot_alias(primary_slot) if primary_slot else "agent",
+            "alias": primary_raw.get("alias") or "agent",
             "model_id": primary_raw["model"],
             "backend_url": primary_raw["base_url"],
             "context_length": primary_raw["context_length"],
-            "backend": (primary_slot or {}).get("backend"),
+            "backend": primary_raw.get("backend"),
         }
+    # Remediation must name a command valid for the box's actual state
+    # (#1892 register `expect`): when an llm slot already exists but has no
+    # model bound, `hal0 slot create` would collide with it — the right
+    # move is loading a model into the existing slot.
+    unwired_llm_slot: str | None = None
+    if primary_for_template is None:
+        unwired_llm_slot = next(
+            (
+                str(s["name"])
+                for s in slots_all
+                if isinstance(s, dict)
+                and str(s.get("type") or s.get("kind") or "").lower() in {"llm", "chat"}
+                and s.get("name")
+            ),
+            None,
+        )
 
     capabilities = _collect_capability_rollup(slots_all)
 
@@ -4099,6 +4160,7 @@ def render_live_context(
 
     state_vars = {
         "primary": primary_for_template,
+        "unwired_llm_slot": unwired_llm_slot,
         "capabilities": capabilities,
         "npu": npu,
         "igpu_sclk_mhz": _igpu_sclk_mhz(),
@@ -4670,7 +4732,12 @@ def _find_slot(slots: list[dict[str, Any]], kind: str) -> dict[str, Any] | None:
     accept = _STT_SLOT_TYPES if kind == "stt" else frozenset({kind})
     for s in slots:
         slot_type = (s.get("type") or s.get("capability") or "").lower()
-        if slot_type in accept and _is_ready(s):
+        # Reject model-requiring slots with nothing bound (the
+        # modelless_ready_blocked `idle` shape) — wiring STT/TTS env vars
+        # at a backend that cannot serve trades #1892 for a worse bug.
+        # Self-managed providers (kokoro, moonshine, …) pass without a
+        # model_id.
+        if slot_type in accept and _is_ready(s) and not _slot_missing_required_model(s):
             return s
     # STT special case: the NPU-trio transcription facade (type=transcription,
     # served_by=<anchor>) always reports state=offline — it has no unit of its
@@ -4678,7 +4745,11 @@ def _find_slot(slots: list[dict[str, Any]], kind: str) -> dict[str, Any] | None:
     # stamps served_by on these shadows. Accept the facade when its anchor is
     # ready so voice_wire auto-provisions STT_OPENAI_BASE_URL.
     if kind == "stt":
-        ready_names = {str(s.get("name")) for s in slots if _is_ready(s) and s.get("name")}
+        ready_names = {
+            str(s.get("name"))
+            for s in slots
+            if _is_ready(s) and not _slot_missing_required_model(s) and s.get("name")
+        }
         for s in slots:
             slot_type = (s.get("type") or s.get("capability") or "").lower()
             anchor = s.get("served_by")

--- a/src/hal0/agents/hermes_templates/STATE.md.j2
+++ b/src/hal0/agents/hermes_templates/STATE.md.j2
@@ -2,14 +2,15 @@
    change, injected into every Hermes session by the on_session_start hook.
    Keep it LEAN: this is fed to the model every session. Stable identity
    lives in SOUL.md; structural map lives in HERMES.md.
-   Params: primary (dict|None), capabilities (list), npu (dict),
-   igpu_sclk_mhz (int|None), dashboard_url, inference_base, daemon, as_of. #}
+   Params: primary (dict|None), unwired_llm_slot (str|None), capabilities
+   (list), npu (dict), igpu_sclk_mhz (int|None), dashboard_url,
+   inference_base, daemon, as_of. #}
 # Live system state
 
 {% if primary -%}
 - Chat model: `{{ primary.model_id }}` ({{ primary.context_length | default("?") }} ctx{% if primary.backend %}, {{ primary.backend }}{% endif %}) via `model_aliases.{{ primary.alias | default("primary") }}`
 {%- else -%}
-- Chat model: _no chat model loaded — wire one via `hal0 slot create`._
+- Chat model: _no chat model loaded — {% if unwired_llm_slot %}load one into the existing `{{ unwired_llm_slot }}` slot via `hal0 model pull <id> && hal0 slot load {{ unwired_llm_slot }} --model <id>`{% else %}wire one via `hal0 slot create`{% endif %}._
 {%- endif %}
 {% if capabilities -%}
 - Capabilities: {% for c in capabilities %}{{ c.capability }} (`{{ c.model_id }}`{% if c.backend %}/{{ c.backend }}{% endif %}){% if not loop.last %}, {% endif %}{% endfor %}

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -816,6 +816,44 @@ def test_resolve_primary_slot_fallback_when_no_slots() -> None:
     assert out["base_url"] == "http://127.0.0.1:8080/v1"
 
 
+def test_resolve_primary_slot_skips_modelless_named_seed_for_serving_slot() -> None:
+    """Regression for #1892.
+
+    A fresh install carries an unwired ``agent`` seed slot (no model bound)
+    alongside a genuinely serving llm slot under another name. The name-based
+    match must not shadow the slot that is actually serving traffic.
+    """
+    fake = lambda: [  # noqa: E731
+        {"name": "agent", "type": "llm", "state": "idle", "model_id": None},
+        {
+            "name": "qwen-coder",
+            "type": "llm",
+            "state": "serving",
+            "model_id": "qwen3-coder:30b",
+            "backend_url": "http://127.0.0.1:8001/v1",
+            "context_length": 32768,
+        },
+    ]
+    out = hp._resolve_primary_slot(slots_fetcher=fake)
+    assert out["model"] == "qwen3-coder:30b"
+    assert out["placeholder"] is False
+
+
+@pytest.mark.parametrize("state", ["ready", "serving", "idle"])
+def test_is_ready_accepts_every_dispatchable_slot_state(state: str) -> None:
+    """Regression for #1892: _is_ready must agree with the canonical
+    dispatchable-state set in hal0.slots.state, not a stale ad-hoc vocabulary.
+    """
+    assert hp._is_ready({"state": state}) is True
+
+
+@pytest.mark.parametrize(
+    "state", ["offline", "pulling", "starting", "warming", "unloading", "error"]
+)
+def test_is_ready_rejects_non_dispatchable_slot_states(state: str) -> None:
+    assert hp._is_ready({"state": state}) is False
+
+
 def _build_overlay_keys(**over):
     """Helper: run _build_config_overlay with sane defaults → ``{key: value}``."""
     base = dict(
@@ -964,9 +1002,13 @@ def test_resolve_delegation_none_when_slot_absent() -> None:
 
 
 def test_resolve_delegation_none_when_slot_not_ready() -> None:
+    # "idle" is a dispatchable state (hal0.slots.state.DISPATCHABLE_STATES) —
+    # a container that's up with a bound model but past its idle timeout is
+    # still safe to route to (#1892). Use "warming" (model still loading,
+    # genuinely not yet dispatchable) as the not-ready fixture instead.
     slots = [
         *_ROLE_SLOTS[:1],
-        {"name": "agent", "type": "llm", "state": "idle", "model_id": "x"},
+        {"name": "agent", "type": "llm", "state": "warming", "model_id": "x"},
     ]
     assert hp._resolve_delegation(slots, hal0_base_url=_HAL0_V1) is None
 

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -23,6 +23,7 @@ from typing import Any
 import pytest
 
 from hal0.agents import hermes_provision as hp
+from hal0.slots.state import DISPATCHABLE_STATES, SlotState
 
 from ._hermes_fakes import fake_hermes_run
 
@@ -830,6 +831,7 @@ def test_resolve_primary_slot_skips_modelless_named_seed_for_serving_slot() -> N
             "type": "llm",
             "state": "serving",
             "model_id": "qwen3-coder:30b",
+            "backend": "vllm",
             "backend_url": "http://127.0.0.1:8001/v1",
             "context_length": 32768,
         },
@@ -837,9 +839,60 @@ def test_resolve_primary_slot_skips_modelless_named_seed_for_serving_slot() -> N
     out = hp._resolve_primary_slot(slots_fetcher=fake)
     assert out["model"] == "qwen3-coder:30b"
     assert out["placeholder"] is False
+    # One selection, one answer: the alias/backend the renderers consume must
+    # come from the SAME slot that supplied the model — never re-derived by
+    # name (which would relabel this model `model_aliases.agent`, an alias
+    # _collect_chat_slots never writes for a model-less seed).
+    assert out["alias"] == "qwen-coder"
+    assert out["backend"] == "vllm"
 
 
-@pytest.mark.parametrize("state", ["ready", "serving", "idle"])
+def test_resolve_primary_slot_accepts_warming_slot_with_bound_model() -> None:
+    """#1892 register `expect`: a resident (warming) model with a bound
+    model_id must never render as "no chat model loaded" for the whole
+    duration of a large load. `model_aliases.<slot>` for it already exists —
+    the gateway cold-loads/queues on demand."""
+    fake = lambda: [  # noqa: E731
+        {
+            "name": "agent",
+            "type": "llm",
+            "state": "warming",
+            "model_id": "qwen3:32b",
+            "context_length": 16384,
+        },
+    ]
+    out = hp._resolve_primary_slot(slots_fetcher=fake)
+    assert out["model"] == "qwen3:32b"
+    assert out["placeholder"] is False
+    assert out["alias"] == "agent"
+
+
+def test_resolve_primary_slot_prefers_dispatchable_over_warming() -> None:
+    """A dispatchable slot outranks a warming one, even when the warming slot
+    carries the canonical `agent` name — name preference applies only within
+    a residency tier."""
+    fake = lambda: [  # noqa: E731
+        {"name": "agent", "type": "llm", "state": "warming", "model_id": "qwen3:32b"},
+        {"name": "qwen-coder", "type": "llm", "state": "serving", "model_id": "qwen3-coder:30b"},
+    ]
+    out = hp._resolve_primary_slot(slots_fetcher=fake)
+    assert out["model"] == "qwen3-coder:30b"
+    assert out["alias"] == "qwen-coder"
+
+
+def test_resolve_primary_slot_warming_without_model_is_placeholder() -> None:
+    """Warming counts as resident only WITH a bound model — a model-less
+    warming slot still falls through to the placeholder."""
+    fake = lambda: [  # noqa: E731
+        {"name": "agent", "type": "llm", "state": "warming", "model_id": None},
+    ]
+    out = hp._resolve_primary_slot(slots_fetcher=fake)
+    assert out["placeholder"] is True
+
+
+# Derived from the canonical enum, not hardcoded lists: a new SlotState
+# member can never slip through untested (#1892 "closes this permanently").
+@pytest.mark.parametrize("state", sorted(str(s) for s in DISPATCHABLE_STATES))
 def test_is_ready_accepts_every_dispatchable_slot_state(state: str) -> None:
     """Regression for #1892: _is_ready must agree with the canonical
     dispatchable-state set in hal0.slots.state, not a stale ad-hoc vocabulary.
@@ -847,9 +900,7 @@ def test_is_ready_accepts_every_dispatchable_slot_state(state: str) -> None:
     assert hp._is_ready({"state": state}) is True
 
 
-@pytest.mark.parametrize(
-    "state", ["offline", "pulling", "starting", "warming", "unloading", "error"]
-)
+@pytest.mark.parametrize("state", sorted(str(s) for s in set(SlotState) - DISPATCHABLE_STATES))
 def test_is_ready_rejects_non_dispatchable_slot_states(state: str) -> None:
     assert hp._is_ready({"state": state}) is False
 

--- a/tests/agents/test_hermes_state_render.py
+++ b/tests/agents/test_hermes_state_render.py
@@ -30,6 +30,62 @@ def test_collect_capability_rollup_filters_and_maps_types():
     assert "unused" not in {r.get("model_id") for r in rollup}
 
 
+def test_collect_capability_rollup_skips_modelless_idle_slot():
+    """#1892 review: `idle` is dispatchable, but the modelless_ready_blocked
+    shape (model-requiring provider, nothing bound) must not be advertised —
+    it would render `Capabilities: embed (None/llamacpp)` into STATE.md."""
+    slots = [
+        {
+            "name": "embed",
+            "type": "embedding",
+            "state": "idle",
+            "model_id": None,
+            "backend": "llamacpp",
+        },
+    ]
+    assert hp._collect_capability_rollup(slots) == []
+
+
+def test_collect_capability_rollup_keeps_self_managed_provider_without_model():
+    """Self-managed providers (SELF_MANAGED_PROVIDERS) bake their model in and
+    legitimately report no model_id — the model-less guard must not drop them."""
+    slots = [
+        {"name": "kokoro", "type": "tts", "state": "ready", "provider": "kokoro"},
+    ]
+    rollup = hp._collect_capability_rollup(slots)
+    assert [r["capability"] for r in rollup] == ["voice-tts"]
+
+
+def test_find_slot_rejects_modelless_idle_transcription_slot():
+    """#1892 review: voice_wire must not stamp STT_OPENAI_BASE_URL at a
+    model-requiring backend with nothing loaded (modelless_ready_blocked idle)."""
+    slots = [
+        {
+            "name": "whisper",
+            "type": "transcription",
+            "state": "idle",
+            "model_id": None,
+            "backend": "llamacpp",
+            "backend_url": "http://127.0.0.1:8088/v1",
+        },
+    ]
+    assert hp._find_slot(slots, "stt") is None
+
+
+def test_find_slot_accepts_self_managed_stt_without_model():
+    slots = [
+        {
+            "name": "moonshine",
+            "type": "transcription",
+            "state": "ready",
+            "provider": "moonshine",
+            "backend_url": "http://127.0.0.1:8088/v1",
+        },
+    ]
+    found = hp._find_slot(slots, "stt")
+    assert found is not None and found["name"] == "moonshine"
+
+
 def test_state_template_renders_full_state():
     body = hp._render_template(
         "STATE.md.j2",
@@ -246,6 +302,101 @@ def test_render_live_context_reachable_empty_is_not_degraded(tmp_path, monkeypat
     body = (tmp_path / "STATE.md").read_text()
     assert "reachable" in body
     assert "no chat model loaded" in body.lower()
+
+
+def test_render_live_context_uses_selected_slot_alias_not_name_match(tmp_path, monkeypatch):
+    """#1892 review finding 1: with an unwired `agent` seed next to a serving
+    slot under another name, STATE.md must advertise the SERVING slot's alias
+    (`model_aliases.qwen-coder` — the only alias the config overlay writes),
+    never relabel its model with the seed's `model_aliases.agent`."""
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {})
+    monkeypatch.setattr(hp, "_igpu_sclk_mhz", lambda: None)
+    home = tmp_path / "home"
+    home.mkdir()
+    slots = [
+        {"name": "agent", "type": "llm", "state": "idle", "model_id": None, "backend": "llamacpp"},
+        {
+            "name": "qwen-coder",
+            "type": "llm",
+            "state": "serving",
+            "model_id": "qwen3-coder:30b",
+            "backend": "vllm",
+            "context_length": 32768,
+        },
+    ]
+    r = hp.render_live_context(
+        hermes_home=home, slots_fetcher=lambda: slots, now_iso="2026-06-04T10:00:00+00:00"
+    )
+    assert r["state_written"] is True
+    body = (tmp_path / "STATE.md").read_text()
+    assert "qwen3-coder:30b" in body
+    assert "model_aliases.qwen-coder" in body
+    assert "model_aliases.agent" not in body
+    assert "llamacpp" not in body  # backend label must come from the serving slot
+    assert "vllm" in body
+
+
+def test_render_live_context_keeps_warming_resident_model(tmp_path, monkeypatch):
+    """#1892 register `expect`: a warming llm slot with a bound model is
+    resident — STATE.md must not claim "no chat model loaded" for the whole
+    duration of a large model load."""
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {})
+    monkeypatch.setattr(hp, "_igpu_sclk_mhz", lambda: None)
+    home = tmp_path / "home"
+    home.mkdir()
+    slots = [
+        {"name": "agent", "type": "llm", "state": "warming", "model_id": "qwen3:32b"},
+    ]
+    hp.render_live_context(
+        hermes_home=home, slots_fetcher=lambda: slots, now_iso="2026-06-04T10:00:00+00:00"
+    )
+    body = (tmp_path / "STATE.md").read_text()
+    assert "qwen3:32b" in body
+    assert "no chat model loaded" not in body.lower()
+
+
+def test_render_live_context_remediation_names_existing_unwired_slot(tmp_path, monkeypatch):
+    """#1892 register `expect`: the remediation must name a command valid for
+    the box's actual state. With a model-less `agent` seed present, telling
+    the operator to `hal0 slot create` a slot that already exists is wrong —
+    point at loading a model into the existing slot instead."""
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {})
+    monkeypatch.setattr(hp, "_igpu_sclk_mhz", lambda: None)
+    home = tmp_path / "home"
+    home.mkdir()
+    slots = [
+        {"name": "agent", "type": "llm", "state": "idle", "model_id": None, "backend": "llamacpp"},
+    ]
+    hp.render_live_context(
+        hermes_home=home, slots_fetcher=lambda: slots, now_iso="2026-06-04T10:00:00+00:00"
+    )
+    body = (tmp_path / "STATE.md").read_text()
+    assert "no chat model loaded" in body.lower()
+    assert "hal0 slot load agent" in body
+    assert "hal0 slot create" not in body
+
+
+def test_render_live_context_remediation_slot_create_when_no_llm_slots(tmp_path, monkeypatch):
+    """No llm slot at all -> `hal0 slot create` remains the right command."""
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", tmp_path)
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)
+    monkeypatch.setattr(hp, "_fetch_model_contexts", lambda: {})
+    monkeypatch.setattr(hp, "_igpu_sclk_mhz", lambda: None)
+    monkeypatch.setattr(hp, "_http_get", lambda *a, **k: 200)  # daemon up, no slots
+    home = tmp_path / "home"
+    home.mkdir()
+    hp.render_live_context(
+        hermes_home=home, slots_fetcher=lambda: [], now_iso="2026-06-04T10:00:00+00:00"
+    )
+    body = (tmp_path / "STATE.md").read_text()
+    assert "no chat model loaded" in body.lower()
+    assert "hal0 slot create" in body
 
 
 def test_render_live_context_bumps_mtime_when_unchanged_reachable(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #1892 — hermes' injected `# Live system state` block claimed "no chat model loaded" while `type=llm` slots were serving on the same gateway. Two independent bugs compose in `hermes_provision.py`:

1. `_resolve_primary_slot()` picked the slot named `agent`/`chat`/`primary` unconditionally, regardless of readiness or whether a model was actually bound, and fell back to the `"primary"` sentinel — which `render_live_context` then silently discards. A model-less `agent` seed slot always shadowed a genuinely serving slot under a different name.
2. `_is_ready()` accepted `{ready, running, loaded, ok, online}` — a vocabulary that never matched the real `SlotState` wire values (`ready`/`serving`/`idle` from `hal0/slots/state.py`). So even the rescue fallback for other ready chat slots was dead: a **serving** slot always read as not-ready.

## Root cause

Both bugs trace to `hermes_provision.py` re-declaring its own, stale notion of "ready" instead of using the canonical dispatchable-state definition (`hal0.slots.state.DISPATCHABLE_STATES` / `is_dispatchable_state`) that `SlotManager`, the GPU arbiter, and the metrics/`slot_view` layer already share (DR-8, issue #696). Fixing `_is_ready()` alone wasn't enough — `_resolve_primary_slot()` also needed to stop trusting the name match unconditionally and instead require the named candidate to actually be dispatchable *and* carry a bound `model_id` before accepting it, falling through to any other dispatchable chat slot with a bound model otherwise.

The `STATE.md.j2` remediation text (`wire one via hal0 slot create`) needed no change — it's generic, not naming a specific slot, and simply stops firing once `primary`/`chat_slots` resolve correctly upstream.

## Changes

- `src/hal0/agents/hermes_provision.py`
  - `_is_ready()` now delegates to `hal0.slots.state.is_dispatchable_state` instead of a hand-rolled, wrong state set.
  - `_resolve_primary_slot()` only accepts a name-matched (`agent`/`chat`/`primary`) candidate once it's dispatchable and has a bound `model_id`; otherwise falls through to the first dispatchable chat slot with a bound model.

## Tests

- `test_is_ready_accepts_every_dispatchable_slot_state` / `test_is_ready_rejects_non_dispatchable_slot_states` — parametrized over the real `SlotState` enum, replacing the fake vocabulary check the issue asked for.
- `test_resolve_primary_slot_skips_modelless_named_seed_for_serving_slot` — repros the exact fresh-install scenario from the issue (unwired `agent` seed + serving slot under another name) and asserts the serving slot's model resolves.
- Updated `test_resolve_delegation_none_when_slot_not_ready` — its fixture used `state="idle"` to represent "not ready", which was only passing because of the old `_is_ready` bug (idle was never in the fake accepted set). `idle` is a canonically dispatchable state, so the fixture now uses `warming` (genuinely not-yet-dispatchable) to keep testing the intended behavior.

All of `tests/agents/`, `tests/slots/`, `tests/dispatcher/`, `tests/cli/test_agent_shim.py` pass (1827 passed). `ruff check` and `ruff format --check` clean on the changed files.

## Out of scope

- Repo-wide pre-existing `ruff check`/`ruff format` findings in unrelated files (installer/packaging scripts) — untouched by this PR, not introduced by it.

Closes #1892