### PR TITLE
fix(ui): reconcile Inference Engine card free-memory with the ruler

### DIFF
--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -1229,6 +1229,12 @@ regressions:
     severity: minor
     tier: mechanical
     lane: ui
+    # Footer-vs-ruler-header basis + the vulkan-only hasGpu gate are covered in CI by the
+    # spec below (red without either half of the #1900 fix, verified by file-level revert).
+    # Entry deliberately RETAINED (not dropped per the usual promoted_to flow): the ruler
+    # BAR's free segment still derives from raw gtt_used (issue #1928), so an eyeball of the
+    # screen can still find two disagreeing "free" figures. Drop this entry when #1928 lands.
+    promoted_to: ui/tests/e2e/specs/inference-card-free-memory-v3.spec.ts
     summary: >-
       The Slots-page Inference Engine card footer computes free memory as
       `pool.totalGb - self.gttUsedGb` (inference-pane.jsx), and memory-map.jsx hard-zeroes

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -683,9 +683,15 @@ export function InferencePane() {
     return k === 'rocm' || k === 'vulkan'
   }).length
 
-  // GTT headroom for the slots status line (the memory map's frame).
+  // Free-memory headroom for the slots status line — MUST share the memory
+  // ruler's basis (telemetry-header.jsx ThRuler) so the two numbers on the
+  // same screen agree. `mm.self.modelUsedGb` is the reconciled per-slot sum
+  // (real mem_mb when the backend reports it) the ruler's "free" is derived
+  // from; `mm.self.gttUsedGb` is a raw host-wide GTT stat that (a) is zeroed
+  // outright on a box with no rocm-smi and (b) counts non-hal0 GPU users the
+  // ruler never counts — either way it disagreed with the ruler (#1900).
   const gttCapGb = mm.pool?.totalGb || 0
-  const gttFreeGb = Math.max(0, Math.round(gttCapGb - (mm.self?.gttUsedGb || 0)))
+  const gttFreeGb = Math.max(0, Math.round(gttCapGb - (mm.self?.modelUsedGb || 0)))
 
   // Fire-and-forget lifecycle action (mirrors SlotsView/PR #781): fire the
   // mutation, toast immediately, and let the slots poll reflect the phase.

--- a/ui/src/dash/memory-map.jsx
+++ b/ui/src/dash/memory-map.jsx
@@ -131,10 +131,12 @@ export function useMemoryMapModel() {
   // sees the host's DRM node (LXC shares the kernel's /sys/class/drm) even
   // when this container has no real GPU compute access, so an unqualified
   // "unified" memoryKind on a CPU-only box reported the host's ~116GB GTT
-  // ceiling as this box's own pool. `computeCapable` is the one probe field
-  // backed by an actual capability check (rocm-smi presence) — gate the
-  // GPU-pool framing on it and fall back to plain system RAM otherwise.
-  const hasGpu = !!rawHw.computeCapable
+  // ceiling as this box's own pool. `computeCapable` (rocm-smi presence) and
+  // `vulkanCapable` (a render node under /dev/dri) are the two probe fields
+  // backed by an actual capability check — gate the GPU-pool framing on
+  // EITHER (a box can be Vulkan-only with no ROCm stack, per #1900) and fall
+  // back to plain system RAM only when NEITHER reports a real GPU.
+  const hasGpu = !!(rawHw.computeCapable || rawHw.vulkanCapable)
   const ramTotalGb = rawHw.ram?.total ?? 0
   const gttCapGb = hasGpu ? mbToGb(stats.data?.gpu_vram_total_mb || stats.data?.gtt_total_mb || 0) : 0
   const unifiedFromProbe = hasGpu ? mbToGb(rawHw.unified_memory_mb || 0) : 0

--- a/ui/tests/e2e/specs/inference-card-free-memory-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-card-free-memory-v3.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * inference-card-free-memory-v3 — #1900 regression.
+ *
+ * The Slots-page Inference Engine card footer ("N serving · X GB free")
+ * and the page-level telemetry ruler ("memory · … free Y GB", same
+ * screen, telemetry-header.jsx ThRuler) MUST derive free memory from the
+ * same basis and agree within rounding — both figures come from
+ * useMemoryMapModel() (memory-map.jsx).
+ *
+ * Two ways the two numbers used to disagree, both covered here:
+ *   1. `inference-pane.jsx`'s footer subtracted `mm.self.gttUsedGb` (a raw
+ *      host-wide GTT stat) instead of `mm.self.modelUsedGb` (the reconciled
+ *      per-slot sum the ruler itself renders against) — wrong basis even
+ *      on a compute-capable (ROCm) box.
+ *   2. `memory-map.jsx` gated the whole GTT-pool framing on
+ *      `computeCapable` (rocm-smi presence) alone, so on a Vulkan-only box
+ *      (no ROCm stack, `vulkan_capable: true`) `hasGpu` was false: the pool
+ *      fell back to plain system RAM and `gttUsedGb` hard-zeroed — the
+ *      footer read free == the ENTIRE pool, ignoring every loaded model.
+ *
+ * The default mock host (mock-data.ts) IS a Vulkan-only box
+ * (`compute_capable: false, vulkan_capable: true`) with several loaded
+ * models carrying real `mem_mb` — the exact rc-validate repro shape.
+ */
+import { test, expect, json, type Page } from '../fixtures/apiMock'
+
+const footerFreeGb = async (page: Page) => {
+  const status = page.locator('.infer-pane .body-status')
+  // The GTT-cap-gated clause only appears once the hardware + stats queries
+  // land (mm.pool.totalGb > 0) — wait for it rather than racing the first
+  // "N serving" render.
+  await expect(status).toContainText(/GB free/)
+  const text = (await status.textContent()) || ''
+  const m = text.match(/([\d.]+)\s*GB free/)
+  expect(m, `footer must render "N GB free": "${text}"`).not.toBeNull()
+  return Number(m![1])
+}
+
+const rulerFreeGb = async (page: Page) => {
+  const ruler = page.getByTestId('telemetry-header').locator('.th-ruler-h')
+  await expect(ruler).toContainText(/free/)
+  const text = (await ruler.textContent()) || ''
+  const m = text.match(/free\s*([\d.]+)\s*GB/)
+  expect(m, `ruler must render "free N GB": "${text}"`).not.toBeNull()
+  return Number(m![1])
+}
+
+test.describe('Inference Engine card footer reconciles with the memory ruler (#1900)', () => {
+  test('vulkan-only box (no rocm-smi): footer free != the whole pool, agrees with the ruler', async ({
+    page,
+  }) => {
+    // Default mock host is already vulkan-only (compute_capable: false,
+    // vulkan_capable: true) with several loaded models — the rc-validate
+    // repro shape verbatim. No stats/hardware override needed: the bug
+    // reproduces off the plain default mock.
+    await page.goto('/#slots')
+    const footer = await footerFreeGb(page)
+    const ruler = await rulerFreeGb(page)
+    // Must reflect the loaded models, not the whole pool — several are
+    // loaded and mem_mb-attributed (mock-data.ts), so free must be
+    // meaningfully below the pool total (previously footer == total,
+    // ignoring every loaded model entirely).
+    expect(footer).toBeLessThan(120)
+    // Same basis → agree within 1 GB (footer rounds to whole GB, ruler to
+    // one decimal).
+    expect(Math.abs(footer - ruler)).toBeLessThanOrEqual(1)
+  })
+
+  test('rocm box: footer free matches the ruler, not the raw host-wide GTT stat', async ({
+    page,
+  }) => {
+    // ROCm-capable box where the host-wide gtt_used_mb (all GPU processes)
+    // diverges sharply from the reconciled per-slot mem_mb sum the ruler
+    // uses — the ct105-prod ~30 GB mismatch from the issue.
+    await page.route('**/api/stats/hardware', (route) =>
+      json(route, {
+        ram_total_mb: 131_072,
+        ram_used_mb: 100_000,
+        ram_available_mb: 31_072,
+        gpu_vram_total_mb: 107_520,
+        gtt_used_mb: 90_000, // host-wide — far above the loaded-model sum
+        vram_used_mb: 0,
+        npu_status: { ok: true, model_mb: 1100 },
+        host: { configured: false, detected: false },
+      }),
+    )
+    await page.addInitScript(() => {
+      let stored: any = undefined
+      Object.defineProperty(window, 'HAL0_DATA', {
+        set(v: any) {
+          stored = {
+            ...v,
+            host: {
+              ...v.host,
+              gpus: [{ ...(v.host?.gpus?.[0] || {}), compute_capable: true, vulkan_capable: true }],
+            },
+          }
+        },
+        get() {
+          return stored
+        },
+        configurable: true,
+      })
+    })
+    await page.goto('/#slots')
+    const footer = await footerFreeGb(page)
+    const ruler = await rulerFreeGb(page)
+    expect(Math.abs(footer - ruler)).toBeLessThanOrEqual(1)
+  })
+})

--- a/ui/tests/e2e/specs/inference-card-free-memory-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-card-free-memory-v3.spec.ts
@@ -18,11 +18,30 @@
  *      fell back to plain system RAM and `gttUsedGb` hard-zeroed — the
  *      footer read free == the ENTIRE pool, ignoring every loaded model.
  *
- * The default mock host (mock-data.ts) IS a Vulkan-only box
- * (`compute_capable: false, vulkan_capable: true`) with several loaded
- * models carrying real `mem_mb` — the exact rc-validate repro shape.
+ * Mock plumbing note (why the tests are shaped this way): the γ-suite runs
+ * forced-mock (VITE_MOCK_HAL0=1), and `/api/hardware` is a non-networkFirst
+ * MOCK_ALLOWLIST row (src/api/mock.ts) — it is substituted from
+ * `window.HAL0_DATA.host` (data.jsx seed: compute_capable AND
+ * vulkan_capable both true) BEFORE any fetch is issued, so a plain
+ * `page.route('**' + '/api/hardware')` override never fires. To actually
+ * drive the hardware shape a test must either claim the path via the
+ * `__hal0MockPassthrough` escape hatch (#1498/#1527) and then route it, or
+ * rewrite `window.HAL0_DATA` itself before the app boots. Test 1 uses the
+ * passthrough; test 2 uses a HAL0_DATA setter shim. `/api/stats/hardware`
+ * is NOT allowlisted, so plain routes work for it.
+ *
+ * Once the footer fix is in, footer and `.th-ruler-h` agree BY
+ * CONSTRUCTION (both are pool.totalGb - self.modelUsedGb off one hook), so
+ * an agreement assertion alone can never detect a `hasGpu` regression. The
+ * observable symptom of that half is the POOL BASIS — "GPU pool (GTT)"
+ * framing vs a silent fallback to system RAM — which test 1 asserts
+ * directly.
  */
 import { test, expect, json, type Page } from '../fixtures/apiMock'
+
+// Fixture-derived pool ceiling both tests drive via /api/stats/hardware.
+const GPU_POOL_TOTAL_MB = 107_520
+const GPU_POOL_TOTAL_GB = GPU_POOL_TOTAL_MB / 1024 // 105
 
 const footerFreeGb = async (page: Page) => {
   const status = page.locator('.infer-pane .body-status')
@@ -36,8 +55,11 @@ const footerFreeGb = async (page: Page) => {
   return Number(m![1])
 }
 
+const rulerLocator = (page: Page) =>
+  page.getByTestId('telemetry-header').locator('.th-ruler-h')
+
 const rulerFreeGb = async (page: Page) => {
-  const ruler = page.getByTestId('telemetry-header').locator('.th-ruler-h')
+  const ruler = rulerLocator(page)
   await expect(ruler).toContainText(/free/)
   const text = (await ruler.textContent()) || ''
   const m = text.match(/free\s*([\d.]+)\s*GB/)
@@ -46,44 +68,80 @@ const rulerFreeGb = async (page: Page) => {
 }
 
 test.describe('Inference Engine card footer reconciles with the memory ruler (#1900)', () => {
-  test('vulkan-only box (no rocm-smi): footer free != the whole pool, agrees with the ruler', async ({
+  test('vulkan-only box (no rocm-smi): GTT pool framing survives, footer agrees with the ruler', async ({
     page,
   }) => {
-    // Default mock host is already vulkan-only (compute_capable: false,
-    // vulkan_capable: true) with several loaded models — the rc-validate
-    // repro shape verbatim. No stats/hardware override needed: the bug
-    // reproduces off the plain default mock.
+    // A genuinely Vulkan-only host (compute_capable: false) — the
+    // rc-validate repro shape. The default forced-mock seed is NOT this
+    // box (it is compute+vulkan capable), so claim /api/hardware via the
+    // passthrough escape hatch and drive it ourselves.
+    await page.addInitScript(() => {
+      ;(window as any).__hal0MockPassthrough = ['/api/hardware']
+    })
+    await page.route('**/api/hardware', (route) =>
+      json(route, {
+        ram_total_mb: 96_000,
+        unified_memory_mb: 131_072,
+        gtt_total_mb: GPU_POOL_TOTAL_MB,
+        memory_kind: 'unified',
+        gpus: [
+          {
+            vendor: 'amd',
+            compute_capable: false,
+            vulkan_capable: true,
+            vram_mb: 81_920,
+          },
+        ],
+        npu: { present: false },
+      }),
+    )
+    await page.route('**/api/stats/hardware', (route) =>
+      json(route, {
+        ram_total_mb: 96_000,
+        gpu_vram_total_mb: GPU_POOL_TOTAL_MB,
+        gtt_used_mb: 40_000, // host-wide GTT — real, non-zero on a vulkan box
+        host: { configured: false, detected: false },
+      }),
+    )
     await page.goto('/#slots')
+    // Pool-basis assertion — the ONLY observable that catches a `hasGpu`
+    // regression (see header note). Pre-fix, vulkan-only ⇒ hasGpu false ⇒
+    // pool silently falls back to system RAM and the ruler reads
+    // "memory · system …" with gttUsedGb hard-zeroed.
+    await expect(rulerLocator(page)).toContainText('GPU pool (GTT)')
     const footer = await footerFreeGb(page)
     const ruler = await rulerFreeGb(page)
-    // Must reflect the loaded models, not the whole pool — several are
-    // loaded and mem_mb-attributed (mock-data.ts), so free must be
-    // meaningfully below the pool total (previously footer == total,
-    // ignoring every loaded model entirely).
-    expect(footer).toBeLessThan(120)
+    // Loaded models must be subtracted: free strictly below the pool
+    // ceiling (fixture-derived, not a magic constant).
+    expect(footer).toBeLessThan(GPU_POOL_TOTAL_GB)
     // Same basis → agree within 1 GB (footer rounds to whole GB, ruler to
     // one decimal).
     expect(Math.abs(footer - ruler)).toBeLessThanOrEqual(1)
   })
 
-  test('rocm box: footer free matches the ruler, not the raw host-wide GTT stat', async ({
+  test('rocm-only box: footer free matches the ruler, not the raw host-wide GTT stat', async ({
     page,
   }) => {
-    // ROCm-capable box where the host-wide gtt_used_mb (all GPU processes)
-    // diverges sharply from the reconciled per-slot mem_mb sum the ruler
-    // uses — the ct105-prod ~30 GB mismatch from the issue.
+    // ROCm-only box (vulkan_capable: false — a real contrast to test 1,
+    // not a restatement of the seed) where the host-wide gtt_used_mb (all
+    // GPU processes) diverges sharply from the reconciled per-slot mem_mb
+    // sum the ruler uses — the ct105-prod ~30 GB mismatch from the issue.
+    // /api/stats/hardware is not allowlisted, so this route IS effective.
     await page.route('**/api/stats/hardware', (route) =>
       json(route, {
         ram_total_mb: 131_072,
         ram_used_mb: 100_000,
         ram_available_mb: 31_072,
-        gpu_vram_total_mb: 107_520,
+        gpu_vram_total_mb: GPU_POOL_TOTAL_MB,
         gtt_used_mb: 90_000, // host-wide — far above the loaded-model sum
         vram_used_mb: 0,
         npu_status: { ok: true, model_mb: 1100 },
         host: { configured: false, detected: false },
       }),
     )
+    // /api/hardware IS allowlisted (forced-mock substitutes it from
+    // window.HAL0_DATA before any fetch), so shape the box by shimming the
+    // HAL0_DATA seed itself rather than routing the request.
     await page.addInitScript(() => {
       let stored: any = undefined
       Object.defineProperty(window, 'HAL0_DATA', {
@@ -92,7 +150,13 @@ test.describe('Inference Engine card footer reconciles with the memory ruler (#1
             ...v,
             host: {
               ...v.host,
-              gpus: [{ ...(v.host?.gpus?.[0] || {}), compute_capable: true, vulkan_capable: true }],
+              gpus: [
+                {
+                  ...(v.host?.gpus?.[0] || {}),
+                  compute_capable: true,
+                  vulkan_capable: false,
+                },
+              ],
             },
           }
         },
@@ -103,6 +167,9 @@ test.describe('Inference Engine card footer reconciles with the memory ruler (#1
       })
     })
     await page.goto('/#slots')
+    // ROCm-only must keep the GPU-pool framing too (computeCapable alone
+    // satisfies the widened gate).
+    await expect(rulerLocator(page)).toContainText('GPU pool (GTT)')
     const footer = await footerFreeGb(page)
     const ruler = await rulerFreeGb(page)
     expect(Math.abs(footer - ruler)).toBeLessThanOrEqual(1)


### PR DESCRIPTION
## Summary

The Slots-page Inference Engine card footer ("N serving · X GB free") and the page-level memory ruler (telemetry-header.jsx `ThRuler`) disagreed on free memory — sometimes wildly (footer reading the entire pool free while every loaded model held real memory).

**Root cause, two layers:**

1. `inference-pane.jsx`'s footer computed free memory as `pool.totalGb - self.gttUsedGb`. `gttUsedGb` is a raw host-wide GTT usage stat (every process on the GPU), while the ruler derives its "free" from `self.modelUsedGb` — the reconciled per-slot sum of real `mem_mb`. Different basis → the two numbers on one screen disagreed (~30GB apart on ct105-prod/ROCm).
2. `memory-map.jsx` gated the entire GTT-pool framing (pool size, `gttUsedGb`, `npuModelGb`) on `computeCapable` alone — which only checks for `rocm-smi`. A Vulkan-only box (no ROCm stack, `vulkan_capable: true`) has a real GPU and real GTT usage, but `computeCapable` is false there, so the pool fell back to plain system RAM and `gttUsedGb` hard-zeroed. Combined with (1), the footer read free == the entire pool on any box without `rocm-smi`, ignoring every loaded model (ct151-cpu-fresh in the issue).

**Fix:**
- `inference-pane.jsx`: footer's free-memory figure now uses `mm.self.modelUsedGb` — the exact basis the ruler already renders against — instead of `mm.self.gttUsedGb`.
- `memory-map.jsx`: `hasGpu` now gates on `computeCapable || vulkanCapable`, so a Vulkan-only box gets its real GTT/unified pool and per-slot GTT usage instead of the CPU-only RAM fallback.

## Basis semantics — a stated choice

The footer now uses `pool.totalGb - modelUsedGb`: the **optimistic** basis (excludes KV/runtime/other-process GTT beyond the per-slot `mem_mb` contract). This matches the ruler header AND `headroom.availableGb` (`unifiedGb - modelUsedGb - SAFETY_MARGIN`), so three of the four free/headroom figures on the screen now share one basis. The remaining outlier is the ruler **bar**'s free segment (`total - gttUsedGb`, conservative) — pre-existing, filed as **#1928** and linked from #1900 and the `ui-inference-card-free-memory-wrong` register entry so that entry is not closed while the screen can still show two "free" values. `gttFreeGb` is display-only (`inference-pane.jsx`); it gates no load decision.

## Intended side effects of the `hasGpu` widening (legacy no-`mem_mb` path)

On a Vulkan-only box whose backend does not yet report per-slot `mem_mb`, widening `hasGpu` also (a) lets `attributeFallback` split the now-non-zero `gttUsedGb` across GPU slots (segments render where they previously showed 0 — this also populates `MemoryHeroCard`'s allocation bar via `mm.self.slots`), and (b) restores `selfShareGb = ramUsedGb + gttUsedGb + npuModelGb` in the Proxmox host block instead of `ramUsedGb` alone. **Both are intended**: they are exactly the pre-#1797(3) behavior for any box with a real GPU, and a Vulkan-only box has one — GTT stats come from amdgpu sysfs (`gpu_view.sample()`), not `rocm-smi`, so the figures are real there. The zeroed variants were the bug, not the baseline.

## Test plan

- New e2e spec `ui/tests/e2e/specs/inference-card-free-memory-v3.spec.ts` (rewritten after review — the first version's "the default mock host is Vulkan-only" premise was false under forced-mock):
  - **Vulkan-only box**: claims `/api/hardware` via the `__hal0MockPassthrough` escape hatch (#1498/#1527) and routes a `compute_capable: false, vulkan_capable: true` host + live stats with non-zero `gtt_used_mb`. Asserts the pool **basis** (`GPU pool (GTT)` in `.th-ruler-h`) — the only observable that can catch a `hasGpu` regression once footer and ruler share one derivation — plus footer < fixture-derived pool ceiling and footer/ruler agreement within 1 GB.
  - **ROCm-only box**: `HAL0_DATA` setter shim with `compute_capable: true, vulkan_capable: false` (a genuine contrast, not a restatement of the seed) + a host-wide `gtt_used_mb` far above the slot sum. Asserts GTT-pool framing and footer/ruler agreement.
- **Red/green verified per half by file-level revert** at this head:
  - `git checkout main -- ui/src/dash/memory-map.jsx` → test 1 fails: `Received: "memory · system model 23.1 GB · free 70.7 GB …"` (pool basis lost).
  - `git checkout main -- ui/src/dash/inference-pane.jsx` → both fail on footer/ruler disagreement (`Received: 15.9` / `Received: 64.9`).
- [x] `npm run typecheck` — clean
- [x] `npx playwright test inference-card-free-memory-v3 system-card telemetry memory-map` — 7 passed
- [x] `make lint`, `uv run ruff format --check src tests`, `scripts/check_sunset.py` — clean

## Register

`tests/release-validation/regressions.yaml`: `ui-inference-card-free-memory-wrong` gets `promoted_to:` pointing at the spec. The entry is deliberately retained (not dropped) until #1928 lands, so a validator eyeballing the bar does not re-file the residual mismatch as new.

## Out of scope / follow-ups

- **#1928** — ruler header vs bar "free" basis mismatch (pre-existing; relocated-not-removed disagreement from review blocker 3).
- **#1929** — dead fallback keys `stats.gtt_total_mb` / `rawHw.unified_memory_mb` in the pool-total derivation (Codex comment 2; fixing them repoints the default-mock pool total and needs its own spec sweep).
- The `computeCapable`-only gate exists in several other places (`dashboard.jsx`, `dashboard-redesign.jsx`, `OverviewPage.jsx`, `HardwareRuntimesPage.jsx`) — outside this issue's blast radius.

Closes #1900