### PR TITLE
fix(dispatcher): typed 409 for chat requests naming embed/rerank models

### DIFF
--- a/src/hal0/dispatcher/_capability_resolve.py
+++ b/src/hal0/dispatcher/_capability_resolve.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from hal0.errors import Hal0Error
+from hal0.errors import CapabilityMismatch, Hal0Error
 from hal0.slots.manager import SLOT_ALIASES
 from hal0.upstreams.registry import Upstream, UpstreamRegistry
 
@@ -128,7 +128,12 @@ def resolve_by_capability(  # TIER1
     require ``kind="slot"``.
       5. Model id contains ``:`` (FLM tag-style) → ``npu`` slot.
       6. Model id starts with ``sdxl``/``sd-1.5``/``sd15``/``flux`` → ``img`` slot.
-      7. Model id contains ``embed`` or ``rerank`` substring → ``embed`` slot.
+      7. Model id contains ``embed`` or ``rerank`` substring on a non-path-
+         pinned endpoint (i.e. not already matched by rules 1-4) → typed
+         ``CapabilityMismatch`` (409). The request is chat/completions-shaped
+         but names a model that can only ever serve embed/rerank requests, so
+         hal0 rejects it instead of forwarding to guaranteed upstream
+         breakage (#1894).
       8. Model id exactly matches a registered slot upstream name (other
          than the default ``agent`` anchor) → that slot.  Back-compat alias
          (``agent-hermes`` → ``agent``) is resolved first.
@@ -146,6 +151,10 @@ def resolve_by_capability(  # TIER1
         LegacyResolutionFailed: If the heuristics select a slot name but no
             matching slot Upstream is registered.  Carries a
             ``dispatch.legacy_unresolved`` code via the typed Hal0Error envelope.
+        CapabilityMismatch: If rule 7 fires — the model id looks embed/
+            rerank-only but the request path isn't one of the path-pinned
+            capability endpoints.  Carries a ``dispatch.capability_mismatch``
+            code (409) via the typed Hal0Error envelope (#1894).
     """
     candidate: str | None = None
     # Path-pinned candidates ("route purely by path") may also resolve to a
@@ -196,8 +205,24 @@ def resolve_by_capability(  # TIER1
                 candidate = "img"
                 path_pinned = True
             # Rule 7 — name-substring pin (embed/rerank → embed slot).
-            elif any(hint in m for hint in _EMBED_NAME_HINTS):
-                candidate = "embed"
+            #
+            # Reaching this branch means the request path did NOT match any
+            # of the path-pinned capability endpoints (rules 1-4: embeddings/
+            # rerankings/audio/images all short-circuit before this ``elif
+            # body:`` block runs). So a model name matching an embed/rerank
+            # hint here always means: a chat/completions-shaped request named
+            # a model that is embed/rerank-only. Forwarding that to the embed
+            # slot can never succeed — the embed llama-server has no chat
+            # template/logits path — so hal0 raises a typed capability
+            # mismatch instead of silently routing to guaranteed upstream
+            # breakage (#1894: the caller previously just saw the embed
+            # server's raw, confusing HTTP 500).
+            elif matched_hint := next((h for h in _EMBED_NAME_HINTS if h in m), None):
+                raise CapabilityMismatch(
+                    f"model {model!r} looks embed/rerank-only (matched "
+                    f"{matched_hint!r}) and cannot serve requests on {path!r}",
+                    details={"model": model, "path": path, "hint": matched_hint},
+                )
             else:
                 # Rule 8 — explicit slot-name addressing.
                 # Resolve back-compat aliases (agent-hermes→agent) before the

--- a/src/hal0/dispatcher/_capability_resolve.py
+++ b/src/hal0/dispatcher/_capability_resolve.py
@@ -76,6 +76,23 @@ _EMBED_NAME_HINTS = ("embed", "rerank")
 # resolution kicks in.
 _IMAGE_NAME_PREFIXES = ("sdxl", "sd-1.5", "sd15", "flux")
 
+# Capability slots that can never serve a chat/completions-shaped request,
+# mapped to the request-path fragments they DO serve.  Keyed by the slot role
+# name (the ``slot_name`` behind the resolved upstream — same for local
+# ``kind="slot"`` upstreams and container-backed remotes).  Used by
+# :func:`guard_capability_mismatch` at the dispatch choke point (#1894).
+_CAPABILITY_ONLY_SLOT_PATHS: dict[str, tuple[str, ...]] = {
+    "embed": _EMBED_PATHS,
+    "rerank": _RERANK_PATHS,
+    "tts": _TTS_PATHS,
+    "img": _IMAGE_PATHS,
+}
+
+# Chat/completions-shaped request paths.  "/completions" is a substring of
+# both "/v1/completions" and "/v1/chat/completions", so one fragment covers
+# both OpenAI-compat completion shapes.
+_CHAT_SHAPED_PATHS = ("/completions",)
+
 
 # ── Typed error ───────────────────────────────────────────────────────────────
 
@@ -128,12 +145,11 @@ def resolve_by_capability(  # TIER1
     require ``kind="slot"``.
       5. Model id contains ``:`` (FLM tag-style) → ``npu`` slot.
       6. Model id starts with ``sdxl``/``sd-1.5``/``sd15``/``flux`` → ``img`` slot.
-      7. Model id contains ``embed`` or ``rerank`` substring on a non-path-
-         pinned endpoint (i.e. not already matched by rules 1-4) → typed
-         ``CapabilityMismatch`` (409). The request is chat/completions-shaped
-         but names a model that can only ever serve embed/rerank requests, so
-         hal0 rejects it instead of forwarding to guaranteed upstream
-         breakage (#1894).
+      7. Model id contains ``embed`` or ``rerank`` substring → ``embed`` slot.
+         (If no embed slot is registered this fails resolution below and the
+         dispatcher surfaces the documented clean 404; if one IS registered,
+         the dispatch-time :func:`guard_capability_mismatch` choke point
+         raises the typed 409 before any upstream call — #1894.)
       8. Model id exactly matches a registered slot upstream name (other
          than the default ``agent`` anchor) → that slot.  Back-compat alias
          (``agent-hermes`` → ``agent``) is resolved first.
@@ -151,10 +167,6 @@ def resolve_by_capability(  # TIER1
         LegacyResolutionFailed: If the heuristics select a slot name but no
             matching slot Upstream is registered.  Carries a
             ``dispatch.legacy_unresolved`` code via the typed Hal0Error envelope.
-        CapabilityMismatch: If rule 7 fires — the model id looks embed/
-            rerank-only but the request path isn't one of the path-pinned
-            capability endpoints.  Carries a ``dispatch.capability_mismatch``
-            code (409) via the typed Hal0Error envelope (#1894).
     """
     candidate: str | None = None
     # Path-pinned candidates ("route purely by path") may also resolve to a
@@ -206,23 +218,18 @@ def resolve_by_capability(  # TIER1
                 path_pinned = True
             # Rule 7 — name-substring pin (embed/rerank → embed slot).
             #
-            # Reaching this branch means the request path did NOT match any
-            # of the path-pinned capability endpoints (rules 1-4: embeddings/
-            # rerankings/audio/images all short-circuit before this ``elif
-            # body:`` block runs). So a model name matching an embed/rerank
-            # hint here always means: a chat/completions-shaped request named
-            # a model that is embed/rerank-only. Forwarding that to the embed
-            # slot can never succeed — the embed llama-server has no chat
-            # template/logits path — so hal0 raises a typed capability
-            # mismatch instead of silently routing to guaranteed upstream
-            # breakage (#1894: the caller previously just saw the embed
-            # server's raw, confusing HTTP 500).
-            elif matched_hint := next((h for h in _EMBED_NAME_HINTS if h in m), None):
-                raise CapabilityMismatch(
-                    f"model {model!r} looks embed/rerank-only (matched "
-                    f"{matched_hint!r}) and cannot serve requests on {path!r}",
-                    details={"model": model, "path": path, "hint": matched_hint},
-                )
+            # Deliberately still *routes* rather than raising: when no embed
+            # slot is registered (the fresh-install/offline default) this
+            # candidate fails resolution below and ``dispatch()`` wraps it
+            # into the documented clean typed 404 (``dispatch.no_route`` —
+            # the contract recorded in tests/release-validation
+            # regressions.yaml/known-issues.yaml). The #1894 typed-409 gate
+            # lives at the dispatch choke point instead
+            # (:func:`guard_capability_mismatch`), keyed on the *resolved*
+            # slot's role — so it fires only when an embed slot actually
+            # exists to mismatch against, on every resolution path.
+            elif any(hint in m for hint in _EMBED_NAME_HINTS):
+                candidate = "embed"
             else:
                 # Rule 8 — explicit slot-name addressing.
                 # Resolve back-compat aliases (agent-hermes→agent) before the
@@ -262,7 +269,69 @@ def resolve_by_capability(  # TIER1
     return upstream
 
 
+def guard_capability_mismatch(
+    slot: str,
+    path: str,
+    *,
+    model: str = "",
+    resolution_path: str = "",
+) -> None:
+    """Raise a typed 409 when a capability-only slot resolved for a chat path.
+
+    The dispatch-time capability gate for #1894, called by
+    :meth:`Dispatcher.dispatch` at the single choke point every resolution
+    branch (container preemption, registry, warm-cache passthrough,
+    cold-prefetch passthrough, capability/path routing) converges on — so a
+    chat/completions-shaped request that resolves to an embed/rerank/tts/img
+    slot is rejected with a typed hal0 envelope *before* any upstream call,
+    instead of being forwarded to a server that structurally cannot serve it
+    (whose raw, confusing error — e.g. llama-server's "the current context
+    does not logits computation" 500 — would otherwise pass through verbatim
+    per ``Dispatcher.forward()``'s documented contract).
+
+    Keyed on the *resolved* slot's role, not on model-name substrings: it
+    fires only when hal0 itself has already decided the request lands on a
+    capability-only slot.  When no such slot resolves at all (embed offline /
+    fresh install), resolution fails upstream of this gate and the documented
+    clean ``dispatch.no_route`` 404 is preserved untouched.
+
+    Args:
+        slot:            Effective slot role behind the resolved upstream
+                         (``slot_name`` or container slot name; ``""`` for a
+                         genuine remote — always a no-op).
+        path:            Incoming request path (e.g. "/v1/chat/completions").
+        model:           Requested model id, for the error envelope.
+        resolution_path: Dispatch resolution breadcrumb, for the envelope.
+
+    Raises:
+        CapabilityMismatch: 409, code ``dispatch.capability_mismatch``, when
+            ``slot`` is a capability-only role and ``path`` is
+            chat/completions-shaped.
+    """
+    serves = _CAPABILITY_ONLY_SLOT_PATHS.get(slot)
+    if serves is None:
+        # Not a capability-only slot (agent/coding/npu/… or a remote) —
+        # chat-shaped requests are exactly what it is for.
+        return
+    if not any(frag in path for frag in _CHAT_SHAPED_PATHS):
+        # The slot's own endpoints (/embeddings, /rerankings, /audio/speech,
+        # /images/*) and anything else non-chat-shaped stay untouched.
+        return
+    raise CapabilityMismatch(
+        f"model {model!r} resolved to the {slot!r} slot, which serves only "
+        f"{', '.join(serves)} requests and cannot serve {path!r}",
+        details={
+            "model": model,
+            "path": path,
+            "slot": slot,
+            "serves": list(serves),
+            "resolution_path": resolution_path,
+        },
+    )
+
+
 __all__ = [
     "LegacyResolutionFailed",
+    "guard_capability_mismatch",
     "resolve_by_capability",
 ]

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -49,6 +49,7 @@ from fastapi.responses import Response, StreamingResponse
 from hal0.dispatcher._capability_resolve import (
     _DEFAULT_MODEL,
     LegacyResolutionFailed,
+    guard_capability_mismatch,
     resolve_by_capability,
 )
 from hal0.dispatcher.lane_pin import lane_slot_pin, rank_slot_name
@@ -474,7 +475,46 @@ class Dispatcher:
             NoRouteFound: No upstream could serve the request.
             UnknownUpstream: Registry pointed at a non-existent upstream.
             RegistryLoadFailed: Reading the registry raised.
+            CapabilityMismatch: The request resolved to a capability-only
+                slot (embed/rerank/tts/img) that structurally cannot serve
+                its chat/completions-shaped path (#1894).
         """
+        call = await self._resolve(request, body)
+        # ── Capability-mismatch choke point (#1894) ──────────────────────
+        # Every resolution branch above (container preemption, registry,
+        # warm-cache passthrough, cold-prefetch passthrough, capability/path
+        # routing) converges here, so the gate covers all of them at once: a
+        # chat/completions-shaped request that resolved to an embed/rerank/
+        # tts/img slot gets a typed 409 BEFORE any upstream call, instead of
+        # forward()'s verbatim passthrough leaking that server's raw 500.
+        # When nothing resolves (embed offline / fresh install), _resolve
+        # already raised the documented clean dispatch.no_route 404 — the
+        # gate never sees it, so that contract is preserved untouched.
+        try:
+            guard_capability_mismatch(
+                call.slot_name or call.container_slot_name,
+                request.url.path,
+                model=call.requested_model or call.resolved_model,
+                resolution_path=call.resolution_path,
+            )
+        except Hal0Error as exc:
+            log.warning(
+                "dispatch.capability_mismatch",
+                model=call.requested_model or call.resolved_model,
+                slot=call.slot_name or call.container_slot_name,
+                path=request.url.path,
+                resolution_path=call.resolution_path,
+                error=exc.message,
+            )
+            raise
+        return call
+
+    async def _resolve(
+        self,
+        request: Request,
+        body: dict[str, Any] | None = None,
+    ) -> UpstreamCall:
+        """Run the resolution ladder (Steps 0-4) — see :meth:`dispatch`."""
         t0 = time.monotonic()
         if body is None:
             try:

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -506,6 +506,11 @@ class Dispatcher:
                 resolution_path=call.resolution_path,
                 error=exc.message,
             )
+            # Resolution DID complete before the gate fired — expose the
+            # resolved call on the exception so the metrics seam
+            # (RequestSeam.record_error) can attribute the failed request
+            # to its slot/model instead of writing a null-attributed row.
+            exc.upstream_call = call  # type: ignore[attr-defined]
             raise
         return call
 

--- a/src/hal0/errors.py
+++ b/src/hal0/errors.py
@@ -173,6 +173,32 @@ class Conflict(Hal0Error):
     status = 409
 
 
+class CapabilityMismatch(Hal0Error):
+    """409 — the named model's disclosed capability does not serve this endpoint.
+
+    Use when dispatch can already tell, from the model id itself (or its
+    ``/v1/models`` labels/recipe), that the request cannot succeed — e.g. a
+    chat-completions request naming a model whose id/labels mark it
+    embed-only or rerank-only. Without this gate, such a request would
+    otherwise be forwarded to a slot that can't serve it and the caller
+    would see that upstream's raw, confusing error (e.g. llama-server's
+    "the current context does not logits computation" 500) instead of a
+    typed hal0 envelope (#1894).
+
+    Example::
+
+        raise CapabilityMismatch(
+            f"model {model!r} looks embed/rerank-only (matched {hint!r}) and "
+            "cannot serve chat/completions requests",
+            code="dispatch.capability_mismatch",
+            details={"model": model, "path": path, "hint": hint},
+        )
+    """
+
+    code = "dispatch.capability_mismatch"
+    status = 409
+
+
 class TooManyRequests(Hal0Error):
     """429 — the caller has exceeded a rate budget and should back off.
 
@@ -241,6 +267,7 @@ class UnprocessableEntity(Hal0Error):
 
 __all__ = [
     "BadRequest",
+    "CapabilityMismatch",
     "Conflict",
     "Forbidden",
     "Hal0Error",

--- a/src/hal0/errors.py
+++ b/src/hal0/errors.py
@@ -176,22 +176,21 @@ class Conflict(Hal0Error):
 class CapabilityMismatch(Hal0Error):
     """409 — the named model's disclosed capability does not serve this endpoint.
 
-    Use when dispatch can already tell, from the model id itself (or its
-    ``/v1/models`` labels/recipe), that the request cannot succeed — e.g. a
-    chat-completions request naming a model whose id/labels mark it
-    embed-only or rerank-only. Without this gate, such a request would
-    otherwise be forwarded to a slot that can't serve it and the caller
-    would see that upstream's raw, confusing error (e.g. llama-server's
-    "the current context does not logits computation" 500) instead of a
-    typed hal0 envelope (#1894).
+    Use when dispatch can already tell, from where the request *resolved*,
+    that it cannot succeed — e.g. a chat-completions request that resolved
+    (via registry binding, warm-cache passthrough, or name heuristics) to a
+    capability-only slot such as embed/rerank/tts/img. Without this gate,
+    such a request would otherwise be forwarded to a slot that can't serve
+    it and the caller would see that upstream's raw, confusing error (e.g.
+    llama-server's "the current context does not logits computation" 500)
+    instead of a typed hal0 envelope (#1894).
 
     Example::
 
         raise CapabilityMismatch(
-            f"model {model!r} looks embed/rerank-only (matched {hint!r}) and "
-            "cannot serve chat/completions requests",
-            code="dispatch.capability_mismatch",
-            details={"model": model, "path": path, "hint": hint},
+            f"model {model!r} resolved to the {slot!r} slot, which cannot "
+            f"serve {path!r}",
+            details={"model": model, "path": path, "slot": slot},
         )
     """
 

--- a/src/hal0/metrics/seam.py
+++ b/src/hal0/metrics/seam.py
@@ -202,6 +202,12 @@ class RequestSeam:
     ) -> None:
         if not self.enabled:
             return
+        if call is None:
+            # A typed error raised AFTER resolution completed (e.g. the
+            # #1894 capability-mismatch gate in Dispatcher.dispatch) carries
+            # the resolved UpstreamCall on the exception, so the failed
+            # request is still attributed to its slot/model in metrics.
+            call = getattr(exc, "upstream_call", None)
         now = time.monotonic()
         row = build_request_metric_row(
             ts=now_iso(),

--- a/tests/dispatcher/test_router.py
+++ b/tests/dispatcher/test_router.py
@@ -31,6 +31,7 @@ from hal0.dispatcher.router import (
     UnknownUpstream,
     UpstreamCall,
 )
+from hal0.errors import CapabilityMismatch
 from hal0.upstreams.registry import Upstream, UpstreamRegistry
 
 # ── test doubles ──────────────────────────────────────────────────────────────
@@ -363,6 +364,46 @@ async def test_legacy_fallback_routes_colon_model_to_npu_slot() -> None:
     )
     assert call.resolution_path == "legacy_slot:flm"
     assert call.upstream_name == "flm"
+
+
+@pytest.mark.asyncio
+async def test_legacy_fallback_chat_request_naming_embed_model_raises_typed_mismatch() -> None:
+    """#1894: a chat/completions request naming an embed/rerank-hinted model
+    must raise a typed ``CapabilityMismatch`` (409) instead of being silently
+    forwarded to the embed slot — which can never serve a chat request and
+    would otherwise leak that slot's raw upstream 500 to the client.
+    """
+    embed = make_slot("embed", "http://127.0.0.1:8082/v1")
+    upstreams = FakeUpstreamRegistry([embed])
+    models = FakeModelRegistry(routes={})
+
+    dispatcher = Dispatcher(upstream_registry=upstreams, model_registry=models)
+    with pytest.raises(CapabilityMismatch) as exc:
+        await dispatcher.dispatch(
+            make_request(path="/v1/chat/completions"),
+            body={"model": "bge-m3-embed", "messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert exc.value.code == "dispatch.capability_mismatch"
+    assert exc.value.status == 409
+    assert exc.value.details["model"] == "bge-m3-embed"
+    assert exc.value.details["hint"] == "embed"
+
+
+@pytest.mark.asyncio
+async def test_legacy_fallback_chat_request_naming_rerank_model_raises_typed_mismatch() -> None:
+    """Same gate for the ``rerank`` name hint (#1894)."""
+    embed = make_slot("embed", "http://127.0.0.1:8082/v1")
+    upstreams = FakeUpstreamRegistry([embed])
+    models = FakeModelRegistry(routes={})
+
+    dispatcher = Dispatcher(upstream_registry=upstreams, model_registry=models)
+    with pytest.raises(CapabilityMismatch) as exc:
+        await dispatcher.dispatch(
+            make_request(path="/v1/chat/completions"),
+            body={"model": "bge-rerank-v2", "messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert exc.value.code == "dispatch.capability_mismatch"
+    assert exc.value.details["hint"] == "rerank"
 
 
 @pytest.mark.asyncio

--- a/tests/dispatcher/test_router.py
+++ b/tests/dispatcher/test_router.py
@@ -437,6 +437,10 @@ async def test_warm_cache_passthrough_chat_request_to_embed_slot_raises_typed_mi
     assert exc.value.status == 409
     assert exc.value.details["slot"] == "embed"
     assert exc.value.details["resolution_path"] == "passthrough:embed"
+    # The resolved call rides on the exception so the metrics seam
+    # (RequestSeam.record_error) can attribute the failed request.
+    assert exc.value.upstream_call.upstream_name == "embed"
+    assert exc.value.upstream_call.resolved_model == "nomic-embed-text-v1.5"
 
 
 @pytest.mark.asyncio

--- a/tests/dispatcher/test_router.py
+++ b/tests/dispatcher/test_router.py
@@ -386,7 +386,7 @@ async def test_legacy_fallback_chat_request_naming_embed_model_raises_typed_mism
     assert exc.value.code == "dispatch.capability_mismatch"
     assert exc.value.status == 409
     assert exc.value.details["model"] == "bge-m3-embed"
-    assert exc.value.details["hint"] == "embed"
+    assert exc.value.details["slot"] == "embed"
 
 
 @pytest.mark.asyncio
@@ -403,7 +403,144 @@ async def test_legacy_fallback_chat_request_naming_rerank_model_raises_typed_mis
             body={"model": "bge-rerank-v2", "messages": [{"role": "user", "content": "hi"}]},
         )
     assert exc.value.code == "dispatch.capability_mismatch"
-    assert exc.value.details["hint"] == "rerank"
+    assert exc.value.details["slot"] == "embed"
+
+
+@pytest.mark.asyncio
+async def test_warm_cache_passthrough_chat_request_to_embed_slot_raises_typed_mismatch() -> None:
+    """#1894's stated repro: the embed slot is LOADED and advertises its model.
+
+    The warm-cache passthrough step resolves the request long before the
+    capability/path heuristics run, so the gate must sit at the dispatch
+    choke point — a chat request naming the slot's own advertised model
+    (the NORMAL prod state per known-issues.yaml) gets the typed 409, not
+    the embed server's raw upstream 500.
+    """
+    embed = make_slot("embed", "http://127.0.0.1:8082/v1")
+    upstreams = FakeUpstreamRegistry([embed])
+    models = FakeModelRegistry(routes={})
+
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        cached_models=lambda name: ["nomic-embed-text-v1.5"] if name == "embed" else [],
+    )
+    with pytest.raises(CapabilityMismatch) as exc:
+        await dispatcher.dispatch(
+            make_request(path="/v1/chat/completions"),
+            body={
+                "model": "nomic-embed-text-v1.5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert exc.value.code == "dispatch.capability_mismatch"
+    assert exc.value.status == 409
+    assert exc.value.details["slot"] == "embed"
+    assert exc.value.details["resolution_path"] == "passthrough:embed"
+
+
+@pytest.mark.asyncio
+async def test_registry_bound_chat_request_to_embed_slot_raises_typed_mismatch() -> None:
+    """#1894 via the registry step: an explicit model→embed binding must not
+    smuggle a chat request past the capability gate either.
+    """
+    embed = make_slot("embed", "http://127.0.0.1:8082/v1")
+    upstreams = FakeUpstreamRegistry([embed])
+    models = FakeModelRegistry(routes={"nomic-embed-text-v1.5": "embed"})
+
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        cached_models=lambda name: ["nomic-embed-text-v1.5"] if name == "embed" else [],
+    )
+    with pytest.raises(CapabilityMismatch) as exc:
+        await dispatcher.dispatch(
+            make_request(path="/v1/chat/completions"),
+            body={
+                "model": "nomic-embed-text-v1.5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert exc.value.code == "dispatch.capability_mismatch"
+    assert exc.value.details["resolution_path"] == "registry"
+
+
+@pytest.mark.asyncio
+async def test_container_backed_embed_slot_chat_request_raises_typed_mismatch() -> None:
+    """#1894 via Step 0 container preemption: a container-backed embed slot
+    (kind="remote" with slot_name) advertising the model hits the same gate.
+    """
+    embed_container = Upstream(
+        name="embed",
+        kind="remote",
+        url="http://127.0.0.1:8082/v1",
+        slot_name="embed",
+    )
+    upstreams = FakeUpstreamRegistry([embed_container])
+    models = FakeModelRegistry(routes={})
+
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        cached_models=lambda name: ["nomic-embed-text-v1.5"] if name == "embed" else [],
+    )
+    with pytest.raises(CapabilityMismatch) as exc:
+        await dispatcher.dispatch(
+            make_request(path="/v1/chat/completions"),
+            body={
+                "model": "nomic-embed-text-v1.5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert exc.value.code == "dispatch.capability_mismatch"
+    assert exc.value.details["resolution_path"] == "container:embed"
+
+
+@pytest.mark.asyncio
+async def test_embed_offline_unknown_embed_named_model_keeps_clean_no_route_404() -> None:
+    """Offline contract (regressions.yaml): with NO embed slot registered, an
+    unknown model that merely contains "embed" must keep returning the clean
+    typed ``dispatch.no_route`` 404 — NOT a 409 asserting a capability hal0
+    never disclosed.
+    """
+    upstreams = FakeUpstreamRegistry([])
+    models = FakeModelRegistry(routes={})
+
+    dispatcher = Dispatcher(upstream_registry=upstreams, model_registry=models)
+    with pytest.raises(NoRouteFound) as exc:
+        await dispatcher.dispatch(
+            make_request(path="/v1/chat/completions"),
+            body={
+                "model": "totally-made-up-embedder",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert exc.value.code == "dispatch.no_route"
+    assert exc.value.status == 404
+
+
+@pytest.mark.asyncio
+async def test_embeddings_request_to_loaded_embed_slot_still_routes() -> None:
+    """Non-regression for the gate: the embed slot's OWN endpoint shape is
+    untouched — /v1/embeddings naming the advertised model still resolves and
+    forwards normally.
+    """
+    embed = make_slot("embed", "http://127.0.0.1:8082/v1")
+    upstreams = FakeUpstreamRegistry([embed])
+    models = FakeModelRegistry(routes={})
+
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        cached_models=lambda name: ["nomic-embed-text-v1.5"] if name == "embed" else [],
+    )
+    call = await dispatcher.dispatch(
+        make_request(path="/v1/embeddings"),
+        body={"model": "nomic-embed-text-v1.5", "input": "hi"},
+    )
+    assert call.upstream_name == "embed"
+    assert call.resolution_path == "passthrough:embed"
+    assert call.target_url == "http://127.0.0.1:8082/v1/embeddings"
 
 
 @pytest.mark.asyncio

--- a/tests/metrics/test_seam.py
+++ b/tests/metrics/test_seam.py
@@ -139,6 +139,41 @@ class TestRecordError:
         _, row = writer.rows[0]
         assert row["error_code"] == "RuntimeError"
 
+    def test_attributes_from_upstream_call_on_exception_when_call_is_none(
+        self, seam: RequestSeam, writer: _FakeWriter
+    ) -> None:
+        """#1894 follow-up: a typed error raised AFTER dispatch resolution
+        (the capability-mismatch gate) carries the resolved call on the
+        exception — record_error must attribute slot/model from it instead
+        of writing a null-attributed row.
+        """
+
+        class _TypedError(Exception):
+            code = "dispatch.capability_mismatch"
+
+        exc = _TypedError("mismatch")
+        exc.upstream_call = _FakeCall(upstream_name="embed", resolved_model="nomic-embed-text-v1.5")
+        seam.record_error(exc, call=None, request=_FakeRequest(), t_entry=time.monotonic())
+        _, row = writer.rows[0]
+        assert row["slot_id"] == "embed"
+        assert row["model_id"] == "nomic-embed-text-v1.5"
+        assert row["error_code"] == "dispatch.capability_mismatch"
+
+    def test_explicit_call_wins_over_exception_attribute(
+        self, seam: RequestSeam, writer: _FakeWriter
+    ) -> None:
+        exc = RuntimeError("boom")
+        exc.upstream_call = _FakeCall(upstream_name="wrong", resolved_model="wrong-model")
+        seam.record_error(
+            exc,
+            call=_FakeCall(upstream_name="primary", resolved_model="qwen3-4b"),
+            request=_FakeRequest(),
+            t_entry=time.monotonic(),
+        )
+        _, row = writer.rows[0]
+        assert row["slot_id"] == "primary"
+        assert row["model_id"] == "qwen3-4b"
+
 
 class TestWrapStreaming:
     async def _drain(self, response: StreamingResponse) -> list[bytes]:


### PR DESCRIPTION
## What changed

A chat/completions-shaped request that resolves to a capability-only slot (embed/rerank/tts/img) now gets a typed `CapabilityMismatch` (409, `dispatch.capability_mismatch`) **before any upstream call**, instead of being forwarded to a server that structurally cannot serve it and leaking that server's raw, confusing `HTTP 500 "the current context does not logits computation. skipping"` through `Dispatcher.forward()`'s verbatim-passthrough contract.

- New typed error `CapabilityMismatch` (`src/hal0/errors.py`, 409, code `dispatch.capability_mismatch`).
- New `guard_capability_mismatch()` in `_capability_resolve.py`, called from `Dispatcher.dispatch()` at the single choke point every resolution branch converges on (container preemption, registry, warm-cache passthrough, cold-prefetch passthrough, capability/path routing). It keys on the **resolved** upstream's slot role (`slot_name`/container slot name in {embed, rerank, tts, img}) versus a chat/completions-shaped path — not on model-name substrings.
- Rule 7 of `resolve_by_capability` is back to its original routing behavior (`candidate = "embed"`), so the fresh-install/offline contract is untouched: with no embed slot registered, an unknown embed-named model still fails resolution and returns the documented clean typed `dispatch.no_route` 404 (`regressions.yaml` / `known-issues.yaml`).

## Why (revised after review)

The first iteration raised inside Rule 7, which (a) never ran for #1894's stated repro — with the embed slot loaded and advertising its model, dispatch returns from the registry/passthrough steps before Step 4 — and (b) silently converted the documented offline 404 into a 409 inferred from a name substring. Gating at the dispatch choke point on the *resolved* slot's role fixes both: every resolution path is covered, and the gate can only fire when hal0 itself has resolved the request onto a capability-only slot — a capability hal0 actually disclosed, matching the issue's "Expected".

## How verified

- New regression tests in `tests/dispatcher/test_router.py`:
  - warm-cache passthrough repro (embed loaded + advertising `nomic-embed-text-v1.5` — the issue's precondition) → 409
  - registry-bound `model → embed` → 409
  - container-backed embed slot (Step 0 preemption) → 409
  - legacy-fallback embed/rerank name hints (embed slot registered) → 409
  - embed OFFLINE + `totally-made-up-embedder` → clean `dispatch.no_route` 404 (contract lock)
  - `/v1/embeddings` to the loaded embed slot still routes (non-regression)
- `pytest tests/dispatcher` → 184 passed; `tests/api/test_v1_dispatch.py tests/api/test_v1_chat_slot_alias.py tests/api/test_v1_proxy.py tests/api/test_v1_audio.py` → 41 passed; `tests/omni_router tests/slots/test_slot_aliases.py` → 135 passed.
- `make lint`, `ruff format --check src tests`, `scripts/check_sunset.py` all clean.

## Left out of scope

- The by-design routing/passthrough mechanism itself is unchanged; `tests/release-validation/regressions.yaml` / `known-issues.yaml` entries are re-probed and updated by the release-validation process, not by this PR.

Closes #1894
