### PR TITLE
fix(providers): catch httpx.TransportError in container health probe

### DIFF
--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -2203,8 +2203,19 @@ class ContainerProvider(Provider):
                     "ok": ok,
                     "status": "healthy" if ok else f"http_{models_resp.status_code}",
                 }
-        except (httpx.ConnectError, httpx.TimeoutException) as exc:
-            return {"ok": False, "status": str(exc)}
+        except httpx.TransportError as exc:
+            # TransportError is the base class for ConnectError,
+            # TimeoutException, ReadError, WriteError, etc. — every failure
+            # mode where the connection dies without producing an HTTP
+            # response (#1898: a runner that binds its port and then dies
+            # mid-read raises ReadError, whose str() is empty; that escaped
+            # the old narrow (ConnectError, TimeoutException) catch as an
+            # unhandled exception, abandoning wait_ready()'s poll loop after
+            # a single strike instead of reporting "unhealthy" and retrying
+            # for the full window). status falls back to the exception's
+            # class name so metadata.message is never empty even when
+            # str(exc) is "".
+            return {"ok": False, "status": str(exc) or type(exc).__name__}
 
     async def wait_ready(self, port: int) -> None:
         """Poll /health until 200 or HEALTH_TIMEOUT_S exceeded.

--- a/tests/providers/test_container_npu.py
+++ b/tests/providers/test_container_npu.py
@@ -302,6 +302,32 @@ async def test_health_connect_refused_stays_unhealthy() -> None:
 
 
 @pytest.mark.anyio
+async def test_health_read_error_stays_unhealthy() -> None:
+    """A mid-read RST (httpx.ReadError, str()=="") must not escape health() as
+    an unhandled exception (#1898). A runner that binds its port and then
+    dies mid-read raises ReadError, which sat outside the narrow
+    (ConnectError, TimeoutException) catch — that unhandled exception
+    aborted the caller's poll loop instead of reporting "unhealthy" for the
+    next retry."""
+    import httpx
+
+    provider = ContainerProvider()
+
+    async def fake_get(url: str, **kwargs: Any) -> MagicMock:
+        raise httpx.ReadError("")
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = fake_get
+
+    with patch("hal0.providers.container.httpx.AsyncClient", return_value=mock_client):
+        result = await provider.health(8088)
+
+    assert result["ok"] is False
+
+
+@pytest.mark.anyio
 async def test_health_200_on_health_still_healthy() -> None:
     """Existing /health→200 path still works (GPU slots use it)."""
     provider = ContainerProvider()


### PR DESCRIPTION
## Summary

`ContainerProvider.health()` (`src/hal0/providers/container.py`) caught only
`(httpx.ConnectError, httpx.TimeoutException)`. A runner that binds its port
and then dies mid-read raises `httpx.ReadError` (`str()` is `""`), which sat
outside that narrow catch and escaped `health()` as an unhandled exception.

That propagated through three layers, matching the exact symptoms in #1898:

1. `wait_ready()`'s poll loop calls `self.health(port)` unguarded — the
   unhandled `ReadError` aborts the loop on the first strike instead of
   continuing to poll for the full `_HEALTH_TIMEOUT_S` (~180s) window, so the
   load dies at ~7s.
2. `SlotManager.load()`'s outer `except Exception as exc: ... message=str(exc)`
   then stamps the slot `ERROR` with an **empty** `metadata.message`, since
   `str(ReadError(""))` is `""` — the `still_report_if` clause of the known
   `crash-loop-warming-180s-window` entry.
3. The same unguarded probe sits on the dispatch hot path
   (`SlotWatchdog.readiness_check` → `Dispatcher._check_container_slot_ready`).
   `readiness_check`'s second probe (`container_provider().health(port, cfg)`)
   is not wrapped in its own try/except (unlike the sibling `is_healthy`
   method just above it, which already catches broadly) — an unhandled
   `ReadError` there would bubble out of `_check_container_slot_ready` as a
   raw 500 instead of the documented retryable `slot.loading` 503.

## Root cause

The root cause is entirely in `ContainerProvider.health()`'s exception
handling — every downstream site (`load()`'s outer except, `readiness_check`'s
sibling probe, `is_healthy`) is already written to defensively catch broadly.
They only misbehave because `health()` itself leaks a transport error instead
of converting it to `{"ok": False, ...}`. Fixing the single narrow `except`
clause resolves all three symptoms without touching `manager.py`, `router.py`,
or `watchdog.py` — no broadening of blast radius needed beyond the one method.

## Fix

- Catch `httpx.TransportError` instead of the two named subclasses — the
  base class covering `ConnectError`, `TimeoutException`, `ReadError`,
  `WriteError`, and every other failure mode where the connection dies
  without producing an HTTP response.
- Fall back to the exception's class name (`type(exc).__name__`) when
  `str(exc)` is empty, so the returned `status` (and therefore any
  downstream `metadata.message`) is never blank.

## Test

Added `test_health_read_error_stays_unhealthy` beside the existing
`test_health_connect_refused_stays_unhealthy` in
`tests/providers/test_container_npu.py` — mocks the client's `GET` to raise
`httpx.ReadError("")` and asserts `health()` returns `{"ok": False, ...}`
instead of letting the exception propagate. Confirmed it fails on `main`
(pre-fix) and passes after the one-line `except` change.

## Verified

- `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/providers/test_container_npu.py tests/providers/test_container_health_gating.py tests/providers/test_container.py tests/slots/ tests/dispatcher/ -q` → 1207 passed
- `uv run ruff check src/hal0/providers/container.py tests/providers/test_container_npu.py` → all checks passed
- `uv run ruff format --check src/hal0/providers/container.py tests/providers/test_container_npu.py` → already formatted

(A full-repo `pytest -q` was also kicked off but the box was under heavy
contention from several other parallel fix-wave worktrees running full
suites simultaneously at the same time; the scoped run above covers every
module touched by this change plus their direct dependents.)

## Out of scope

- Did not touch `CHANGELOG.md` (per fix-wave process — consolidated at the
  end of the wave).
- Did not add defensive try/except wrapping in `watchdog.py`'s
  `readiness_check` or `router.py`'s `_check_container_slot_ready` — those
  are the *symptom* sites and are already written correctly to trust that
  `health()` never raises; the fix belongs in `health()` itself.

Closes #1898