### PR TITLE
feat(dispatcher): bound relayed upstream streams with a stall guard

### DIFF
--- a/docs/reference/api/streaming.mdx
+++ b/docs/reference/api/streaming.mdx
@@ -16,11 +16,12 @@ hal0's streaming forward path in the dispatcher (`hal0.dispatcher.router`).
   specifically so a connect failure surfaces as a clean `502 UpstreamUnavailable`
   rather than failing partway through an already-started response generator.
 - The client response is a Starlette `StreamingResponse` whose body iterator does a
-  **raw byte passthrough** — `async for chunk in resp.aiter_raw(): yield chunk`. hal0
+  **raw byte passthrough** — every upstream chunk is yielded unmodified. hal0
   does **not** parse or re-emit SSE events itself; the OpenAI-standard
   `data: {...}\n\n` ... `data: [DONE]\n\n` framing and the `text/event-stream`
   content-type come from whatever upstream is serving the slot (llama-server, FLM, or
-  a remote provider), copied through verbatim.
+  a remote provider), copied through verbatim. The one exception is the stall guard
+  below, which may **append** a terminal chunk after cutting a stream off.
 - Status code and `content-type` on the client response are copied verbatim from the
   upstream response.
 
@@ -34,6 +35,45 @@ apply — only the underlying HTTP client's `connect` (5.0s), `write` (10.0s), a
 `pool` (5.0s) timeouts constrain the streaming path's connection setup. There is no
 separate configurable read timeout once bytes start flowing.
 </Aside>
+
+## Stall guard
+
+Because no read timeout applies to an open stream, a pathological upstream that
+never terminates (`finish_reason` forever `null`) would be relayed forever, leaving
+the client — Hermes `--cli`, the dashboard, any OpenAI-compatible caller — waiting
+on a socket that never closes, with no output and no diagnostic. Two bounds prevent
+that:
+
+| Key | Default | Meaning |
+|---|---|---|
+| `[dispatcher].stream_total_timeout_s` | `900.0` | Max wall clock for one relayed stream |
+| `[dispatcher].stream_idle_timeout_s` | `300.0` | Max gap between two upstream chunks |
+
+Either bound tripping closes the upstream stream and logs
+`dispatch.stream_stall_guard_tripped` (with `reason`, `elapsed_s`, and the upstream
+name). On a `text/event-stream` response hal0 then appends a final
+`chat.completion.chunk` before `data: [DONE]`:
+
+```json
+{
+  "id": "hal0-stall-guard",
+  "object": "chat.completion.chunk",
+  "choices": [
+    {
+      "index": 0,
+      "delta": { "role": "assistant", "content": "\n\n[hal0] stall guard: ..." },
+      "finish_reason": "length"
+    }
+  ],
+  "x_hal0_stall": { "reason": "total", "elapsed_s": 900.0, "upstream": "llm" }
+}
+```
+
+The notice is rendered as ordinary assistant content so the operator sees the cutoff,
+`finish_reason` is the standard `"length"` so strict clients terminate cleanly, and
+the precise cause lives in the `x_hal0_stall` extension. Non-SSE streaming bodies
+(audio, images) are cut off without any injected frame. Set either key to `0` to
+disable that bound.
 
 ## Slot state during a stream
 

--- a/docs/reference/api/streaming.mdx
+++ b/docs/reference/api/streaming.mdx
@@ -32,9 +32,12 @@ hal0's streaming forward path in the dispatcher (`hal0.dispatcher.router`).
 [Config schema](/docs/reference/config-schema/#dispatcher)) sets the HTTP client's
 `read` timeout, which httpx applies to **every** body read — streaming included.
 While the stall guard is active, streaming requests therefore disable it
-per-request so the guard owns the read bound and a stall always produces the
+per-request so the guard owns the *body* bound and a stall always produces the
 diagnostic frame below (a bare `httpx.ReadTimeout` would tear the stream with no
-terminal frame). Only with **both** stall-guard bounds set to `0` is the client's
+terminal frame). `direct_read_timeout_s` still bounds the wait for response
+headers on those requests — the guard's own clocks only start once headers
+arrive, so a header wait needs its own bound. Only with **both** stall-guard
+bounds set to `0` is the client's
 read timeout kept on the streaming path, as a per-read transport backstop; if it
 trips, the guard still converts it into a diagnostic frame with reason `read`.
 The `connect` (5.0s), `write` (10.0s), and `pool` (5.0s) timeouts constrain the

--- a/docs/reference/api/streaming.mdx
+++ b/docs/reference/api/streaming.mdx
@@ -29,20 +29,27 @@ hal0's streaming forward path in the dispatcher (`hal0.dispatcher.router`).
 
 <Aside type="caution">
 `[dispatcher].direct_read_timeout_s` (default `300.0`, range `30.0-600.0` — see
-[Config schema](/docs/reference/config-schema/#dispatcher)) governs the
-**non-streaming** forward path only. Once a stream is open, this timeout does not
-apply — only the underlying HTTP client's `connect` (5.0s), `write` (10.0s), and
-`pool` (5.0s) timeouts constrain the streaming path's connection setup. There is no
-separate configurable read timeout once bytes start flowing.
+[Config schema](/docs/reference/config-schema/#dispatcher)) sets the HTTP client's
+`read` timeout, which httpx applies to **every** body read — streaming included.
+While the stall guard is active, streaming requests therefore disable it
+per-request so the guard owns the read bound and a stall always produces the
+diagnostic frame below (a bare `httpx.ReadTimeout` would tear the stream with no
+terminal frame). Only with **both** stall-guard bounds set to `0` is the client's
+read timeout kept on the streaming path, as a per-read transport backstop; if it
+trips, the guard still converts it into a diagnostic frame with reason `read`.
+The `connect` (5.0s), `write` (10.0s), and `pool` (5.0s) timeouts constrain the
+streaming path's connection setup as usual.
 </Aside>
 
 ## Stall guard
 
-Because no read timeout applies to an open stream, a pathological upstream that
-never terminates (`finish_reason` forever `null`) would be relayed forever, leaving
-the client — Hermes `--cli`, the dashboard, any OpenAI-compatible caller — waiting
-on a socket that never closes, with no output and no diagnostic. Two bounds prevent
-that:
+httpx's per-read timeout is no defense against a *chatty* pathological upstream
+that never terminates (`finish_reason` forever `null`): every chunk resets the
+read timer, so the stream would be relayed forever, leaving the client — Hermes
+`--cli`, the dashboard, any OpenAI-compatible caller — waiting on a socket that
+never closes, with no output and no diagnostic. And against a *silent* upstream a
+bare transport timeout tears the stream without any terminal frame. Two
+guard-owned bounds prevent both:
 
 | Key | Default | Meaning |
 |---|---|---|
@@ -51,8 +58,14 @@ that:
 
 Either bound tripping closes the upstream stream and logs
 `dispatch.stream_stall_guard_tripped` (with `reason`, `elapsed_s`, and the upstream
-name). On a `text/event-stream` response hal0 then appends a final
-`chat.completion.chunk` before `data: [DONE]`:
+name). `reason` is `total`, `idle`, or `read` (transport read timeout — only
+possible with the guard fully disabled). On a `text/event-stream` response hal0
+then appends a final chunk before `data: [DONE]`, preceded by a blank line so it
+parses as its own SSE event even when the upstream stalled midway through a
+`data:` line. For `/chat/completions` (and any other chat-shaped SSE stream) it is
+a `chat.completion.chunk`; for the legacy `/v1/completions` it is a
+`text_completion` chunk carrying the notice in `choices[].text` instead of
+`choices[].delta`:
 
 ```json
 {
@@ -75,6 +88,14 @@ the precise cause lives in the `x_hal0_stall` extension. Non-SSE streaming bodie
 (audio, images) are cut off without any injected frame. Set either key to `0` to
 disable that bound.
 
+<Aside type="note">
+`stream_total_timeout_s` is wall clock, not a health signal: a genuinely healthy
+long generation — e.g. a big turn at a few tok/s on a CPU-only box — that outlives
+the budget is also cut, with the notice injected as assistant content. On slow
+hardware that routinely runs long turns, raise the total bound (up to `86400`) or
+set it to `0` and rely on the idle bound, which only fires on true silence.
+</Aside>
+
 ## Slot state during a stream
 
 A slot dispatching a streaming request is held in the `SERVING` state until the client
@@ -92,6 +113,11 @@ sent to the client:
 - **Time-to-first-token (TTFT)**: recorded at the first chunk containing a `"delta":`
   marker, deliberately skipping llama-server's initial role-only chunk — stored in a
   per-slot TTFT event deque.
+
+The synthetic stall-guard frame is recognized by its `x_hal0_stall` marker and
+excluded from both: it never counts as a generated token or a TTFT sample, and the
+request-metrics row for a guard-tripped stream is recorded as a failure
+(`ok = 0`, `error_code = stream_stall_<reason>`) rather than a clean success.
 
 Non-streaming responses get an analogous hook that pulls `usage.completion_tokens`
 (and, for FLM/NPU responses, the hal0-specific `usage.decoding_speed_tps` /

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -76,11 +76,16 @@ Root model `Hal0Config`, `extra="allow"`.
 | `prefetch_parallel_cap` | int | `4` | `>= 1` |
 
 `stream_total_timeout_s` / `stream_idle_timeout_s` are the streaming **stall
-guard**: no read timeout applies once a stream is open, so a never-terminating
-upstream would otherwise be relayed forever. When either bound trips, hal0
-closes the upstream stream and — on `text/event-stream` responses — appends one
-terminal chunk carrying a human-readable notice, `finish_reason: "length"`, and
-an `x_hal0_stall` object naming the reason, followed by `data: [DONE]`.
+guard**: a chatty never-terminating upstream resets the transport read timer
+with every chunk, so it would otherwise be relayed forever. While the guard is
+active, streaming requests disable the HTTP client's read timeout per-request so
+the guard owns the bound (`direct_read_timeout_s` then applies to non-streaming
+requests only); with both bounds set to `0` the client read timeout stays on as
+a transport backstop. When a bound trips, hal0 closes the upstream stream and —
+on `text/event-stream` responses — appends one terminal chunk carrying a
+human-readable notice, `finish_reason: "length"`, and an `x_hal0_stall` object
+naming the reason, followed by `data: [DONE]`. Note the total bound is wall
+clock: a healthy long generation on slow hardware that outlives it is also cut.
 
 ### `[telemetry]`
 

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -71,7 +71,16 @@ Root model `Hal0Config`, `extra="allow"`.
 |---|---|---|---|
 | `prefetch_timeout_s` | float | `8.0` | `> 0.0` |
 | `direct_read_timeout_s` | float | `300.0` | `30.0-600.0` |
+| `stream_total_timeout_s` | float | `900.0` | `0.0-86400.0` (`0` disables) |
+| `stream_idle_timeout_s` | float | `300.0` | `0.0-86400.0` (`0` disables) |
 | `prefetch_parallel_cap` | int | `4` | `>= 1` |
+
+`stream_total_timeout_s` / `stream_idle_timeout_s` are the streaming **stall
+guard**: no read timeout applies once a stream is open, so a never-terminating
+upstream would otherwise be relayed forever. When either bound trips, hal0
+closes the upstream stream and — on `text/event-stream` responses — appends one
+terminal chunk carrying a human-readable notice, `finish_reason: "length"`, and
+an `x_hal0_stall` object naming the reason, followed by `data: [DONE]`.
 
 ### `[telemetry]`
 

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -79,8 +79,9 @@ Root model `Hal0Config`, `extra="allow"`.
 guard**: a chatty never-terminating upstream resets the transport read timer
 with every chunk, so it would otherwise be relayed forever. While the guard is
 active, streaming requests disable the HTTP client's read timeout per-request so
-the guard owns the bound (`direct_read_timeout_s` then applies to non-streaming
-requests only); with both bounds set to `0` the client read timeout stays on as
+the guard owns the body bound; `direct_read_timeout_s` still bounds the wait for
+response headers on those requests, since the guard's own clocks only start once
+headers arrive. With both bounds set to `0` the client read timeout stays on as
 a transport backstop. When a bound trips, hal0 closes the upstream stream and —
 on `text/event-stream` responses — appends one terminal chunk carrying a
 human-readable notice, `finish_reason: "length"`, and an `x_hal0_stall` object

--- a/installer/agents/hermes/plugins/hal0-provider/profile.py
+++ b/installer/agents/hermes/plugins/hal0-provider/profile.py
@@ -167,15 +167,37 @@ def is_alias(model_id: str) -> bool:
 
 _DONE_SENTINEL = "[DONE]"
 
+# hal0's stall-guard extension field (see hal0.dispatcher.router). The gateway
+# stamps it on the terminal chunk when it cuts off a never-terminating upstream
+# so the consumer can name the cutoff instead of reporting a clean stop.
+_STALL_FIELD = "x_hal0_stall"
 
-def iter_sse_data(lines: Iterable[bytes | str]) -> Iterator[str]:
+# Consumer-side ceiling on SSE events per turn (#1893). A pathological upstream
+# that the gateway's guard somehow does not bound (a direct slot connection, a
+# gateway on an older build) still cannot spin this consumer forever.
+DEFAULT_MAX_SSE_EVENTS = 200_000
+
+
+def iter_sse_data(
+    lines: Iterable[bytes | str],
+    *,
+    max_events: int | None = DEFAULT_MAX_SSE_EVENTS,
+) -> Iterator[str]:
     """Yield the ``data:`` payloads of an SSE stream.
 
     Tolerates gaps: blank keep-alive lines and ``:``-comment heartbeats are
     skipped, non-``data:`` fields are ignored, and the terminal ``[DONE]``
     sentinel stops iteration.
+
+    ``max_events`` bounds how many payloads are consumed before iteration
+    stops regardless of what the upstream is doing — a never-terminating
+    stream must never become an unbounded loop here (#1893). Pass ``None``
+    to disable the ceiling.
     """
+    emitted = 0
     for raw in lines:
+        if max_events is not None and emitted >= max_events:
+            return
         line = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else raw
         line = line.rstrip("\r\n")
         if not line or line.startswith(":"):
@@ -185,12 +207,17 @@ def iter_sse_data(lines: Iterable[bytes | str]) -> Iterator[str]:
         payload = line[len("data:") :].strip()
         if payload == _DONE_SENTINEL:
             return
+        emitted += 1
         yield payload
 
 
-def parse_sse_chunks(lines: Iterable[bytes | str]) -> Iterator[dict[str, Any]]:
+def parse_sse_chunks(
+    lines: Iterable[bytes | str],
+    *,
+    max_events: int | None = DEFAULT_MAX_SSE_EVENTS,
+) -> Iterator[dict[str, Any]]:
     """Parse SSE ``data:`` payloads into chunk dicts, dropping malformed ones."""
-    for payload in iter_sse_data(lines):
+    for payload in iter_sse_data(lines, max_events=max_events):
         try:
             obj = json.loads(payload)
         except (ValueError, TypeError):
@@ -206,14 +233,26 @@ def assemble_stream(chunks: Iterable[dict[str, Any]]) -> dict[str, Any]:
     across chunks, preserves ``reasoning_content`` verbatim, and reassembles
     indexed ``tool_calls`` with gap tolerance (missing / non-contiguous /
     repeated indices are folded by index, then emitted in index order).
+
+    Also reports whether the turn actually *finished* (#1893). ``stalled`` is
+    True when the stream ended without any ``finish_reason`` — the shape a
+    never-terminating upstream produces once something bounds it — or when
+    hal0's gateway stamped its ``x_hal0_stall`` stall-guard extension on the
+    terminal chunk. ``stall`` carries the gateway's structured reason when
+    there is one. Callers must render a cutoff notice rather than presenting
+    a stalled turn as a clean, complete answer.
     """
     content_parts: list[str] = []
     reasoning_parts: list[str] = []
     tool_calls: dict[int, dict[str, Any]] = {}
     role: str | None = None
     finish_reason: str | None = None
+    stall: dict[str, Any] | None = None
 
     for chunk in chunks:
+        raw_stall = chunk.get(_STALL_FIELD)
+        if isinstance(raw_stall, dict):
+            stall = dict(raw_stall)
         for choice in chunk.get("choices") or []:
             if not isinstance(choice, dict):
                 continue
@@ -249,7 +288,14 @@ def assemble_stream(chunks: Iterable[dict[str, Any]]) -> dict[str, Any]:
         message["reasoning_content"] = "".join(reasoning_parts)
     if tool_calls:
         message["tool_calls"] = [tool_calls[i] for i in sorted(tool_calls)]
-    return {"message": message, "finish_reason": finish_reason}
+    result: dict[str, Any] = {
+        "message": message,
+        "finish_reason": finish_reason,
+        "stalled": stall is not None or finish_reason is None,
+    }
+    if stall is not None:
+        result["stall"] = stall
+    return result
 
 
 # ── The profile ────────────────────────────────────────────────────────────

--- a/src/hal0/agents/hermes/plugins/provider_hal0/profile.py
+++ b/src/hal0/agents/hermes/plugins/provider_hal0/profile.py
@@ -167,15 +167,37 @@ def is_alias(model_id: str) -> bool:
 
 _DONE_SENTINEL = "[DONE]"
 
+# hal0's stall-guard extension field (see hal0.dispatcher.router). The gateway
+# stamps it on the terminal chunk when it cuts off a never-terminating upstream
+# so the consumer can name the cutoff instead of reporting a clean stop.
+_STALL_FIELD = "x_hal0_stall"
 
-def iter_sse_data(lines: Iterable[bytes | str]) -> Iterator[str]:
+# Consumer-side ceiling on SSE events per turn (#1893). A pathological upstream
+# that the gateway's guard somehow does not bound (a direct slot connection, a
+# gateway on an older build) still cannot spin this consumer forever.
+DEFAULT_MAX_SSE_EVENTS = 200_000
+
+
+def iter_sse_data(
+    lines: Iterable[bytes | str],
+    *,
+    max_events: int | None = DEFAULT_MAX_SSE_EVENTS,
+) -> Iterator[str]:
     """Yield the ``data:`` payloads of an SSE stream.
 
     Tolerates gaps: blank keep-alive lines and ``:``-comment heartbeats are
     skipped, non-``data:`` fields are ignored, and the terminal ``[DONE]``
     sentinel stops iteration.
+
+    ``max_events`` bounds how many payloads are consumed before iteration
+    stops regardless of what the upstream is doing — a never-terminating
+    stream must never become an unbounded loop here (#1893). Pass ``None``
+    to disable the ceiling.
     """
+    emitted = 0
     for raw in lines:
+        if max_events is not None and emitted >= max_events:
+            return
         line = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else raw
         line = line.rstrip("\r\n")
         if not line or line.startswith(":"):
@@ -185,12 +207,17 @@ def iter_sse_data(lines: Iterable[bytes | str]) -> Iterator[str]:
         payload = line[len("data:") :].strip()
         if payload == _DONE_SENTINEL:
             return
+        emitted += 1
         yield payload
 
 
-def parse_sse_chunks(lines: Iterable[bytes | str]) -> Iterator[dict[str, Any]]:
+def parse_sse_chunks(
+    lines: Iterable[bytes | str],
+    *,
+    max_events: int | None = DEFAULT_MAX_SSE_EVENTS,
+) -> Iterator[dict[str, Any]]:
     """Parse SSE ``data:`` payloads into chunk dicts, dropping malformed ones."""
-    for payload in iter_sse_data(lines):
+    for payload in iter_sse_data(lines, max_events=max_events):
         try:
             obj = json.loads(payload)
         except (ValueError, TypeError):
@@ -206,14 +233,26 @@ def assemble_stream(chunks: Iterable[dict[str, Any]]) -> dict[str, Any]:
     across chunks, preserves ``reasoning_content`` verbatim, and reassembles
     indexed ``tool_calls`` with gap tolerance (missing / non-contiguous /
     repeated indices are folded by index, then emitted in index order).
+
+    Also reports whether the turn actually *finished* (#1893). ``stalled`` is
+    True when the stream ended without any ``finish_reason`` — the shape a
+    never-terminating upstream produces once something bounds it — or when
+    hal0's gateway stamped its ``x_hal0_stall`` stall-guard extension on the
+    terminal chunk. ``stall`` carries the gateway's structured reason when
+    there is one. Callers must render a cutoff notice rather than presenting
+    a stalled turn as a clean, complete answer.
     """
     content_parts: list[str] = []
     reasoning_parts: list[str] = []
     tool_calls: dict[int, dict[str, Any]] = {}
     role: str | None = None
     finish_reason: str | None = None
+    stall: dict[str, Any] | None = None
 
     for chunk in chunks:
+        raw_stall = chunk.get(_STALL_FIELD)
+        if isinstance(raw_stall, dict):
+            stall = dict(raw_stall)
         for choice in chunk.get("choices") or []:
             if not isinstance(choice, dict):
                 continue
@@ -249,7 +288,14 @@ def assemble_stream(chunks: Iterable[dict[str, Any]]) -> dict[str, Any]:
         message["reasoning_content"] = "".join(reasoning_parts)
     if tool_calls:
         message["tool_calls"] = [tool_calls[i] for i in sorted(tool_calls)]
-    return {"message": message, "finish_reason": finish_reason}
+    result: dict[str, Any] = {
+        "message": message,
+        "finish_reason": finish_reason,
+        "stalled": stall is not None or finish_reason is None,
+    }
+    if stall is not None:
+        result["stall"] = stall
+    return result
 
 
 # ── The profile ────────────────────────────────────────────────────────────

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1313,6 +1313,8 @@ async def _boot_dispatcher(app: FastAPI, ctx: BootState) -> None:
         model_registry=ctx.model_registry,
         prefetch_timeout_s=ctx.hal0_config.dispatcher.prefetch_timeout_s,
         direct_read_timeout_s=ctx.hal0_config.dispatcher.direct_read_timeout_s,
+        stream_total_timeout_s=ctx.hal0_config.dispatcher.stream_total_timeout_s,
+        stream_idle_timeout_s=ctx.hal0_config.dispatcher.stream_idle_timeout_s,
         prefetch_parallel_cap=ctx.hal0_config.dispatcher.prefetch_parallel_cap,
         cached_models=lambda name: ctx.model_cache.get(name, []),
         fetch_models=ctx.fetch_and_cache,

--- a/src/hal0/api/_settings_apply.py
+++ b/src/hal0/api/_settings_apply.py
@@ -120,6 +120,9 @@ SERVICE_HAL0_API: str = "hal0-api"
 #                                            Router at create_app time,
 #                                            same as the other two
 #                                            dispatcher knobs above).
+#   * ``[dispatcher].{stream_total_timeout_s, → service-restart[hal0-api]
+#     stream_idle_timeout_s}``                (stall-guard bounds, same
+#                                            create_app-time wiring).
 #   * ``[memory].unified_bank``             → service-restart[hal0-api]
 #                                            (constructor arg to
 #                                            HindsightProvider, built once
@@ -242,6 +245,14 @@ _HAL0_REGISTRY: dict[str, ApplyPlanEntry] = {
     },
     # [dispatcher] — same create_app-time wiring as the other two entries.
     "dispatcher.direct_read_timeout_s": {
+        "apply_class": "service-restart",
+        "services": [SERVICE_HAL0_API],
+    },
+    "dispatcher.stream_total_timeout_s": {
+        "apply_class": "service-restart",
+        "services": [SERVICE_HAL0_API],
+    },
+    "dispatcher.stream_idle_timeout_s": {
         "apply_class": "service-restart",
         "services": [SERVICE_HAL0_API],
     },

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -131,10 +131,16 @@ def _instrument_streaming_throughput(
     async def _counting() -> Any:
         nonlocal ttft_pending
         async for chunk in original:
+            # The dispatcher's stall-guard terminal frame (#1893) is synthetic
+            # — it carries a "delta": but no generated token ever crossed the
+            # wire.  It is always yielded as its own chunk, so a per-chunk
+            # marker check keeps it out of throughput and (crucially) TTFT:
+            # for a silent upstream it would otherwise record a bogus
+            # ~idle-timeout-sized TTFT sample.
             if isinstance(chunk, (bytes, bytearray)):
-                tokens = chunk.count(b'"delta":')
+                tokens = 0 if b'"x_hal0_stall"' in chunk else chunk.count(b'"delta":')
             elif isinstance(chunk, str):
-                tokens = chunk.count('"delta":')
+                tokens = 0 if '"x_hal0_stall"' in chunk else chunk.count('"delta":')
             else:
                 tokens = 0
             if tokens > 0:

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2175,7 +2175,10 @@ class DispatcherConfig(BaseModel):
         description=(
             "Non-streaming upstream read timeout in seconds. "
             "Large consolidation/extraction prompts can exceed 60s on slow slots. "
-            "Streaming paths are unaffected. Range 30-600."
+            "Streaming requests disable this per-request while the stall guard "
+            "is active (the guard owns the bound); with both stall-guard "
+            "bounds set to 0 it applies per body read as the transport "
+            "backstop. Range 30-600."
         ),
     )
     stream_total_timeout_s: float = Field(
@@ -2185,9 +2188,11 @@ class DispatcherConfig(BaseModel):
         description=(
             "Stall guard: max wall-clock duration of a relayed upstream stream "
             "before hal0 cuts it off and emits a terminal diagnostic chunk. "
-            "httpx applies no read timeout once a stream is open, so without "
-            "this a never-terminating upstream hangs the client forever (#1893). "
-            "0 disables the bound."
+            "Without this a chatty never-terminating upstream is relayed "
+            "forever — each chunk resets the transport read timer (#1893). "
+            "Note this is wall clock: a healthy long generation on slow "
+            "hardware that outlives the budget is also cut. 0 disables the "
+            "bound."
         ),
     )
     stream_idle_timeout_s: float = Field(

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2178,6 +2178,29 @@ class DispatcherConfig(BaseModel):
             "Streaming paths are unaffected. Range 30-600."
         ),
     )
+    stream_total_timeout_s: float = Field(
+        default=900.0,
+        ge=0.0,
+        le=86400.0,
+        description=(
+            "Stall guard: max wall-clock duration of a relayed upstream stream "
+            "before hal0 cuts it off and emits a terminal diagnostic chunk. "
+            "httpx applies no read timeout once a stream is open, so without "
+            "this a never-terminating upstream hangs the client forever (#1893). "
+            "0 disables the bound."
+        ),
+    )
+    stream_idle_timeout_s: float = Field(
+        default=300.0,
+        ge=0.0,
+        le=86400.0,
+        description=(
+            "Stall guard: max gap between two chunks of a relayed upstream "
+            "stream before hal0 cuts it off. Must stay above the slowest "
+            "expected prompt-processing silence on a cold CPU slot. "
+            "0 disables the bound."
+        ),
+    )
     prefetch_parallel_cap: int = Field(
         default=4,
         ge=1,

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2176,7 +2176,9 @@ class DispatcherConfig(BaseModel):
             "Non-streaming upstream read timeout in seconds. "
             "Large consolidation/extraction prompts can exceed 60s on slow slots. "
             "Streaming requests disable this per-request while the stall guard "
-            "is active (the guard owns the bound); with both stall-guard "
+            "is active so the guard owns the body bound; it still bounds the "
+            "wait for response headers on those requests, since the guard's "
+            "own clocks only start once headers arrive. With both stall-guard "
             "bounds set to 0 it applies per body read as the transport "
             "backstop. Range 30-600."
         ),

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -136,6 +136,28 @@ _DISPATCHER_MAX_KEEPALIVE: int = 16
 # unaffected — the read timeout is not applied once the stream is open).
 _DIRECT_READ_TIMEOUT_S: float = 60.0
 
+# Streaming stall guard (#1893).  httpx applies NO read timeout once a stream
+# is open, so a never-terminating upstream — the shape the Vulkan garbage-token
+# defect produces, ``finish_reason`` forever null — used to be relayed forever:
+# the client (Hermes ``--cli``, the dashboard, any OpenAI-compat caller) sat on
+# an open socket with no output and no diagnostic for as long as the operator
+# waited.  Two independent bounds close that:
+#
+#   * total   — wall clock from first byte of the response to end of stream.
+#   * idle    — the gap between two consecutive upstream chunks.
+#
+# Both are deliberately generous: prompt processing on a cold CPU-only slot is
+# genuinely silent for minutes, and a long agentic turn genuinely runs for
+# minutes.  The guard exists to convert "hangs forever" into "ends with a named
+# reason", not to police slow-but-working inference.  ``0`` disables a bound.
+_STREAM_TOTAL_TIMEOUT_S: float = 900.0
+_STREAM_IDLE_TIMEOUT_S: float = 300.0
+
+# Content types that get the operator-visible terminal frame.  Anything else
+# (binary audio, image bytes) is cut off silently — injecting SSE into a
+# non-SSE body would corrupt it.
+_SSE_CONTENT_TYPE = "text/event-stream"
+
 # Outgoing upstream path rewrites applied before forwarding.
 # Key: incoming /v1/* path (as-is from the client).
 # Value: replacement path to use in the upstream URL.
@@ -380,6 +402,11 @@ class Dispatcher:
                             (PLAN.md §5 Tier 2 — was hardcoded 4s, now 8s).
         direct_read_timeout_s: Non-streaming upstream read timeout in seconds.
                             Configurable via [dispatcher].direct_read_timeout_s.
+        stream_total_timeout_s: Max wall-clock duration of a relayed stream
+                            before the stall guard cuts it off (#1893).
+                            ``0`` disables the bound.
+        stream_idle_timeout_s: Max gap between two upstream chunks before the
+                            stall guard cuts the stream off.  ``0`` disables.
         prefetch_parallel_cap: Max concurrent cold-prefetch legs
                             ([dispatcher].prefetch_parallel_cap, default 4).
         cached_models:      Returns the cached /v1/models for an upstream.
@@ -395,6 +422,8 @@ class Dispatcher:
         *,
         prefetch_timeout_s: float = 8.0,  # TIER2 — configurable (was hardcoded 4s)
         direct_read_timeout_s: float = _DIRECT_READ_TIMEOUT_S,
+        stream_total_timeout_s: float = _STREAM_TOTAL_TIMEOUT_S,
+        stream_idle_timeout_s: float = _STREAM_IDLE_TIMEOUT_S,
         prefetch_parallel_cap: int = 4,  # max concurrent cold-prefetch legs
         cached_models: CachedModelsFn | None = None,
         is_online: IsOnlineFn | None = None,
@@ -420,6 +449,11 @@ class Dispatcher:
         self._owns_http_client: bool = http_client is None
         # Non-streaming read timeout — configurable via TOML (default 300s).
         self._direct_read_timeout_s: float = direct_read_timeout_s
+        # Streaming stall guard bounds (#1893) — configurable via TOML.
+        # Negative is coerced to 0 ("disabled") so a bad value can never make
+        # every stream cut off instantly.
+        self._stream_total_timeout_s: float = max(0.0, stream_total_timeout_s)
+        self._stream_idle_timeout_s: float = max(0.0, stream_idle_timeout_s)
         # SlotManager — when supplied, forward() wraps slot-kind calls in
         # SlotManager.serving() so the slot transitions READY/IDLE →
         # SERVING → READY around each /v1 request (task #10 SERVING).
@@ -1212,19 +1246,90 @@ class Dispatcher:
                 },
             ) from exc
 
-        async def _iter() -> AsyncIterator[bytes]:
-            try:
-                async for chunk in resp.aiter_raw():
-                    yield chunk
-            finally:
-                await resp.aclose()
-
         return StreamingResponse(
-            _iter(),
+            self._guarded_stream(resp, call),
             status_code=resp.status_code,
             headers=_filter_response_headers(resp.headers),
             media_type=resp.headers.get("content-type"),
         )
+
+    async def _guarded_stream(
+        self,
+        resp: httpx.Response,
+        call: UpstreamCall,
+    ) -> AsyncIterator[bytes]:
+        """Relay ``resp`` to the client under the stall guard (#1893).
+
+        Chunks pass through byte-for-byte.  What changes is that the relay is
+        now *bounded*: it ends when the upstream ends, when the total
+        wall-clock budget is spent, or when the gap since the last chunk
+        exceeds the idle budget — whichever comes first.  A stream that trips
+        a bound is closed and, if it is an OpenAI-compatible SSE stream,
+        terminated with one chunk naming the cutoff plus ``data: [DONE]``, so
+        the client's stream loop exits cleanly with the partial output it
+        already received instead of waiting forever on a socket that will
+        never close.
+        """
+        started = time.monotonic()
+        source = resp.aiter_raw().__aiter__()
+        stall: str | None = None
+        try:
+            while True:
+                budget = self._next_chunk_budget(started)
+                if budget is not None and budget <= 0.0:
+                    stall = "total"
+                    break
+                try:
+                    if budget is None:
+                        chunk = await source.__anext__()
+                    else:
+                        chunk = await asyncio.wait_for(source.__anext__(), timeout=budget)
+                except StopAsyncIteration:
+                    return
+                except TimeoutError:
+                    stall = self._stall_reason(started)
+                    break
+                yield chunk
+        finally:
+            await resp.aclose()
+
+        elapsed = round(time.monotonic() - started, 3)
+        log.warning(
+            "dispatch.stream_stall_guard_tripped",
+            upstream=call.upstream_name,
+            target=call.target_url,
+            reason=stall,
+            elapsed_s=elapsed,
+            total_timeout_s=self._stream_total_timeout_s,
+            idle_timeout_s=self._stream_idle_timeout_s,
+        )
+        content_type = (resp.headers.get("content-type") or "").lower()
+        if content_type.startswith(_SSE_CONTENT_TYPE):
+            yield _stall_sse_frames(
+                reason=stall or "total",
+                elapsed_s=elapsed,
+                upstream=call.upstream_name,
+                total_timeout_s=self._stream_total_timeout_s,
+                idle_timeout_s=self._stream_idle_timeout_s,
+            )
+
+    def _next_chunk_budget(self, started: float) -> float | None:
+        """Seconds to wait for the next chunk, or ``None`` when unbounded."""
+        idle = self._stream_idle_timeout_s or None
+        if not self._stream_total_timeout_s:
+            return idle
+        remaining_total = self._stream_total_timeout_s - (time.monotonic() - started)
+        if idle is None:
+            return remaining_total
+        return min(idle, remaining_total)
+
+    def _stall_reason(self, started: float) -> str:
+        """Classify which bound a timed-out read hit."""
+        if not self._stream_total_timeout_s:
+            return "idle"
+        if (time.monotonic() - started) >= self._stream_total_timeout_s:
+            return "total"
+        return "idle"
 
     # ── internals ────────────────────────────────────────────────────────
 
@@ -1521,6 +1626,69 @@ def _join_url(upstream_url: str, request_path: str) -> str:
 def _filter_response_headers(headers: httpx.Headers) -> dict[str, str]:
     """Drop hop-by-hop and length headers so Starlette can recompute them."""
     return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP_RESPONSE_HEADERS}
+
+
+_STALL_MESSAGES = {
+    "total": (
+        "upstream stream exceeded the {total_timeout_s:g}s total budget "
+        "without terminating (stall guard)"
+    ),
+    "idle": ("upstream stream sent nothing for {idle_timeout_s:g}s (stall guard)"),
+}
+
+
+def _stall_sse_frames(
+    *,
+    reason: str,
+    elapsed_s: float,
+    upstream: str,
+    total_timeout_s: float,
+    idle_timeout_s: float,
+) -> bytes:
+    """Build the terminal SSE frames for a stall-guard cutoff (#1893).
+
+    Shaped as a normal ``chat.completion.chunk`` so every OpenAI-compatible
+    client handles it without special-casing:
+
+    * ``delta.content`` carries a human-readable line — the operator sees
+      *something* rather than a silent terminal, which is the whole point.
+    * ``finish_reason`` is ``"length"``, the closest standard enum member for
+      "cut off at a limit"; clients that branch on the enum terminate cleanly.
+      The precise cause lives in the ``x_hal0_stall`` extension so nothing is
+      lost to that approximation.
+    * ``data: [DONE]`` ends the stream loop for clients that wait for the
+      sentinel rather than for the socket to close.
+    """
+    detail = _STALL_MESSAGES.get(reason, _STALL_MESSAGES["total"]).format(
+        total_timeout_s=total_timeout_s,
+        idle_timeout_s=idle_timeout_s,
+    )
+    text = (
+        f"\n\n[hal0] stall guard: {detail} after {elapsed_s:g}s "
+        f"(upstream {upstream!r}). Output above is partial."
+    )
+    chunk = {
+        "id": "hal0-stall-guard",
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": "",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": text},
+                "finish_reason": "length",
+            }
+        ],
+        "x_hal0_stall": {
+            "reason": reason,
+            "elapsed_s": elapsed_s,
+            "upstream": upstream,
+            "total_timeout_s": total_timeout_s,
+            "idle_timeout_s": idle_timeout_s,
+            "detail": detail,
+        },
+    }
+    return (f"data: {json.dumps(chunk, separators=(',', ':'))}\n\ndata: [DONE]\n\n").encode()
 
 
 __all__ = [

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -1221,7 +1221,8 @@ class Dispatcher:
         # transport backstop; _guarded_stream still converts its ReadTimeout
         # into a diagnostic frame rather than a torn stream.
         timeout: httpx.Timeout | httpx._client.UseClientDefault
-        if self._stream_total_timeout_s or self._stream_idle_timeout_s:
+        guard_active = bool(self._stream_total_timeout_s or self._stream_idle_timeout_s)
+        if guard_active:
             timeout = httpx.Timeout(connect=5.0, read=None, write=10.0, pool=5.0)
         else:
             timeout = httpx.USE_CLIENT_DEFAULT
@@ -1233,7 +1234,25 @@ class Dispatcher:
                 headers=call.headers,
                 timeout=timeout,
             )
-            resp = await client.send(req, stream=True)
+            # client.send() blocks until response *headers* are on the wire,
+            # even with stream=True — and it's bound by the same ``read``
+            # timeout we just set.  With the guard active that's ``None``
+            # (the guard's own clocks in _guarded_stream own the body bound),
+            # which also disables the bound on *this* header wait.  Those
+            # clocks only start after send() returns, so an upstream that
+            # accepts the TCP connection and then wedges before writing a
+            # status line would hang forward() forever (#1918 review,
+            # blocking).  Bound the header wait explicitly, matching the
+            # pre-guard direct-request timeout — asyncio.TimeoutError is a
+            # builtin TimeoutError, itself an OSError subclass, so it falls
+            # into the same UpstreamUnavailable handling as a transport
+            # error below.
+            if guard_active:
+                resp = await asyncio.wait_for(
+                    client.send(req, stream=True), timeout=self._direct_read_timeout_s
+                )
+            else:
+                resp = await client.send(req, stream=True)
         except _DEAD_PORT_TRANSPORT_ERRORS as exc:
             self._guard_dead_port_image_mode(call)
             log.warning(

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -132,16 +132,24 @@ _DISPATCHER_MAX_KEEPALIVE: int = 16
 # Non-streaming (direct) read timeout.  300 s was too generous: a stuck
 # upstream could hold a connection slot for 5 min, rapidly exhausting the
 # pool under even modest sustained load.  60 s is still well above the
-# longest expected non-streaming completion time (and streaming paths are
-# unaffected — the read timeout is not applied once the stream is open).
+# longest expected non-streaming completion time.  Streaming requests
+# override this per-request (see ``_forward_streaming``): while the stall
+# guard is active the httpx read timeout is disabled so the guard owns the
+# bound; with the guard fully disabled this read timeout is the per-read
+# transport backstop (httpx applies ``read`` to every body read, streaming
+# included, and raises ``httpx.ReadTimeout`` — NOT the builtin
+# ``TimeoutError``).
 _DIRECT_READ_TIMEOUT_S: float = 60.0
 
-# Streaming stall guard (#1893).  httpx applies NO read timeout once a stream
-# is open, so a never-terminating upstream — the shape the Vulkan garbage-token
-# defect produces, ``finish_reason`` forever null — used to be relayed forever:
-# the client (Hermes ``--cli``, the dashboard, any OpenAI-compat caller) sat on
-# an open socket with no output and no diagnostic for as long as the operator
-# waited.  Two independent bounds close that:
+# Streaming stall guard (#1893).  Before the guard, the only bound on an open
+# stream was httpx's per-read timeout, which tears the socket with a bare
+# ``httpx.ReadTimeout`` — no terminal frame, no ``[DONE]`` — and does nothing
+# at all against a *chatty* never-terminating upstream (the shape the Vulkan
+# garbage-token defect produces, ``finish_reason`` forever null): each read
+# resets the timer, so the stream was relayed forever.  The client (Hermes
+# ``--cli``, the dashboard, any OpenAI-compat caller) sat on an open socket
+# with no output and no diagnostic for as long as the operator waited.  Two
+# independent bounds close that:
 #
 #   * total   — wall clock from first byte of the response to end of stream.
 #   * idle    — the gap between two consecutive upstream chunks.
@@ -462,9 +470,10 @@ class Dispatcher:
 
     def _get_http_client(self) -> httpx.AsyncClient:
         if self._http_client is None:
-            # Short connect/write/pool; non-streaming read capped at
-            # _direct_read_timeout_s (streaming paths ignore the read timeout
-            # once the first byte arrives — see httpx docs on stream=True).
+            # Short connect/write/pool; read capped at _direct_read_timeout_s.
+            # httpx applies ``read`` to *every* body read, streaming included —
+            # streaming requests therefore override it per-request in
+            # _forward_streaming so the stall guard owns the bound (#1893).
             # Connection limits match registry.py to prevent pool starvation
             # under sustained slow-upstream load (#415).
             self._http_client = httpx.AsyncClient(
@@ -1202,12 +1211,27 @@ class Dispatcher:
         # We open the stream eagerly so connect errors surface as
         # UpstreamUnavailable instead of leaking through StreamingResponse
         # as a generator-time exception that confuses the error middleware.
+        # While the stall guard is active, disable the client's per-read
+        # timeout for this request so the guard owns the bound outright.
+        # httpx applies ``read`` to every body read — streaming included —
+        # and raises ``httpx.ReadTimeout``, which is NOT a subclass of the
+        # builtin ``TimeoutError``; left in place it would race the guard
+        # and tear the stream with no terminal frame.  With the guard fully
+        # disabled (both bounds 0) the client's read timeout is kept as the
+        # transport backstop; _guarded_stream still converts its ReadTimeout
+        # into a diagnostic frame rather than a torn stream.
+        timeout: httpx.Timeout | httpx._client.UseClientDefault
+        if self._stream_total_timeout_s or self._stream_idle_timeout_s:
+            timeout = httpx.Timeout(connect=5.0, read=None, write=10.0, pool=5.0)
+        else:
+            timeout = httpx.USE_CLIENT_DEFAULT
         try:
             req = client.build_request(
                 call.method,
                 call.target_url,
                 content=call.body or None,
                 headers=call.headers,
+                timeout=timeout,
             )
             resp = await client.send(req, stream=True)
         except _DEAD_PORT_TRANSPORT_ERRORS as exc:
@@ -1289,6 +1313,17 @@ class Dispatcher:
                 except TimeoutError:
                     stall = self._stall_reason(started)
                     break
+                except httpx.ReadTimeout:
+                    # Transport-level per-read timeout.  Reached only when the
+                    # guard is fully disabled (both bounds 0, so the client's
+                    # read timeout was kept) or when an injected http_client
+                    # carries its own read bound.  ``httpx.ReadTimeout`` is
+                    # NOT a subclass of builtin ``TimeoutError``; without this
+                    # clause it would escape after response headers are on the
+                    # wire — a torn stream with no diagnostic, the exact
+                    # outcome #1893 is about.
+                    stall = "read"
+                    break
                 yield chunk
         finally:
             await resp.aclose()
@@ -1311,6 +1346,7 @@ class Dispatcher:
                 upstream=call.upstream_name,
                 total_timeout_s=self._stream_total_timeout_s,
                 idle_timeout_s=self._stream_idle_timeout_s,
+                endpoint=call.target_url,
             )
 
     def _next_chunk_budget(self, started: float) -> float | None:
@@ -1634,6 +1670,7 @@ _STALL_MESSAGES = {
         "without terminating (stall guard)"
     ),
     "idle": ("upstream stream sent nothing for {idle_timeout_s:g}s (stall guard)"),
+    "read": ("upstream stream read timed out at the transport (stall guard)"),
 }
 
 
@@ -1644,13 +1681,17 @@ def _stall_sse_frames(
     upstream: str,
     total_timeout_s: float,
     idle_timeout_s: float,
+    endpoint: str = "",
 ) -> bytes:
     """Build the terminal SSE frames for a stall-guard cutoff (#1893).
 
-    Shaped as a normal ``chat.completion.chunk`` so every OpenAI-compatible
-    client handles it without special-casing:
+    Shaped as a normal stream chunk for the endpoint being relayed — a
+    ``chat.completion.chunk`` with ``choices[].delta`` for
+    ``/chat/completions``, a ``text_completion`` chunk with ``choices[].text``
+    for the pre-chat ``/completions`` — so every OpenAI-compatible client
+    handles it without special-casing:
 
-    * ``delta.content`` carries a human-readable line — the operator sees
+    * the content field carries a human-readable line — the operator sees
       *something* rather than a silent terminal, which is the whole point.
     * ``finish_reason`` is ``"length"``, the closest standard enum member for
       "cut off at a limit"; clients that branch on the enum terminate cleanly.
@@ -1658,6 +1699,12 @@ def _stall_sse_frames(
       lost to that approximation.
     * ``data: [DONE]`` ends the stream loop for clients that wait for the
       sentinel rather than for the socket to close.
+
+    The frames start with a blank line: ``aiter_raw()`` yields transport
+    chunks, not complete SSE events, so the upstream may have stalled midway
+    through a ``data:`` line.  The leading separator terminates any such
+    partial event so the diagnostic frame always parses on its own; before a
+    complete event a stray blank line is a no-op for every SSE parser.
     """
     detail = _STALL_MESSAGES.get(reason, _STALL_MESSAGES["total"]).format(
         total_timeout_s=total_timeout_s,
@@ -1667,28 +1714,50 @@ def _stall_sse_frames(
         f"\n\n[hal0] stall guard: {detail} after {elapsed_s:g}s "
         f"(upstream {upstream!r}). Output above is partial."
     )
-    chunk = {
-        "id": "hal0-stall-guard",
-        "object": "chat.completion.chunk",
-        "created": int(time.time()),
-        "model": "",
-        "choices": [
-            {
-                "index": 0,
-                "delta": {"role": "assistant", "content": text},
-                "finish_reason": "length",
-            }
-        ],
-        "x_hal0_stall": {
-            "reason": reason,
-            "elapsed_s": elapsed_s,
-            "upstream": upstream,
-            "total_timeout_s": total_timeout_s,
-            "idle_timeout_s": idle_timeout_s,
-            "detail": detail,
-        },
+    x_hal0_stall = {
+        "reason": reason,
+        "elapsed_s": elapsed_s,
+        "upstream": upstream,
+        "total_timeout_s": total_timeout_s,
+        "idle_timeout_s": idle_timeout_s,
+        "detail": detail,
     }
-    return (f"data: {json.dumps(chunk, separators=(',', ':'))}\n\ndata: [DONE]\n\n").encode()
+    # Legacy /v1/completions streams carry ``choices[].text``; everything else
+    # SSE-shaped through this dispatcher is chat-completions-compatible.
+    legacy_completions = "/completions" in endpoint and "/chat/completions" not in endpoint
+    chunk: dict[str, Any]
+    if legacy_completions:
+        chunk = {
+            "id": "hal0-stall-guard",
+            "object": "text_completion",
+            "created": int(time.time()),
+            "model": "",
+            "choices": [
+                {
+                    "index": 0,
+                    "text": text,
+                    "logprobs": None,
+                    "finish_reason": "length",
+                }
+            ],
+            "x_hal0_stall": x_hal0_stall,
+        }
+    else:
+        chunk = {
+            "id": "hal0-stall-guard",
+            "object": "chat.completion.chunk",
+            "created": int(time.time()),
+            "model": "",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": text},
+                    "finish_reason": "length",
+                }
+            ],
+            "x_hal0_stall": x_hal0_stall,
+        }
+    return (f"\n\ndata: {json.dumps(chunk, separators=(',', ':'))}\n\ndata: [DONE]\n\n").encode()
 
 
 __all__ = [

--- a/src/hal0/metrics/seam.py
+++ b/src/hal0/metrics/seam.py
@@ -124,6 +124,7 @@ class RequestSeam:
             first_content_ts: float | None = None
             token_chunks = 0
             last_payload: dict[str, Any] | None = None
+            stall_reason: str | None = None
             ok = True
             error_code: str | None = None
             try:
@@ -134,7 +135,14 @@ class RequestSeam:
                         if raw is not None
                         else (chunk if isinstance(chunk, str) else "")
                     )
-                    if '"delta":' in text:
+                    # The dispatcher's stall-guard terminal frame (#1893) is
+                    # synthetic: its "delta" is not a generated token and its
+                    # finish_reason must not masquerade as a clean stop.  It
+                    # is always yielded as its own chunk; keep it out of the
+                    # token/TTFT/payload accounting and record the request as
+                    # a stalled failure instead.
+                    is_stall_frame = '"x_hal0_stall"' in text
+                    if '"delta":' in text and not is_stall_frame:
                         token_chunks += text.count('"delta":')
                         if first_content_ts is None:
                             first_content_ts = time.monotonic()
@@ -146,7 +154,12 @@ class RequestSeam:
                         if not data_str or data_str == "[DONE]":
                             continue
                         parsed = parse_json_object(data_str)
-                        if parsed is not None:
+                        if parsed is None:
+                            continue
+                        stall_info = parsed.get("x_hal0_stall")
+                        if isinstance(stall_info, dict):
+                            stall_reason = str(stall_info.get("reason") or "unknown")
+                        else:
                             last_payload = parsed
                     yield chunk
             except Exception as exc:  # pragma: no cover -- upstream/client disconnect
@@ -154,6 +167,9 @@ class RequestSeam:
                 error_code = type(exc).__name__
                 raise
             finally:
+                if stall_reason is not None and ok:
+                    ok = False
+                    error_code = f"stream_stall_{stall_reason}"
                 now = time.monotonic()
                 ttft_ms = (
                     (first_content_ts - dispatch_started) * 1000.0

--- a/tests/agents/hermes/plugins/test_hal0_provider_plugin.py
+++ b/tests/agents/hermes/plugins/test_hal0_provider_plugin.py
@@ -337,6 +337,72 @@ def test_assemble_stream_preserves_reasoning_content() -> None:
     assert result["message"]["content"] == "The answer is 42."
 
 
+# ── stall guard (#1893) ────────────────────────────────────────────────────
+
+
+def test_iter_sse_data_stops_at_the_event_ceiling() -> None:
+    """A never-terminating stream must not spin the consumer forever."""
+
+    def endless() -> Any:
+        while True:
+            yield 'data: {"choices": [{"delta": {"content": "!"}}]}'
+
+    payloads = list(iter_sse_data(endless(), max_events=25))
+    assert len(payloads) == 25
+
+
+def test_assemble_stream_flags_a_stream_that_never_finished() -> None:
+    """No ``finish_reason`` anywhere means the turn was cut off, not completed."""
+    lines = [_sse(_delta(role="assistant", content="!")) for _ in range(5)]
+    result = assemble_stream(parse_sse_chunks(lines))
+    assert result["finish_reason"] is None
+    assert result["stalled"] is True
+    assert "stall" not in result  # no gateway diagnostic on this path
+
+
+def test_assemble_stream_surfaces_the_gateway_stall_diagnostic() -> None:
+    """hal0's ``x_hal0_stall`` terminal chunk is carried through to the caller."""
+    lines = [
+        _sse(_delta(role="assistant", content="partial")),
+        _sse(
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": "\n\n[hal0] stall guard: ..."},
+                        "finish_reason": "length",
+                    }
+                ],
+                "x_hal0_stall": {
+                    "reason": "total",
+                    "elapsed_s": 900.0,
+                    "upstream": "llm",
+                    "detail": "upstream stream exceeded the 900s total budget",
+                },
+            }
+        ),
+        "data: [DONE]",
+    ]
+    result = assemble_stream(parse_sse_chunks(lines))
+    assert result["stalled"] is True
+    assert result["stall"]["reason"] == "total"
+    assert result["stall"]["upstream"] == "llm"
+    # The partial output survives — the operator sees what the model did emit.
+    assert result["message"]["content"].startswith("partial")
+    assert "[hal0] stall guard" in result["message"]["content"]
+
+
+def test_assemble_stream_does_not_flag_a_clean_turn() -> None:
+    lines = [
+        _sse(_delta(role="assistant", content="done")),
+        _sse({"choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]}),
+        "data: [DONE]",
+    ]
+    result = assemble_stream(parse_sse_chunks(lines))
+    assert result["stalled"] is False
+    assert "stall" not in result
+
+
 # ── registration seam ──────────────────────────────────────────────────────
 
 

--- a/tests/api/test_throughput_history.py
+++ b/tests/api/test_throughput_history.py
@@ -188,3 +188,77 @@ def test_window_clamped_to_max(client: TestClient) -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["window_s"] == 3600
+
+
+# ── stall-guard frame exclusion (#1893 / PR #1918 review) ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stall_guard_frame_excluded_from_throughput_and_ttft() -> None:
+    """The dispatcher's synthetic stall frame carries a ``"delta":`` but is
+    not generated output: it must record neither a token event nor a TTFT
+    sample (for a silent upstream that would be a bogus ~idle-timeout TTFT)."""
+    from types import SimpleNamespace
+
+    from starlette.responses import StreamingResponse
+
+    from hal0.api.routes.v1 import _instrument_streaming_throughput
+
+    stall_frame = (
+        b'\n\ndata: {"id":"hal0-stall-guard","object":"chat.completion.chunk",'
+        b'"choices":[{"index":0,"delta":{"role":"assistant","content":"[hal0] stall"},'
+        b'"finish_reason":"length"}],'
+        b'"x_hal0_stall":{"reason":"idle","elapsed_s":300.0}}\n\ndata: [DONE]\n\n'
+    )
+
+    async def _gen():
+        yield b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'
+        yield stall_frame
+
+    app_state = SimpleNamespace(
+        tps_events=defaultdict(lambda: deque(maxlen=64)),
+        ttft_events=defaultdict(lambda: deque(maxlen=64)),
+    )
+    response = StreamingResponse(_gen(), media_type="text/event-stream")
+    wrapped = _instrument_streaming_throughput(
+        response, app_state, "primary", dispatch_started=time.monotonic()
+    )
+    async for _ in wrapped.body_iterator:
+        pass
+
+    # Only the real upstream delta counted — one token event, one TTFT sample.
+    assert [tokens for _, tokens in app_state.tps_events["primary"]] == [1]
+    assert len(app_state.ttft_events["primary"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_stall_guard_frame_alone_records_nothing() -> None:
+    """A guard-cut silent upstream yields only the synthetic frame — no token
+    events and, crucially, no TTFT sample at all."""
+    from types import SimpleNamespace
+
+    from starlette.responses import StreamingResponse
+
+    from hal0.api.routes.v1 import _instrument_streaming_throughput
+
+    async def _gen():
+        yield (
+            b'\n\ndata: {"id":"hal0-stall-guard","object":"chat.completion.chunk",'
+            b'"choices":[{"index":0,"delta":{"role":"assistant","content":"[hal0] stall"},'
+            b'"finish_reason":"length"}],'
+            b'"x_hal0_stall":{"reason":"total","elapsed_s":900.0}}\n\ndata: [DONE]\n\n'
+        )
+
+    app_state = SimpleNamespace(
+        tps_events=defaultdict(lambda: deque(maxlen=64)),
+        ttft_events=defaultdict(lambda: deque(maxlen=64)),
+    )
+    response = StreamingResponse(_gen(), media_type="text/event-stream")
+    wrapped = _instrument_streaming_throughput(
+        response, app_state, "primary", dispatch_started=time.monotonic()
+    )
+    async for _ in wrapped.body_iterator:
+        pass
+
+    assert len(app_state.tps_events["primary"]) == 0
+    assert len(app_state.ttft_events["primary"]) == 0

--- a/tests/dispatcher/test_stream_stall_guard.py
+++ b/tests/dispatcher/test_stream_stall_guard.py
@@ -3,19 +3,25 @@
 A pathological upstream — the shape the Vulkan garbage-token defect produces
 (``finish_reason`` forever ``null``, tokens forever) — used to be relayed
 verbatim and forever: ``_forward_streaming`` piped ``aiter_raw()`` to
-exhaustion, and httpx applies no read timeout once a stream is open. Every
-downstream client (Hermes ``--cli`` included) therefore sat on an open socket
-with no output and no diagnostic for as long as the operator waited.
+exhaustion, and httpx's per-read timeout is reset by every chunk, so a chatty
+stream never trips it. Every downstream client (Hermes ``--cli`` included)
+therefore sat on an open socket with no output and no diagnostic for as long
+as the operator waited.
 
 These tests pin the guard: a bounded total duration, a bounded inter-chunk
 gap, and — on an OpenAI-compatible SSE stream — a terminal chunk that names
 the cutoff followed by ``data: [DONE]`` so the client's stream loop ends
 cleanly instead of hanging.
+
+The real-socket tests exist because ``httpx.MockTransport`` ignores client
+timeouts entirely: only a live connection can prove that ``httpx.ReadTimeout``
+(NOT a subclass of builtin ``TimeoutError``) never escapes the guard.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 from collections.abc import AsyncIterator
 
@@ -56,10 +62,14 @@ class _EndlessStream(httpx.AsyncByteStream):
 _GARBAGE_CHUNK = b'data: {"id":"1","choices":[{"delta":{"content":"!"},"finish_reason":null}]}\n\n'
 
 
-def _call(*, streaming: bool = True) -> UpstreamCall:
+def _call(
+    *,
+    streaming: bool = True,
+    target_url: str = "http://upstream.test/chat/completions",
+) -> UpstreamCall:
     return UpstreamCall(
         upstream_name="test-upstream",
-        target_url="http://upstream.test/chat/completions",
+        target_url=target_url,
         headers={"content-type": "application/json"},
         body=b"",
         streaming=streaming,
@@ -191,3 +201,182 @@ async def test_guard_can_be_disabled_with_zero() -> None:
     # 20 chunks are relayed; only the idle bound ends it.
     assert body.count(_GARBAGE_CHUNK) == 20
     assert _stall_payload(body)["x_hal0_stall"]["reason"] == "idle"
+
+
+# ── real-socket tests: httpx.ReadTimeout must never escape the guard ─────────
+#
+# MockTransport ignores client timeouts entirely, so only a live connection
+# can exercise the httpx read-timeout interaction (review of PR #1918,
+# blocking 1).
+
+
+@contextlib.asynccontextmanager
+async def _silent_sse_upstream(prelude: bytes) -> AsyncIterator[int]:
+    """A real TCP server: sends ``prelude`` as an SSE body, then goes silent."""
+
+    handlers: list[asyncio.Task[None]] = []
+
+    async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        handlers.append(asyncio.current_task())  # type: ignore[arg-type]
+        with contextlib.suppress(Exception):
+            await reader.readuntil(b"\r\n\r\n")
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"content-type: text/event-stream\r\n"
+                b"connection: close\r\n"
+                b"\r\n" + prelude
+            )
+            await writer.drain()
+            await asyncio.sleep(3600)  # opened, then silent forever
+
+    server = await asyncio.start_server(_handle, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        yield port
+    finally:
+        server.close()
+        # Python ≥3.12 wait_closed() waits for handler coroutines; ours sleeps
+        # forever by design, so cancel it before waiting.
+        for task in handlers:
+            task.cancel()
+        with contextlib.suppress(Exception):
+            await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_idle_bound_above_read_timeout_still_produces_the_diagnostic() -> None:
+    """``stream_idle_timeout_s > direct_read_timeout_s`` must not hand the
+    cutoff to httpx: ``httpx.ReadTimeout`` is not a ``TimeoutError`` subclass
+    and used to escape after headers were sent — a torn stream with no frame."""
+    async with _silent_sse_upstream(_GARBAGE_CHUNK) as port:
+        dispatcher = Dispatcher(
+            direct_read_timeout_s=0.2,
+            stream_total_timeout_s=60.0,
+            stream_idle_timeout_s=0.8,
+        )
+        try:
+            resp = await dispatcher.forward(
+                _call(target_url=f"http://127.0.0.1:{port}/v1/chat/completions")
+            )
+            body = await _drain(resp)
+        finally:
+            await dispatcher.aclose()
+
+    assert _GARBAGE_CHUNK in body  # the partial output was relayed
+    assert _stall_payload(body)["x_hal0_stall"]["reason"] == "idle"
+
+
+@pytest.mark.asyncio
+async def test_idle_zero_disables_the_idle_cutoff_and_total_still_bounds() -> None:
+    """``stream_idle_timeout_s = 0`` genuinely disables the idle bound — it
+    must not silently fall through to httpx's read timeout.  The total bound
+    then ends the stream with the diagnostic."""
+    async with _silent_sse_upstream(_GARBAGE_CHUNK) as port:
+        dispatcher = Dispatcher(
+            direct_read_timeout_s=0.2,
+            stream_total_timeout_s=0.7,
+            stream_idle_timeout_s=0.0,
+        )
+        try:
+            resp = await dispatcher.forward(
+                _call(target_url=f"http://127.0.0.1:{port}/v1/chat/completions")
+            )
+            body = await _drain(resp)
+        finally:
+            await dispatcher.aclose()
+
+    payload = _stall_payload(body)
+    assert payload["x_hal0_stall"]["reason"] == "total"
+    # The stream outlived the 0.2s client read timeout — proof httpx's
+    # ReadTimeout neither cut it early nor escaped.
+    assert payload["x_hal0_stall"]["elapsed_s"] >= 0.7
+
+
+class _ReadTimeoutStream(httpx.AsyncByteStream):
+    """An upstream body that raises a transport-level read timeout."""
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:  # type: ignore[override]
+        yield _GARBAGE_CHUNK
+        raise httpx.ReadTimeout("simulated transport read timeout")
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_transport_read_timeout_becomes_a_read_stall_frame() -> None:
+    """Even with the guard fully disabled, a transport read timeout ends the
+    stream with a diagnostic frame (reason ``read``), never a bare escape."""
+    dispatcher = _dispatcher(_ReadTimeoutStream(), total=0.0, idle=0.0)
+    try:
+        resp = await dispatcher.forward(_call())
+        body = await _drain(resp)
+    finally:
+        await dispatcher.aclose()
+
+    payload = _stall_payload(body)
+    assert payload["x_hal0_stall"]["reason"] == "read"
+    assert body.count(b"data: [DONE]") == 1
+
+
+# ── SSE event-boundary and endpoint-shape tests ──────────────────────────────
+
+
+class _SplitEventThenSilentStream(httpx.AsyncByteStream):
+    """Emits one clean event, then *half* of the next, then goes silent —
+    ``aiter_raw()`` yields transport chunks, not complete SSE events."""
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:  # type: ignore[override]
+        yield b'data: {"id":"1","choices":[{"delta":{"content":"word"}}]}\n\n'
+        yield b'data: {"id":"2","cho'
+        await asyncio.sleep(3600)
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_stall_frame_after_a_mid_event_stall_parses_standalone() -> None:
+    """A stall midway through a ``data:`` line must not swallow the diagnostic:
+    the injected frames start on a fresh SSE event boundary (PR #1918
+    review, blocking 2)."""
+    dispatcher = _dispatcher(_SplitEventThenSilentStream(), total=60.0, idle=0.2)
+    try:
+        resp = await dispatcher.forward(_call())
+        body = await _drain(resp)
+    finally:
+        await dispatcher.aclose()
+
+    events = body.split(b"\n\n")
+    # The partial upstream line was terminated as its own (discardable) event…
+    assert b'data: {"id":"2","cho' in events
+    # …and the stall frame is a standalone, parseable event of its own.
+    stall_events = [e for e in events if e.startswith(b'data: {"id":"hal0-stall-guard"')]
+    assert len(stall_events) == 1, f"stall frame not standalone: {events!r}"
+    payload = json.loads(stall_events[0][len(b"data: ") :])
+    assert payload["x_hal0_stall"]["reason"] == "idle"
+    assert b"data: [DONE]" in body
+
+
+@pytest.mark.asyncio
+async def test_legacy_completions_stall_frame_is_text_shaped() -> None:
+    """``/v1/completions`` streams get a ``text_completion`` chunk with
+    ``choices[].text`` — not a chat-shaped ``delta`` (PR #1918 review,
+    non-blocking 4)."""
+    upstream = _EndlessStream(
+        b'data: {"id":"1","choices":[{"text":"!","finish_reason":null}]}\n\n', gap=30.0
+    )
+    dispatcher = _dispatcher(upstream, total=60.0, idle=0.2)
+    try:
+        resp = await dispatcher.forward(_call(target_url="http://upstream.test/v1/completions"))
+        body = await _drain(resp)
+    finally:
+        await dispatcher.aclose()
+
+    payload = _stall_payload(body)
+    assert payload["object"] == "text_completion"
+    choice = payload["choices"][0]
+    assert "delta" not in choice
+    assert "stall" in choice["text"].lower()
+    assert choice["finish_reason"] == "length"
+    assert payload["x_hal0_stall"]["reason"] == "idle"

--- a/tests/dispatcher/test_stream_stall_guard.py
+++ b/tests/dispatcher/test_stream_stall_guard.py
@@ -1,0 +1,193 @@
+"""Stall guard for a never-terminating upstream stream (#1893).
+
+A pathological upstream — the shape the Vulkan garbage-token defect produces
+(``finish_reason`` forever ``null``, tokens forever) — used to be relayed
+verbatim and forever: ``_forward_streaming`` piped ``aiter_raw()`` to
+exhaustion, and httpx applies no read timeout once a stream is open. Every
+downstream client (Hermes ``--cli`` included) therefore sat on an open socket
+with no output and no diagnostic for as long as the operator waited.
+
+These tests pin the guard: a bounded total duration, a bounded inter-chunk
+gap, and — on an OpenAI-compatible SSE stream — a terminal chunk that names
+the cutoff followed by ``data: [DONE]`` so the client's stream loop ends
+cleanly instead of hanging.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+from hal0.dispatcher.router import Dispatcher, UpstreamCall
+
+
+class _EndlessStream(httpx.AsyncByteStream):
+    """An upstream body that never ends.
+
+    ``gap`` is the delay between chunks: a small gap models the chatty
+    garbage-token stream (total-duration guard), a large one models an
+    upstream that opened the stream and then went silent (idle guard).
+    """
+
+    def __init__(self, chunk: bytes, *, gap: float, burst: int | None = None) -> None:
+        self._chunk = chunk
+        self._gap = gap
+        self._burst = burst
+        self.closed = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:  # type: ignore[override]
+        emitted = 0
+        while True:
+            if self._burst is not None and emitted >= self._burst:
+                await asyncio.sleep(3600)  # opened, then silent forever
+                continue
+            await asyncio.sleep(self._gap)
+            emitted += 1
+            yield self._chunk
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+_GARBAGE_CHUNK = b'data: {"id":"1","choices":[{"delta":{"content":"!"},"finish_reason":null}]}\n\n'
+
+
+def _call(*, streaming: bool = True) -> UpstreamCall:
+    return UpstreamCall(
+        upstream_name="test-upstream",
+        target_url="http://upstream.test/chat/completions",
+        headers={"content-type": "application/json"},
+        body=b"",
+        streaming=streaming,
+        method="POST",
+    )
+
+
+def _dispatcher(
+    stream: httpx.AsyncByteStream,
+    *,
+    content_type: str = "text/event-stream",
+    total: float = 0.25,
+    idle: float = 0.25,
+) -> Dispatcher:
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=stream, headers={"content-type": content_type})
+
+    return Dispatcher(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        stream_total_timeout_s=total,
+        stream_idle_timeout_s=idle,
+    )
+
+
+async def _drain(resp: object, *, limit: float = 10.0) -> bytes:
+    async def _read() -> bytes:
+        collected = b""
+        async for chunk in resp.body_iterator:  # type: ignore[attr-defined]
+            collected += chunk if isinstance(chunk, bytes) else chunk.encode()
+        return collected
+
+    # The whole point is that this terminates; the outer bound only keeps a
+    # regression from wedging the suite.
+    return await asyncio.wait_for(_read(), timeout=limit)
+
+
+def _stall_payload(body: bytes) -> dict:
+    frames = [ln for ln in body.decode().splitlines() if ln.startswith("data: ")]
+    assert frames[-1] == "data: [DONE]", f"stream did not end with [DONE]: {frames[-1]!r}"
+    return json.loads(frames[-2][len("data: ") :])
+
+
+@pytest.mark.asyncio
+async def test_chatty_never_terminating_stream_is_cut_off_with_a_named_reason() -> None:
+    """A stream that emits forever is cut at the total-duration bound."""
+    upstream = _EndlessStream(_GARBAGE_CHUNK, gap=0.001)
+    dispatcher = _dispatcher(upstream, total=0.2, idle=5.0)
+    try:
+        resp = await dispatcher.forward(_call())
+        body = await _drain(resp)
+    finally:
+        await dispatcher.aclose()
+
+    assert body.count(b"data: [DONE]") == 1
+    payload = _stall_payload(body)
+    stall = payload["x_hal0_stall"]
+    assert stall["reason"] == "total"
+    assert stall["upstream"] == "test-upstream"
+    assert stall["elapsed_s"] >= 0.2
+    choice = payload["choices"][0]
+    # Operator-visible: the cutoff is rendered as text AND terminates the
+    # client's stream loop via a non-null finish_reason.
+    assert choice["finish_reason"] == "length"
+    assert "hal0" in choice["delta"]["content"]
+    assert "stall" in choice["delta"]["content"].lower()
+    # The partial tokens the upstream did produce are still delivered.
+    assert b'"content":"!"' in body
+
+
+@pytest.mark.asyncio
+async def test_silent_stream_is_cut_off_at_the_idle_bound() -> None:
+    """An opened-then-silent stream trips the inter-chunk gap guard."""
+    upstream = _EndlessStream(_GARBAGE_CHUNK, gap=30.0)
+    dispatcher = _dispatcher(upstream, total=60.0, idle=0.2)
+    try:
+        resp = await dispatcher.forward(_call())
+        body = await _drain(resp)
+    finally:
+        await dispatcher.aclose()
+
+    assert _stall_payload(body)["x_hal0_stall"]["reason"] == "idle"
+
+
+@pytest.mark.asyncio
+async def test_non_sse_stream_is_bounded_without_injecting_sse_frames() -> None:
+    """Binary/JSON streaming bodies are cut off, never rewritten."""
+    upstream = _EndlessStream(b"\x00\x01\x02", gap=0.001)
+    dispatcher = _dispatcher(upstream, content_type="application/octet-stream", total=0.2)
+    try:
+        resp = await dispatcher.forward(_call())
+        body = await _drain(resp)
+    finally:
+        await dispatcher.aclose()
+
+    assert b"[DONE]" not in body
+    assert b"x_hal0_stall" not in body
+
+
+@pytest.mark.asyncio
+async def test_well_behaved_stream_is_untouched() -> None:
+    """A stream that terminates normally is relayed byte-for-byte."""
+    chunks = [
+        b'data: {"id":"1","choices":[{"delta":{"content":"hi"}}]}\n\n',
+        b'data: {"id":"1","choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+    dispatcher = _dispatcher(httpx.ByteStream(b"".join(chunks)), total=0.2, idle=0.2)
+    try:
+        resp = await dispatcher.forward(_call())
+        body = await _drain(resp)
+    finally:
+        await dispatcher.aclose()
+
+    assert body == b"".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_guard_can_be_disabled_with_zero() -> None:
+    """``0`` disables a bound — the escape hatch for a deliberate long stream."""
+    upstream = _EndlessStream(_GARBAGE_CHUNK, gap=0.02, burst=20)
+    dispatcher = _dispatcher(upstream, total=0.0, idle=0.15)
+    try:
+        resp = await dispatcher.forward(_call())
+        body = await _drain(resp)
+    finally:
+        await dispatcher.aclose()
+
+    # Total is disabled (0.0), so the stream survives well past 0.0s and all
+    # 20 chunks are relayed; only the idle bound ends it.
+    assert body.count(_GARBAGE_CHUNK) == 20
+    assert _stall_payload(body)["x_hal0_stall"]["reason"] == "idle"

--- a/tests/dispatcher/test_stream_stall_guard.py
+++ b/tests/dispatcher/test_stream_stall_guard.py
@@ -28,7 +28,7 @@ from collections.abc import AsyncIterator
 import httpx
 import pytest
 
-from hal0.dispatcher.router import Dispatcher, UpstreamCall
+from hal0.dispatcher.router import Dispatcher, UpstreamCall, UpstreamUnavailable
 
 
 class _EndlessStream(httpx.AsyncByteStream):
@@ -317,6 +317,60 @@ async def test_transport_read_timeout_becomes_a_read_stall_frame() -> None:
     payload = _stall_payload(body)
     assert payload["x_hal0_stall"]["reason"] == "read"
     assert body.count(b"data: [DONE]") == 1
+
+
+@contextlib.asynccontextmanager
+async def _header_wedge_upstream() -> AsyncIterator[int]:
+    """Real TCP server: accepts the connection, reads the request, then never
+    writes anything back — no status line, no headers, ever.  Models an
+    upstream that accepted the socket and then wedged before producing a
+    response (PR #1918 review, blocking)."""
+
+    handlers: list[asyncio.Task[None]] = []
+
+    async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        handlers.append(asyncio.current_task())  # type: ignore[arg-type]
+        with contextlib.suppress(Exception):
+            await reader.readuntil(b"\r\n\r\n")
+            await asyncio.sleep(3600)  # accepted, then never responds
+
+    server = await asyncio.start_server(_handle, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        yield port
+    finally:
+        server.close()
+        for task in handlers:
+            task.cancel()
+        with contextlib.suppress(Exception):
+            await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_header_wedge_with_guard_active_terminates_bounded() -> None:
+    """``_forward_streaming`` sets ``read=None`` for the whole request while
+    the guard is active, so the guard's clocks fully own the body bound —
+    but ``client.send(..., stream=True)`` blocks on response *headers*, and
+    the guard's clocks (``_guarded_stream``) only start after ``send()``
+    returns.  An upstream that accepts the TCP connection and then wedges
+    before writing a status line must not hang ``forward()`` forever; the
+    header wait needs its own bound (PR #1918 review, blocking)."""
+    async with _header_wedge_upstream() as port:
+        dispatcher = Dispatcher(
+            direct_read_timeout_s=0.2,
+            stream_total_timeout_s=60.0,
+            stream_idle_timeout_s=60.0,
+        )
+        try:
+            with pytest.raises(UpstreamUnavailable):
+                await asyncio.wait_for(
+                    dispatcher.forward(
+                        _call(target_url=f"http://127.0.0.1:{port}/v1/chat/completions")
+                    ),
+                    timeout=5.0,
+                )
+        finally:
+            await dispatcher.aclose()
 
 
 # ── SSE event-boundary and endpoint-shape tests ──────────────────────────────

--- a/tests/metrics/test_seam.py
+++ b/tests/metrics/test_seam.py
@@ -213,6 +213,75 @@ class TestWrapStreaming:
         assert row["stop_reason"] == "stop"
 
     @pytest.mark.asyncio
+    async def test_stall_guard_frame_recorded_as_failure_not_success(
+        self, seam: RequestSeam, writer: _FakeWriter
+    ) -> None:
+        """The dispatcher's synthetic stall frame (#1893) must not persist the
+        request as a clean success: ok=0, error_code names the stall, and the
+        frame's delta is not counted as a generated token."""
+
+        async def _gen():
+            yield b'data: {"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}\n\n'
+            yield (
+                b'\n\ndata: {"id":"hal0-stall-guard","object":"chat.completion.chunk",'
+                b'"choices":[{"index":0,"delta":{"role":"assistant","content":"[hal0] stall"},'
+                b'"finish_reason":"length"}],'
+                b'"x_hal0_stall":{"reason":"idle","elapsed_s":0.2}}\n\n'
+                b"data: [DONE]\n\n"
+            )
+
+        response = StreamingResponse(_gen(), media_type="text/event-stream")
+        t_entry = time.monotonic()
+        wrapped = seam.wrap_streaming(
+            response,
+            call=_FakeCall(upstream_name="primary", resolved_model="qwen3-4b"),
+            request=_FakeRequest(),
+            t_entry=t_entry,
+            dispatch_started=t_entry,
+        )
+        chunks = await self._drain(wrapped)
+        assert len(chunks) == 2  # passthrough untouched
+
+        assert len(writer.rows) == 1
+        _, row = writer.rows[0]
+        assert row["ok"] == 0
+        assert row["error_code"] == "stream_stall_idle"
+        # Only the real upstream delta counts; the synthetic frame does not.
+        assert row["completion_tokens"] == 1
+
+    @pytest.mark.asyncio
+    async def test_stall_frame_alone_records_no_ttft(
+        self, seam: RequestSeam, writer: _FakeWriter
+    ) -> None:
+        """A completely silent upstream cut by the guard must not record the
+        idle-timeout latency as a bogus TTFT sample."""
+
+        async def _gen():
+            yield (
+                b'\n\ndata: {"id":"hal0-stall-guard","object":"chat.completion.chunk",'
+                b'"choices":[{"index":0,"delta":{"role":"assistant","content":"[hal0] stall"},'
+                b'"finish_reason":"length"}],'
+                b'"x_hal0_stall":{"reason":"total","elapsed_s":900.0}}\n\n'
+                b"data: [DONE]\n\n"
+            )
+
+        response = StreamingResponse(_gen(), media_type="text/event-stream")
+        t_entry = time.monotonic()
+        wrapped = seam.wrap_streaming(
+            response,
+            call=_FakeCall(upstream_name="primary", resolved_model="qwen3-4b"),
+            request=_FakeRequest(),
+            t_entry=t_entry,
+            dispatch_started=t_entry,
+        )
+        await self._drain(wrapped)
+
+        _, row = writer.rows[0]
+        assert row["ok"] == 0
+        assert row["error_code"] == "stream_stall_total"
+        assert row["ttft_ms"] is None
+
+    @pytest.mark.asyncio
     async def test_disabled_seam_returns_response_unwrapped(self, writer: _FakeWriter) -> None:
         seam = RequestSeam(writer, enabled=False)
 


### PR DESCRIPTION
## What

A never-terminating upstream stream had no bound anywhere in hal0. Adds a **stall guard** to the gateway's streaming relay, plus the consumer-side half in the hal0 Hermes provider plugin.

## Why — the root cause is one layer below the report

#1893 was filed against hermes / the provider plugin: `hermes -z ... --cli` printed zero bytes, never self-terminated, and left no session file. The provider plugin is not where the defect lives.

`Dispatcher._forward_streaming` relayed `resp.aiter_raw()` to exhaustion, and **httpx applies no read timeout once a stream is open** (the existing `direct_read_timeout_s` is explicitly documented as non-streaming-only). So an upstream that never terminates — `finish_reason` forever `null`, the shape the Vulkan garbage-token defect (#1888) produces — was piped forever to *every* hal0 client: Hermes `--cli`, the dashboard, any OpenAI-compatible caller. None of them could produce a diagnostic because none of them ever saw an end of stream. Fixing this only in the hermes plugin would have left the gap open for every other client, and would not even have fixed hermes (Hermes' own OpenAI client consumes the stream, not hal0's helpers).

## What changed

**`src/hal0/dispatcher/router.py`** — the relay is now bounded by two independent budgets:

| Key | Default | Meaning |
|---|---|---|
| `[dispatcher].stream_total_timeout_s` | `900.0` | Max wall clock for one relayed stream |
| `[dispatcher].stream_idle_timeout_s` | `300.0` | Max gap between two upstream chunks |

Both are deliberately generous — prompt processing on a cold CPU-only slot is genuinely silent for minutes. The guard converts "hangs forever" into "ends with a named reason"; it does not police slow-but-working inference. `0` disables a bound; a negative value is coerced to `0` so a bad config can never cut every stream off instantly.

On a trip: the upstream stream is closed, `dispatch.stream_stall_guard_tripped` is logged (reason, elapsed, upstream, both budgets), and — **on `text/event-stream` only** — one terminal `chat.completion.chunk` is appended before `data: [DONE]`:

- `delta.content` carries a human-readable notice, so the operator sees the cutoff instead of a silent terminal;
- `finish_reason` is the standard `"length"`, so strict clients terminate cleanly;
- `x_hal0_stall` carries the precise reason, elapsed time, and budgets.

Non-SSE streaming bodies (audio, image bytes) are cut off with no injected frame — rewriting them would corrupt them. Chunks that do arrive still pass through byte-for-byte, so partial output is preserved.

**`provider_hal0/profile.py`** (+ byte-identical installer seed) — the consumer-side half: `iter_sse_data` / `parse_sse_chunks` take a `max_events` ceiling (default 200k) so a direct slot connection can't spin them forever, and `assemble_stream` now reports `stalled` — True when the stream ended with no `finish_reason` at all, or when the gateway stamped `x_hal0_stall` — plus the gateway's structured `stall` dict when present. A cut-off turn no longer looks identical to a clean one.

**Config plumbing** — `DispatcherConfig` schema fields, `_settings_apply` registry entries (`service-restart[hal0-api]`, matching `direct_read_timeout_s`), and the `_boot_dispatcher` wiring.

**Docs** — `docs/reference/config-schema.mdx` and a new "Stall guard" section in `docs/reference/api/streaming.mdx` (which previously documented "there is no separate configurable read timeout once bytes start flowing" as a caution — now it has one).

## How it was verified

New `tests/dispatcher/test_stream_stall_guard.py` drives a real never-terminating `httpx.AsyncByteStream` through `Dispatcher.forward`:

- chatty endless stream → cut at the total bound, terminal frame names `reason: "total"`, partial tokens still delivered;
- opened-then-silent stream → cut at the idle bound, `reason: "idle"`;
- non-SSE endless stream → bounded, no `[DONE]` / no `x_hal0_stall` injected;
- well-behaved stream → relayed byte-for-byte, untouched;
- `0` → that bound is disabled (all 20 chunks relayed, only the idle bound ends it).

Every one of these hangs or fails on `main` (the first fails at construction — the knobs don't exist; the relay itself has no exit).

Plus 4 provider-plugin tests for the `max_events` ceiling and the `stalled` / `stall` surfacing.

```
uv run --extra dev pytest tests/ -q -p no:randomly
  -> 10314 passed, 16 skipped, 1 xfailed in 1057s
uv run --extra dev ruff check src tests           -> All checks passed!
uv run --extra dev ruff format --check src tests  -> 1145 files already formatted
```

No test needs a live hermes or a live gateway (CI has neither).

## Deliberately out of scope

- **#1888** — the garbage-token defect that produces this stream shape. This is the independent gap that remains once the model is fixed, exactly as the issue frames it.
- **No `StreamStalled` type in `hermes/core/errors.py`.** The blast-radius plan suggested one, but `core/client.py` is a non-streaming transport and the provider plugin runs inside the Hermes venv where hal0 core is not importable — the error would have had no raiser and no consumer. The stall is surfaced through the SSE contract instead, which is the seam that actually crosses the process boundary.
- **`hermes/driver.py` partial-render surfacing.** The driver installs and health-checks Hermes; it is not in the token path. Hermes' own CLI renders the stream, and it renders our terminal chunk like any other assistant content.
- **CHANGELOG.md** — per the fix-wave convention (#1545), one consolidated entry lands at the end of the wave.

Closes #1893

🤖 Generated with [Claude Code](https://claude.com/claude-code)
