### PR TITLE
fix(memory): preflight extraction slot's context window before /api/memory/add

### DIFF
--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -632,32 +632,50 @@ async def _extraction_window(request: Request, wrapper: Any) -> Any | None:
     on it (same "unknown is not a pass, but it is also not a block" rule
     :mod:`hal0.agents.anchor_window` documents for its own callers).
 
-    Resolves fully in-process: the same catalog + by-id virtual-model
-    resolution ``GET /v1/models/{id}`` performs (:mod:`hal0.api.routes.v1`),
-    called directly rather than looped back over HTTP.
+    Resolves fully LOCALLY, on purpose — not via ``_aggregate_models``:
+
+    * ``_aggregate_models`` honours the *caller's* ``owned_by`` query param /
+      ``X-hal0-Model-Filter`` header. Those are discovery-surface curation;
+      applied to an internal safety check they let arbitrary request
+      metadata empty the catalog, degrade the verdict to ``unknown``, and
+      silently disable the preflight.
+    * ``_aggregate_models`` also fans out a live, uncached ``fetch_models``
+      HTTP round-trip to every enabled upstream — several seconds of
+      connect/read timeout per offline remote, on every memory write (a hot
+      path: auto-retain fires on a timer for every agent on the box).
+
+    The preflight needs neither: ``hal0/<slot>`` only ever resolves through
+    the local slot-alias rows (:func:`hal0.api.hal0_slot_alias_models` — a
+    slot_manager/model_registry read, no HTTP), and
+    ``_resolve_virtual_model_entry`` matches the resolver's answer against
+    exactly those rows, the same way chat dispatch does.
     """
     slot = getattr(wrapper, "extraction_slot", None)
     if not slot or getattr(wrapper, "hindsight_client", None) is None:
         return None
 
-    from hal0.api.routes.v1 import _aggregate_models, _resolve_virtual_model_entry
+    from hal0.api import hal0_slot_alias_models
+    from hal0.api.routes.v1 import _resolve_virtual_model_entry
     from hal0.memory.extraction_env import extraction_model_name, resolve_extraction_window
+
+    slot_manager = getattr(request.app.state, "slot_manager", None)
+    model_registry = getattr(request.app.state, "model_registry", None)
+    if slot_manager is None or model_registry is None:
+        return None
 
     model_name = extraction_model_name(slot)
     try:
-        catalog = await _aggregate_models(request, show_all=True)
+        catalog = await hal0_slot_alias_models(slot_manager, model_registry)
     except Exception:
         return None
-    entry = next(
-        (row for row in catalog if isinstance(row, dict) and row.get("id") == model_name), None
-    )
-    if entry is None:
-        try:
-            entry = await _resolve_virtual_model_entry(request, model_name, catalog)
-        except Exception:
-            entry = None
+    try:
+        entry = await _resolve_virtual_model_entry(request, model_name, catalog)
+    except Exception:
+        entry = None
 
-    return resolve_extraction_window(slot, entry=entry, catalog=catalog, endpoint="/v1/models")
+    return resolve_extraction_window(
+        slot, entry=entry, catalog=catalog, endpoint="the local slot catalog"
+    )
 
 
 @router.post("/add")

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -179,6 +179,26 @@ class MemoryGraphSlotInvalid(Hal0Error):
     status = 422
 
 
+class MemoryExtractionCtxTooSmall(Hal0Error):
+    """The resolved extraction slot's effective window can't fit the extraction prompt (#1903).
+
+    Hindsight builds its graph via its own extraction LLM call, dispatched to
+    ``hal0/<extraction_slot>`` regardless of ``[memory.graph].enabled``
+    (reporting-only on this engine — see :meth:`HindsightProvider.graph_status`).
+    Nothing preflighted that dispatch's window before this: an undersized slot
+    used to answer ``/add`` with HTTP 200 + a document id, then either dropped
+    the retain entirely (``retain_extract_facts`` 500 "Context size has been
+    exceeded", the document never actually stored) or — worse — persisted the
+    extraction prompt's own scaffolding as a "fact" with no grounding check.
+    Failing fast here, before the retain is even attempted, means a caller
+    never gets back an id for a document write that was always going to be
+    dropped.
+    """
+
+    code = "memory.extraction_ctx_too_small"
+    status = 503
+
+
 class MemoryUnavailable(Hal0Error):
     """The memory engine failed to initialise at boot.
 
@@ -602,6 +622,44 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
 # the cheapest unblock so identity cards actually get written.
 
 
+async def _extraction_window(request: Request, wrapper: Any) -> Any | None:
+    """Resolve the live extraction slot's effective window, or ``None`` when unprovable/N-A.
+
+    ``None`` covers "this provider doesn't do slot-dispatched extraction at
+    all" (no ``hindsight_client`` — e.g. the in-memory ``PgVectorProvider``
+    fallback) alongside "the catalog lookup itself failed" — both mean the
+    caller cannot make a below-floor call, so ``memory_add`` must not block
+    on it (same "unknown is not a pass, but it is also not a block" rule
+    :mod:`hal0.agents.anchor_window` documents for its own callers).
+
+    Resolves fully in-process: the same catalog + by-id virtual-model
+    resolution ``GET /v1/models/{id}`` performs (:mod:`hal0.api.routes.v1`),
+    called directly rather than looped back over HTTP.
+    """
+    slot = getattr(wrapper, "extraction_slot", None)
+    if not slot or getattr(wrapper, "hindsight_client", None) is None:
+        return None
+
+    from hal0.api.routes.v1 import _aggregate_models, _resolve_virtual_model_entry
+    from hal0.memory.extraction_env import extraction_model_name, resolve_extraction_window
+
+    model_name = extraction_model_name(slot)
+    try:
+        catalog = await _aggregate_models(request, show_all=True)
+    except Exception:
+        return None
+    entry = next(
+        (row for row in catalog if isinstance(row, dict) and row.get("id") == model_name), None
+    )
+    if entry is None:
+        try:
+            entry = await _resolve_virtual_model_entry(request, model_name, catalog)
+        except Exception:
+            entry = None
+
+    return resolve_extraction_window(slot, entry=entry, catalog=catalog, endpoint="/v1/models")
+
+
 @router.post("/add")
 async def memory_add(request: Request) -> dict[str, Any]:
     """Add a memory item. Body: ``{text, dataset?, tags?, metadata?, document_id?}``.
@@ -666,6 +724,33 @@ async def memory_add(request: Request) -> dict[str, Any]:
         )
 
     wrapper = _wrapper(request)
+
+    # #1903: preflight the extraction slot's effective window against the
+    # extraction prompt's own footprint BEFORE the retain is attempted. A
+    # slot too small to fit the prompt can never complete extraction no
+    # matter what is retained, so failing here — before a document id is
+    # even minted — beats a 200 for a write the engine was always going to
+    # drop (or, worse, one it answers by persisting prompt scaffolding as
+    # a "fact"). ``unknown`` (no evidence either way) does not block: a
+    # preflight that can't prove the slot is broken must not refuse writes
+    # on a healthy box just because the catalog lookup came back thin.
+    window = await _extraction_window(request, wrapper)
+    if window is not None and window.verdict == "below_floor":
+        log.warning(
+            "memory.extraction_ctx_below_floor slot=%r effective=%r floor=%r",
+            window.slot,
+            window.effective,
+            window.floor,
+        )
+        raise MemoryExtractionCtxTooSmall(
+            window.message(),
+            details={
+                "slot": window.slot,
+                "effective_context": window.effective,
+                "required_context": window.floor,
+            },
+        )
+
     return await wrapper.add(
         text=text,
         dataset=dataset,
@@ -921,6 +1006,7 @@ async def _read_json_body(request: Request) -> dict[str, Any]:
 __all__ = [
     "DEFAULT_DATASET",
     "MemoryAgentIdInvalid",
+    "MemoryExtractionCtxTooSmall",
     "MemoryGraphConfig",
     "MemoryGraphConfigInvalid",
     "MemoryGraphSlotInvalid",

--- a/src/hal0/memory/extraction_env.py
+++ b/src/hal0/memory/extraction_env.py
@@ -268,6 +268,14 @@ def extraction_model_name(slot: str) -> str:
 EXTRACTION_FLOOR_ENV = "HAL0_MEMORY_EXTRACTION_FLOOR"
 
 
+#: Invalid override values already warned about, so a persistent typo in the
+#: service environment logs ONCE per value instead of once per memory write —
+#: ``extraction_floor`` runs on the write hot path (auto-retain fires on a
+#: timer for every agent on the box), which would otherwise flood the journal
+#: indefinitely.
+_floor_override_warned: set[str] = set()
+
+
 def extraction_floor() -> tuple[int, str]:
     """Return ``(floor, floor_source)`` honouring :data:`EXTRACTION_FLOOR_ENV`.
 
@@ -283,7 +291,9 @@ def extraction_floor() -> tuple[int, str]:
             value = 0
         if value > 0:
             return (value, f"env:{EXTRACTION_FLOOR_ENV}")
-        log.warning("hal0.memory.extraction_floor_override_invalid", raw=raw)
+        if raw not in _floor_override_warned:
+            _floor_override_warned.add(raw)
+            log.warning("hal0.memory.extraction_floor_override_invalid", raw=raw)
     return (EXTRACTION_MIN_CONTEXT_TOKENS, "hal0:extraction-prompt-floor")
 
 

--- a/src/hal0/memory/extraction_env.py
+++ b/src/hal0/memory/extraction_env.py
@@ -39,8 +39,10 @@ raising, so the API can surface a partial result instead of 500ing.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -75,7 +77,7 @@ DEFAULT_LLM_TIMEOUT_S = 300
 #: repo), so this is deliberately a ROUND, DEFENSIBLE floor rather than an
 #: exact token count: rc.6 validation observed the prompt (few-shot examples
 #: + narrator scaffolding + the extraction schema) run ~3-4k tokens on its
-#: own, and the reproduced failure (ct150, `known-issues.yaml:
+#: own, and the reproduced failure (ct151-cpu-fresh, `known-issues.yaml:
 #: memory-extraction-quality-is-anchor-dependent`) sat at ctx=4096 — i.e.
 #: at or below the prompt's own footprint, before a single byte of the
 #: document being retained is added. 8192 doubles that observed prompt cost
@@ -257,46 +259,167 @@ def extraction_model_name(slot: str) -> str:
     return f"{_VIRTUAL_PREFIX}{slot}"
 
 
+#: Operator escape hatch for :data:`EXTRACTION_MIN_CONTEXT_TOKENS`. The floor
+#: is honestly an estimate (hal0 never sees the vendored prompt template), so
+#: a box where the estimate is wrong must not be stuck between "no memory
+#: writes" and "resize a slot": set this on the hal0-api service to any
+#: positive token count and it replaces the default floor. Recorded in
+#: ``floor_source`` so the rendered error says when it was in play.
+EXTRACTION_FLOOR_ENV = "HAL0_MEMORY_EXTRACTION_FLOOR"
+
+
+def extraction_floor() -> tuple[int, str]:
+    """Return ``(floor, floor_source)`` honouring :data:`EXTRACTION_FLOOR_ENV`.
+
+    An unset/blank variable yields the default; a non-integer or non-positive
+    value is *ignored* (with the default returned) rather than raised — a
+    typo'd override must not turn every memory write into a 500.
+    """
+    raw = (os.environ.get(EXTRACTION_FLOOR_ENV) or "").strip()
+    if raw:
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 0
+        if value > 0:
+            return (value, f"env:{EXTRACTION_FLOOR_ENV}")
+        log.warning("hal0.memory.extraction_floor_override_invalid", raw=raw)
+    return (EXTRACTION_MIN_CONTEXT_TOKENS, "hal0:extraction-prompt-floor")
+
+
+@dataclass(frozen=True)
+class ExtractionWindow(AnchorWindow):
+    """An :class:`AnchorWindow` whose rendered message names THIS subsystem.
+
+    The parent's :meth:`~AnchorWindow.message` is hard-coded for Hermes'
+    64,000-token anchor preflight ("Hermes requires", "EVERY turn will
+    fail") — fed the extraction floor it would tell an operator debugging a
+    failed memory write that their agent runtime is broken, against a
+    threshold that contradicts the real Hermes check. Same resolved facts
+    (slot, effective window, binding ceiling, fix command), memory-extraction
+    words.
+    """
+
+    def message(self) -> str:
+        where = f" at {self.endpoint}" if self.endpoint else ""
+        floor_note = (
+            f" (operator override via {EXTRACTION_FLOOR_ENV})"
+            if self.floor_source.startswith("env:")
+            else (
+                f" (a conservative estimate of the prompt's footprint — override with "
+                f"{EXTRACTION_FLOOR_ENV} on the hal0-api service if it is wrong for "
+                f"this engine)"
+            )
+        )
+        if self.verdict == "unknown":
+            return (
+                f"memory extraction model {self.model!r} advertises no context window"
+                f"{where} right now — cannot check it against the {self.floor:,}-token "
+                f"extraction-prompt floor. Not a pass, but memory writes are not "
+                f"blocked on an unproven window; re-check once the extraction slot's "
+                f"model is loaded"
+            )
+        if self.verdict == "ok":
+            return (
+                f"memory extraction model {self.model!r} ({self._slot_note}) resolves "
+                f"to {self.effective:,} tokens ≥ the {self.floor:,}-token "
+                f"extraction-prompt floor"
+            )
+        head = (
+            f"memory write refused: Hindsight's extraction call dispatches to "
+            f"{self.model!r}, which resolves to {self._slot_note} with an effective "
+            f"context window of {self.effective:,} tokens — below the {self.floor:,} "
+            f"tokens the extraction prompt alone needs{floor_note}. A retain would be "
+            f"accepted and then silently dropped (or answered by persisting prompt "
+            f'scaffolding as a "fact"), so /api/memory/add fails fast instead. Chat '
+            f"is unaffected — only memory extraction is gated."
+        )
+        if self.slot is None:
+            return (
+                f"{head} hal0 could not prove which slot is serving it, so it cannot "
+                f"name the ceiling to raise — run `hal0 slot list` and raise the "
+                f"window of the slot behind {self.model!r} to at least {self.floor:,}."
+            )
+        if self.ceiling_is_binding:
+            return (
+                f"{head} The limit is this slot's own configured ceiling: "
+                f"[model].context_size = {self.ceiling:,} in {self.slot_path}. "
+                f"Fix: {self.fix_command}"
+            )
+        ceiling_note = (
+            f"the slot ceiling ({self.ceiling:,} in {self.slot_path}) is not the limit; "
+            if self.ceiling is not None
+            else f"no ceiling is set in {self.slot_path}; "
+        )
+        return (
+            f"{head} The limit is the model behind the slot — {ceiling_note}"
+            f"the model itself only advertises {self.effective:,}. Point slot "
+            f"{self.slot!r} at a model whose window is at least {self.floor:,} "
+            f"(`hal0 slot edit {self.slot} --model <model-id>`), or set "
+            f"defaults.context_size on the current model if it really supports more."
+        )
+
+
 def resolve_extraction_window(
     slot: str,
     *,
     entry: Mapping[str, Any] | None,
     catalog: Sequence[Mapping[str, Any]] | None = None,
-    floor: int = EXTRACTION_MIN_CONTEXT_TOKENS,
+    floor: int | None = None,
     slots_dir: Path = SLOTS_DIR,
     endpoint: str = "",
-) -> AnchorWindow:
+) -> ExtractionWindow:
     """Resolve the extraction slot's effective window against the prompt floor (#1903).
 
     Reuses :func:`hal0.agents.anchor_window.resolve_anchor_window` — the
     #1877 resolver — rather than reimplementing the virtual-model routing
     resolution it already gets right (never trust the ``hal0/<slot>``
     spelling; ask the by-id catalog row the routing fallback chain actually
-    answered with). Only the model handle and the floor differ from the
-    Hermes-anchor call: extraction is checked against
-    :data:`EXTRACTION_MIN_CONTEXT_TOKENS` (the prompt's own footprint), not
-    Hermes' much larger hard floor.
+    answered with). Only the model handle, the floor, and the rendered
+    message differ from the Hermes-anchor call: extraction is checked
+    against :func:`extraction_floor` (the prompt's own footprint, or the
+    operator's :data:`EXTRACTION_FLOOR_ENV` override), not Hermes' much
+    larger hard floor, and the verdict renders through
+    :class:`ExtractionWindow` so a below-floor 503 talks about memory
+    extraction rather than Hermes.
 
-    ``entry``/``catalog`` are the caller's ``GET /v1/models/{id}`` row and
-    ``GET /v1/models`` list for ``hal0/<slot>`` — injected so this stays pure
-    and testable without a running gateway (see :class:`AnchorWindow`).
+    ``entry``/``catalog`` are the resolved virtual-model row and the local
+    slot-alias catalog for ``hal0/<slot>`` — injected so this stays pure and
+    testable without a running gateway (see :class:`AnchorWindow`).
     """
-    return resolve_anchor_window(
+    if floor is None:
+        floor, floor_source = extraction_floor()
+    else:
+        floor_source = "hal0:extraction-prompt-floor"
+    window = resolve_anchor_window(
         extraction_model_name(slot),
         entry=entry,
         catalog=catalog,
         floor=floor,
-        floor_source="hal0:extraction-prompt-floor",
+        floor_source=floor_source,
         slots_dir=slots_dir,
         endpoint=endpoint,
+    )
+    return ExtractionWindow(
+        model=window.model,
+        slot=window.slot,
+        effective=window.effective,
+        ceiling=window.ceiling,
+        floor=window.floor,
+        floor_source=window.floor_source,
+        slots_dir=window.slots_dir,
+        endpoint=window.endpoint,
     )
 
 
 __all__ = [
     "DROP_IN_PATH",
+    "EXTRACTION_FLOOR_ENV",
     "EXTRACTION_MIN_CONTEXT_TOKENS",
+    "ExtractionWindow",
     "apply_extraction_slot",
     "drop_in_matches",
+    "extraction_floor",
     "extraction_model_name",
     "render_drop_in",
     "resolve_extraction_window",

--- a/src/hal0/memory/extraction_env.py
+++ b/src/hal0/memory/extraction_env.py
@@ -40,11 +40,13 @@ raising, so the API can surface a partial result instead of 500ing.
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
 import structlog
 
+from hal0.agents.anchor_window import SLOTS_DIR, AnchorWindow, resolve_anchor_window
 from hal0.system.seam import SystemCtlSeam
 
 log = structlog.get_logger(__name__)
@@ -62,6 +64,26 @@ _SYSTEMCTL_TIMEOUT_S = 60.0
 
 #: Default daemon LLM timeout (seconds) — mirrors MemoryGraphConfig.llm_timeout_s.
 DEFAULT_LLM_TIMEOUT_S = 300
+
+#: Conservative floor for Hindsight's native extraction prompt (#1903).
+#:
+#: Hindsight builds its graph via its OWN extraction LLM call, dispatched to
+#: ``hal0/<extraction_slot>`` (see the module docstring) — the same
+#: virtual-model-through-the-routing-fallback-chain shape #1867 preflights
+#: for Hermes' anchor, just never checked on this side. hal0 never sees the
+#: vendored prompt template (it lives in the hindsight-api package, not this
+#: repo), so this is deliberately a ROUND, DEFENSIBLE floor rather than an
+#: exact token count: rc.6 validation observed the prompt (few-shot examples
+#: + narrator scaffolding + the extraction schema) run ~3-4k tokens on its
+#: own, and the reproduced failure (ct150, `known-issues.yaml:
+#: memory-extraction-quality-is-anchor-dependent`) sat at ctx=4096 — i.e.
+#: at or below the prompt's own footprint, before a single byte of the
+#: document being retained is added. 8192 doubles that observed prompt cost
+#: so a slot which clears the floor has headroom left for the document text
+#: itself; a slot still under it cannot fit the prompt regardless of what is
+#: being retained, which is the catastrophic (retain silently dropped, or
+#: prompt content persisted as fact) shape this preflight exists to catch.
+EXTRACTION_MIN_CONTEXT_TOKENS = 8192
 
 _DROP_IN_TEMPLATE = (
     "# Managed by hal0 (ADR-0023 — memory.graph.extraction_slot / llm_timeout_s).\n"
@@ -220,4 +242,62 @@ def apply_extraction_slot(
     return result
 
 
-__all__ = ["DROP_IN_PATH", "apply_extraction_slot", "drop_in_matches", "render_drop_in"]
+#: Local alias so this module doesn't have to re-derive the ``hal0/`` prefix
+#: :mod:`hal0.agents.anchor_window` already owns.
+_VIRTUAL_PREFIX = "hal0/"
+
+
+def extraction_model_name(slot: str) -> str:
+    """The virtual model id Hindsight's extraction LLM call is spelled as.
+
+    Mirrors :data:`_DROP_IN_TEMPLATE`'s ``HINDSIGHT_API_LLM_MODEL=hal0/{slot}``
+    — the same string, so a caller resolving the extraction window is asking
+    about the exact handle the drop-in actually points the engine at.
+    """
+    return f"{_VIRTUAL_PREFIX}{slot}"
+
+
+def resolve_extraction_window(
+    slot: str,
+    *,
+    entry: Mapping[str, Any] | None,
+    catalog: Sequence[Mapping[str, Any]] | None = None,
+    floor: int = EXTRACTION_MIN_CONTEXT_TOKENS,
+    slots_dir: Path = SLOTS_DIR,
+    endpoint: str = "",
+) -> AnchorWindow:
+    """Resolve the extraction slot's effective window against the prompt floor (#1903).
+
+    Reuses :func:`hal0.agents.anchor_window.resolve_anchor_window` — the
+    #1877 resolver — rather than reimplementing the virtual-model routing
+    resolution it already gets right (never trust the ``hal0/<slot>``
+    spelling; ask the by-id catalog row the routing fallback chain actually
+    answered with). Only the model handle and the floor differ from the
+    Hermes-anchor call: extraction is checked against
+    :data:`EXTRACTION_MIN_CONTEXT_TOKENS` (the prompt's own footprint), not
+    Hermes' much larger hard floor.
+
+    ``entry``/``catalog`` are the caller's ``GET /v1/models/{id}`` row and
+    ``GET /v1/models`` list for ``hal0/<slot>`` — injected so this stays pure
+    and testable without a running gateway (see :class:`AnchorWindow`).
+    """
+    return resolve_anchor_window(
+        extraction_model_name(slot),
+        entry=entry,
+        catalog=catalog,
+        floor=floor,
+        floor_source="hal0:extraction-prompt-floor",
+        slots_dir=slots_dir,
+        endpoint=endpoint,
+    )
+
+
+__all__ = [
+    "DROP_IN_PATH",
+    "EXTRACTION_MIN_CONTEXT_TOKENS",
+    "apply_extraction_slot",
+    "drop_in_matches",
+    "extraction_model_name",
+    "render_drop_in",
+    "resolve_extraction_window",
+]

--- a/tests/api/test_memory_extraction_ctx_preflight.py
+++ b/tests/api/test_memory_extraction_ctx_preflight.py
@@ -172,3 +172,151 @@ async def test_extraction_window_helper_no_ops_without_hindsight_client() -> Non
     request = object()  # never touched if the guard fires correctly
     assert await memory_routes._extraction_window(request, NoHindsight()) is None
     assert await memory_routes._extraction_window(request, WithNoneClient()) is None
+
+
+# ── Real-seam coverage (PR #1917 review, findings 1/3/6) ────────────────────
+#
+# Everything below exercises the REAL ``_extraction_window`` — no
+# monkeypatching of the function under test — against fake slot_manager /
+# model_registry / upstreams objects on app state (the
+# ``tests/api/test_virtual_models.py`` fixture shape). This is the seam the
+# review's blocking findings all lived in: the preflight must resolve from
+# the LOCAL slot-alias catalog only, so caller-supplied discovery filters
+# cannot disable it and no live upstream catalog fetch rides every write.
+
+
+class _FakeSlotManager:
+    """One enabled llm slot named ``utility`` with model ``small``."""
+
+    def __init__(self, ctx: int) -> None:
+        self._ctx = ctx
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "utility",
+                "type": "llm",
+                "model": {"default": "small"},
+                "ctx_size": self._ctx,
+                "device": "cpu",
+            }
+        ]
+
+
+class _FakeModelEntry:
+    def __init__(self, model_id: str, ctx: int) -> None:
+        self.name = model_id
+        self._ctx = ctx
+
+    def model_dump(self) -> dict[str, Any]:
+        return {"defaults": {"context_size": self._ctx}, "metadata": {}}
+
+
+class _FakeModelRegistry:
+    def __init__(self, ctx: int) -> None:
+        self._ctx = ctx
+
+    def has(self, model_id: str) -> bool:
+        return True
+
+    def get(self, model_id: str) -> _FakeModelEntry:
+        return _FakeModelEntry(model_id, self._ctx)
+
+
+class _RecordingUpstreams:
+    """Fails the test loudly if the preflight ever fans out to upstreams."""
+
+    def __init__(self) -> None:
+        self.fetch_calls: list[str] = []
+
+    def list(self) -> list[Any]:
+        return []
+
+    def get(self, name: str) -> Any | None:
+        return None
+
+    async def fetch_models(self, name: str) -> list[str]:
+        self.fetch_calls.append(name)
+        return []
+
+
+def _real_seam_app(ctx: int) -> tuple[FastAPI, StubHindsightWrapper, _RecordingUpstreams]:
+    stub = StubHindsightWrapper()
+    app = _build_app(stub)
+    app.state.slot_manager = _FakeSlotManager(ctx)
+    app.state.model_registry = _FakeModelRegistry(ctx)
+    upstreams = _RecordingUpstreams()
+    app.state.upstreams = upstreams
+    app.state.upstream_models = {}
+    return app, stub, upstreams
+
+
+def test_real_preflight_blocks_a_below_floor_slot_with_an_extraction_message() -> None:
+    """End-to-end through the real glue: local alias catalog →
+    ``_resolve_virtual_model_entry`` → ``resolve_extraction_window`` →
+    503 whose message talks about memory extraction, not Hermes."""
+    app, stub, _ = _real_seam_app(4096)
+
+    with TestClient(app) as c:
+        r = c.post("/api/memory/add", json={"text": "hello"})
+
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["error"]["code"] == "memory.extraction_ctx_too_small"
+    message = body["error"]["message"]
+    assert "Hermes" not in message
+    assert "memory" in message and "extraction" in message
+    assert stub.add_calls == []
+
+
+@pytest.mark.parametrize(
+    ("path", "headers"),
+    [
+        ("/api/memory/add?owned_by=nope", {}),
+        ("/api/memory/add", {"X-hal0-Model-Filter": "openrouter"}),
+        ("/api/memory/add?owned_by=nope", {"X-hal0-Model-Filter": "openrouter"}),
+    ],
+    ids=["owned_by-param", "model-filter-header", "both"],
+)
+def test_real_preflight_is_not_disabled_by_caller_catalog_filters(
+    path: str, headers: dict[str, str]
+) -> None:
+    """Finding 1 on PR #1917: ``owned_by`` / ``X-hal0-Model-Filter`` are
+    discovery-surface curation. Routed through ``_aggregate_models`` they
+    emptied the preflight's catalog, degraded the verdict to ``unknown``,
+    and let arbitrary request metadata silently turn the safety check off.
+    The preflight now builds its catalog locally, so the same below-floor
+    box must 503 regardless of what filters the caller sends."""
+    app, stub, _ = _real_seam_app(4096)
+
+    with TestClient(app) as c:
+        r = c.post(path, json={"text": "hello"}, headers=headers)
+
+    assert r.status_code == 503, r.text
+    assert r.json()["error"]["code"] == "memory.extraction_ctx_too_small"
+    assert stub.add_calls == []
+
+
+def test_real_preflight_never_fetches_upstream_catalogs() -> None:
+    """Finding 3 on PR #1917: the preflight used to ride
+    ``_aggregate_models``'s uncached, sequential ``fetch_models`` HTTP
+    fan-out — up to seconds of connect timeout per offline upstream on
+    EVERY memory write. The resolution is local slot state only; any
+    ``fetch_models`` call here is a regression."""
+    app, _, upstreams = _real_seam_app(4096)
+
+    with TestClient(app) as c:
+        c.post("/api/memory/add", json={"text": "hello"})
+
+    assert upstreams.fetch_calls == []
+
+
+def test_real_preflight_passes_a_healthy_slot_through_to_the_wrapper() -> None:
+    app, stub, upstreams = _real_seam_app(32768)
+
+    with TestClient(app) as c:
+        r = c.post("/api/memory/add", json={"text": "hello"})
+
+    assert r.status_code == 200, r.text
+    assert len(stub.add_calls) == 1
+    assert upstreams.fetch_calls == []

--- a/tests/api/test_memory_extraction_ctx_preflight.py
+++ b/tests/api/test_memory_extraction_ctx_preflight.py
@@ -1,0 +1,174 @@
+"""``POST /api/memory/add`` preflights the extraction slot's context window (#1903).
+
+Hindsight builds its graph via its own extraction LLM call, dispatched to
+``hal0/<extraction_slot>`` regardless of ``[memory.graph].enabled``
+(reporting-only on this engine — ``HindsightProvider.graph_status``). Nothing
+ever checked that dispatch's effective window against the extraction prompt's
+own footprint before landing a write: an undersized resolved slot used to
+answer ``/add`` with HTTP 200 + a document id, and the retain was then either
+silently dropped by the engine (``retain_extract_facts`` 500 "Context size has
+been exceeded") or answered by persisting the extraction prompt's own
+scaffolding as a "fact" with no grounding check.
+
+These pin the route-level contract: a below-floor window fails fast (503,
+before ``wrapper.add`` is ever called — no document id minted for a write
+that was always going to be dropped); an ``ok``/``unknown`` window still
+reaches the wrapper unchanged, so a healthy box (or one the preflight simply
+can't prove anything about) is never blocked.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.agents.anchor_window import AnchorWindow
+from hal0.api.middleware import error_codes
+from hal0.api.routes import memory as memory_routes
+
+
+class StubHindsightWrapper:
+    """Duck-typed stand-in exposing the two attributes the route probes for
+    ("this provider does slot-dispatched extraction") — ``hindsight_client``
+    and ``extraction_slot`` — mirroring :class:`HindsightProvider`."""
+
+    def __init__(self, *, extraction_slot: str = "utility") -> None:
+        self.hindsight_client = object()
+        self.extraction_slot = extraction_slot
+        self.add_calls: list[dict[str, Any]] = []
+
+    async def add(self, **kwargs: Any) -> dict[str, Any]:
+        self.add_calls.append(kwargs)
+        return {"id": kwargs.get("document_id") or "generated-id", "timestamp": "now"}
+
+
+@pytest.fixture
+def stub_wrapper() -> StubHindsightWrapper:
+    return StubHindsightWrapper()
+
+
+def _build_app(stub: StubHindsightWrapper) -> FastAPI:
+    app = FastAPI()
+    error_codes.install(app)
+    app.include_router(memory_routes.router, prefix="/api/memory", tags=["memory"])
+    app.state.memory_provider = stub
+    return app
+
+
+@pytest.fixture
+def client(stub_wrapper: StubHindsightWrapper) -> Iterator[TestClient]:
+    app = _build_app(stub_wrapper)
+    with TestClient(app) as c:
+        yield c
+
+
+def _window(
+    verdict_effective: int | None, *, floor: int = 8192, slot: str = "utility"
+) -> AnchorWindow:
+    return AnchorWindow(
+        model=f"hal0/{slot}",
+        slot=slot,
+        effective=verdict_effective,
+        ceiling=verdict_effective,
+        floor=floor,
+        floor_source="hal0:extraction-prompt-floor",
+        slots_dir=Path("/etc/hal0/slots"),
+        endpoint="/v1/models",
+    )
+
+
+def test_add_blocked_when_extraction_slot_is_below_the_ctx_floor(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient, stub_wrapper: StubHindsightWrapper
+) -> None:
+    """The reported repro shape: the resolved extraction slot's effective
+    window (4096) sits under the extraction prompt's own floor. The route
+    must fail fast — 503, never a 200 for a write the engine can't extract —
+    and MUST NOT call ``wrapper.add`` at all (no document id minted for a
+    write that was always going to be dropped)."""
+
+    async def _fake_window(request, wrapper):
+        assert wrapper is stub_wrapper
+        return _window(4096)
+
+    monkeypatch.setattr(memory_routes, "_extraction_window", _fake_window)
+
+    r = client.post("/api/memory/add", json={"text": "hello"})
+
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["error"]["code"] == "memory.extraction_ctx_too_small"
+    assert stub_wrapper.add_calls == []
+
+
+def test_add_proceeds_when_extraction_slot_clears_the_floor(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient, stub_wrapper: StubHindsightWrapper
+) -> None:
+    async def _fake_window(request, wrapper):
+        return _window(32768)
+
+    monkeypatch.setattr(memory_routes, "_extraction_window", _fake_window)
+
+    r = client.post("/api/memory/add", json={"text": "hello"})
+
+    assert r.status_code == 200, r.text
+    assert len(stub_wrapper.add_calls) == 1
+
+
+def test_add_proceeds_when_the_window_cannot_be_proven(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient, stub_wrapper: StubHindsightWrapper
+) -> None:
+    """``unknown`` (no evidence either way) must not block writes on a
+    healthy box just because the catalog lookup came back thin — the same
+    "unknown is not a pass, but it is also not a refusal" rule the route
+    docstring cites from #1877's own resolver."""
+
+    async def _fake_window(request, wrapper):
+        return _window(None)
+
+    monkeypatch.setattr(memory_routes, "_extraction_window", _fake_window)
+
+    r = client.post("/api/memory/add", json={"text": "hello"})
+
+    assert r.status_code == 200, r.text
+    assert len(stub_wrapper.add_calls) == 1
+
+
+def test_add_skips_the_preflight_for_providers_without_slot_dispatched_extraction() -> None:
+    """A provider with no ``hindsight_client`` (e.g. the in-memory
+    ``PgVectorProvider`` fallback) never dispatches extraction to a slot at
+    all — the REAL ``_extraction_window`` (not a stub) must resolve to
+    ``None`` for it without attempting any catalog lookup, and ``/add`` must
+    proceed normally."""
+
+    class PlainWrapper:
+        async def add(self, **kwargs: Any) -> dict[str, Any]:
+            return {"id": "x", "timestamp": "now"}
+
+    stub = PlainWrapper()
+    app = _build_app(stub)  # type: ignore[arg-type]
+
+    with TestClient(app) as c:
+        r = c.post("/api/memory/add", json={"text": "hello"})
+
+    assert r.status_code == 200, r.text
+
+
+async def test_extraction_window_helper_no_ops_without_hindsight_client() -> None:
+    """Direct unit check of the real guard: no ``hindsight_client`` attribute
+    (or a ``None`` one) short-circuits before any catalog call is made."""
+
+    class NoHindsight:
+        pass
+
+    class WithNoneClient:
+        hindsight_client = None
+        extraction_slot = "utility"
+
+    request = object()  # never touched if the guard fires correctly
+    assert await memory_routes._extraction_window(request, NoHindsight()) is None
+    assert await memory_routes._extraction_window(request, WithNoneClient()) is None

--- a/tests/memory/test_extraction_env.py
+++ b/tests/memory/test_extraction_env.py
@@ -14,9 +14,12 @@ from pathlib import Path
 
 from hal0.memory.extraction_env import (
     DROP_IN_PATH,
+    EXTRACTION_MIN_CONTEXT_TOKENS,
     apply_extraction_slot,
     drop_in_matches,
+    extraction_model_name,
     render_drop_in,
+    resolve_extraction_window,
 )
 from hal0.system.seam import SEAM_BIN, SystemCtlSeam
 
@@ -322,3 +325,64 @@ def test_apply_writes_directly_when_not_the_hal0_user(monkeypatch, tmp_path: Pat
         ["systemctl", "daemon-reload"],
         ["systemctl", "restart", "hindsight-api.service"],
     ]
+
+
+# ── #1903: extraction-slot context-window preflight ─────────────────────────
+#
+# Hindsight's native extraction call is dispatched to ``hal0/<extraction_slot>``
+# regardless of the hal0-side enable toggle (reporting-only on this engine).
+# Nothing ever preflighted that dispatch's window before this — an undersized
+# resolved slot used to answer /add with HTTP 200 + a document id and then
+# either drop the retain (Hindsight's own "Context size has been exceeded")
+# or persist the extraction prompt's own scaffolding as fact. These pin the
+# resolution logic reused from #1877's `resolve_anchor_window`.
+
+
+def test_extraction_model_name_matches_the_drop_in_spelling():
+    assert extraction_model_name("utility") == "hal0/utility"
+    assert extraction_model_name("agent") == "hal0/agent"
+
+
+def test_resolve_extraction_window_below_floor_on_the_repro_shape(tmp_path: Path):
+    """The reported ct150 shape: extraction slot resolves to a live 4096-token
+    window — clearly under the extraction prompt's own footprint."""
+    entry = {"id": "hal0/utility", "context_length": 4096}
+    catalog = [{"id": "utility", "context_length": 4096}]
+
+    window = resolve_extraction_window("utility", entry=entry, catalog=catalog, slots_dir=tmp_path)
+
+    assert window.verdict == "below_floor"
+    assert window.effective == 4096
+    assert window.floor == EXTRACTION_MIN_CONTEXT_TOKENS
+    assert window.slot == "utility"
+
+
+def test_resolve_extraction_window_ok_when_the_slot_clears_the_floor(tmp_path: Path):
+    entry = {"id": "hal0/utility", "context_length": 32768}
+    catalog = [{"id": "utility", "context_length": 32768}]
+
+    window = resolve_extraction_window("utility", entry=entry, catalog=catalog, slots_dir=tmp_path)
+
+    assert window.verdict == "ok"
+
+
+def test_resolve_extraction_window_unknown_when_the_catalog_has_no_evidence(tmp_path: Path):
+    """No advertised context anywhere — the caller must treat this as
+    "cannot prove", never as a silent pass (#1831's lesson, reused here)."""
+    window = resolve_extraction_window("utility", entry=None, catalog=[], slots_dir=tmp_path)
+
+    assert window.verdict == "unknown"
+
+
+def test_resolve_extraction_window_uses_a_dedicated_floor_not_hermes():
+    """The extraction floor is the prompt's own footprint, not Hermes' much
+    larger MINIMUM_CONTEXT_LENGTH — an extraction slot deliberately sized
+    well below 64,000 (typical for a small local utility model) must not be
+    flagged just because it would fail Hermes' anchor check."""
+    entry = {"id": "hal0/utility", "context_length": 16384}
+    catalog = [{"id": "utility", "context_length": 16384}]
+
+    window = resolve_extraction_window("utility", entry=entry, catalog=catalog)
+
+    assert window.verdict == "ok"
+    assert window.floor < 64_000

--- a/tests/memory/test_extraction_env.py
+++ b/tests/memory/test_extraction_env.py
@@ -483,3 +483,20 @@ def test_explicit_floor_argument_still_wins_over_the_env(monkeypatch, tmp_path: 
 
     assert window.verdict == "below_floor"
     assert window.floor == 8192
+
+
+def test_invalid_floor_override_warns_once_not_per_write(monkeypatch):
+    """Codex on PR #1917: extraction_floor() runs on the memory-write hot
+    path, so a persistent typo'd override must not emit a journal warning on
+    every auto-retain — once per distinct value is enough."""
+    from hal0.memory import extraction_env as mod
+
+    monkeypatch.setattr(mod, "_floor_override_warned", set())
+    monkeypatch.setenv(EXTRACTION_FLOOR_ENV, "8k")
+    warnings: list[str] = []
+    monkeypatch.setattr(mod.log, "warning", lambda event, **kw: warnings.append(event))
+
+    for _ in range(3):
+        assert extraction_floor() == (EXTRACTION_MIN_CONTEXT_TOKENS, "hal0:extraction-prompt-floor")
+
+    assert warnings == ["hal0.memory.extraction_floor_override_invalid"]

--- a/tests/memory/test_extraction_env.py
+++ b/tests/memory/test_extraction_env.py
@@ -14,9 +14,11 @@ from pathlib import Path
 
 from hal0.memory.extraction_env import (
     DROP_IN_PATH,
+    EXTRACTION_FLOOR_ENV,
     EXTRACTION_MIN_CONTEXT_TOKENS,
     apply_extraction_slot,
     drop_in_matches,
+    extraction_floor,
     extraction_model_name,
     render_drop_in,
     resolve_extraction_window,
@@ -344,7 +346,7 @@ def test_extraction_model_name_matches_the_drop_in_spelling():
 
 
 def test_resolve_extraction_window_below_floor_on_the_repro_shape(tmp_path: Path):
-    """The reported ct150 shape: extraction slot resolves to a live 4096-token
+    """The reported ct151-cpu-fresh shape: extraction slot resolves to a live 4096-token
     window — clearly under the extraction prompt's own footprint."""
     entry = {"id": "hal0/utility", "context_length": 4096}
     catalog = [{"id": "utility", "context_length": 4096}]
@@ -374,7 +376,7 @@ def test_resolve_extraction_window_unknown_when_the_catalog_has_no_evidence(tmp_
     assert window.verdict == "unknown"
 
 
-def test_resolve_extraction_window_uses_a_dedicated_floor_not_hermes():
+def test_resolve_extraction_window_uses_a_dedicated_floor_not_hermes(tmp_path: Path):
     """The extraction floor is the prompt's own footprint, not Hermes' much
     larger MINIMUM_CONTEXT_LENGTH — an extraction slot deliberately sized
     well below 64,000 (typical for a small local utility model) must not be
@@ -382,7 +384,102 @@ def test_resolve_extraction_window_uses_a_dedicated_floor_not_hermes():
     entry = {"id": "hal0/utility", "context_length": 16384}
     catalog = [{"id": "utility", "context_length": 16384}]
 
-    window = resolve_extraction_window("utility", entry=entry, catalog=catalog)
+    window = resolve_extraction_window("utility", entry=entry, catalog=catalog, slots_dir=tmp_path)
 
     assert window.verdict == "ok"
     assert window.floor < 64_000
+
+
+def test_below_floor_message_names_memory_extraction_not_hermes(tmp_path: Path):
+    """Finding 2 on PR #1917: the parent ``AnchorWindow.message`` is
+    hard-coded for Hermes' 64,000-token anchor preflight. The 503 an operator
+    sees for a refused memory write must talk about memory extraction — the
+    right subsystem, the right floor semantics, the right failure scope —
+    while keeping the resolver's numbers, slot, and fix command."""
+    entry = {"id": "hal0/utility", "context_length": 4096}
+    catalog = [{"id": "utility", "context_length": 4096}]
+
+    window = resolve_extraction_window("utility", entry=entry, catalog=catalog, slots_dir=tmp_path)
+    msg = window.message()
+
+    assert window.verdict == "below_floor"
+    assert "Hermes" not in msg
+    assert "EVERY turn" not in msg
+    assert "memory" in msg
+    assert "extraction" in msg
+    assert "4,096" in msg
+    assert f"{EXTRACTION_MIN_CONTEXT_TOKENS:,}" in msg
+    assert "slot 'utility'" in msg
+
+
+def test_below_floor_message_includes_the_fix_command_for_a_binding_ceiling(tmp_path: Path):
+    (tmp_path / "utility.toml").write_text("[model]\ncontext_size = 4096\n")
+    entry = {"id": "hal0/utility", "context_length": 4096}
+    catalog = [{"id": "utility", "context_length": 4096}]
+
+    window = resolve_extraction_window("utility", entry=entry, catalog=catalog, slots_dir=tmp_path)
+    msg = window.message()
+
+    assert "context_size = 4,096" in msg
+    assert "hal0 slot edit utility --ctx-size 8192" in msg
+
+
+def test_unknown_and_ok_messages_are_extraction_specific(tmp_path: Path):
+    unknown = resolve_extraction_window("utility", entry=None, catalog=[], slots_dir=tmp_path)
+    ok = resolve_extraction_window(
+        "utility",
+        entry={"id": "hal0/utility", "context_length": 32768},
+        catalog=[{"id": "utility", "context_length": 32768}],
+        slots_dir=tmp_path,
+    )
+
+    assert "Hermes" not in unknown.message()
+    assert "Hermes" not in ok.message()
+    assert "memory extraction" in unknown.message()
+    assert "memory extraction" in ok.message()
+
+
+# ── HAL0_MEMORY_EXTRACTION_FLOOR override (PR #1917 review, finding 7) ──────
+
+
+def test_extraction_floor_defaults_without_the_env_var(monkeypatch):
+    monkeypatch.delenv(EXTRACTION_FLOOR_ENV, raising=False)
+    assert extraction_floor() == (EXTRACTION_MIN_CONTEXT_TOKENS, "hal0:extraction-prompt-floor")
+
+
+def test_extraction_floor_env_override_is_honoured(monkeypatch, tmp_path: Path):
+    """The floor is a documented estimate hal0 cannot measure; an operator
+    whose engine's prompt is genuinely smaller must have a knob that doesn't
+    require resizing a slot."""
+    monkeypatch.setenv(EXTRACTION_FLOOR_ENV, "4000")
+
+    assert extraction_floor() == (4000, f"env:{EXTRACTION_FLOOR_ENV}")
+
+    entry = {"id": "hal0/utility", "context_length": 4096}
+    catalog = [{"id": "utility", "context_length": 4096}]
+    window = resolve_extraction_window("utility", entry=entry, catalog=catalog, slots_dir=tmp_path)
+
+    assert window.verdict == "ok"
+    assert window.floor == 4000
+
+
+def test_extraction_floor_garbage_override_falls_back(monkeypatch):
+    """A typo'd override must not 500 every write — it is ignored."""
+    for garbage in ("8k", "-1", "0", "  "):
+        monkeypatch.setenv(EXTRACTION_FLOOR_ENV, garbage)
+        floor, source = extraction_floor()
+        assert floor == EXTRACTION_MIN_CONTEXT_TOKENS
+        assert source == "hal0:extraction-prompt-floor"
+
+
+def test_explicit_floor_argument_still_wins_over_the_env(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv(EXTRACTION_FLOOR_ENV, "4000")
+    entry = {"id": "hal0/utility", "context_length": 4096}
+    catalog = [{"id": "utility", "context_length": 4096}]
+
+    window = resolve_extraction_window(
+        "utility", entry=entry, catalog=catalog, floor=8192, slots_dir=tmp_path
+    )
+
+    assert window.verdict == "below_floor"
+    assert window.floor == 8192


### PR DESCRIPTION
## Summary

`/api/memory/add` never preflighted the resolved Hindsight extraction slot's
effective context window against the extraction prompt's own footprint.
Hindsight builds its graph via its own extraction LLM call dispatched to
`hal0/<extraction_slot>` — regardless of `[memory.graph].enabled`, which is
reporting-only on this engine. When the resolved slot's window couldn't fit
the prompt, `/add` still answered HTTP 200 + a document id, and the retain
was then either silently dropped by the engine (`retain_extract_facts` 500
"Context size has been exceeded", the document never actually stored) or —
worse — answered by persisting the extraction prompt's own scaffolding
(few-shot examples, narrator text) as a "fact", with no grounding check.

## Root cause

The `hal0/<slot>` extraction dispatch is the exact same "virtual model
through the routing fallback chain" shape #1877 already preflights for
Hermes' anchor (`hal0/agent`) — the slot a virtual name is *spelled* like is
not necessarily the slot actually serving it. Nothing on the extraction side
ever ran that check; the gap was purely the missing preflight, not a new
routing defect, so the fix reuses `hal0.agents.anchor_window.resolve_anchor_window`
rather than reimplementing its resolution logic.

## What changed

- `hal0.memory.extraction_env`: new `EXTRACTION_MIN_CONTEXT_TOKENS` (8192 —
  a conservative floor: rc.6 validation observed the extraction prompt itself
  runs ~3-4k tokens, and the reproduced failure sat at ctx=4096, at or below
  the prompt's own footprint before any document text is added),
  `extraction_model_name()`, and `resolve_extraction_window()` (thin wrapper
  around #1877's `resolve_anchor_window` with the extraction-specific floor).
- `hal0.api.routes.memory`: new `_extraction_window()` helper resolves the
  live extraction slot's window in-process (reuses `v1.py`'s
  `_aggregate_models` / `_resolve_virtual_model_entry` directly rather than
  looping back over HTTP). `memory_add` calls it before `wrapper.add` and
  raises the new `MemoryExtractionCtxTooSmall` (503,
  `memory.extraction_ctx_too_small`) on a `below_floor` verdict — no
  document id is ever minted for a write that was always going to be
  dropped. An `unknown` verdict (no evidence either way) does not block,
  matching the "unknown is not a pass, but not a refusal either" rule
  #1877's own resolver already documents. Providers without slot-dispatched
  extraction (no `hindsight_client`, e.g. the in-memory `PgVectorProvider`
  fallback) are skipped entirely.

## How it was verified

- New unit tests in `tests/memory/test_extraction_env.py` pin
  `resolve_extraction_window`'s below-floor / ok / unknown verdicts against
  the reported ct150 repro shape (4096-token effective window), and confirm
  the floor is extraction-specific (well under Hermes' 64,000 floor).
- New `tests/api/test_memory_extraction_ctx_preflight.py` pins the route
  contract: a below-floor window → 503 with `wrapper.add` never called; an
  ok/unknown window → the write proceeds unchanged; a provider without
  `hindsight_client` skips the preflight.
- Confirmed the new route-level tests fail against the pre-fix tree
  (`_extraction_window` doesn't exist) and pass after.
- `uv run pytest` — full suite: 2995 passed, 2 skipped, 1 xfailed (unrelated
  pre-existing xfail), no failures.
- `uv run ruff check` / `uv run ruff format --check` on all touched files —
  clean (repo-wide check shows only pre-existing, unrelated issues in
  `packaging/`/`scripts/`/`installer/comfyui/`).

## Left out of scope

- The floor (8192) is a defensible, documented estimate — hal0 has no
  visibility into the vendored Hindsight prompt template's exact token
  count. Making it configurable (or measuring it precisely) is a follow-up
  if it proves too conservative/loose in practice.
- The by-design "no grounding validation on the extracted output" gap
  (`known-issues.yaml: memory-extraction-quality-is-anchor-dependent`)
  stays out of scope — this PR only closes the missing preflight, which
  that entry explicitly calls out as the separate, filable defect.

Closes #1903