### PR TITLE
fix(registry): drop unloadable bge-reranker-base curated row

### DIFF
--- a/src/hal0/registry/curated.py
+++ b/src/hal0/registry/curated.py
@@ -831,32 +831,16 @@ CURATED_MODELS: list[CuratedModel] = [
     # Per memory hal0_rerank_slot_wiring, the working recipe is
     # llama-server on a non-8081 port with --reranking; bge-reranker-v2-m3
     # Q4_K_M is already running in production on hal0 LXC.
-    CuratedModel(
-        id="bge-reranker-base-q4_k_m",
-        display_name="BGE Reranker Base (Q4_K_M)",
-        description=(
-            "Light cross-encoder reranker for English RAG. ~260 MB on "
-            "disk, runs on CPU comfortably."
-        ),
-        family="bge",
-        size_gb=0.26,
-        vram_gb_min=0.5,
-        license="MIT",
-        license_url="https://opensource.org/license/mit",
-        hf_repo="cstr/bge-reranker-base-GGUF",
-        hf_file="bge-reranker-base-q4_k.gguf",
-        context_length=512,
-        recommended_slot="embed",
-        tags=["rerank", "light"],
-        notes=(
-            "cstr's GGUF mirror includes the classifier-head fix needed "
-            "for llama-server --reranking; the upstream BAAI repo ships "
-            "PyTorch only. Q4_K is the smallest quant that preserves "
-            "rerank ordering on BEIR."
-        ),
-        capability="rerank",
-        backend="llamacpp",
-    ),
+    # bge-reranker-base-q4_k_m (cstr/bge-reranker-base-GGUF) was removed
+    # here (#1891): that mirror carries a non-mainline fork's bert KV
+    # schema (no `bert.context_length`) and cannot load on the shipped
+    # runner ("key not found in model: bert.context_length"). It was
+    # offered FIRST and smallest in the rerank catalog with
+    # fit_status=allowed, so hal0 pulled it unvalidated and the slot
+    # crash-looped invisibly. The row's note claiming the mirror "includes
+    # the classifier-head fix needed for llama-server --reranking" was
+    # also false. Use bge-reranker-v2-m3-q4_k_m below instead — it loads
+    # and scores correctly on the identical runner image.
     CuratedModel(
         id="bge-reranker-v2-m3-q4_k_m",
         display_name="BGE Reranker v2 M3 (Q4_K_M)",

--- a/tests/registry/test_curated.py
+++ b/tests/registry/test_curated.py
@@ -69,6 +69,34 @@ def test_lookup_index_matches_list() -> None:
     assert set(CURATED_BY_ID.keys()) == {m.id for m in CURATED_MODELS}
 
 
+def test_bge_reranker_base_row_removed() -> None:
+    """#1891: cstr/bge-reranker-base-GGUF carries a non-mainline bert KV
+    schema (no ``bert.context_length``) and cannot load on the shipped
+    runner ("key not found in model: bert.context_length"). hal0 offered
+    it FIRST and smallest in the rerank catalog with fit_status=allowed,
+    pulled it unvalidated, and the slot crash-looped invisibly. The row's
+    "classifier-head fix" note was also false. The row must not be in the
+    curated catalogue, and no remaining rerank row may cite that false
+    fix-note language.
+    """
+    assert get_curated("bge-reranker-base-q4_k_m") is None
+    assert "bge-reranker-base-q4_k_m" not in CURATED_BY_ID
+    for m in CURATED_MODELS:
+        assert "classifier-head fix" not in (m.notes or ""), (
+            f"{m.id}: false 'classifier-head fix' claim about cstr's mirror survives"
+        )
+
+
+def test_every_curated_rerank_row_has_hf_coordinates() -> None:
+    """#1891 guard: every curated rerank row the picker offers must resolve
+    to a pullable hf_repo/hf_file so a bad catalog artifact can't silently
+    become the offered default again."""
+    rerank_rows = [m for m in CURATED_MODELS if m.capability == "rerank"]
+    assert rerank_rows, "expected at least one curated rerank row"
+    for m in rerank_rows:
+        assert m.hf_repo and m.hf_file, f"{m.id}: rerank row missing hf coordinates"
+
+
 def test_memory_pipeline_default_embed_model_is_pullable() -> None:
     """The memory pipeline's default embed id must resolve to a real curated pull source (#F28).
 


### PR DESCRIPTION
## What changed

Removed the `bge-reranker-base-q4_k_m` row (`cstr/bge-reranker-base-GGUF`) from the curated model catalogue in `src/hal0/registry/curated.py`, and its false "classifier-head fix" note. Added a comment in its place recording why, plus two regression tests in `tests/registry/test_curated.py`.

## Why

That row was offered **first and smallest** in the rerank catalog with `fit_status: allowed`, so hal0 pulled it unvalidated. cstr's GGUF mirror carries a non-mainline fork's bert KV schema with no `bert.context_length`, so the runner fails to load it: `"error loading model hyperparameters: key not found in model: bert.context_length"`. The slot then crash-loops invisibly. The row's note — "cstr's GGUF mirror includes the classifier-head fix needed for llama-server --reranking" — was also false.

This is not a rerank-capability defect: the seeded default `bge-reranker-v2-m3-q4_k_m` already loads and returns correctly-ordered scores on the identical runner image, so dropping the row (rather than repointing it at another mirror) leaves no gap in rerank coverage.

Root cause is the curated-catalog data itself (an unvalidated third-party GGUF re-quant claimed to fix an upstream gap it didn't actually fix) — not the pull layer, the runner, or the flag plumbing (`#1787`), which are explicitly out of scope here per the issue.

## How verified

- Added `test_bge_reranker_base_row_removed` (fails before the fix — the row and its false note were present; passes after) and `test_every_curated_rerank_row_has_hf_coordinates` as a forward guard against a bad rerank row silently becoming the offered default again.
- `HAL0_HOME=$(mktemp -d) uv run pytest tests/registry/ tests/install/test_curated_seed_wins.py -q` → 410 passed.
- `uv run ruff check src/hal0/registry/curated.py tests/registry/test_curated.py` → clean.
- `uv run ruff format --check src/hal0/registry/curated.py tests/registry/test_curated.py` → already formatted.
- Confirmed `/api/capabilities` fit_status sourcing (`src/hal0/capabilities/catalog.py`) reads directly from `CURATED`/`CURATED_BY_ID`, so removing the catalog row removes it from the offered rerank picks with no route change needed (read-only touch, per plan).

## Left out of scope

- The runner, flag plumbing, and `#1787` — explicitly excluded by the issue.
- The known `#1429`/`#1424` `LogDriver=none` invisible-crash-loop gap that compounded this — tracked separately, not re-litigated here.
- `tests/release-validation/regressions.yaml` — versioned release-validation artifact, not touched (owned by the validation kit, not this fix).

Closes #1891