### PR TITLE
fix(cli): catch mkstemp PermissionError in config edit seed with sudo hint

### DIFF
--- a/src/hal0/cli/config_commands.py
+++ b/src/hal0/cli/config_commands.py
@@ -292,6 +292,21 @@ def config_edit(
                 "a seed owned by you at this file's canonical mode. Re-run "
                 "with [bold]sudo[/bold] so the seed lands hal0-owned."
             )
+        except OSError as exc:
+            # tempfile.mkstemp() itself can fail before _fchown_to_service_owner
+            # is ever reached: /etc/hal0 is mode 2775 hal0:hal0, so an
+            # unprivileged caller who isn't in the hal0 group can't create the
+            # temp file there at all (PermissionError), and a read-only mount
+            # would raise EROFS the same way. Only worth the sudo hint against
+            # the real /etc/hal0 — same gate _fchown_to_service_owner uses — a
+            # HAL0_HOME sandbox failing to seed is a different, unrelated
+            # problem (e.g. a genuinely full or missing filesystem).
+            if _config_paths.etc() == Path("/etc/hal0"):
+                die(
+                    f"cannot seed {path}: {exc}. Re-run with [bold]sudo[/bold] "
+                    "so the seed lands hal0-owned."
+                )
+            die(f"cannot seed {path}: {exc}")
     try:
         subprocess.run([editor, str(path)], check=True)
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:

--- a/tests/cli/test_config_show_edit_selector.py
+++ b/tests/cli/test_config_show_edit_selector.py
@@ -227,6 +227,29 @@ def test_config_edit_seed_rejects_seed_on_other_oserror(monkeypatch, tmp_path: P
     assert "sudo" in result.output
 
 
+def test_config_edit_seed_hints_sudo_when_mkstemp_denied(monkeypatch, tmp_path: Path) -> None:
+    """/etc/hal0 itself (mode 2775 hal0:hal0) is not writable by an ordinary
+    user outside the ``hal0`` group, so ``tempfile.mkstemp`` raises
+    ``PermissionError`` before ``_fchown_to_service_owner`` is ever reached —
+    a failure point the ownership-focused ``ConfigSeedOwnershipError`` catch
+    doesn't cover. Must abort with the same sudo hint, not an unhandled
+    traceback (#1885).
+    """
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    _simulate_real_etc_hal0(monkeypatch)
+    monkeypatch.setenv("EDITOR", "true")
+
+    def _denied_mkstemp(*_a, **_k):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(config_commands.tempfile, "mkstemp", _denied_mkstemp)
+
+    result = runner.invoke(config_commands.app, ["edit", "hal0"])
+    assert result.exit_code != 0, "a permission-denied seed dir must abort, not traceback"
+    assert not (cfg_dir / "hal0.toml").exists()
+    assert "sudo" in result.output, f"error must point the operator at sudo: {result.output}"
+
+
 def test_config_edit_seed_ignores_host_hal0_account_in_sandbox(monkeypatch, tmp_path: Path) -> None:
     """A HAL0_HOME sandbox seed must succeed regardless of whether the real
     host machine happens to have a system ``hal0`` account.


### PR DESCRIPTION
## What changed

`config_edit`'s seed path caught only `ConfigSeedOwnershipError` from
`_seed_config_file()`. That error is raised by `_fchown_to_service_owner()`
when the `os.fchown()` call fails — but there is an earlier failure point in
the same function: `tempfile.mkstemp(dir=path.parent)`. A non-root user who
is not in the `hal0` group cannot write into `/etc/hal0` (mode `2775
hal0:hal0`), so `mkstemp` raises a bare `PermissionError` before
`_fchown_to_service_owner` is ever reached. That escaped as an unhandled
traceback instead of the sudo hint the ownership path already gives.

Added an `except OSError` clause around the `_seed_config_file()` call in
`config_edit`, alongside the existing `ConfigSeedOwnershipError` clause. The
sudo-hinted message is only shown when the target is the real `/etc/hal0`
(same gate `_fchown_to_service_owner` uses) — a `HAL0_HOME` sandbox failing
to seed is an unrelated problem (e.g. genuinely out of space), and the
"this box has a hal0 service account" framing would be misleading there.

## Why

Flagged by Codex review on #1884 as a gap in #1881's ownership-hint fix:
the seed path has two distinct failure modes (can't create the temp file at
all vs. can create it but can't chown it), and only one of them got the
clean sudo message.

## How verified

- Added `test_config_edit_seed_hints_sudo_when_mkstemp_denied`, which
  monkeypatches `tempfile.mkstemp` to raise `PermissionError` against the
  real-`/etc/hal0` gate. Confirmed it fails (raw `PermissionError` traceback,
  empty CLI output) on the pre-fix code and passes after the fix.
- `uv run --extra dev pytest tests/cli -q` — 783 passed.
- `uv run --extra dev pytest -q` (full suite) — passed.
- `make lint` — clean.
- `uv run ruff format --check` on changed files — already formatted.

## Out of scope

`config_show`'s analogous `PermissionError` handling on `path.read_text()`
was already correct (that's the pre-existing hint this issue's title
references as the reference UX) — untouched.

Closes #1885