### PR TITLE
docs(mcp): fix bare mount URLs and enumerate every MCP tool

### DIFF
--- a/docs/guides/connect-mcp.mdx
+++ b/docs/guides/connect-mcp.mdx
@@ -67,11 +67,12 @@ or behind your own reverse proxy — do not expose `/mcp/*` to the internet.
 
 ### Connect
 
-Point your MCP client at the mount URL on the hal0 host:
+Point your MCP client at the Streamable-HTTP endpoint on the hal0 host — the
+mount root itself 405s (no redirect); the working path always ends in `/mcp`:
 
 ```
-http://localhost:8080/mcp/admin
-http://localhost:8080/mcp/memory
+http://localhost:8080/mcp/admin/mcp
+http://localhost:8080/mcp/memory/mcp
 ```
 
 ### Authenticate

--- a/docs/reference/mcp-tools.mdx
+++ b/docs/reference/mcp-tools.mdx
@@ -33,6 +33,11 @@ Tools fall into three gating tiers. Treat the frozensets in source
 (`AUTONOMOUS_READ_TOOLS`, `AUTONOMOUS_WRITE_TOOLS`, `GATED_TOOLS`) as ground truth if
 this table drifts.
 
+Full argument schemas are not reproduced per tool here — the REST route each
+tool passes through documents its own body/query shape; hand-authored
+overrides for the handful that don't map 1:1 onto their route live in
+`TOOL_PARAM_HINTS` in source.
+
 ### Autonomous — read (no approval)
 
 | Tool | REST route |
@@ -45,7 +50,6 @@ this table drifts.
 | `slot_by_id` | `GET /api/slots/by-id/{slot_id}` |
 | `slot_resolved` | `GET /api/slots/{name}/resolved` |
 | `slot_state` | `GET /api/slots/{name}/state` |
-| `port_list` | `GET /api/ports` |
 | `model_list` | `GET /api/models` |
 | `model_show` | `GET /api/models/{model_id}` |
 | `model_scan_preview` | `POST /api/models/scan/preview` |
@@ -53,16 +57,15 @@ this table drifts.
 | `model_update_check` | `GET /api/models/updates/check` |
 | `model_pulls_list` | `GET /api/models/pulls` |
 | `model_pull_status` | `GET /api/models/{model_id}/pull/status` |
-| `model_inspect` | `POST /api/models/inspect` — args: `hf_repo` (`org/name`) or `hf_url` |
+| `model_inspect` | `POST /api/models/inspect` |
 | `model_store` | `GET /api/settings/models/store` |
 | `hardware_probe` | `GET /api/stats/hardware` |
 | `system_info` | `GET /api/system-info` |
+| `port_list` | `GET /api/ports` |
 | `capability_list` | `GET /api/capabilities` |
 | `provider_list` | `GET /api/providers` |
 | `version_info` | `GET /api/status` |
 | `upstream_list` | `GET /api/upstreams` |
-| `upstream_get` | `GET /api/upstreams/{name}` |
-| `upstream_test` | `POST /api/upstreams/{name}/test` |
 | `stack_list` | `GET /api/stacks` |
 | `stack_status` | `GET /api/stacks/{slug}` |
 | `profile_list` | `GET /api/profiles` |
@@ -78,64 +81,135 @@ this table drifts.
 | `npu_status` | in-process host probe |
 | `env_report` | in-process host probe |
 | `model_store_probe` | in-process host probe — arg: `path` (required) |
-| `memory_search`, `memory_list`, `memory_recall` | delegate to `hal0-memory` — see below |
+| `upstream_get` | `GET /api/upstreams/{name}` |
+| `upstream_test` | `POST /api/upstreams/{name}/test` |
+| `service_list` | `GET /api/services` |
+| `service_health` | `GET /api/services/health` |
+| `comfyui_status` | `GET /api/comfyui/status` |
+| `comfyui_workflows` | `GET /api/comfyui/workflows` |
+| `updater_state` | `GET /api/updates/state` |
+| `updater_check` | `GET /api/updates/check` |
+| `updater_channel_get` | `GET /api/updates/channel` |
+| `updater_slot_drift` | `GET /api/updates/slot-drift` |
+| `updater_job_status` | `GET /api/updates/status/{job_id}` |
+| `doctor_report` | `GET /api/doctor` |
+| `health_system` | `GET /api/health/system` |
+| `feature_list` | `GET /api/features` |
+| `metrics_snapshot` | `GET /api/metrics` |
+| `hardware_snapshot` | `GET /api/hardware` |
+| `slot_stats` | `GET /api/stats/slots` |
+| `stats_overview` | `GET /api/stats` |
+| `request_metrics` | `GET /api/stats/requests` |
+| `system_stats` | `GET /api/system-stats` |
+| `power_stats` | `GET /api/stats/power` |
+| `throughput_history` | `GET /api/stats/throughput/history` |
+| `npu_occupancy` | `GET /api/npu/occupancy` |
+| `npu_swap_status` | `GET /api/npu/swap-status` |
+| `model_health_check` | `GET /api/models/health` |
+| `slot_config` | `GET /api/slots/{name}/config` |
+| `slot_voices` | `GET /api/slots/{name}/voices` |
+| `flm_model_list` | `GET /api/slots/flm/models` |
+| `slot_pull_status` | `GET /api/slots/{name}/pull/status` |
+| `model_validate` | `POST /api/models/validate` |
+| `hf_search` | `GET /api/hf/search` |
+| `model_config_read` | `GET /api/config/models` |
+| `bench_roster` | `GET /api/benchmarks/roster` |
+| `bench_plan` | `GET /api/benchmarks/plan` |
+| `bench_cells` | `GET /api/benchmarks/cells` |
+| `bench_history` | `GET /api/benchmarks/history` |
+| `bench_evals` | `GET /api/benchmarks/evals` |
+| `journal_snapshot` | `GET /api/journal` |
+| `activity_list` | `GET /api/activity` |
+| `activity_export` | `GET /api/activity/export` |
+| `approval_list` | `GET /api/agent/approvals` |
+| `runner_image_list` | `GET /api/runner-images` |
+| `runner_image_downloaded` | `GET /api/runner-images/downloaded` |
+| `runner_image_pulls` | `GET /api/runner-images/pulls/list` |
+| `backend_list` | `GET /api/backends` |
+| `backend_detail` | `GET /api/backends/{backend_id}` |
+| `mcp_server_list` | `GET /api/mcp/servers` |
+| `mcp_client_list` | `GET /api/mcp/clients` |
+| `mcp_catalog` | `GET /api/mcp/catalog` |
+| `profile_generate` | `POST /api/profiles/generate` |
+| `memory_search`, `memory_list`, `memory_recall`, `memory_reflect`, `memory_history`, `memory_mental_model_list`, `memory_mental_model_get`, `memory_directive_list`, `memory_directive_get`, `memory_operation_list`, `memory_operation_get`, `memory_tags_list`, `memory_bank_stats` | delegate to `hal0-memory` — see below |
 
 ### Autonomous — write (no approval; reversible, low blast radius)
 
-| Tool | REST route | Args |
-|---|---|---|
-| `model_swap` | `POST /api/slots/{name}/swap` | `name` (path), `model_id` (required) |
-| `model_assign` | `PUT /api/slots/{name}/config` | `name` (path), `model` (required) |
-| `model_edit` | `PUT /api/models/{model_id}` | — |
-| `model_scan` | `POST /api/models/scan` | `prune` (optional bool) |
-| `model_pull_cancel` | `POST /api/models/{model_id}/pull/cancel` | — |
-| `model_pull_delete` | `DELETE /api/models/pulls/{model_id}` | — |
-| `model_set_default` | `POST /api/models/{model_id}/default` | `model_id`, `default` (bool, default `true`) |
-| `slot_load` | `POST /api/slots/{name}/load` | — |
-| `slot_unload` | `POST /api/slots/{name}/unload` | — |
-| `slot_edit` | `PUT /api/slots/{name}/config` | — |
-| `slot_set_defaults` | `PATCH /api/slots/{name}/defaults` | — |
-| `settings_reload` | `POST /api/settings/reload` | — |
-| `memory_add` | delegates to `hal0-memory` | — |
-| `memory_delete` | delegates to `hal0-memory` — gates itself when deleting more than one id, or a foreign/list dataset | — |
+| Tool | REST route |
+|---|---|
+| `model_swap` | `POST /api/slots/{name}/swap` |
+| `model_assign` | `PUT /api/slots/{name}/config` |
+| `model_edit` | `PUT /api/models/{model_id}` |
+| `model_scan` | `POST /api/models/scan` |
+| `model_pull_cancel` | `POST /api/models/{model_id}/pull/cancel` |
+| `model_pull_delete` | `DELETE /api/models/pulls/{model_id}` |
+| `model_set_default` | `POST /api/models/{model_id}/default` |
+| `slot_load` | `POST /api/slots/{name}/load` |
+| `slot_unload` | `POST /api/slots/{name}/unload` |
+| `slot_edit` | `PUT /api/slots/{name}/config` |
+| `slot_set_defaults` | `PATCH /api/slots/{name}/defaults` |
+| `settings_reload` | `POST /api/settings/reload` |
+| `hardware_reprobe` | `POST /api/hardware/probe` |
+| `memory_add`, `memory_curate`, `memory_mental_model_create`, `memory_mental_model_update`, `memory_mental_model_refresh`, `memory_directive_create`, `memory_directive_update`, `memory_operation_cancel`, `memory_operation_retry`, `memory_bank_consolidate` | delegate to `hal0-memory` — see below |
+| `memory_delete` | delegates to `hal0-memory` — gates itself when deleting more than one id, or a foreign/list dataset |
 
 ### Gated (destructive — require operator approval)
 
-| Tool | REST route | Args |
-|---|---|---|
-| `model_pull` | `POST /api/models/{model_id}/pull` | `model_id` (local, no slashes), `hf_repo`, `hf_filename`, `mmproj_filename` |
-| `model_delete` | `DELETE /api/models/{model_id}` | — |
-| `model_register` | `POST /api/models` | — |
-| `model_add` | `POST /api/models/add-from-path` | — |
-| `model_store_set` | `POST /api/settings/models/store` | — |
-| `model_store_migrate` | `POST /api/settings/models/store/migrate` | — |
-| `model_update` | `POST /api/models/{model_id}/update` | — |
-| `slot_create` | `POST /api/slots` | `name`, `model` (required), `type`, `port`, `image`, `runtime` |
-| `slot_delete` | `DELETE /api/slots/{name}` | — |
-| `slot_restart` | `POST /api/slots/{name}/restart` | — |
-| `slot_rename` | `POST /api/slots/{name}/rename` | `name` (current), `new_name` (required) |
-| `capability_set` | `POST /api/capabilities/{slot}/{child}` | — |
-| `config_write` | `PUT /api/settings` | — |
-| `provider_credential_write` | `POST /api/providers/{name}/credentials` | — |
-| `stack_create` | `POST /api/stacks` | — |
-| `stack_update` | `PUT /api/stacks/{slug}` | — |
-| `stack_apply` | `POST /api/stacks/{slug}/apply` | — |
-| `stack_import` | `POST /api/stacks/import` | — |
-| `stack_export` | `POST /api/stacks/{slug}/export` | — |
-| `stack_snapshot` | `POST /api/stacks/snapshot` | — |
-| `stack_delete` | `DELETE /api/stacks/{slug}` | — |
-| `profile_create` | `POST /api/profiles` | — |
-| `profile_update` | `PUT /api/profiles/{name}` | — |
-| `profile_import` | `POST /api/profiles/import` | — |
-| `profile_delete` | `DELETE /api/profiles/{name}` | — |
-| `bench_enqueue` | `POST /api/benchmarks/queue` | — |
-| `bench_control` | `POST /api/benchmarks/control` | — |
-| `bench_queue_delete` | `DELETE /api/benchmarks/queue/{item_id}` | — |
-| `logs_tail` | `GET /api/logs` | output is secret-redacted |
-| `slot_logs` | `GET /api/slots/{name}/logs` | output is secret-redacted |
-| `upstream_create` | `POST /api/upstreams` | `name` (required), `catalog_id`, `url`, `auth_value_env` |
-| `upstream_update` | `PATCH /api/upstreams/{name}` | `name`, `enabled`, `advertise_models`, `model_filters` |
-| `upstream_delete` | `DELETE /api/upstreams/{name}` | — |
+| Tool | REST route |
+|---|---|
+| `model_pull` | `POST /api/models/{model_id}/pull` |
+| `model_delete` | `DELETE /api/models/{model_id}` |
+| `model_register` | `POST /api/models` |
+| `model_add` | `POST /api/models/add-from-path` |
+| `model_store_set` | `POST /api/settings/models/store` |
+| `model_store_migrate` | `POST /api/settings/models/store/migrate` |
+| `model_update` | `POST /api/models/{model_id}/update` |
+| `slot_create` | `POST /api/slots` |
+| `slot_delete` | `DELETE /api/slots/{name}` |
+| `slot_restart` | `POST /api/slots/{name}/restart` |
+| `slot_rename` | `POST /api/slots/{name}/rename` |
+| `capability_set` | `POST /api/capabilities/{slot}/{child}` |
+| `config_write` | `PUT /api/settings` |
+| `provider_credential_write` | `POST /api/providers/{name}/credentials` |
+| `stack_create` | `POST /api/stacks` |
+| `stack_update` | `PUT /api/stacks/{slug}` |
+| `stack_apply` | `POST /api/stacks/{slug}/apply` |
+| `stack_import` | `POST /api/stacks/import` |
+| `stack_export` | `POST /api/stacks/{slug}/export` |
+| `stack_snapshot` | `POST /api/stacks/snapshot` |
+| `stack_delete` | `DELETE /api/stacks/{slug}` |
+| `profile_create` | `POST /api/profiles` |
+| `profile_update` | `PUT /api/profiles/{name}` |
+| `profile_import` | `POST /api/profiles/import` |
+| `profile_delete` | `DELETE /api/profiles/{name}` |
+| `bench_enqueue` | `POST /api/benchmarks/queue` |
+| `bench_control` | `POST /api/benchmarks/control` |
+| `bench_queue_delete` | `DELETE /api/benchmarks/queue/{item_id}` |
+| `logs_tail` | `GET /api/logs` — output is secret-redacted |
+| `slot_logs` | `GET /api/slots/{name}/logs` — output is secret-redacted |
+| `upstream_create` | `POST /api/upstreams` |
+| `upstream_update` | `PATCH /api/upstreams/{name}` |
+| `upstream_delete` | `DELETE /api/upstreams/{name}` |
+| `service_action` | `POST /api/services/{service_id}/action` |
+| `comfyui_switchover` | `POST /api/comfyui/switchover` |
+| `comfyui_pin` | `POST /api/comfyui/pin` |
+| `comfyui_models_fetch` | `POST /api/comfyui/models/fetch` |
+| `comfyui_render_cancel` | `POST /api/comfyui/render/cancel` |
+| `comfyui_restart` | `POST /api/comfyui/restart` |
+| `comfyui_workflow_launch` | `POST /api/comfyui/workflows/{name}/launch` |
+| `comfyui_logs` | `GET /api/comfyui/logs` — output is secret-redacted |
+| `slot_pull_image` | `POST /api/slots/{name}/pull` |
+| `model_config_write` | `PUT /api/config/models` |
+| `bench_run` | `POST /api/benchmarks/run` |
+| `runner_image_sync` | `POST /api/runner-images/sync` |
+| `npu_backend_load` | `POST /api/backends/npu/load` |
+| `npu_backend_unload` | `POST /api/backends/npu/unload` |
+| `mcp_server_install` | `POST /api/mcp/install` |
+| `mcp_server_uninstall` | `DELETE /api/mcp/{server_id}` |
+| `mcp_server_config_write` | `PATCH /api/mcp/{server_id}/config` |
+| `mcp_server_action` | `POST /api/mcp/{server_id}/{action}` |
+| `mcp_server_logs` | `GET /api/mcp/{server_id}/logs` |
+| `memory_mental_model_delete`, `memory_directive_delete` | delegate to `hal0-memory` — destructive, always gated |
 
 ### Deliberately excluded
 
@@ -148,13 +222,52 @@ surface (each with a documented reason in source) — not gaps, policy.
 Unlike `hal0-admin`, each tool here registers with a real typed signature, so
 `tools/list` returns real per-field schemas, not an opaque `args` blob.
 
-| Tool | Signature | Required | Returns |
-|---|---|---|---|
-| `memory_add` | `text, dataset?, tags?, metadata?, document_id?` | `text` (non-empty) | `{id, timestamp, operation_id?}` |
-| `memory_search` | `query, limit=10, dataset?, tags?, before?, after?` | `query` | `{results: [{id, text, score, timestamp, dataset, tags, source, metadata}]}` |
-| `memory_list` | `dataset?, cursor?, limit=50` | none | `{items: [...], next_cursor}` |
-| `memory_delete` | `ids, dataset?` | `ids` (non-empty list) | `{deleted: int}`; bulk deletes (>1 id) return `{status: "pending_approval", approval_id, detail}` |
-| `memory_recall` | `query, max_tokens=4096, types?, dataset?, tags?, tags_match?` | `query` | `{results: [...]}` |
+hal0-memory registers 26 tools total. Gating tier is classified the same way as
+the admin tools above — via `AUTONOMOUS_READ_TOOLS` / `AUTONOMOUS_WRITE_TOOLS`
+/ `GATED_TOOLS` in `hal0.mcp.admin`, which is the single owner of the
+classification even for tools that only ever run through the standalone
+`/mcp/memory` mount.
+
+**Autonomous — read**
+
+| Tool | Required | Returns |
+|---|---|---|
+| `memory_search` | `query` | `{results: [{id, text, score, timestamp, dataset, tags, source, metadata}]}` |
+| `memory_list` | none | `{items: [...], next_cursor}` |
+| `memory_recall` | `query` | token-budgeted, consolidated memory — `{results: [...]}` |
+| `memory_reflect` | `query` | LLM-backed synthesis grounded in recalled facts; `{status: "unsupported"}` on engines without this capability |
+| `memory_history` | `id` | curation history for one memory unit |
+| `memory_mental_model_list` | none | a bank's mental models (stored `memory_reflect` answers kept refreshed) |
+| `memory_mental_model_get` | `id` | one mental model |
+| `memory_directive_list` | none | a bank's directives (standing instructions injected into prompts) |
+| `memory_directive_get` | `id` | one directive |
+| `memory_operation_list` | none | async operations (retain, consolidation, refresh, ...) |
+| `memory_operation_get` | `id` | one async operation's status — the poll target for `memory_add`'s `operation_id`, `memory_mental_model_refresh`, `memory_bank_consolidate` |
+| `memory_tags_list` | none | tags in use in a bank, with usage counts |
+| `memory_bank_stats` | none | node/link/observation/operation counts for a bank |
+
+**Autonomous — write** (reversible, low blast radius)
+
+| Tool | Required | Returns |
+|---|---|---|
+| `memory_add` | `text` (non-empty) | `{id, timestamp, operation_id?}` |
+| `memory_delete` | `ids` (non-empty list) | `{deleted: int}`; bulk deletes (>1 id) or a foreign/list dataset instead return `{status: "pending_approval", approval_id, detail}` |
+| `memory_curate` | `id` | edits a memory unit's text/context/occurred-range/fact_type/entities, or soft-invalidates it via `state` — the non-destructive correction path |
+| `memory_mental_model_create` | `name`, `source_query` | `{mental_model_id, operation_id}` — initial content generation runs as an async refresh |
+| `memory_mental_model_update` | `id` | updates name/source_query/max_tokens/tags/trigger |
+| `memory_mental_model_refresh` | `id` | triggers a mental model refresh (async) — `{operation_id, ...}` |
+| `memory_directive_create` | `name`, `content` | creates a directive |
+| `memory_directive_update` | `id` | updates name/content/priority/is_active/tags |
+| `memory_operation_cancel` | `id` | aborts pending/processing work |
+| `memory_operation_retry` | `id` | re-queues a failed operation |
+| `memory_bank_consolidate` | none | triggers the engine's world/experience → observation consolidation pass early — `{operation_id, deduplicated}` |
+
+**Gated** (destructive — require operator approval)
+
+| Tool | Required | Returns |
+|---|---|---|
+| `memory_mental_model_delete` | `id` | deletes a mental model |
+| `memory_directive_delete` | `id` | deletes a directive |
 
 Validation errors return `{"status": "error", "error": {"code": "mcp.memory_schema", "detail": ...}}`.
 

--- a/docs/reference/mcp-tools.mdx
+++ b/docs/reference/mcp-tools.mdx
@@ -25,7 +25,9 @@ truth if this table ever drifts.
 
 Return shape for every admin tool is `dict[str, Any]`:
 - **success (autonomous)**: the raw REST JSON response — `slot_list`, `provider_list`,
-  and `upstream_list` wrap their bare-list REST response as `{"<key>": [...], "count": N}`.
+  `upstream_list`, `runner_image_pulls`, and `backend_list` wrap their bare-list REST
+  response as `{"<key>": [...], "count": N}` (`_LIST_TOOL_WRAP_KEY` in source is the
+  authoritative list).
 - **pending approval (gated)**: `{"status": "pending_approval", "approval_id": "...", "detail": "..."}`.
 - **error**: `{"status": "error", "error": {"code": ..., ...}}`.
 
@@ -224,9 +226,9 @@ Unlike `hal0-admin`, each tool here registers with a real typed signature, so
 
 hal0-memory registers 26 tools total. Gating tier is classified the same way as
 the admin tools above — via `AUTONOMOUS_READ_TOOLS` / `AUTONOMOUS_WRITE_TOOLS`
-/ `GATED_TOOLS` in `hal0.mcp.admin`, which is the single owner of the
-classification even for tools that only ever run through the standalone
-`/mcp/memory` mount.
+/ `GATED_TOOLS` in `hal0.mcp.admin` (the standalone mount additionally
+hard-gates its two delete tools through its own local list, checked first —
+same verdict, belt and braces).
 
 **Autonomous — read**
 
@@ -252,7 +254,7 @@ classification even for tools that only ever run through the standalone
 |---|---|---|
 | `memory_add` | `text` (non-empty) | `{id, timestamp, operation_id?}` |
 | `memory_delete` | `ids` (non-empty list) | `{deleted: int}`; bulk deletes (>1 id) or a foreign/list dataset instead return `{status: "pending_approval", approval_id, detail}` |
-| `memory_curate` | `id` | edits a memory unit's text/context/occurred-range/fact_type/entities, or soft-invalidates it via `state` — the non-destructive correction path |
+| `memory_curate` | `id`, plus at least one field to change (`text`, `context`, `occurred_start`, `occurred_end`, `fact_type`, `entities`, or `state`) | edits a memory unit's text/context/occurred-range/fact_type/entities, or soft-invalidates it via `state` — the non-destructive correction path; `id` alone returns `mcp.memory_schema` |
 | `memory_mental_model_create` | `name`, `source_query` | `{mental_model_id, operation_id}` — initial content generation runs as an async refresh |
 | `memory_mental_model_update` | `id` | updates name/source_query/max_tokens/tags/trigger |
 | `memory_mental_model_refresh` | `id` | triggers a mental model refresh (async) — `{operation_id, ...}` |

--- a/tests/docs/test_mcp_docs_match_source.py
+++ b/tests/docs/test_mcp_docs_match_source.py
@@ -69,11 +69,43 @@ def _connect_section(text: str) -> str:
     return rest if nxt == -1 else rest[:nxt]
 
 
-def _backticked_names(text: str) -> set[str]:
-    """Every ``tool_name``-shaped backticked token in the doc."""
-    return {
-        name for name in re.findall(r"`([a-z][a-z_0-9]*)`", text) if "_" in name or name.islower()
-    }
+def _section(text: str, start_marker: str, *end_markers: str) -> str:
+    """Slice ``text`` from ``start_marker`` to the first end marker found after it."""
+    start = text.index(start_marker)
+    rest = text[start:]
+    cut = len(rest)
+    for marker in end_markers:
+        pos = rest.find(marker, len(start_marker))
+        if pos != -1:
+            cut = min(cut, pos)
+    return rest[:cut]
+
+
+def _table_row_names(section: str) -> set[str]:
+    """Backticked tool names from the *first cell* of each markdown table row.
+
+    First-cell-only matters: delegate rows list several names in one cell
+    (all wanted), while Returns/route cells contain backticked payload shapes
+    and cross-references to other tools (not wanted).
+    """
+    names: set[str] = set()
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|") or stripped.startswith(("|---", "| Tool", "| Method")):
+            continue
+        first_cell = stripped.split("|")[1]
+        names |= set(re.findall(r"`([a-z][a-z_0-9]*)`", first_cell))
+    return names
+
+
+def _assert_tier_matches(tier: str, doc: set[str], src: frozenset[str] | set[str]) -> None:
+    missing = sorted(set(src) - doc)
+    stale = sorted(doc - set(src))
+    assert not missing and not stale, (
+        f"mcp-tools.mdx {tier} table has drifted from source: "
+        f"missing {missing or 'nothing'}, stale/misplaced rows {stale or 'none'} — "
+        "a tool must appear in exactly the table matching its frozenset tier"
+    )
 
 
 def test_connect_section_has_no_bare_mount_urls() -> None:
@@ -98,21 +130,42 @@ def test_connect_section_urls_end_in_mcp() -> None:
         )
 
 
-def test_admin_tool_tables_name_every_classified_tool() -> None:
-    all_admin_tools = AUTONOMOUS_READ_TOOLS | AUTONOMOUS_WRITE_TOOLS | GATED_TOOLS
-    doc_names = _backticked_names(_tools_text())
-    missing = sorted(all_admin_tools - doc_names)
-    assert not missing, (
-        f"mcp-tools.mdx is missing {len(missing)} admin tool(s) that "
-        f"hal0.mcp.admin classifies: {missing}"
-    )
+def test_admin_tool_tables_match_frozensets_per_tier() -> None:
+    """Set equality per gating tier, not "name appears somewhere on the page".
+
+    This is the ratchet #1902 asked to promote: it fails on a deleted or gutted
+    section, on tier drift (a Gated tool row moved to an Autonomous table), and
+    on stale rows for tools that no longer exist in source.
+    """
+    admin = _section(_tools_text(), "## `hal0-admin`", "\n## `hal0-memory`")
+    tiers = {
+        "Autonomous — read": AUTONOMOUS_READ_TOOLS,
+        "Autonomous — write": AUTONOMOUS_WRITE_TOOLS,
+        "Gated": GATED_TOOLS,
+    }
+    for heading, src in tiers.items():
+        table = _section(admin, f"### {heading}", "\n### ")
+        _assert_tier_matches(f"admin '{heading}'", _table_row_names(table), src)
 
 
-def test_memory_tool_table_names_every_registered_tool() -> None:
+def test_memory_tool_tables_match_registrations_per_tier() -> None:
+    """The three hal0-memory sub-tables must name exactly the registered
+    ``@server.tool``s, each in the table matching its admin-frozenset tier."""
     memory_tools = _memory_tool_names()
-    doc_names = _backticked_names(_tools_text())
-    missing = sorted(memory_tools - doc_names)
-    assert not missing, (
-        f"mcp-tools.mdx is missing {len(missing)} memory tool(s) registered "
-        f"in hal0.mcp.memory: {missing}"
+    mem = _section(_tools_text(), "## `hal0-memory`", "\n## ")
+    tiers = {
+        "Autonomous — read": memory_tools & AUTONOMOUS_READ_TOOLS,
+        "Autonomous — write": memory_tools & AUTONOMOUS_WRITE_TOOLS,
+        "Gated": memory_tools & GATED_TOOLS,
+    }
+    documented: set[str] = set()
+    for heading, src in tiers.items():
+        table = _section(mem, f"**{heading}**", "\n**", "\nValidation errors")
+        rows = _table_row_names(table)
+        _assert_tier_matches(f"memory '{heading}'", rows, src)
+        documented |= rows
+    unclassified = sorted(memory_tools - documented)
+    assert not unclassified, (
+        f"hal0.mcp.memory registers tool(s) with no admin-frozenset tier and no "
+        f"doc row: {unclassified} — classify them in hal0.mcp.admin and document them"
     )

--- a/tests/docs/test_mcp_docs_match_source.py
+++ b/tests/docs/test_mcp_docs_match_source.py
@@ -1,0 +1,118 @@
+"""``docs/reference/mcp-tools.mdx`` and ``docs/guides/connect-mcp.mdx`` must
+match the MCP tool catalog and mount contract in source (#1902).
+
+Two shipped-docs defects, both found by ``rc-validate`` v1.0.0-rc.6:
+
+1. ``connect-mcp.mdx``'s "### Connect" section told a client to point at the
+   bare mount URL (``http://localhost:8080/mcp/admin``). That 405s — FastMCP's
+   Streamable-HTTP sub-app expects ``POST`` on ``/mcp/admin/mcp``, not the
+   mount root (see ``hal0.api.routes.mcp.mcp_url`` and #1796, which pinned
+   this exact rule for the REST introspection surface). The curl example
+   further down the same doc already gets this right; the "Connect" prose
+   above it did not.
+2. ``mcp-tools.mdx`` claims to enumerate "every MCP tool" but its tables
+   named a stale subset — 89 of 180 admin tools and 21 of 26 memory tools
+   were undocumented, most of them added after the page was first written.
+   The ``AUTONOMOUS_READ_TOOLS`` / ``AUTONOMOUS_WRITE_TOOLS`` / ``GATED_TOOLS``
+   frozensets in ``hal0.mcp.admin``, and the ``@server.tool`` registrations in
+   ``hal0.mcp.memory``, are ground truth — this test diffs the doc's table
+   rows against them by name set (not count, which a docs author could pad
+   to pass without naming the actual missing tools).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from hal0.mcp.admin import (
+    AUTONOMOUS_READ_TOOLS,
+    AUTONOMOUS_WRITE_TOOLS,
+    GATED_TOOLS,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CONNECT_MD = _REPO_ROOT / "docs" / "guides" / "connect-mcp.mdx"
+_TOOLS_MD = _REPO_ROOT / "docs" / "reference" / "mcp-tools.mdx"
+
+# Every @server.tool(name="...") registration in hal0.mcp.memory (the
+# module doesn't export its own frozenset of tool names, so this test
+# mirrors the same source-of-truth pattern as admin's tools).
+_MEMORY_SERVER_TOOL_RE = re.compile(r'@server\.tool\(\s*name="([a-z_0-9]+)"')
+
+
+def _memory_tool_names() -> frozenset[str]:
+    from hal0.mcp import memory as memory_mod
+
+    src = Path(memory_mod.__file__).read_text(encoding="utf-8")
+    names = _MEMORY_SERVER_TOOL_RE.findall(src)
+    assert names, (
+        "found no @server.tool registrations in hal0.mcp.memory — extraction regex is stale"
+    )
+    return frozenset(names)
+
+
+def _connect_text() -> str:
+    assert _CONNECT_MD.exists(), f"missing {_CONNECT_MD}"
+    return _CONNECT_MD.read_text(encoding="utf-8")
+
+
+def _tools_text() -> str:
+    assert _TOOLS_MD.exists(), f"missing {_TOOLS_MD}"
+    return _TOOLS_MD.read_text(encoding="utf-8")
+
+
+def _connect_section(text: str) -> str:
+    start = text.index("### Connect")
+    rest = text[start:]
+    nxt = rest.find("\n### ", 1)
+    return rest if nxt == -1 else rest[:nxt]
+
+
+def _backticked_names(text: str) -> set[str]:
+    """Every ``tool_name``-shaped backticked token in the doc."""
+    return {
+        name for name in re.findall(r"`([a-z][a-z_0-9]*)`", text) if "_" in name or name.islower()
+    }
+
+
+def test_connect_section_has_no_bare_mount_urls() -> None:
+    """A client POSTing to the bare mount root gets a 405 (#1796); the
+    Connect section must send them straight to the working ``/mcp`` path."""
+    section = _connect_section(_connect_text())
+    for bare in ("localhost:8080/mcp/admin\n", "localhost:8080/mcp/memory\n"):
+        assert bare not in section, (
+            f"Connect section still gives the bare mount URL {bare.strip()!r} — "
+            "it 405s on loopback (#1796); the doc must point at "
+            f"{bare.strip()}/mcp instead"
+        )
+
+
+def test_connect_section_urls_end_in_mcp() -> None:
+    section = _connect_section(_connect_text())
+    urls = re.findall(r"https?://\S+/mcp/(?:admin|memory)\S*", section)
+    assert urls, "Connect section names no /mcp/admin or /mcp/memory URL to check"
+    for url in urls:
+        assert url.rstrip("`").endswith("/mcp"), (
+            f"Connect section URL {url!r} does not end in '/mcp' — the mount root 405s (#1796)"
+        )
+
+
+def test_admin_tool_tables_name_every_classified_tool() -> None:
+    all_admin_tools = AUTONOMOUS_READ_TOOLS | AUTONOMOUS_WRITE_TOOLS | GATED_TOOLS
+    doc_names = _backticked_names(_tools_text())
+    missing = sorted(all_admin_tools - doc_names)
+    assert not missing, (
+        f"mcp-tools.mdx is missing {len(missing)} admin tool(s) that "
+        f"hal0.mcp.admin classifies: {missing}"
+    )
+
+
+def test_memory_tool_table_names_every_registered_tool() -> None:
+    memory_tools = _memory_tool_names()
+    doc_names = _backticked_names(_tools_text())
+    missing = sorted(memory_tools - doc_names)
+    assert not missing, (
+        f"mcp-tools.mdx is missing {len(missing)} memory tool(s) registered "
+        f"in hal0.mcp.memory: {missing}"
+    )


### PR DESCRIPTION
## What changed

1. **`docs/guides/connect-mcp.mdx`** — the "### Connect" section told a client to point at the bare mount URL (`http://localhost:8080/mcp/admin`, `.../mcp/memory`). Those 405 with no redirect: FastMCP's Streamable-HTTP sub-app only serves `POST` on `/mcp/admin/mcp` / `/mcp/memory/mcp`, the mount root itself is not the transport endpoint (`hal0.api.routes.mcp.mcp_url` and #1796 already pinned this exact rule for the REST introspection surface — the curl example a few lines further down the same doc already used the correct `/mcp/admin/mcp` path; only the prose above it was wrong).
2. **`docs/reference/mcp-tools.mdx`** — claimed to enumerate "every MCP tool" but its tables named a stale subset: 89 of 180 admin tools (`AUTONOMOUS_READ_TOOLS`/`AUTONOMOUS_WRITE_TOOLS`/`GATED_TOOLS` in `hal0.mcp.admin`) and 21 of 26 memory tools (`@server.tool` registrations in `hal0.mcp.memory`) were missing — mostly tools added in later waves that never got backfilled into the doc. Regenerated both tables directly from source: the admin tables now list all 180 tools with their REST route (via `TOOL_NAME_ALIASES`), and the memory section is restructured into the same three gating tiers as the admin section (read / write / gated), since `hal0.mcp.admin` is the single owner of that classification even for memory-only tools.

## Why

Found by `rc-validate` v1.0.0-rc.6 on `ct151-cpu-fresh` (issue #1902): an agent following the doc's Connect section got a bare 405 with the URLs as written, and a name-set diff of the tool tables against the source frozensets showed the "every tool" claim was false.

## How verified

- New regression test `tests/docs/test_mcp_docs_match_source.py`:
  - `test_connect_section_has_no_bare_mount_urls` / `test_connect_section_urls_end_in_mcp` — reproduce the bare-URL defect (failed before the fix, pass after).
  - `test_admin_tool_tables_name_every_classified_tool` — diffs the mdx admin tables against `AUTONOMOUS_READ_TOOLS | AUTONOMOUS_WRITE_TOOLS | GATED_TOOLS` by name set. Failed with the exact 89 missing tool names before the fix; passes after.
  - `test_memory_tool_table_names_every_registered_tool` — same diff against the memory module's `@server.tool` registrations. Failed with the exact 21 missing tool names before the fix; passes after.
- `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/docs/ -q` → 10 passed.
- `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest -q -x` (full suite) → 1170 passed, 1 unrelated pre-existing flake (`test_health_degraded.py::test_health_system_ok_when_no_errored_slots`, fails only under full-suite CPU/global-state contention, passes standalone; not touched by this change), 1 skipped, 1 xfailed.
- `uv run --extra dev ruff check tests/docs/test_mcp_docs_match_source.py docs` → all checks passed.
- `uv run --extra dev ruff format --check tests/docs/test_mcp_docs_match_source.py` → already formatted (after running `ruff format` once to apply the project's line-wrap convention).

## Left out of scope

- Per-tool argument schemas for the 89 newly-added admin rows were intentionally left out of the table (only the REST route is listed) — reproducing every tool's full arg list by hand across 180 rows is itself a drift-prone manual doc, and the table now points readers at `TOOL_PARAM_HINTS` in source for that detail, consistent with the intro paragraph's existing "treat the frozensets/route map in source as ground truth if this table drifts" guidance.
- Did not touch `CHANGELOG.md` per the fix-wave convention (tracked in #1545 — consolidated at the end of the wave).

Closes #1902