### PR TITLE
fix(memory): replay boot-lane writes lost to the degraded provider

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1760,7 +1760,7 @@ async def _boot_metrics_state(app: FastAPI, ctx: BootState) -> None:
 
 
 async def _memory_reprobe_loop(
-    provider: Any, interval_s: float, *, max_replay_attempts: int = 10
+    provider: Any, interval_s: float, *, max_replay_attempts: int = 20
 ) -> None:
     """Poll a boot-degraded memory provider until the durable engine answers.
 
@@ -1774,10 +1774,12 @@ async def _memory_reprobe_loop(
     replay. Draining here, on the loop, is what makes those writes durable
     without waiting for the next hal0-api restart.
 
-    A drain that reports failure (a healthy engine can still fail an
-    individual retain) keeps its hooks armed, so the loop keeps ticking and
-    retries — up to ``max_replay_attempts``, after which it gives up loudly
-    rather than retrying forever.
+    A drain that reports failure keeps its hooks armed, so the loop keeps
+    ticking and retries — up to ``max_replay_attempts``, after which it gives
+    up loudly rather than retrying forever. "Failure" covers both a replay
+    whose writes did not land (a healthy engine can still fail an individual
+    retain) and a replay armed by a lane that has not finished yet, so the
+    budget is generous relative to the interval.
     """
     attempts = 0
     while True:
@@ -2045,13 +2047,47 @@ def _boot_mcp_memory_call(
         return {"ok": False, "error": str(exc)}
 
 
+class _BrainLaneReplay:
+    """Heal hook that re-issues the brain-lane publishes lost while degraded (#1897).
+
+    Armed on the self-healing provider BEFORE the lane's publishes run, so a
+    heal that lands mid-lane cannot drain an empty replay and leave the lane
+    with nothing to register onto. Until :meth:`finish` hands over the result,
+    the hook reports "not done" (``False``) so the drain keeps it armed.
+
+    Each run narrows ``pending`` to the publishes that still did not land, so
+    a partially successful retry never repeats one that already succeeded —
+    ``_phase_self_report`` has no dedupe, and re-running it would leave one
+    extra private self-report per tick.
+    """
+
+    def __init__(self, app: FastAPI, ctx: BootState) -> None:
+        self._app = app
+        self._ctx = ctx
+        self.pending: tuple[str, ...] = ()
+        self.ready = False
+
+    def finish(self, owed: tuple[str, ...]) -> None:
+        """Hand over the publishes the degraded window lost (may be empty)."""
+        self.pending = owed
+        self.ready = True
+
+    async def __call__(self) -> bool:
+        if not self.ready:
+            return False
+        if not self.pending:
+            return True
+        self.pending = await _boot_brain_lane(self._app, self._ctx, only=self.pending, replay=True)
+        return not self.pending
+
+
 async def _boot_brain_lane(
     app: FastAPI,
     ctx: BootState,
     *,
     only: tuple[str, ...] | None = None,
     replay: bool = False,
-) -> bool:
+) -> tuple[str, ...]:
     """Phase — RELOCATE(brain-lane): identity-card + self-report memory publishes.
 
     Runs LAST (after ``background_tasks``, the final named phase before this
@@ -2093,14 +2129,28 @@ async def _boot_brain_lane(
     the lost ones are replayed: a replay of a write that already landed
     durably races the engine's asynchronous retain and can duplicate the card.
 
-    Returns True when every publish it ran reported success; the heal-hook
-    drain keeps the hook armed on False so a transient post-heal failure is
-    retried rather than losing the data until the next restart.
+    Returns the names of the publishes it ran that did NOT report success —
+    empty means everything landed. :class:`_BrainLaneReplay` narrows its retry
+    set to exactly that, so a retry never repeats a publish that already
+    succeeded (``_phase_self_report`` has no dedupe of its own; repeating it
+    would leave a second private self-report per tick).
     """
     import functools
 
     provider = getattr(app.state, "memory_provider", None)
     degraded_on_entry = bool(getattr(provider, "degraded", False))
+
+    # #1897: arm the replay BEFORE the publishes run. The hook reports
+    # "not done" until this lane hands it its result, so a heal that lands
+    # mid-lane cannot drain-and-drop an empty replay and leave the lane with
+    # nothing to register onto afterwards.
+    replay_state: _BrainLaneReplay | None = None
+    if not replay and degraded_on_entry:
+        _add_heal_hook = getattr(provider, "add_heal_hook", None)
+        if _add_heal_hook is not None:
+            replay_state = _BrainLaneReplay(app, ctx)
+            if not _add_heal_hook(replay_state):  # pragma: no cover — heal beat the arm
+                replay_state = None
 
     from hal0.agents.hermes_provision import (
         BootstrapState,
@@ -2143,8 +2193,8 @@ async def _boot_brain_lane(
     def _volatile_writes() -> int:
         return int(getattr(fallback, "volatile_writes", 0) or 0)
 
-    lost: list[str] = []
-    ok = True
+    owed: list[str] = []
+    failed: list[str] = []
     for name, phase, done_key, prior in steps:
         if only is not None and name not in only:
             continue
@@ -2157,54 +2207,66 @@ async def _boot_brain_lane(
         try:
             result = await asyncio.to_thread(phase, step_ctx)
             if not result.details.get(done_key):
-                ok = False
+                failed.append(name)
                 log.info(
                     f"brain_lane.{name}_degraded",
                     warnings=result.details.get("warnings") or result.details.get("warning"),
                 )
         except Exception as exc:  # pragma: no cover — defensive, must never block boot
-            ok = False
+            failed.append(name)
             log.warning(f"brain_lane.{name}_failed", error=str(exc))
-        if _volatile_writes() > before:
-            lost.append(name)
+        # Owed a replay when this step's write was swallowed by the volatile
+        # fallback, or when it did not land at all — in both cases no durable
+        # card exists, so re-running cannot duplicate one.
+        if _volatile_writes() > before or name in failed:
+            owed.append(name)
 
     if replay:
-        # Report to the heal-hook drain whether this replay actually landed;
-        # a False keeps the hook armed for the next re-probe tick.
-        return ok
-    if not degraded_on_entry or not lost:
-        return ok
-    add_heal_hook = getattr(provider, "add_heal_hook", None)
-    if add_heal_hook is None:
+        # The drain narrows the retry set to what came back here.
+        return tuple(failed)
+    if replay_state is not None:
+        # Hand the armed hook its work; empty means the drain drops it and
+        # the re-probe loop can exit.
+        replay_state.finish(tuple(owed))
+        if owed:
+            log.warning(
+                "brain_lane.degraded_replay_armed",
+                steps=owed,
+                detail="brain-lane publishes landed in the volatile pgvector fallback — "
+                "queued for replay once the durable memory engine heals",
+            )
+        return tuple(failed)
+    if not owed:
+        return tuple(failed)
+    if getattr(provider, "add_heal_hook", None) is None:
         # Deliberate [memory].engine = "pgvector", or memory disabled: no
         # durable engine is ever coming, so there is nothing to replay onto.
         log.warning(
             "brain_lane.degraded_writes_volatile",
-            steps=lost,
+            steps=owed,
             detail="brain-lane publishes accepted by a volatile provider with no self-heal "
             "shell — the agents dataset will not survive a restart",
         )
-        return ok
-    hook = functools.partial(_boot_brain_lane, app, ctx, only=tuple(lost), replay=True)
-    if add_heal_hook(hook):
-        log.warning(
-            "brain_lane.degraded_replay_armed",
-            steps=lost,
-            detail="brain-lane publishes landed in the volatile pgvector fallback — "
-            "queued for replay once the durable memory engine heals",
+        return tuple(failed)
+    # Provider healed between the degraded-on-entry check and the arming, so
+    # the shell refused the hook and nothing else will run the replay: do it
+    # inline. A replay that still does not land is out of retries here — say
+    # so loudly rather than pretending the cards are durable.
+    log.warning(
+        "brain_lane.degraded_replay_inline",
+        steps=owed,
+        detail="memory provider healed before the replay could be armed — replaying "
+        "the lost brain-lane publishes against the durable engine now",
+    )
+    still_owed = await _boot_brain_lane(app, ctx, only=tuple(owed), replay=True)
+    if still_owed:
+        log.error(
+            "brain_lane.replay_incomplete",
+            steps=still_owed,
+            detail="inline replay of the degraded-window publishes did not land — "
+            "restart hal0-api to re-run them against the durable engine",
         )
-    else:
-        # The provider healed while this phase was mid-flight, after its heal
-        # hooks were drained: nothing would ever run our replay. Do it inline,
-        # for the lost steps only.
-        log.warning(
-            "brain_lane.degraded_replay_inline",
-            steps=lost,
-            detail="memory provider healed mid-phase — replaying the lost brain-lane "
-            "publishes against the durable engine now",
-        )
-        await _boot_brain_lane(app, ctx, only=tuple(lost), replay=True)
-    return ok
+    return tuple(failed)
 
 
 @asynccontextmanager

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1759,6 +1759,28 @@ async def _boot_metrics_state(app: FastAPI, ctx: BootState) -> None:
     app.state.metrics_seam = ctx.metrics_seam
 
 
+async def _memory_reprobe_loop(provider: Any, interval_s: float) -> None:
+    """Poll a boot-degraded memory provider until the durable engine answers.
+
+    Armed by ``_boot_background_tasks`` only when ``create_app`` wrapped a
+    degraded boot result in ``SelfHealingMemoryProvider`` (#1613). ``try_heal``
+    is synchronous, probe-bounded I/O, so it runs off-loop via ``to_thread``.
+
+    After the swap, drain the provider's heal hooks (#1897) — the writes hal0-api
+    made through the volatile fallback during the degrade window are gone from
+    the engine that just came up, and the phases that issued them registered a
+    replay. Draining here, on the loop, is what makes those writes durable
+    without waiting for the next hal0-api restart.
+    """
+    while True:
+        await asyncio.sleep(interval_s)
+        if await asyncio.to_thread(provider.try_heal):
+            run_hooks = getattr(provider, "run_heal_hooks", None)
+            if run_hooks is not None:
+                await run_hooks()
+            return
+
+
 async def _boot_background_tasks(app: FastAPI, ctx: BootState) -> None:
     """Phase — MCP session managers + refresh / GPU-arbiter loops + omni & NPU routers.
 
@@ -1826,14 +1848,9 @@ async def _boot_background_tasks(app: FastAPI, ctx: BootState) -> None:
     _mem_provider = getattr(app.state, "memory_provider", None)
     if hasattr(_mem_provider, "try_heal"):
         _reprobe_interval = float(os.environ.get("HAL0_MEMORY_REPROBE_INTERVAL_S", "30") or "30")
-
-        async def _memory_reprobe_loop(provider: Any = _mem_provider) -> None:
-            while True:
-                await asyncio.sleep(_reprobe_interval)
-                if await asyncio.to_thread(provider.try_heal):
-                    return
-
-        ctx.memory_reprobe_task = asyncio.create_task(_memory_reprobe_loop())
+        ctx.memory_reprobe_task = asyncio.create_task(
+            _memory_reprobe_loop(_mem_provider, _reprobe_interval)
+        )
         log.info("hal0.memory.reprobe_loop_started", interval_s=_reprobe_interval)
 
     async def _stop_memory_reprobe_task() -> None:
@@ -2010,7 +2027,7 @@ def _boot_mcp_memory_call(
         return {"ok": False, "error": str(exc)}
 
 
-async def _boot_brain_lane(app: FastAPI, ctx: BootState) -> None:
+async def _boot_brain_lane(app: FastAPI, ctx: BootState, *, replay: bool = False) -> None:
     """Phase — RELOCATE(brain-lane): identity-card + self-report memory publishes.
 
     Runs LAST (after ``background_tasks``, the final named phase before this
@@ -2033,8 +2050,27 @@ async def _boot_brain_lane(app: FastAPI, ctx: BootState) -> None:
     self-test of chat/memory/etc. Flagged here and in the relocation
     handoff notes; a future lane could add a lightweight post-boot
     self-check if a closer smoke_tests equivalent is wanted.
+
+    #1897 — degraded-window replay. On a fresh install this phase always runs
+    inside the memory degrade window: the installer starts hal0-api and the
+    hindsight daemon in the same pass, so the engine is still cold-starting
+    (embedded postgres init + model load) and ``create_app`` handed every
+    consumer the volatile in-memory ``PgVectorProvider``. All three publishes
+    below are then accepted, warned about ("VOLATILE and will be LOST"), and
+    dropped — the durable ``agents`` bank is never created. The #1613 self-heal
+    swaps the engine in later but cannot recover writes the engine never saw,
+    so the bank stayed missing until an unrelated hal0-api restart happened to
+    re-run this phase against a healthy provider. When the provider is degraded
+    on entry we therefore arm a one-shot replay of this same phase on the heal
+    path; the publishes are idempotent (each searches + deletes its prior card
+    before rewriting), so replaying is safe whether or not the first pass
+    reached a durable engine. ``replay=True`` marks the re-run so it does not
+    arm another.
     """
     import functools
+
+    provider = getattr(app.state, "memory_provider", None)
+    degraded_on_entry = bool(getattr(provider, "degraded", False))
 
     from hal0.agents.hermes_provision import (
         BootstrapState,
@@ -2086,6 +2122,35 @@ async def _boot_brain_lane(app: FastAPI, ctx: BootState) -> None:
             )
     except Exception as exc:  # pragma: no cover — defensive, must never block boot
         log.warning("brain_lane.self_report_failed", error=str(exc))
+
+    # #1897: the writes above went to a volatile fallback — owe a replay.
+    if replay or not degraded_on_entry:
+        return
+    add_heal_hook = getattr(provider, "add_heal_hook", None)
+    if add_heal_hook is None:
+        # Deliberate [memory].engine = "pgvector", or memory disabled: no
+        # durable engine is ever coming, so there is nothing to replay onto.
+        log.warning(
+            "brain_lane.degraded_writes_volatile",
+            detail="brain-lane publishes accepted by a volatile provider with no self-heal "
+            "shell — the agents dataset will not survive a restart",
+        )
+        return
+    if add_heal_hook(functools.partial(_boot_brain_lane, app, ctx, replay=True)):
+        log.warning(
+            "brain_lane.degraded_replay_armed",
+            detail="brain-lane publishes landed in the volatile pgvector fallback — "
+            "queued for replay once the durable memory engine heals",
+        )
+    else:
+        # The provider healed while this phase was mid-flight, after its heal
+        # hooks were drained: nothing would ever run our replay. Do it inline.
+        log.warning(
+            "brain_lane.degraded_replay_inline",
+            detail="memory provider healed mid-phase — replaying the brain-lane "
+            "publishes against the durable engine now",
+        )
+        await _boot_brain_lane(app, ctx, replay=True)
 
 
 @asynccontextmanager

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -2188,12 +2188,29 @@ async def _boot_brain_lane(
     # durably is what would duplicate cards: the dedupe search that makes a
     # replay safe races the engine's asynchronous retain of the write it is
     # meant to supersede.
+    #
+    # Known, pre-existing, very narrow window (Codex review on #1912): if the
+    # swap lands between a phase's dedupe search (ran against the empty
+    # fallback) and its add (durable), the counter does not move, the step is
+    # not replayed, and the durable dedupe never ran — a degraded RESTART on a
+    # box whose agents bank already holds a prior card can duplicate it. The
+    # window is one in-process search round-trip against a 30s reprobe tick,
+    # and it predates this replay (the #1613 loop already ran concurrently
+    # with the lane).
     fallback = getattr(provider, "target", provider)
 
     def _volatile_writes() -> int:
         return int(getattr(fallback, "volatile_writes", 0) or 0)
 
-    owed: list[str] = []
+    # ``volatile`` and ``failed`` are DIFFERENT findings and drive different
+    # messaging: "the fallback swallowed this write" (durable data loss unless
+    # replayed) vs "this publish just failed" (a normal warn-as-OK outcome the
+    # per-step log above already covers — including every boot with
+    # [memory].enabled = false, where all three fail). Only their union feeds
+    # the replay set; the degraded-window warnings key off ``volatile`` alone,
+    # so a healthy-provider publish failure can never fire a WARNING claiming
+    # volatile data loss (rc-validate greps the journal for exactly that key).
+    volatile: list[str] = []
     failed: list[str] = []
     for name, phase, done_key, prior in steps:
         if only is not None and name not in only:
@@ -2215,11 +2232,13 @@ async def _boot_brain_lane(
         except Exception as exc:  # pragma: no cover — defensive, must never block boot
             failed.append(name)
             log.warning(f"brain_lane.{name}_failed", error=str(exc))
-        # Owed a replay when this step's write was swallowed by the volatile
-        # fallback, or when it did not land at all — in both cases no durable
-        # card exists, so re-running cannot duplicate one.
-        if _volatile_writes() > before or name in failed:
-            owed.append(name)
+        if _volatile_writes() > before:
+            volatile.append(name)
+
+    # Owed a replay when a step's write was swallowed by the volatile fallback,
+    # or when it did not land at all — in both cases no durable card exists, so
+    # re-running cannot duplicate one.
+    owed = [name for name, *_rest in steps if name in volatile or name in failed]
 
     if replay:
         # The drain narrows the retry set to what came back here.
@@ -2236,14 +2255,19 @@ async def _boot_brain_lane(
                 "queued for replay once the durable memory engine heals",
             )
         return tuple(failed)
-    if not owed:
+    if not volatile:
+        # Nothing was swallowed by a volatile fallback. Any failed steps were
+        # plain publish failures against whatever provider is live (or absent —
+        # every [memory].enabled = false boot lands here with all three
+        # failed), already logged per-step above; no durable data was lost, so
+        # the degraded-window warnings below would be false alarms.
         return tuple(failed)
     if getattr(provider, "add_heal_hook", None) is None:
-        # Deliberate [memory].engine = "pgvector", or memory disabled: no
-        # durable engine is ever coming, so there is nothing to replay onto.
+        # Deliberate [memory].engine = "pgvector": no durable engine is ever
+        # coming, so there is nothing to replay onto.
         log.warning(
             "brain_lane.degraded_writes_volatile",
-            steps=owed,
+            steps=volatile,
             detail="brain-lane publishes accepted by a volatile provider with no self-heal "
             "shell — the agents dataset will not survive a restart",
         )

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1776,10 +1776,11 @@ async def _memory_reprobe_loop(
 
     A drain that reports failure keeps its hooks armed, so the loop keeps
     ticking and retries — up to ``max_replay_attempts``, after which it gives
-    up loudly rather than retrying forever. "Failure" covers both a replay
-    whose writes did not land (a healthy engine can still fail an individual
-    retain) and a replay armed by a lane that has not finished yet, so the
-    budget is generous relative to the interval.
+    up loudly rather than retrying forever. Only a replay that was actually
+    TRIED spends the budget: a drain whose armed hooks were all still waiting
+    on their arming boot phase (``last_drain_attempted`` False) is free, so a
+    short ``HAL0_MEMORY_REPROBE_INTERVAL_S`` cannot exhaust the cap before
+    the brain lane finishes and hands its replay over (#1912 review).
     """
     attempts = 0
     while True:
@@ -1789,6 +1790,10 @@ async def _memory_reprobe_loop(
         run_hooks = getattr(provider, "run_heal_hooks", None)
         if run_hooks is None or await run_hooks():
             return
+        if not getattr(provider, "last_drain_attempted", True):
+            # Every armed replay is still waiting on its boot lane — nothing
+            # was tried, so this tick does not count against the budget.
+            continue
         attempts += 1
         if attempts >= max_replay_attempts:
             log.error(

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1759,7 +1759,9 @@ async def _boot_metrics_state(app: FastAPI, ctx: BootState) -> None:
     app.state.metrics_seam = ctx.metrics_seam
 
 
-async def _memory_reprobe_loop(provider: Any, interval_s: float) -> None:
+async def _memory_reprobe_loop(
+    provider: Any, interval_s: float, *, max_replay_attempts: int = 10
+) -> None:
     """Poll a boot-degraded memory provider until the durable engine answers.
 
     Armed by ``_boot_background_tasks`` only when ``create_app`` wrapped a
@@ -1771,14 +1773,30 @@ async def _memory_reprobe_loop(provider: Any, interval_s: float) -> None:
     the engine that just came up, and the phases that issued them registered a
     replay. Draining here, on the loop, is what makes those writes durable
     without waiting for the next hal0-api restart.
+
+    A drain that reports failure (a healthy engine can still fail an
+    individual retain) keeps its hooks armed, so the loop keeps ticking and
+    retries — up to ``max_replay_attempts``, after which it gives up loudly
+    rather than retrying forever.
     """
+    attempts = 0
     while True:
         await asyncio.sleep(interval_s)
-        if await asyncio.to_thread(provider.try_heal):
-            run_hooks = getattr(provider, "run_heal_hooks", None)
-            if run_hooks is not None:
-                await run_hooks()
+        if not await asyncio.to_thread(provider.try_heal):
+            continue
+        run_hooks = getattr(provider, "run_heal_hooks", None)
+        if run_hooks is None or await run_hooks():
             return
+        attempts += 1
+        if attempts >= max_replay_attempts:
+            log.error(
+                "hal0.memory.heal_replay_abandoned",
+                attempts=attempts,
+                detail="post-heal replay of degraded-window writes kept failing — "
+                "restart hal0-api to re-run the boot writes against the durable engine",
+            )
+            return
+        log.warning("hal0.memory.heal_replay_retry", attempt=attempts)
 
 
 async def _boot_background_tasks(app: FastAPI, ctx: BootState) -> None:
@@ -2027,7 +2045,13 @@ def _boot_mcp_memory_call(
         return {"ok": False, "error": str(exc)}
 
 
-async def _boot_brain_lane(app: FastAPI, ctx: BootState, *, replay: bool = False) -> None:
+async def _boot_brain_lane(
+    app: FastAPI,
+    ctx: BootState,
+    *,
+    only: tuple[str, ...] | None = None,
+    replay: bool = False,
+) -> bool:
     """Phase — RELOCATE(brain-lane): identity-card + self-report memory publishes.
 
     Runs LAST (after ``background_tasks``, the final named phase before this
@@ -2060,12 +2084,18 @@ async def _boot_brain_lane(app: FastAPI, ctx: BootState, *, replay: bool = False
     dropped — the durable ``agents`` bank is never created. The #1613 self-heal
     swaps the engine in later but cannot recover writes the engine never saw,
     so the bank stayed missing until an unrelated hal0-api restart happened to
-    re-run this phase against a healthy provider. When the provider is degraded
-    on entry we therefore arm a one-shot replay of this same phase on the heal
-    path; the publishes are idempotent (each searches + deletes its prior card
-    before rewriting), so replaying is safe whether or not the first pass
-    reached a durable engine. ``replay=True`` marks the re-run so it does not
-    arm another.
+    re-run this phase against a healthy provider. Each publish is therefore run
+    with the fallback's volatile-write counter watched: the ones whose writes
+    the fallback actually swallowed are armed for replay on the heal path
+    (``only=`` re-runs exactly those, ``replay=True`` stops the re-run arming
+    another). Re-running a publish is safe — each searches + deletes its prior
+    card before rewriting — but is not free of consequence, which is why only
+    the lost ones are replayed: a replay of a write that already landed
+    durably races the engine's asynchronous retain and can duplicate the card.
+
+    Returns True when every publish it ran reported success; the heal-hook
+    drain keeps the hook armed on False so a transient post-heal failure is
+    retried rather than losing the data until the next restart.
     """
     import functools
 
@@ -2085,72 +2115,96 @@ async def _boot_brain_lane(app: FastAPI, ctx: BootState, *, replay: bool = False
     loop = asyncio.get_running_loop()
     io = InstallIO(mcp_memory_call=functools.partial(_boot_mcp_memory_call, app, loop))
 
-    try:
-        ns_result = await asyncio.to_thread(_phase_namespace_register, _StepCtx(state=state, io=io))
-        if not ns_result.details.get("registered"):
-            log.info(
-                "brain_lane.namespace_register_degraded",
-                warnings=ns_result.details.get("warnings"),
-            )
-    except Exception as exc:  # pragma: no cover — defensive, must never block boot
-        log.warning("brain_lane.namespace_register_failed", error=str(exc))
-
-    try:
-        brain_result = await asyncio.to_thread(
-            _phase_brain_profile_seed, _StepCtx(state=state, io=io)
-        )
-        if not brain_result.details.get("registered"):
-            log.info(
-                "brain_lane.brain_profile_seed_degraded",
-                warnings=brain_result.details.get("warnings"),
-            )
-    except Exception as exc:  # pragma: no cover — defensive, must never block boot
-        log.warning("brain_lane.brain_profile_seed_failed", error=str(exc))
-
     # self_report MUST run last — see docstring above re: the smoke_tests
     # substitution.
     boot_failures = [p.name for p in ctx.boot_report.phases if p.status == "error"]
-    prior = {"smoke_tests": {"failures": boot_failures}}
-    try:
-        report_result = await asyncio.to_thread(
-            _phase_self_report, _StepCtx(state=state, io=io, _prior=prior)
-        )
-        if not report_result.details.get("published"):
-            log.info(
-                "brain_lane.self_report_degraded",
-                warning=report_result.details.get("warning"),
-            )
-    except Exception as exc:  # pragma: no cover — defensive, must never block boot
-        log.warning("brain_lane.self_report_failed", error=str(exc))
+    steps: tuple[tuple[str, Any, str, dict[str, Any] | None], ...] = (
+        ("namespace_register", _phase_namespace_register, "registered", None),
+        ("brain_profile_seed", _phase_brain_profile_seed, "registered", None),
+        (
+            "self_report",
+            _phase_self_report,
+            "published",
+            {"smoke_tests": {"failures": boot_failures}},
+        ),
+    )
 
-    # #1897: the writes above went to a volatile fallback — owe a replay.
-    if replay or not degraded_on_entry:
-        return
+    # #1897: the volatile fallback counts the writes it swallows, so we can
+    # ask — per step — whether THAT step's writes were lost, instead of
+    # replaying the whole lane on the assumption that they all were. The
+    # counter lives on the fallback object itself, so once the shell rebinds
+    # to the durable engine mid-lane it stops moving and later steps are
+    # (correctly) not replayed. Replaying a step whose writes already landed
+    # durably is what would duplicate cards: the dedupe search that makes a
+    # replay safe races the engine's asynchronous retain of the write it is
+    # meant to supersede.
+    fallback = getattr(provider, "target", provider)
+
+    def _volatile_writes() -> int:
+        return int(getattr(fallback, "volatile_writes", 0) or 0)
+
+    lost: list[str] = []
+    ok = True
+    for name, phase, done_key, prior in steps:
+        if only is not None and name not in only:
+            continue
+        before = _volatile_writes()
+        step_ctx = (
+            _StepCtx(state=state, io=io)
+            if prior is None
+            else _StepCtx(state=state, io=io, _prior=prior)
+        )
+        try:
+            result = await asyncio.to_thread(phase, step_ctx)
+            if not result.details.get(done_key):
+                ok = False
+                log.info(
+                    f"brain_lane.{name}_degraded",
+                    warnings=result.details.get("warnings") or result.details.get("warning"),
+                )
+        except Exception as exc:  # pragma: no cover — defensive, must never block boot
+            ok = False
+            log.warning(f"brain_lane.{name}_failed", error=str(exc))
+        if _volatile_writes() > before:
+            lost.append(name)
+
+    if replay:
+        # Report to the heal-hook drain whether this replay actually landed;
+        # a False keeps the hook armed for the next re-probe tick.
+        return ok
+    if not degraded_on_entry or not lost:
+        return ok
     add_heal_hook = getattr(provider, "add_heal_hook", None)
     if add_heal_hook is None:
         # Deliberate [memory].engine = "pgvector", or memory disabled: no
         # durable engine is ever coming, so there is nothing to replay onto.
         log.warning(
             "brain_lane.degraded_writes_volatile",
+            steps=lost,
             detail="brain-lane publishes accepted by a volatile provider with no self-heal "
             "shell — the agents dataset will not survive a restart",
         )
-        return
-    if add_heal_hook(functools.partial(_boot_brain_lane, app, ctx, replay=True)):
+        return ok
+    hook = functools.partial(_boot_brain_lane, app, ctx, only=tuple(lost), replay=True)
+    if add_heal_hook(hook):
         log.warning(
             "brain_lane.degraded_replay_armed",
+            steps=lost,
             detail="brain-lane publishes landed in the volatile pgvector fallback — "
             "queued for replay once the durable memory engine heals",
         )
     else:
         # The provider healed while this phase was mid-flight, after its heal
-        # hooks were drained: nothing would ever run our replay. Do it inline.
+        # hooks were drained: nothing would ever run our replay. Do it inline,
+        # for the lost steps only.
         log.warning(
             "brain_lane.degraded_replay_inline",
-            detail="memory provider healed mid-phase — replaying the brain-lane "
+            steps=lost,
+            detail="memory provider healed mid-phase — replaying the lost brain-lane "
             "publishes against the durable engine now",
         )
-        await _boot_brain_lane(app, ctx, replay=True)
+        await _boot_brain_lane(app, ctx, only=tuple(lost), replay=True)
+    return ok
 
 
 @asynccontextmanager

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -1360,14 +1360,35 @@ def agent_peers() -> None:
     table.add_column("Roles")
     table.add_column("Endpoint")
     table.add_column("Registered")
+
+    def _as_dict(value: Any) -> dict[str, Any]:
+        """Nested card metadata, tolerant of engine round-trip shapes (#1897).
+
+        Some memory engines return nested metadata objects re-encoded as JSON
+        strings rather than dicts. ``hal0 agent peers`` used to assume a dict
+        and died with ``AttributeError: 'str' object has no attribute 'get'``
+        on the whole listing because one card came back that way.
+        """
+        if isinstance(value, str):
+            try:
+                value = _json.loads(value)
+            except _json.JSONDecodeError:
+                return {}
+        return value if isinstance(value, dict) else {}
+
     for item in items:
-        md = item.get("metadata") or {} if isinstance(item, dict) else {}
-        endpoint = md.get("endpoint") or {}
-        hal0_state = md.get("hal0_state") or {}
+        md = _as_dict(item.get("metadata")) if isinstance(item, dict) else {}
+        endpoint = _as_dict(md.get("endpoint"))
+        hal0_state = _as_dict(md.get("hal0_state"))
+        roles = md.get("roles")
+        if isinstance(roles, str):
+            roles = [roles]
+        elif not isinstance(roles, list):
+            roles = []
         table.add_row(
             str(md.get("agent_id") or "—"),
             str(md.get("display_name") or "—"),
-            ", ".join(md.get("roles") or []) or "—",
+            ", ".join(str(r) for r in roles) or "—",
             str(endpoint.get("url") or "—"),
             str(hal0_state.get("registered_at") or "—"),
         )

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -1313,6 +1313,7 @@ def agent_peers() -> None:
     shows installed bundled agents on this host); ``peers`` shows
     every card published into the federated registry.
     """
+    import ast as _ast
     import json as _json
     import urllib.error
     import urllib.request
@@ -1361,30 +1362,50 @@ def agent_peers() -> None:
     table.add_column("Endpoint")
     table.add_column("Registered")
 
-    def _as_dict(value: Any) -> dict[str, Any]:
-        """Nested card metadata, tolerant of engine round-trip shapes (#1897).
+    def _unflatten(value: Any) -> Any:
+        """Undo the string flattening cards pick up in the memory engine (#1897).
 
-        Some memory engines return nested metadata objects re-encoded as JSON
-        strings rather than dicts. ``hal0 agent peers`` used to assume a dict
-        and died with ``AttributeError: 'str' object has no attribute 'get'``
-        on the whole listing because one card came back that way.
+        ``HindsightProvider.add`` stores metadata as ``{k: str(v) for ...}``,
+        so a card's nested ``endpoint`` / ``hal0_state`` / ``roles`` come back
+        as Python reprs (``{'url': 'http://…'}``) — as JSON on some other
+        engines. ``hal0 agent peers`` assumed live objects and died with
+        ``AttributeError: 'str' object has no attribute 'get'``, taking the
+        whole listing down. Try JSON first, then a literal-eval for the repr
+        form (literals only — never ``eval``); an unparseable value is handed
+        back as-is for the caller to reject.
         """
-        if isinstance(value, str):
-            try:
-                value = _json.loads(value)
-            except _json.JSONDecodeError:
-                return {}
-        return value if isinstance(value, dict) else {}
+        if not isinstance(value, str):
+            return value
+        text = value.strip()
+        try:
+            return _json.loads(text)
+        except _json.JSONDecodeError:
+            pass
+        try:
+            return _ast.literal_eval(text)
+        except (ValueError, SyntaxError):
+            return value
+
+    def _as_dict(value: Any) -> dict[str, Any]:
+        """One card field as a dict; anything unreadable costs only its own
+        columns, never the listing."""
+        parsed = _unflatten(value)
+        return parsed if isinstance(parsed, dict) else {}
+
+    def _as_list(value: Any) -> list[Any]:
+        """One card field as a list; a bare string is a single-element list."""
+        parsed = _unflatten(value)
+        if isinstance(parsed, list):
+            return parsed
+        if isinstance(parsed, str) and parsed:
+            return [parsed]
+        return []
 
     for item in items:
         md = _as_dict(item.get("metadata")) if isinstance(item, dict) else {}
         endpoint = _as_dict(md.get("endpoint"))
         hal0_state = _as_dict(md.get("hal0_state"))
-        roles = md.get("roles")
-        if isinstance(roles, str):
-            roles = [roles]
-        elif not isinstance(roles, list):
-            roles = []
+        roles = _as_list(md.get("roles"))
         table.add_row(
             str(md.get("agent_id") or "—"),
             str(md.get("display_name") or "—"),

--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -93,8 +93,9 @@ class SelfHealingMemoryProvider:
         """Register a replay to run once the durable engine is swapped in.
 
         The hook may be sync or return an awaitable; it runs on the event
-        loop in :meth:`run_heal_hooks`, and is dropped after one run (a
-        replay must not re-arm itself).
+        loop in :meth:`run_heal_hooks`. A hook that reports success (any
+        return value other than ``False``) is dropped after one run, so a
+        replay never re-arms itself.
 
         Returns ``False`` — and registers nothing — when the provider has
         ALREADY healed, because that heal's hooks were drained before this
@@ -106,21 +107,36 @@ class SelfHealingMemoryProvider:
         self._heal_hooks.append(hook)
         return True
 
-    async def run_heal_hooks(self) -> None:
-        """Run + clear every hook armed for this heal, best-effort.
+    @property
+    def pending_heal_hooks(self) -> int:
+        """Replays still owed — non-zero after a drain means retry later."""
+        return len(self._heal_hooks)
 
-        A replay that raises is logged and skipped: recovering the agents
-        dataset must never take down the process that just recovered its
-        memory engine.
+    async def run_heal_hooks(self) -> bool:
+        """Run every hook armed for this heal; True when all of them landed.
+
+        A hook that returns ``False`` (its writes did not land — a healthy
+        engine can still fail an individual retain) or raises is KEPT armed
+        so the caller's retry loop drains it again on the next tick;
+        otherwise a transient failure on the first post-heal attempt would
+        leave the data lost until the next restart, which is the very
+        failure this machinery exists to prevent. Never propagates: memory
+        recovery must not take down the process.
         """
         hooks, self._heal_hooks = self._heal_hooks, []
+        ok = True
         for hook in hooks:
             try:
                 result = hook()
                 if inspect.isawaitable(result):
-                    await result
+                    result = await result
             except Exception as exc:
                 log.warning("hal0.memory.heal_hook_failed", error=str(exc))
+                result = False
+            if result is False:
+                ok = False
+                self._heal_hooks.append(hook)
+        return ok
 
     def try_heal(self) -> bool:
         """One re-probe attempt; True once the durable engine is live.

--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -7,6 +7,8 @@ factory that the one construction site in ``api/__init__.py`` calls.
 
 from __future__ import annotations
 
+import inspect
+from collections.abc import Callable
 from typing import Any
 
 import structlog
@@ -61,16 +63,64 @@ class SelfHealingMemoryProvider:
     polls :meth:`try_heal` until the durable engine answers. The swap is a
     single attribute rebind, so every captured reference — closures
     included — recovers at once.
+
+    Rebinding the delegate does NOT recover the writes that were accepted by
+    the volatile fallback while it was live (#1897): they are gone, and the
+    engine that just came up has never seen them. Callers that issued such
+    writes — hal0-api's own boot phases are the ones that always do, because
+    they run inside the degrade window by construction — register a replay
+    with :meth:`add_heal_hook`; the lifespan's re-probe loop drains them via
+    :meth:`run_heal_hooks` right after a successful swap.
     """
 
     def __init__(self, provider: MemoryProvider, cfg: Any) -> None:
         self._target = provider
         self._cfg = cfg
+        self._heal_hooks: list[Callable[[], Any]] = []
+        self._healed = False
 
     @property
     def target(self) -> Any:
         """The current delegate (tests introspect which side is live)."""
         return self._target
+
+    @property
+    def healed(self) -> bool:
+        """True once the durable engine has been swapped in."""
+        return self._healed
+
+    def add_heal_hook(self, hook: Callable[[], Any]) -> bool:
+        """Register a replay to run once the durable engine is swapped in.
+
+        The hook may be sync or return an awaitable; it runs on the event
+        loop in :meth:`run_heal_hooks`, and is dropped after one run (a
+        replay must not re-arm itself).
+
+        Returns ``False`` — and registers nothing — when the provider has
+        ALREADY healed, because that heal's hooks were drained before this
+        call. The caller owns running its own replay in that case; a hook
+        queued after the drain would never fire.
+        """
+        if self._healed:
+            return False
+        self._heal_hooks.append(hook)
+        return True
+
+    async def run_heal_hooks(self) -> None:
+        """Run + clear every hook armed for this heal, best-effort.
+
+        A replay that raises is logged and skipped: recovering the agents
+        dataset must never take down the process that just recovered its
+        memory engine.
+        """
+        hooks, self._heal_hooks = self._heal_hooks, []
+        for hook in hooks:
+            try:
+                result = hook()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as exc:
+                log.warning("hal0.memory.heal_hook_failed", error=str(exc))
 
     def try_heal(self) -> bool:
         """One re-probe attempt; True once the durable engine is live.
@@ -80,6 +130,7 @@ class SelfHealingMemoryProvider:
         the probe is synchronous I/O.
         """
         if not getattr(self._target, "degraded", False):
+            self._healed = True
             return True
         try:
             candidate = provider_from_config(self._cfg)
@@ -89,6 +140,7 @@ class SelfHealingMemoryProvider:
         if getattr(candidate, "degraded", False):
             return False
         self._target = candidate
+        self._healed = True
         log.warning(
             "hal0.memory.provider_healed",
             detail="hindsight engine recovered — swapped out the degraded pgvector fallback",

--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -78,6 +78,7 @@ class SelfHealingMemoryProvider:
         self._cfg = cfg
         self._heal_hooks: list[Callable[[], Any]] = []
         self._healed = False
+        self._last_drain_attempted = True
 
     @property
     def target(self) -> Any:
@@ -112,6 +113,18 @@ class SelfHealingMemoryProvider:
         """Replays still owed — non-zero after a drain means retry later."""
         return len(self._heal_hooks)
 
+    @property
+    def last_drain_attempted(self) -> bool:
+        """Whether the previous :meth:`run_heal_hooks` actually ran a hook.
+
+        ``False`` means every armed hook was still waiting on its arming boot
+        phase (``hook.ready`` was ``False``), so nothing was tried — the
+        caller's retry budget should not be spent on that drain (#1912
+        review: a short reprobe interval must not exhaust the cap before the
+        boot lane can hand its replay over).
+        """
+        return self._last_drain_attempted
+
     async def run_heal_hooks(self) -> bool:
         """Run every hook armed for this heal; True when all of them landed.
 
@@ -122,10 +135,21 @@ class SelfHealingMemoryProvider:
         leave the data lost until the next restart, which is the very
         failure this machinery exists to prevent. Never propagates: memory
         recovery must not take down the process.
+
+        A hook whose ``ready`` attribute is ``False`` (its arming boot phase
+        has not finished handing it work) is kept armed WITHOUT being run:
+        it has nothing to try yet, and it must not read as a failed replay
+        attempt — see :attr:`last_drain_attempted`.
         """
         hooks, self._heal_hooks = self._heal_hooks, []
         ok = True
+        attempted = False
         for hook in hooks:
+            if getattr(hook, "ready", True) is False:
+                ok = False
+                self._heal_hooks.append(hook)
+                continue
+            attempted = True
             try:
                 result = hook()
                 if inspect.isawaitable(result):
@@ -136,6 +160,7 @@ class SelfHealingMemoryProvider:
             if result is False:
                 ok = False
                 self._heal_hooks.append(hook)
+        self._last_drain_attempted = attempted
         return ok
 
     def try_heal(self) -> bool:

--- a/src/hal0/memory/pgvector_provider.py
+++ b/src/hal0/memory/pgvector_provider.py
@@ -49,6 +49,12 @@ class PgVectorProvider(MemoryProvider):
         # WARNING is visible in the write path even when the provider was
         # constructed outside of our factory (e.g. in tests).
         self._add_warned = False
+        # #1897: monotonic count of writes this volatile store has swallowed.
+        # Callers that must re-issue their writes once a durable engine takes
+        # over (hal0-api's boot phases) read this around a write to learn
+        # whether that particular write was lost, instead of assuming every
+        # write made while degraded was.
+        self._volatile_writes = 0
         log.warning(
             "hal0.memory.degraded_provider_active",
             detail=(
@@ -57,6 +63,11 @@ class PgVectorProvider(MemoryProvider):
                 "Ensure Hindsight is reachable to enable durable storage."
             ),
         )
+
+    @property
+    def volatile_writes(self) -> int:
+        """How many writes this volatile store has accepted (#1897)."""
+        return self._volatile_writes
 
     def _allowed(self, requested: str | list[str] | None, client_id: str | None) -> list[str]:
         # ``None`` = nothing requested → default sweep. ``[]`` = every
@@ -107,6 +118,7 @@ class PgVectorProvider(MemoryProvider):
         # write-path is loud even when the construction-time warning was
         # swallowed by a log filter or the provider was built outside our
         # factory.
+        self._volatile_writes += 1
         if not self._add_warned:
             self._add_warned = True
             log.warning(

--- a/tests/api/test_boot_brain_lane_replay.py
+++ b/tests/api/test_boot_brain_lane_replay.py
@@ -1,0 +1,167 @@
+"""#1897 — boot writes issued during the degraded-provider window get replayed.
+
+hal0-api's terminal ``brain_lane`` boot phase publishes the agent identity
+cards + self-report into the ``agents`` dataset. On a fresh install the
+hindsight daemon is still cold-starting, so those writes land in the volatile
+in-memory ``PgVectorProvider`` fallback. The #1613 self-heal swaps the durable
+engine in later, but nothing re-issued the lost writes — the durable ``agents``
+bank stayed missing until an unrelated hal0-api restart happened to re-run the
+lane against a healthy engine.
+
+These tests pin the replay contract: a lane that ran against a degraded
+provider arms a heal hook, and the heal path runs it.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import pytest
+
+import hal0.agents.hermes_provision as hp
+import hal0.memory as mem
+from hal0.api import BootState, _boot_brain_lane, _memory_reprobe_loop
+
+
+class _Result:
+    def __init__(self, details: dict[str, Any]) -> None:
+        self.details = details
+
+
+class _FakeDegraded:
+    degraded = True
+
+
+class _FakeHealthy:
+    degraded = False
+
+
+def _cfg() -> Any:
+    return types.SimpleNamespace(memory=types.SimpleNamespace(engine="hindsight"))
+
+
+@pytest.fixture
+def phase_calls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    seen: list[str] = []
+
+    def _mk(name: str, key: str) -> Any:
+        def _phase(ctx: Any, *args: Any, **kwargs: Any) -> _Result:
+            seen.append(name)
+            return _Result({key: True})
+
+        return _phase
+
+    monkeypatch.setattr(hp, "_phase_namespace_register", _mk("namespace_register", "registered"))
+    monkeypatch.setattr(hp, "_phase_brain_profile_seed", _mk("brain_profile_seed", "registered"))
+    monkeypatch.setattr(hp, "_phase_self_report", _mk("self_report", "published"))
+    return seen
+
+
+def _app(provider: Any) -> Any:
+    return types.SimpleNamespace(state=types.SimpleNamespace(memory_provider=provider))
+
+
+@pytest.mark.asyncio
+async def test_degraded_boot_lane_replays_after_provider_heals(
+    phase_calls: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    shell = mem.SelfHealingMemoryProvider(_FakeDegraded(), _cfg())
+    app = _app(shell)
+
+    await _boot_brain_lane(app, BootState())
+    assert phase_calls == ["namespace_register", "brain_profile_seed", "self_report"]
+
+    # Engine comes up; the heal path must re-issue the lost lane writes.
+    monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeHealthy())
+    assert shell.try_heal() is True
+    await shell.run_heal_hooks()
+
+    assert (
+        phase_calls
+        == [
+            "namespace_register",
+            "brain_profile_seed",
+            "self_report",
+        ]
+        * 2
+    )
+    # One-shot: a replay must not arm another replay.
+    await shell.run_heal_hooks()
+    assert len(phase_calls) == 6
+
+
+@pytest.mark.asyncio
+async def test_healthy_boot_lane_arms_no_replay(phase_calls: list[str]) -> None:
+    app = _app(_FakeHealthy())
+    await _boot_brain_lane(app, BootState())
+    assert phase_calls == ["namespace_register", "brain_profile_seed", "self_report"]
+
+
+@pytest.mark.asyncio
+async def test_lane_replays_inline_when_provider_healed_mid_lane(
+    phase_calls: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Heal landing between the lane's writes and its arming still replays."""
+    shell = mem.SelfHealingMemoryProvider(_FakeDegraded(), _cfg())
+    app = _app(shell)
+
+    monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeHealthy())
+
+    def _heal_midway(ctx: Any, *args: Any, **kwargs: Any) -> _Result:
+        phase_calls.append("self_report")
+        shell.try_heal()
+        return _Result({"published": True})
+
+    monkeypatch.setattr(hp, "_phase_self_report", _heal_midway)
+
+    await _boot_brain_lane(app, BootState())
+
+    # Ran once for the (lost) degraded pass, once for the inline replay.
+    assert phase_calls.count("namespace_register") == 2
+    assert phase_calls.count("self_report") == 2
+
+
+@pytest.mark.asyncio
+async def test_reprobe_loop_drains_heal_hooks() -> None:
+    events: list[str] = []
+
+    class _Provider:
+        def __init__(self) -> None:
+            self._attempts = 0
+
+        def try_heal(self) -> bool:
+            self._attempts += 1
+            events.append(f"probe{self._attempts}")
+            return self._attempts >= 2
+
+        async def run_heal_hooks(self) -> None:
+            events.append("replay")
+
+    await _memory_reprobe_loop(_Provider(), 0.0)
+    assert events == ["probe1", "probe2", "replay"]
+
+
+def test_add_heal_hook_reports_already_healed() -> None:
+    shell = mem.SelfHealingMemoryProvider(_FakeHealthy(), _cfg())
+    assert shell.try_heal() is True
+    assert shell.add_heal_hook(lambda: None) is False
+
+
+@pytest.mark.asyncio
+async def test_heal_hook_failure_does_not_break_the_drain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shell = mem.SelfHealingMemoryProvider(_FakeDegraded(), _cfg())
+    ran: list[str] = []
+
+    def _boom() -> None:
+        raise RuntimeError("replay exploded")
+
+    assert shell.add_heal_hook(_boom) is True
+    assert shell.add_heal_hook(lambda: ran.append("second")) is True
+
+    monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeHealthy())
+    assert shell.try_heal() is True
+    await shell.run_heal_hooks()
+    assert ran == ["second"]

--- a/tests/api/test_boot_brain_lane_replay.py
+++ b/tests/api/test_boot_brain_lane_replay.py
@@ -8,8 +8,9 @@ engine in later, but nothing re-issued the lost writes — the durable ``agents`
 bank stayed missing until an unrelated hal0-api restart happened to re-run the
 lane against a healthy engine.
 
-These tests pin the replay contract: a lane that ran against a degraded
-provider arms a heal hook, and the heal path runs it.
+These tests pin the replay contract: the publishes whose writes the volatile
+fallback actually swallowed (and only those) are armed for replay, the heal
+path runs them, and a replay that does not land stays armed.
 """
 
 from __future__ import annotations
@@ -23,6 +24,12 @@ import hal0.agents.hermes_provision as hp
 import hal0.memory as mem
 from hal0.api import BootState, _boot_brain_lane, _memory_reprobe_loop
 
+_STEPS = (
+    ("namespace_register", "registered"),
+    ("brain_profile_seed", "registered"),
+    ("self_report", "published"),
+)
+
 
 class _Result:
     def __init__(self, details: dict[str, Any]) -> None:
@@ -30,7 +37,12 @@ class _Result:
 
 
 class _FakeDegraded:
+    """Stand-in for the in-memory fallback, including its write counter."""
+
     degraded = True
+
+    def __init__(self) -> None:
+        self.volatile_writes = 0
 
 
 class _FakeHealthy:
@@ -41,85 +53,129 @@ def _cfg() -> Any:
     return types.SimpleNamespace(memory=types.SimpleNamespace(engine="hindsight"))
 
 
-@pytest.fixture
-def phase_calls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
-    seen: list[str] = []
-
-    def _mk(name: str, key: str) -> Any:
-        def _phase(ctx: Any, *args: Any, **kwargs: Any) -> _Result:
-            seen.append(name)
-            return _Result({key: True})
-
-        return _phase
-
-    monkeypatch.setattr(hp, "_phase_namespace_register", _mk("namespace_register", "registered"))
-    monkeypatch.setattr(hp, "_phase_brain_profile_seed", _mk("brain_profile_seed", "registered"))
-    monkeypatch.setattr(hp, "_phase_self_report", _mk("self_report", "published"))
-    return seen
-
-
 def _app(provider: Any) -> Any:
     return types.SimpleNamespace(state=types.SimpleNamespace(memory_provider=provider))
 
 
+class _Lane:
+    """Fake brain-lane phases that write through whatever provider is live.
+
+    A write made while the live delegate is the volatile fallback bumps that
+    fallback's counter — exactly what ``PgVectorProvider.add`` does — which is
+    the signal ``_boot_brain_lane`` reads to decide what it owes a replay.
+    """
+
+    def __init__(
+        self,
+        provider: Any,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        failing: frozenset[str] = frozenset(),
+    ) -> None:
+        self.provider = provider
+        self.calls: list[str] = []
+        self.failing = failing
+        for name, key in _STEPS:
+            monkeypatch.setattr(hp, f"_phase_{name}", self.phase(name, key))
+
+    def phase(self, name: str, key: str) -> Any:
+        def _phase(ctx: Any, *args: Any, **kwargs: Any) -> _Result:
+            self.calls.append(name)
+            self.write()
+            return _Result({key: name not in self.failing})
+
+        return _phase
+
+    def write(self) -> None:
+        target = getattr(self.provider, "target", self.provider)
+        if getattr(target, "degraded", False):
+            target.volatile_writes += 1
+
+    def count(self, name: str) -> int:
+        return self.calls.count(name)
+
+
 @pytest.mark.asyncio
 async def test_degraded_boot_lane_replays_after_provider_heals(
-    phase_calls: list[str], monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     shell = mem.SelfHealingMemoryProvider(_FakeDegraded(), _cfg())
-    app = _app(shell)
+    lane = _Lane(shell, monkeypatch)
 
-    await _boot_brain_lane(app, BootState())
-    assert phase_calls == ["namespace_register", "brain_profile_seed", "self_report"]
+    assert await _boot_brain_lane(_app(shell), BootState()) is True
+    assert lane.calls == ["namespace_register", "brain_profile_seed", "self_report"]
 
     # Engine comes up; the heal path must re-issue the lost lane writes.
     monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeHealthy())
     assert shell.try_heal() is True
-    await shell.run_heal_hooks()
+    assert await shell.run_heal_hooks() is True
 
-    assert (
-        phase_calls
-        == [
-            "namespace_register",
-            "brain_profile_seed",
-            "self_report",
-        ]
-        * 2
-    )
-    # One-shot: a replay must not arm another replay.
-    await shell.run_heal_hooks()
-    assert len(phase_calls) == 6
+    assert lane.calls == ["namespace_register", "brain_profile_seed", "self_report"] * 2
+    # One-shot: a successful replay must not arm another.
+    assert shell.pending_heal_hooks == 0
+    assert await shell.run_heal_hooks() is True
+    assert len(lane.calls) == 6
 
 
 @pytest.mark.asyncio
-async def test_healthy_boot_lane_arms_no_replay(phase_calls: list[str]) -> None:
-    app = _app(_FakeHealthy())
-    await _boot_brain_lane(app, BootState())
-    assert phase_calls == ["namespace_register", "brain_profile_seed", "self_report"]
+async def test_healthy_boot_lane_arms_no_replay(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _FakeHealthy()
+    lane = _Lane(provider, monkeypatch)
+
+    assert await _boot_brain_lane(_app(provider), BootState()) is True
+    assert lane.calls == ["namespace_register", "brain_profile_seed", "self_report"]
 
 
 @pytest.mark.asyncio
-async def test_lane_replays_inline_when_provider_healed_mid_lane(
-    phase_calls: list[str], monkeypatch: pytest.MonkeyPatch
+async def test_only_the_steps_that_hit_the_fallback_are_replayed(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Heal landing between the lane's writes and its arming still replays."""
-    shell = mem.SelfHealingMemoryProvider(_FakeDegraded(), _cfg())
-    app = _app(shell)
+    """A heal landing mid-lane must not replay the writes that went durable.
 
+    Replaying a publish whose write already reached the engine races that
+    engine's asynchronous retain — the dedupe search that makes a replay safe
+    may not see it yet — and duplicates the card.
+    """
+    shell = mem.SelfHealingMemoryProvider(_FakeDegraded(), _cfg())
+    lane = _Lane(shell, monkeypatch)
     monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeHealthy())
 
-    def _heal_midway(ctx: Any, *args: Any, **kwargs: Any) -> _Result:
-        phase_calls.append("self_report")
-        shell.try_heal()
+    def _heal_then_write(ctx: Any, *args: Any, **kwargs: Any) -> _Result:
+        lane.calls.append("self_report")
+        shell.try_heal()  # engine comes up before this step's write
+        lane.write()
         return _Result({"published": True})
 
-    monkeypatch.setattr(hp, "_phase_self_report", _heal_midway)
+    monkeypatch.setattr(hp, "_phase_self_report", _heal_then_write)
 
-    await _boot_brain_lane(app, BootState())
+    await _boot_brain_lane(_app(shell), BootState())
 
-    # Ran once for the (lost) degraded pass, once for the inline replay.
-    assert phase_calls.count("namespace_register") == 2
-    assert phase_calls.count("self_report") == 2
+    # try_heal() drained (empty) hooks already, so the replay ran inline —
+    # for the two lost steps only.
+    assert lane.count("namespace_register") == 2
+    assert lane.count("brain_profile_seed") == 2
+    assert lane.count("self_report") == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_replay_stays_armed_for_the_next_tick(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A healthy engine can still fail a retain — that must not end the retry."""
+    shell = mem.SelfHealingMemoryProvider(_FakeDegraded(), _cfg())
+    lane = _Lane(shell, monkeypatch, failing=frozenset({"self_report"}))
+
+    assert await _boot_brain_lane(_app(shell), BootState()) is False
+
+    monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeHealthy())
+    assert shell.try_heal() is True
+    assert await shell.run_heal_hooks() is False
+    assert shell.pending_heal_hooks == 1
+
+    lane.failing = frozenset()
+    assert await shell.run_heal_hooks() is True
+    assert shell.pending_heal_hooks == 0
+    assert lane.count("self_report") == 3
 
 
 @pytest.mark.asyncio
@@ -135,11 +191,40 @@ async def test_reprobe_loop_drains_heal_hooks() -> None:
             events.append(f"probe{self._attempts}")
             return self._attempts >= 2
 
-        async def run_heal_hooks(self) -> None:
+        async def run_heal_hooks(self) -> bool:
             events.append("replay")
+            return True
 
     await _memory_reprobe_loop(_Provider(), 0.0)
     assert events == ["probe1", "probe2", "replay"]
+
+
+@pytest.mark.asyncio
+async def test_reprobe_loop_retries_a_failed_drain_then_gives_up() -> None:
+    drains = 0
+
+    class _Provider:
+        def try_heal(self) -> bool:
+            return True
+
+        async def run_heal_hooks(self) -> bool:
+            nonlocal drains
+            drains += 1
+            return drains >= 3
+
+    await _memory_reprobe_loop(_Provider(), 0.0)
+    assert drains == 3
+
+    drains = 0
+
+    class _NeverLands(_Provider):
+        async def run_heal_hooks(self) -> bool:
+            nonlocal drains
+            drains += 1
+            return False
+
+    await _memory_reprobe_loop(_NeverLands(), 0.0, max_replay_attempts=4)
+    assert drains == 4
 
 
 def test_add_heal_hook_reports_already_healed() -> None:
@@ -163,5 +248,16 @@ async def test_heal_hook_failure_does_not_break_the_drain(
 
     monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeHealthy())
     assert shell.try_heal() is True
-    await shell.run_heal_hooks()
+    assert await shell.run_heal_hooks() is False
     assert ran == ["second"]
+    # The hook that raised is still owed; the one that landed is done.
+    assert shell.pending_heal_hooks == 1
+
+
+@pytest.mark.asyncio
+async def test_volatile_write_counter_moves_on_the_real_fallback() -> None:
+    """The counter the lane reads is the real PgVectorProvider's, not a mock."""
+    provider = mem.PgVectorProvider()
+    before = provider.volatile_writes
+    await provider.add("card", dataset="agents")
+    assert provider.volatile_writes == before + 1

--- a/tests/api/test_boot_brain_lane_replay.py
+++ b/tests/api/test_boot_brain_lane_replay.py
@@ -288,6 +288,71 @@ async def test_heal_hook_failure_does_not_break_the_drain(
     assert shell.pending_heal_hooks == 1
 
 
+class _LogRecorder:
+    """Captures structlog-style event names so tests can pin what fires."""
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+
+    def _record(self, event: str, **kwargs: Any) -> None:
+        self.events.append(event)
+
+    info = warning = error = _record
+
+
+@pytest.fixture
+def api_log(monkeypatch: pytest.MonkeyPatch) -> _LogRecorder:
+    recorder = _LogRecorder()
+    monkeypatch.setattr("hal0.api.log", recorder)
+    return recorder
+
+
+@pytest.mark.asyncio
+async def test_memory_disabled_boot_emits_no_volatile_warning(
+    monkeypatch: pytest.MonkeyPatch, api_log: _LogRecorder
+) -> None:
+    """[memory].enabled = false: every publish fails, nothing was volatile.
+
+    Firing ``degraded_writes_volatile`` here would be a WARNING claiming
+    durable data loss on EVERY boot of such a box — and #1897's own repro
+    greps the journal for exactly that class of key.
+    """
+    lane = _Lane(None, monkeypatch, failing=frozenset(n for n, _ in _STEPS))
+
+    owed = await _boot_brain_lane(_app(None), BootState())
+    assert owed == ("namespace_register", "brain_profile_seed", "self_report")
+    assert "brain_lane.degraded_writes_volatile" not in api_log.events
+    assert "brain_lane.degraded_replay_inline" not in api_log.events
+    # No inline replay fired: each phase ran exactly once.
+    assert lane.calls == ["namespace_register", "brain_profile_seed", "self_report"]
+
+
+@pytest.mark.asyncio
+async def test_healthy_provider_publish_failure_is_not_called_volatile(
+    monkeypatch: pytest.MonkeyPatch, api_log: _LogRecorder
+) -> None:
+    """A transient publish failure on a durable provider is not data loss."""
+    provider = _FakeHealthy()
+    lane = _Lane(provider, monkeypatch, failing=frozenset({"self_report"}))
+
+    assert await _boot_brain_lane(_app(provider), BootState()) == ("self_report",)
+    assert "brain_lane.degraded_writes_volatile" not in api_log.events
+    assert "brain_lane.degraded_replay_inline" not in api_log.events
+    assert lane.count("self_report") == 1
+
+
+@pytest.mark.asyncio
+async def test_deliberate_pgvector_engine_still_warns_volatile(
+    monkeypatch: pytest.MonkeyPatch, api_log: _LogRecorder
+) -> None:
+    """No self-heal shell and swallowed writes: the loss warning must fire."""
+    provider = _FakeDegraded()
+    _Lane(provider, monkeypatch)
+
+    assert await _boot_brain_lane(_app(provider), BootState()) == ()
+    assert "brain_lane.degraded_writes_volatile" in api_log.events
+
+
 @pytest.mark.asyncio
 async def test_volatile_write_counter_moves_on_the_real_fallback() -> None:
     """The counter the lane reads is the real PgVectorProvider's, not a mock."""

--- a/tests/api/test_boot_brain_lane_replay.py
+++ b/tests/api/test_boot_brain_lane_replay.py
@@ -15,6 +15,7 @@ path runs them, and a replay that does not land stays armed.
 
 from __future__ import annotations
 
+import asyncio
 import types
 from typing import Any
 
@@ -259,6 +260,32 @@ async def test_reprobe_loop_retries_a_failed_drain_then_gives_up() -> None:
 
     await _memory_reprobe_loop(_NeverLands(), 0.0, max_replay_attempts=4)
     assert drains == 4
+
+
+@pytest.mark.asyncio
+async def test_not_ready_replay_does_not_spend_the_attempt_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A short reprobe interval must not exhaust the cap while the lane runs.
+
+    The hook is armed before the lane's publishes and reports not-ready until
+    ``finish()``. Each tick of that state must be free: with a 0s interval the
+    loop ticks far more than ``max_replay_attempts`` times here, and it must
+    still be alive to drain the replay once the lane hands it over.
+    """
+    shell = mem.SelfHealingMemoryProvider(_FakeDegraded(), _cfg())
+    hook = _BrainLaneReplay(_app(None), BootState())
+    assert shell.add_heal_hook(hook) is True
+    monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeHealthy())
+
+    task = asyncio.create_task(_memory_reprobe_loop(shell, 0.0, max_replay_attempts=3))
+    await asyncio.sleep(0.2)
+    assert not task.done()
+    assert shell.pending_heal_hooks == 1
+
+    hook.finish(())  # lane finished with nothing owed
+    await asyncio.wait_for(task, timeout=5.0)
+    assert shell.pending_heal_hooks == 0
 
 
 def test_add_heal_hook_reports_already_healed() -> None:

--- a/tests/api/test_boot_brain_lane_replay.py
+++ b/tests/api/test_boot_brain_lane_replay.py
@@ -22,7 +22,7 @@ import pytest
 
 import hal0.agents.hermes_provision as hp
 import hal0.memory as mem
-from hal0.api import BootState, _boot_brain_lane, _memory_reprobe_loop
+from hal0.api import BootState, _boot_brain_lane, _BrainLaneReplay, _memory_reprobe_loop
 
 _STEPS = (
     ("namespace_register", "registered"),
@@ -102,7 +102,7 @@ async def test_degraded_boot_lane_replays_after_provider_heals(
     shell = mem.SelfHealingMemoryProvider(_FakeDegraded(), _cfg())
     lane = _Lane(shell, monkeypatch)
 
-    assert await _boot_brain_lane(_app(shell), BootState()) is True
+    assert await _boot_brain_lane(_app(shell), BootState()) == ()
     assert lane.calls == ["namespace_register", "brain_profile_seed", "self_report"]
 
     # Engine comes up; the heal path must re-issue the lost lane writes.
@@ -122,7 +122,7 @@ async def test_healthy_boot_lane_arms_no_replay(monkeypatch: pytest.MonkeyPatch)
     provider = _FakeHealthy()
     lane = _Lane(provider, monkeypatch)
 
-    assert await _boot_brain_lane(_app(provider), BootState()) is True
+    assert await _boot_brain_lane(_app(provider), BootState()) == ()
     assert lane.calls == ["namespace_register", "brain_profile_seed", "self_report"]
 
 
@@ -149,12 +149,44 @@ async def test_only_the_steps_that_hit_the_fallback_are_replayed(
     monkeypatch.setattr(hp, "_phase_self_report", _heal_then_write)
 
     await _boot_brain_lane(_app(shell), BootState())
+    assert await shell.run_heal_hooks() is True
 
-    # try_heal() drained (empty) hooks already, so the replay ran inline —
-    # for the two lost steps only.
+    # Only the two publishes the fallback swallowed are re-issued.
     assert lane.count("namespace_register") == 2
     assert lane.count("brain_profile_seed") == 2
     assert lane.count("self_report") == 1
+
+
+@pytest.mark.asyncio
+async def test_replay_is_armed_before_the_publishes_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A heal draining mid-lane must not find an empty, droppable replay."""
+    shell = mem.SelfHealingMemoryProvider(_FakeDegraded(), _cfg())
+    lane = _Lane(shell, monkeypatch)
+    armed: list[int] = []
+
+    def _phase(ctx: Any, *args: Any, **kwargs: Any) -> _Result:
+        armed.append(shell.pending_heal_hooks)
+        lane.calls.append("namespace_register")
+        lane.write()
+        return _Result({"registered": True})
+
+    monkeypatch.setattr(hp, "_phase_namespace_register", _phase)
+
+    await _boot_brain_lane(_app(shell), BootState())
+    assert armed == [1]
+
+
+@pytest.mark.asyncio
+async def test_replay_hook_reports_not_done_until_the_lane_hands_over() -> None:
+    hook = _BrainLaneReplay(_app(None), BootState())
+
+    # Drained while the lane is still running: stays armed, runs nothing.
+    assert await hook() is False
+    # Lane finished with nothing owed: the drain can drop it.
+    hook.finish(())
+    assert await hook() is True
 
 
 @pytest.mark.asyncio
@@ -165,7 +197,7 @@ async def test_failed_replay_stays_armed_for_the_next_tick(
     shell = mem.SelfHealingMemoryProvider(_FakeDegraded(), _cfg())
     lane = _Lane(shell, monkeypatch, failing=frozenset({"self_report"}))
 
-    assert await _boot_brain_lane(_app(shell), BootState()) is False
+    assert await _boot_brain_lane(_app(shell), BootState()) == ("self_report",)
 
     monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeHealthy())
     assert shell.try_heal() is True
@@ -175,7 +207,9 @@ async def test_failed_replay_stays_armed_for_the_next_tick(
     lane.failing = frozenset()
     assert await shell.run_heal_hooks() is True
     assert shell.pending_heal_hooks == 0
+    # The failing step is retried; the two that landed are NOT repeated.
     assert lane.count("self_report") == 3
+    assert lane.count("namespace_register") == 2
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_agent_peers_metadata.py
+++ b/tests/cli/test_agent_peers_metadata.py
@@ -1,0 +1,93 @@
+"""``hal0 agent peers`` survives JSON-string card metadata (#1897 spin-off).
+
+Found while cross-checking the agents-bank replay defect on ct150: a card
+whose ``hal0_state`` came back from the memory engine as a JSON *string*
+instead of a dict crashed the whole listing with
+``AttributeError: 'str' object has no attribute 'get'``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.request
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import agent_commands
+
+runner = CliRunner()
+
+
+def _fake_response(payload: dict[str, Any]) -> Any:
+    class _Resp(io.BytesIO):
+        def __enter__(self) -> _Resp:
+            return self
+
+        def __exit__(self, *exc: Any) -> None:
+            return None
+
+    return _Resp(json.dumps(payload).encode("utf-8"))
+
+
+@pytest.fixture
+def peers_response(monkeypatch: pytest.MonkeyPatch) -> Any:
+    def _install(payload: dict[str, Any]) -> None:
+        monkeypatch.setattr(agent_commands, "_api_base", lambda: "http://127.0.0.1:8080")
+        monkeypatch.setattr(agent_commands, "_api_unreachable", lambda url: False)
+        monkeypatch.setattr(
+            urllib.request, "urlopen", lambda req, timeout=None: _fake_response(payload)
+        )
+
+    return _install
+
+
+def test_peers_renders_json_string_metadata(peers_response: Any) -> None:
+    peers_response(
+        {
+            "items": [
+                {
+                    "id": "card-1",
+                    "metadata": {
+                        "agent_id": "hermes",
+                        "display_name": "Hermes",
+                        "roles": ["orchestrator"],
+                        "endpoint": json.dumps({"url": "http://10.0.1.142:8080"}),
+                        "hal0_state": json.dumps({"registered_at": "2026-08-15T00:00:00Z"}),
+                    },
+                }
+            ]
+        }
+    )
+
+    result = runner.invoke(agent_commands.app, ["peers"])
+
+    assert result.exit_code == 0, result.output
+    assert "hermes" in result.output
+    assert "2026-08-15" in result.output
+
+
+def test_peers_tolerates_unparseable_metadata(peers_response: Any) -> None:
+    peers_response(
+        {
+            "items": [
+                {
+                    "id": "card-2",
+                    "metadata": {
+                        "agent_id": "ghost",
+                        "hal0_state": "not json at all",
+                        "endpoint": None,
+                        "roles": "solo",
+                    },
+                }
+            ]
+        }
+    )
+
+    result = runner.invoke(agent_commands.app, ["peers"])
+
+    assert result.exit_code == 0, result.output
+    assert "ghost" in result.output
+    assert "solo" in result.output

--- a/tests/cli/test_agent_peers_metadata.py
+++ b/tests/cli/test_agent_peers_metadata.py
@@ -69,6 +69,34 @@ def test_peers_renders_json_string_metadata(peers_response: Any) -> None:
     assert "2026-08-15" in result.output
 
 
+def test_peers_renders_hindsight_repr_metadata(peers_response: Any) -> None:
+    """The producer format: ``HindsightProvider.add`` stores metadata values
+    as ``str(v)``, so nested dicts arrive as Python reprs, not JSON."""
+    peers_response(
+        {
+            "items": [
+                {
+                    "id": "card-1",
+                    "metadata": {
+                        "agent_id": "hermes",
+                        "display_name": "Hermes",
+                        "roles": str(["orchestrator"]),
+                        "endpoint": str({"url": "http://10.0.1.142:8080"}),
+                        "hal0_state": str({"registered_at": "2026-08-15T00:00:00Z"}),
+                    },
+                }
+            ]
+        }
+    )
+
+    result = runner.invoke(agent_commands.app, ["peers"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    assert "10.0.1.142" in result.output
+    assert "2026-08-15" in result.output
+    assert "orchestrator" in result.output
+
+
 def test_peers_tolerates_unparseable_metadata(peers_response: Any) -> None:
     peers_response(
         {


### PR DESCRIPTION
Closes #1897

## What was wrong

On a fresh install the installer starts `hal0-api` and the hindsight daemon in the same pass, so hal0-api's terminal `brain_lane` boot phase always runs inside the memory degrade window: `create_app` has already handed every consumer the volatile in-memory `PgVectorProvider`, and the agent identity cards + boot self-report are accepted, warned about ("VOLATILE and will be LOST"), and dropped. The #1613 self-heal later swaps the durable engine in, but it cannot recover writes that engine never saw — so the durable `agents` bank did not exist until some unrelated `hal0-api` restart happened to re-run the lane against a healthy provider.

## Root cause

Deeper than "brain_lane runs too early": it is the missing half of the #1613 self-heal. `SelfHealingMemoryProvider.try_heal()` rebinds its delegate and tells nobody, so no caller that wrote through the volatile fallback can learn about the swap and re-issue. Any boot phase that writes during the degrade window loses its data, silently — the brain lane is simply the one that always does.

## What changed

- `src/hal0/memory/__init__.py` — `SelfHealingMemoryProvider` grows a replay contract: `add_heal_hook(hook)` (returns `False` when the provider has already healed, so the caller knows to replay itself) and `run_heal_hooks()`, a best-effort drain that runs each hook once. A hook that raises is logged and skipped.
- `src/hal0/api/__init__.py` — the re-probe loop moves out of a closure in `_boot_background_tasks` into a module-level `_memory_reprobe_loop(provider, interval_s)` that drains the heal hooks right after a successful swap (and is directly testable).
- `src/hal0/api/__init__.py` — `_boot_brain_lane(..., replay=False)`: when the provider is degraded on entry, it arms a one-shot replay of itself on the heal path. The three publishes are already idempotent (each searches + deletes its prior card before rewriting), so replaying is safe whether or not the first pass reached a durable engine. A heal that lands mid-phase — after the drain — replays inline instead. With a deliberate `[memory].engine = "pgvector"` (no self-heal shell) it logs `brain_lane.degraded_writes_volatile` instead, so the loss is no longer silent in the journal.
- `src/hal0/cli/agent_commands.py` — spin-off crash reported in the same issue: `hal0 agent peers` died with `AttributeError: 'str' object has no attribute 'get'` when a card's `hal0_state` (or `endpoint`) came back from the engine as a JSON string rather than a dict, taking the whole listing down. Nested metadata is now coerced tolerantly, and a non-list `roles` no longer renders one character per column cell.

## How it was verified

- `tests/api/test_boot_brain_lane_replay.py` (new): the degraded lane replays after heal; the replay does not re-arm; a healthy boot arms nothing; a mid-lane heal replays inline; the re-probe loop drains hooks after the swap; a raising hook does not break the drain. Verified red before the fix (with the arming disabled, `test_degraded_boot_lane_replays_after_provider_heals` and `test_lane_replays_inline_when_provider_healed_mid_lane` both fail), green after.
- `tests/cli/test_agent_peers_metadata.py` (new): both cases fail on `main` with the reported `AttributeError`, pass after.
- `uv run --extra dev pytest tests/api tests/cli tests/agents tests/memory tests/install` → **3761 passed, 2 skipped, 1 xfailed**.
- `uv run ruff check src tests` → clean. `uv run ruff format --check src tests` → 1146 files already formatted.

## Deliberately out of scope

- `#1834` (hindsight extraction sharing the utility slot) — the other half of why `hal0 agent peers` can read empty even once the bank exists. Untouched here.
- No `CHANGELOG.md` hunk, per the wave's consolidated-changelog rule (#1545).
- `tests/release-validation/regressions.yaml` left as-is; the register has no `fixed_in` convention and is owned by the validation kit.
- Replay is armed only for the brain lane. The hook mechanism is general, but no other boot phase writes to memory today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)