### PR TITLE
fix(registry): store detected quant at pull registration, not just API display

### DIFF
--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -1219,8 +1219,11 @@ def _register_pulled(
     from hal0.registry.detect import detect
 
     ctx_len: int | None = None
+    detected_quant: str | None = None
     try:
-        ctx_len = detect(Path(path)).context_length
+        detection = detect(Path(path))
+        ctx_len = detection.context_length
+        detected_quant = detection.quant
     except Exception:  # header parse must never fail a completed pull
         ctx_len = None
     if not ctx_len and curated is not None and curated.context_length:
@@ -1231,6 +1234,13 @@ def _register_pulled(
         # backfill) so a LATER re-pull can tell it apart from an operator's
         # explicit metadata edit — see the merge below.
         fresh_meta["context_length_detected"] = True
+    # #1890: stamp the detected quant on the row itself (not just metadata),
+    # the same detection ``hal0 model add``/scan already performs — this is
+    # the ONLY registration a pull-installed model (including the installer-
+    # seeded FPX brain model) ever gets. Leaving ``quant`` null here is what
+    # made the #1790 FPX-on-wrong-runner guard inert: it reads
+    # ``model_dump()`` directly, never the API list serializer's
+    # ``lazy_quant`` backfill.
     updates: dict[str, Any] = {
         "path": path,
         "size_bytes": size_bytes,
@@ -1238,6 +1248,8 @@ def _register_pulled(
         "hf_filename": hf_filename,
         "metadata": fresh_meta,
     }
+    if detected_quant:
+        updates["quant"] = detected_quant
     if mmproj is not None:
         updates["mmproj"] = mmproj
     try:
@@ -1265,6 +1277,7 @@ def _register_pulled(
                 size_bytes=size_bytes,
                 hf_repo=hf_repo,
                 hf_filename=hf_filename,
+                quant=detected_quant,
                 capabilities=caps,
                 backends=backends,
                 mmproj=mmproj,
@@ -1474,6 +1487,16 @@ def _register_pulled_fileset(
     fresh_meta: dict[str, Any] = {"pulled_at": int(time.time())}
     if entry_sha:
         fresh_meta["sha256"] = entry_sha
+    # #1890: same quant detection as :func:`_register_pulled` — a file-set
+    # pull (ML-2/3) is registration too, and must not leave ``quant`` null
+    # any more than the single-file path does.
+    from hal0.registry.detect import detect
+
+    detected_quant: str | None = None
+    try:
+        detected_quant = detect(entry_dest).quant
+    except Exception:  # header parse must never fail a completed pull
+        detected_quant = None
     updates: dict[str, Any] = {
         "path": str(entry_dest),
         "size_bytes": total_size,
@@ -1482,6 +1505,8 @@ def _register_pulled_fileset(
     }
     if mmproj_dest is not None:
         updates["mmproj"] = str(mmproj_dest)
+    if detected_quant:
+        updates["quant"] = detected_quant
 
     try:
         existing = registry.get(model_id)
@@ -1494,6 +1519,7 @@ def _register_pulled_fileset(
                 size_bytes=total_size,
                 hf_repo=fileset.repo,
                 hf_filename=Path(fileset.entry_rel).name,
+                quant=detected_quant,
                 capabilities=["chat"],
                 mmproj=str(mmproj_dest) if mmproj_dest else None,
                 metadata=dict(fresh_meta),

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -1216,7 +1216,11 @@ def _register_pulled(
     # ~7.3k tokens, so the second turn 400s with exceed_context. The
     # artifact's own GGUF header is authoritative; the curated catalogue
     # window backfills an unreadable header.
-    from hal0.registry.detect import detect
+    from hal0.registry.detect import (
+        detect,
+        quant_from_filename,
+        quant_from_rocmfpx_filename,
+    )
 
     ctx_len: int | None = None
     detected_quant: str | None = None
@@ -1226,6 +1230,17 @@ def _register_pulled(
         detected_quant = detection.quant
     except Exception:  # header parse must never fail a completed pull
         ctx_len = None
+    # #1890: capability-grouped installs (``_final_path_for_entry``) rename the
+    # artifact to a canonical ``model.gguf``, so on-disk detection has no
+    # filename token to work with — and the ROCmFPX family's custom
+    # ``general.file_type`` is deliberately unmapped, so the header yields
+    # nothing either. That is exactly the installer-seeded FPX brain model's
+    # shape. Fall back to the quant-bearing HF source filename (the same
+    # signal ``lazy_quant`` and ``write_model_meta`` preserve).
+    if not detected_quant:
+        detected_quant = quant_from_rocmfpx_filename(hf_filename or "") or quant_from_filename(
+            hf_filename or ""
+        )
     if not ctx_len and curated is not None and curated.context_length:
         ctx_len = int(curated.context_length)
     if ctx_len:
@@ -1234,22 +1249,22 @@ def _register_pulled(
         # backfill) so a LATER re-pull can tell it apart from an operator's
         # explicit metadata edit — see the merge below.
         fresh_meta["context_length_detected"] = True
-    # #1890: stamp the detected quant on the row itself (not just metadata),
-    # the same detection ``hal0 model add``/scan already performs — this is
-    # the ONLY registration a pull-installed model (including the installer-
-    # seeded FPX brain model) ever gets. Leaving ``quant`` null here is what
-    # made the #1790 FPX-on-wrong-runner guard inert: it reads
-    # ``model_dump()`` directly, never the API list serializer's
-    # ``lazy_quant`` backfill.
+    # #1890: stamp the detected quant on the row itself — the pull path is the
+    # ONLY registration a pull-installed model ever gets, and a null ``quant``
+    # left the #1790 FPX-on-wrong-runner guard inert (it reads the raw
+    # ``model_dump()``, never the API serializer's ``lazy_quant`` backfill).
+    # Written UNCONDITIONALLY: a re-pull replaces path/hf_filename/bytes, so a
+    # replacement artifact that detection cannot classify must clear the prior
+    # value rather than leave a stale quant attached to new bytes (which would
+    # falsely 422 a non-FPX replacement on a cpu/vulkan runner).
     updates: dict[str, Any] = {
         "path": path,
         "size_bytes": size_bytes,
         "hf_repo": hf_repo,
         "hf_filename": hf_filename,
         "metadata": fresh_meta,
+        "quant": detected_quant,
     }
-    if detected_quant:
-        updates["quant"] = detected_quant
     if mmproj is not None:
         updates["mmproj"] = mmproj
     try:
@@ -1489,24 +1504,33 @@ def _register_pulled_fileset(
         fresh_meta["sha256"] = entry_sha
     # #1890: same quant detection as :func:`_register_pulled` — a file-set
     # pull (ML-2/3) is registration too, and must not leave ``quant`` null
-    # any more than the single-file path does.
-    from hal0.registry.detect import detect
+    # any more than the single-file path does. Same source-filename fallback
+    # (an installed name with no token / unmapped file_type still classifies
+    # via the HF entry filename) and same unconditional write (a re-pull that
+    # detection cannot classify clears the stale value with the stale bytes).
+    from hal0.registry.detect import (
+        detect,
+        quant_from_filename,
+        quant_from_rocmfpx_filename,
+    )
 
+    entry_name = Path(fileset.entry_rel).name
     detected_quant: str | None = None
     try:
         detected_quant = detect(entry_dest).quant
     except Exception:  # header parse must never fail a completed pull
         detected_quant = None
+    if not detected_quant:
+        detected_quant = quant_from_rocmfpx_filename(entry_name) or quant_from_filename(entry_name)
     updates: dict[str, Any] = {
         "path": str(entry_dest),
         "size_bytes": total_size,
         "hf_repo": fileset.repo,
-        "hf_filename": Path(fileset.entry_rel).name,
+        "hf_filename": entry_name,
+        "quant": detected_quant,
     }
     if mmproj_dest is not None:
         updates["mmproj"] = str(mmproj_dest)
-    if detected_quant:
-        updates["quant"] = detected_quant
 
     try:
         existing = registry.get(model_id)

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -3603,6 +3603,21 @@ class SlotManager:
 
         registry_dump = model.model_dump() if hasattr(model, "model_dump") else dict(model)
         info.update(registry_dump)
+        # #1890: belt-and-suspenders — the pull registration path now stores
+        # ``quant`` directly (the root fix), but this is also the ONE place
+        # every launch/preview path resolves model_info for
+        # ``_guard_fpx_quant_runner``. A row that somehow still has no quant
+        # (a hand-staged model, a pre-#1890 registry never re-pulled) must
+        # not silently disarm the guard — fall back to the same filename-
+        # token derivation the API list serializer already uses
+        # (``models_service.lazy_quant``) rather than trusting ``quant`` is
+        # always populated.
+        if not info.get("quant"):
+            from hal0.services.models_service import lazy_quant
+
+            derived_quant = lazy_quant(registry_dump)
+            if derived_quant:
+                info["quant"] = derived_quant
         return info
 
     # ── health probe (TIER1 tightened) ───────────────────────────────────────

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -491,6 +491,132 @@ async def test_run_pull_refreshes_quant_on_repull(tmp_hal0_home: str) -> None:
     assert registry.get("some-random-gguf").quant == "Q8_0"
 
 
+@pytest.mark.asyncio
+async def test_run_pull_capability_grouped_install_stamps_quant_from_hf_filename(
+    tmp_hal0_home: str,
+) -> None:
+    """The installer-seeded FPX brain model's exact shape: ``capability=`` routes
+    through ``_final_path_for_entry``, which renames the artifact to a canonical
+    ``model.gguf`` — a basename with NO quant token, and the ROCmFPX custom
+    ``general.file_type`` is deliberately unmapped, so on-disk detection alone
+    yields ``None``. The quant must be derived from the HF source filename."""
+    body = _payload(4096)
+    job = make_job("hal0-brain-sft-q8-rocmfpx")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_ok_handler(body))
+    try:
+        await run_pull(
+            job,
+            hf_repo="Hal0ai/hal0-brain-sft-ROCmFPX-GGUF",
+            hf_file="hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf",
+            registry=registry,
+            client=client,
+            capability="chat",
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    entry = registry.get("hal0-brain-sft-q8-rocmfpx")
+    # Prove the on-disk basename really carries no signal — the whole point.
+    assert Path(entry.path).name == "model.gguf"
+    assert entry.quant == "ROCmFP8"
+    assert entry.model_dump()["quant"] == "ROCmFP8"
+
+
+@pytest.mark.asyncio
+async def test_run_pull_repull_clears_quant_when_replacement_unclassifiable(
+    tmp_hal0_home: str,
+) -> None:
+    """A re-pull that swaps in an artifact detection cannot classify must CLEAR
+    the stored quant, not leave the old value attached to the new bytes — a
+    stale ``ROCmFP8`` on a plain gguf would falsely 422 the replacement on a
+    cpu/vulkan runner via ``_guard_fpx_quant_runner``."""
+    job = make_job("swappable-gguf")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_ok_handler(_payload(4096)))
+    try:
+        await run_pull(
+            job,
+            hf_repo="org/swap-GGUF",
+            hf_file="model-Q8_0_ROCMFPX.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    assert registry.get("swappable-gguf").quant == "ROCmFP8"
+
+    job2 = make_job("swappable-gguf")
+    client2 = httpx.AsyncClient(transport=_ok_handler(_payload(4096)))
+    try:
+        await run_pull(
+            job2,
+            hf_repo="org/swap-GGUF",
+            hf_file="plainmodel.gguf",
+            registry=registry,
+            client=client2,
+        )
+    finally:
+        await client2.aclose()
+    assert job2.state == "completed", f"got {job2.state}: {job2.error}"
+    entry = registry.get("swappable-gguf")
+    assert entry.quant is None
+    assert entry.hf_filename == "plainmodel.gguf"
+
+
+def test_register_pulled_fileset_stamps_and_clears_quant(tmp_hal0_home: str) -> None:
+    """The file-set registration path (ML-2/3) gets the same #1890 treatment as
+    the single-file path: quant from the entry filename when the header carries
+    no signal, and an unclassifiable replacement clears the stale value."""
+    from hal0.registry.fileset import FileSetEntry, FileSetPlan
+    from hal0.registry.pull import _register_pulled_fileset
+
+    registry = ModelRegistry()
+    root = Path(tmp_hal0_home) / "fileset-models"
+    root.mkdir(parents=True, exist_ok=True)
+    entry_dest = root / "model-Q8_0_ROCMFPX.gguf"
+    entry_dest.write_bytes(_payload(2048))
+
+    plan = FileSetPlan(
+        repo="org/fpx-GGUF",
+        revision="deadbeef",
+        entry_rel="model-Q8_0_ROCMFPX.gguf",
+        files=[FileSetEntry(rel="model-Q8_0_ROCMFPX.gguf", role="model")],
+    )
+    _register_pulled_fileset(
+        registry,
+        model_id="fileset-fpx",
+        fileset=plan,
+        installed=[(plan.files[0], entry_dest)],
+        entry_dest=entry_dest,
+        mmproj_dest=None,
+    )
+    assert registry.get("fileset-fpx").quant == "ROCmFP8"
+
+    # Replacement set whose entry has no quant token → stale value cleared.
+    plain_dest = root / "plainmodel.gguf"
+    plain_dest.write_bytes(_payload(2048))
+    plan2 = FileSetPlan(
+        repo="org/fpx-GGUF",
+        revision="deadbeef",
+        entry_rel="plainmodel.gguf",
+        files=[FileSetEntry(rel="plainmodel.gguf", role="model")],
+    )
+    _register_pulled_fileset(
+        registry,
+        model_id="fileset-fpx",
+        fileset=plan2,
+        installed=[(plan2.files[0], plain_dest)],
+        entry_dest=plain_dest,
+        mmproj_dest=None,
+    )
+    entry = registry.get("fileset-fpx")
+    assert entry.quant is None
+    assert entry.hf_filename == "plainmodel.gguf"
+
+
 # ── MR-1: run_pull persists a durable snapshot for ALL callers ────────────────
 
 

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -415,6 +415,82 @@ async def test_run_pull_keeps_operator_tool_calling(tmp_hal0_home: str) -> None:
     assert registry.get("hal0-brain-sft-q8-rocmfpx").capability_flags.tool_calling is False
 
 
+# ── quant stamping at pull time (#1890) ───────────────────────────────────────
+#
+# _register_pulled is the ONLY registration a pull-installed model ever gets
+# (including the installer-seeded FPX brain model). Before this fix it built
+# ``Model(...)`` with no ``quant=``, so every pull-registered row stored
+# ``quant=None`` on the actual registry object — only the API list
+# serializer's ``lazy_quant`` backfilled it for display, which made
+# hal0#1790's ``_guard_fpx_quant_runner`` (fed the raw ``model_dump()``)
+# silently inert for every model hal0 installs itself.
+
+
+@pytest.mark.asyncio
+async def test_run_pull_stamps_rocmfpx_quant_on_fresh_registration(tmp_hal0_home: str) -> None:
+    """The exact hal0#1890 shape: a fresh pull of the FPX brain artifact must
+    store ``quant="ROCmFP8"`` on the ``Model`` row itself, not just leave it
+    for the API serializer to lazily derive."""
+    body = _payload(4096)
+    job = make_job("hal0-brain-sft-q8-rocmfpx")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_ok_handler(body))
+    try:
+        await run_pull(
+            job,
+            hf_repo="Hal0ai/hal0-brain-sft-ROCmFPX-GGUF",
+            hf_file="hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    entry = registry.get("hal0-brain-sft-q8-rocmfpx")
+    assert entry.quant == "ROCmFP8"
+    # And the raw model_dump() the guard reads directly must carry it too —
+    # this is the exact shape _guard_fpx_quant_runner is handed.
+    assert entry.model_dump()["quant"] == "ROCmFP8"
+
+
+@pytest.mark.asyncio
+async def test_run_pull_refreshes_quant_on_repull(tmp_hal0_home: str) -> None:
+    """A re-pull that replaces the bytes with a different quant build must
+    update the stored quant, not leave the first pull's value stuck."""
+    job = make_job("some-random-gguf")
+    registry = ModelRegistry()
+
+    client = httpx.AsyncClient(transport=_ok_handler(_payload(4096)))
+    try:
+        await run_pull(
+            job,
+            hf_repo="org/random-GGUF",
+            hf_file="random-Q4_K_M.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    assert registry.get("some-random-gguf").quant == "Q4_K_M"
+
+    job2 = make_job("some-random-gguf")
+    client2 = httpx.AsyncClient(transport=_ok_handler(_payload(4096)))
+    try:
+        await run_pull(
+            job2,
+            hf_repo="org/random-GGUF",
+            hf_file="random-Q8_0.gguf",
+            registry=registry,
+            client=client2,
+        )
+    finally:
+        await client2.aclose()
+    assert job2.state == "completed", f"got {job2.state}: {job2.error}"
+    assert registry.get("some-random-gguf").quant == "Q8_0"
+
+
 # ── MR-1: run_pull persists a durable snapshot for ALL callers ────────────────
 
 

--- a/tests/slots/test_resolve_model_info_quant_guard.py
+++ b/tests/slots/test_resolve_model_info_quant_guard.py
@@ -1,0 +1,93 @@
+"""hal0#1890: the FPX-on-wrong-runner guard (hal0#1790) through the REAL
+launch/preview path, not a hand-built ``model_info`` dict.
+
+``tests/providers/test_container.py::TestFPXQuantRunnerGuard`` proves
+``_guard_fpx_quant_runner`` itself is correct — but every one of those tests
+hand-builds ``model_info`` with ``quant="ROCmFP8"`` set directly, which is
+exactly why the guard's suite kept passing while it was inert in production:
+a pull-registered model (the installer-seeded FPX brain model included)
+never got ``quant`` on the actual registry row, only lazily at API-serializer
+time. This file drives the real chain instead: ``run_pull`` registers the
+model the way hal0 installs it, ``SlotManager._resolve_model_info`` resolves
+it the way ``load()``/preview do, and the guard is fed exactly that dict.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from hal0.providers.container import UnprocessableEntity, _guard_fpx_quant_runner
+from hal0.registry.pull import make_job, run_pull
+from hal0.registry.store import ModelRegistry
+from hal0.slots.manager import SlotManager
+
+
+def _mgr() -> SlotManager:
+    # _resolve_model_info only touches the registry — a bare instance
+    # (no __init__, no slot config, no provider) is enough to exercise it.
+    return SlotManager.__new__(SlotManager)
+
+
+async def _pull_registered_model_info(model_id: str, hf_file: str) -> dict:
+    """Register ``model_id`` the way a real pull install does, then resolve
+    it through the exact method the launch/preview paths call."""
+    job = make_job(model_id)
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda req: httpx.Response(200, content=b"x" * 4096))
+    )
+    try:
+        await run_pull(
+            job,
+            hf_repo="Hal0ai/hal0-brain-sft-ROCmFPX-GGUF",
+            hf_file=hf_file,
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    return await _mgr()._resolve_model_info(model_id)
+
+
+async def test_resolve_model_info_surfaces_quant_for_pull_registered_model(
+    tmp_hal0_home: str,
+) -> None:
+    """The dict _guard_fpx_quant_runner is actually handed must carry the
+    detected quant — not just the API list serializer's lazy backfill."""
+    info = await _pull_registered_model_info(
+        "hal0-brain-sft-q8-rocmfpx", "hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf"
+    )
+    assert info.get("quant") == "ROCmFP8"
+
+
+async def test_guard_refuses_pull_registered_fpx_model_on_cpu_runner(
+    tmp_hal0_home: str,
+) -> None:
+    """End-to-end hal0#1790 shape via the real pull → resolve chain: loading
+    a pull-installed FPX model on a non-FPX runner must 422, not silently
+    pass the guard because ``quant`` was never stored."""
+    info = await _pull_registered_model_info(
+        "hal0-brain-sft-q8-rocmfpx", "hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf"
+    )
+    cpu_runner = SimpleNamespace(key="cpu")
+    with pytest.raises(UnprocessableEntity) as exc_info:
+        _guard_fpx_quant_runner({"name": "brain"}, info, cpu_runner)
+    assert exc_info.value.code == "slot.unsupported_quant_for_runner"
+    assert exc_info.value.details["quant"] == "ROCmFP8"
+
+
+async def test_guard_allows_pull_registered_fpx_model_on_fpx_runner(
+    tmp_hal0_home: str,
+) -> None:
+    """Sanity: the same pull-registered model on its own runner family
+    still launches — the guard is quant/runner-pair specific, not a
+    blanket refusal."""
+    info = await _pull_registered_model_info(
+        "hal0-brain-sft-q8-rocmfpx", "hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf"
+    )
+    rocmfpx_runner = SimpleNamespace(key="rocmfpx")
+    _guard_fpx_quant_runner({"name": "brain"}, info, rocmfpx_runner)  # no raise


### PR DESCRIPTION
## What

Pull-registered models (including the installer-seeded FPX brain model)
never got `Model.quant` set — `registry/pull.py::_register_pulled` and
`_register_pulled_fileset` built the `Model(...)` row with no `quant=`
argument. Only the API list serializer's `lazy_quant` (`models_service.py`)
backfilled it for *display*, so `GET /api/models` showed `"quant": "ROCmFP8"`
and looked correct while the actual registry row stayed `quant=None`.

That silently disarmed the hal0#1790 belt-and-suspenders guard
(`_guard_fpx_quant_runner` in `providers/container.py`): it reads
`model_dump()` directly on both the launch and preview paths, so binding a
ROCmFPX quant to a non-FPX runner crash-looped (SIGSEGV, exit 139) instead
of returning the promised `422 slot.unsupported_quant_for_runner`. The
guard's own unit tests all hand-build `model_info` with `quant` already
set, so none of them caught the gap.

## Why (root cause, not just the symptom)

- `_register_pulled` already calls `registry.detect.detect(Path(path))` to
  derive `context_length` at registration time — the same call's `.quant`
  was simply discarded.
- `_register_pulled_fileset` (the multi-file/shard-set pull path) never
  called `detect()` at all.
- `SlotManager._resolve_model_info` — the ONE place both the launch and
  preview paths resolve `model_info` for the guard — just forwards the raw
  registry `model_dump()`, with no fallback to the same `lazy_quant`
  filename-token derivation the API serializer already trusts.

Fixed all three:
1. `_register_pulled` now captures `detection.quant` alongside
   `context_length` and stamps it on the `Model` row (both the fresh-add
   and update branches).
2. `_register_pulled_fileset` runs the same `detect()` call and stamps
   `quant` too.
3. `SlotManager._resolve_model_info` falls back to `lazy_quant` when a
   registry row still has no stored `quant`, so any *other* future
   registration gap can't silently disarm the guard either (belt-and-
   suspenders for the belt-and-suspenders guard).

## How verified

- `tests/registry/test_pull.py`: new tests assert `quant` lands on the
  actual `Model` row (and its `model_dump()`) for a fresh pull of the
  ROCmFPX brain artifact, and refreshes correctly across a re-pull with a
  different quant build. Both fail on `main` (`assert None == 'ROCmFP8'`)
  and pass with this change.
- `tests/slots/test_resolve_model_info_quant_guard.py`: drives the **real**
  chain the issue asked for — `run_pull` → `SlotManager._resolve_model_info`
  → `_guard_fpx_quant_runner` — instead of a hand-built dict. Confirmed
  (via `git stash`) that both the quant-surfacing test and the
  guard-refuses-cpu-runner test fail on `main` and pass with the fix.
- Full suite: `uv run pytest -q` → 9980 passed, 16 skipped, 1 xfailed, 330
  errors — all 330 are the known `tests/mcp/*` `/etc/hal0-perms`
  `PermissionError` environment artifact (unrelated to this change);
  re-run with `HAL0_HOME=$(mktemp -d)` confirms those pass clean.
- `uv run ruff check src/ tests/` → all checks passed.
- `uv run ruff format --check src/ tests/` → all files already formatted.

## Left out of scope

The `meta.json` sidecar `write_model_meta()` writes for capability-grouped
pulls still records `quant=None` — it's provenance metadata (HF repo/file/
sha), not read by the guard or any other consumer, so it wasn't touched.

Closes #1890