### PR TITLE
fix(bench): print no-records notice for empty history results

### DIFF
--- a/src/hal0/bench/cli.py
+++ b/src/hal0/bench/cli.py
@@ -548,6 +548,10 @@ def cmd_history(args: argparse.Namespace) -> int:
     rows = store.history(cell_key=args.cell, model=args.model, limit=args.limit)
     if args.json:
         print(json.dumps(rows, indent=2))
+    elif not rows:
+        # Same "empty table" vs. "nothing has ever run" ambiguity as
+        # cmd_results (#1796) — say so instead of printing nothing (#1904).
+        print("no records")
     else:
         for r in rows:
             print(f"  {r['ts']}  {r['model_id']:40s} {r['decode_ts_med']}")

--- a/tests/bench/test_cli_history.py
+++ b/tests/bench/test_cli_history.py
@@ -1,0 +1,27 @@
+"""`hal0 bench history` — empty-store output (#1904).
+
+Before this fix an empty query result (empty store, or a non-matching
+``--model``/``--cell`` filter on a populated store) printed nothing at all
+for the non-``--json`` path, indistinguishable from a hung/broken command.
+``cmd_results`` got this fix in #1807; ``cmd_history`` was missed.
+"""
+
+from __future__ import annotations
+
+from hal0.bench.cli import main
+
+
+def test_history_empty_prints_no_records(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    rc = main(["history"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no records" in out
+
+
+def test_history_empty_json_stays_empty_list(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    rc = main(["history", "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.strip() == "[]"


### PR DESCRIPTION
## What
`hal0 bench history` now prints `no records` at rc=0 when its query
matches no rows (empty store, or a non-matching `--model`/`--cell`
filter on a populated store), mirroring the sibling `cmd_results`
branch added by #1807. `--json` already correctly printed `[]` and is
unchanged.

## Why
Before this fix, an empty non-`--json` result printed zero bytes at
rc=0 — indistinguishable from a hung command. `cmd_results` got this
fix in #1807 for the same reason; `cmd_history` was missed.

## Verified
- New regression test `tests/bench/test_cli_history.py` (mirrors
  `test_cli_results.py`'s two empty-state cases): confirmed it fails
  against the pre-fix code (`assert 'no records' in ''`) and passes
  after the fix.
- `uv run pytest tests/bench/` — 387 passed.
- `make lint` — clean.
- `uv run ruff format --check` on changed files — clean.

## Out of scope
Nothing else touched; this is a one-line mirror of the existing
`cmd_results` empty-state branch plus its regression test.

Closes #1904