### PR TITLE
fix: rc.6 polish rollup — capabilities status, synthetic hal0 reason, live uptime, peers AttributeError

### DIFF
--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -218,9 +218,11 @@ def _with_live_uptime(flat: dict[str, Any]) -> dict[str, Any]:
     can be off by weeks (under- or over-reporting). The dashboard renders
     this as if it were live, so every serve of this shape must recompute
     it. The read is a cheap sysfs stat (not the heavy subprocess-fanout
-    probe), so doing it on every request is fine.
+    probe), so doing it on every request is fine. If /proc/uptime is
+    unreadable (``read_uptime_s`` returns 0), keep the cached value —
+    stale-but-plausible degrades better than a hard 0.
     """
-    flat["uptime_s"] = read_uptime_s()
+    flat["uptime_s"] = read_uptime_s() or flat.get("uptime_s", 0)
     return flat
 
 

--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -24,6 +24,7 @@ from hal0.config import paths
 from hal0.config.loader import load_hardware_info
 from hal0.hardware import gpu_view
 from hal0.hardware.gpu_view import GPUMemorySample
+from hal0.hardware.uptime import read_uptime_s
 from hal0.providers import podman_introspect
 from hal0.providers.podman_introspect import PodmanImagesResult
 
@@ -209,25 +210,40 @@ async def _gpu_sample(request: Request) -> GPUMemorySample | None:
         return None
 
 
+def _with_live_uptime(flat: dict[str, Any]) -> dict[str, Any]:
+    """Overwrite ``uptime_s`` with a fresh ``/proc/uptime`` read.
+
+    #1905: ``hardware.json``'s ``uptime_s`` is frozen at the last ``hal0
+    probe`` write — on a box that's never re-probed since an upgrade it
+    can be off by weeks (under- or over-reporting). The dashboard renders
+    this as if it were live, so every serve of this shape must recompute
+    it. The read is a cheap sysfs stat (not the heavy subprocess-fanout
+    probe), so doing it on every request is fine.
+    """
+    flat["uptime_s"] = read_uptime_s()
+    return flat
+
+
 @router.get("/hardware")
 async def get_hardware(request: Request) -> dict[str, Any]:
     """Return cached /etc/hal0/hardware.json, falling back to a fresh probe.
 
     The probe is heavy enough (subprocess fanout) that we prefer the
     cached snapshot; ``POST /api/hardware/probe`` forces a re-run.
+    ``uptime_s`` is always re-read live (#1905) regardless of cache state.
     """
     gpu = await _gpu_sample(request)
     target = paths.hardware_json()
     if target.exists():
         try:
             info = load_hardware_info().model_dump(mode="python")
-            return _flatten_for_ui(info, gpu)
+            return _with_live_uptime(_flatten_for_ui(info, gpu))
         except Exception:
             pass
     # Cache miss → probe now.
     probe = request.app.state.hardware_probe
     info = (await probe.probe_async()).model_dump(mode="python")
-    return _flatten_for_ui(info, gpu)
+    return _with_live_uptime(_flatten_for_ui(info, gpu))
 
 
 @router.post("/hardware/probe")

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1483,14 +1483,20 @@ def _find_synthetic_entry(request: Request, name: str) -> dict[str, Any] | None:
 
 
 def _synthetic_logs_hint(entry: dict[str, Any]) -> str:
-    """Explain why a synthetic entry has no journal, worded by kind.
+    """Explain why a synthetic entry has no journal, worded per entry.
 
-    #1905 asked about the ``hal0`` composite, but remote upstreams reach
-    this path too — calling one of those a "composite" would be wrong,
-    so mirror the kind split ``_synthetic_reason`` already makes.
+    #1905 asked about the ``hal0`` composite, but remote upstreams and
+    (in stale-registry states) ordinary container-slot registrations
+    reach this path too — calling those a "composite" would be wrong, so
+    mirror the classification ``slot_view._synthetic_reason`` makes: the
+    composite hint needs BOTH the reserved name and ``kind="slot"``.
     """
+    from hal0.upstreams.registry import RESERVED_UPSTREAM_NAME
+
     if entry.get("kind") == "slot":
-        return "synthetic composite slot has no journal of its own"
+        if entry.get("name") == RESERVED_UPSTREAM_NAME:
+            return "synthetic composite slot has no journal of its own"
+        return "upstream registration without a configured slot; no journal to read"
     return "backed by a remote upstream; no local journal to read"
 
 

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1588,6 +1588,15 @@ async def slot_logs_stream(
                 + json.dumps({"message": _synthetic_logs_hint(entry)})
                 + "\n\n"
             )
+            # Hold the stream open after the degraded frame: the client's
+            # degraded listener only records the message, while its onerror
+            # closes and RECONNECTS (ui/src/api/hooks/useLogs.ts) — so a
+            # stream that ends here would put the viewer in a silent retry
+            # loop against this endpoint forever. Keepalive cadence matches
+            # the journal streams (#1472) so proxy idle timeouts are covered.
+            while True:
+                await asyncio.sleep(15)
+                yield ": keepalive\n\n"
 
         return StreamingResponse(
             synthetic_source(),

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1485,11 +1485,29 @@ async def slot_logs(
     never started, returns an empty string with a hint. The UI tolerates
     that (renders "No logs available") rather than treating it as an error.
     The journalctl tail lives in :func:`hal0.slots.logs.read_tail`.
+
+    #1905: a synthetic upstream entry (e.g. the ``hal0`` composite) isn't
+    a real slot and has no ``hal0-slot@{name}.service`` journal of its
+    own, but it also isn't "not found" — it's a legitimate, listable
+    entry. Distinguish the two: a genuinely unknown name still 404s with
+    the typed ``slot.not_found`` envelope, but a synthetic entry gets a
+    200 with an explanatory hint instead, mirroring how :func:`get_slot`
+    already falls through for its detail view.
     """
     sm = _get_slot_manager(request)
     # Validate slot exists so unknown names get the typed slot.not_found
     # envelope instead of an empty 200.
-    await sm.status(name)
+    try:
+        await sm.status(name)
+    except Exception:
+        for entry in _synthesize_slots_from_upstreams(request):
+            if entry["name"] == name:
+                return {
+                    "name": name,
+                    "logs": "",
+                    "hint": "synthetic composite slot has no journal of its own",
+                }
+        raise
 
     text, hint = await _logs.read_tail(f"hal0-slot@{name}.service", lines, quiet)
     if hint is not None:

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -55,6 +55,7 @@ from hal0.slots import metrics_collect as _metrics_collect
 from hal0.slots import port_alloc as _port_alloc
 from hal0.slots import voices as _voices
 from hal0.slots.manager import Slot, SlotManager
+from hal0.slots.state import SlotNotFound
 
 log = structlog.get_logger(__name__)
 
@@ -1473,6 +1474,26 @@ async def swap_slot(name: str, request: Request) -> dict[str, object]:
 # the ``StreamingResponse``.
 
 
+def _find_synthetic_entry(request: Request, name: str) -> dict[str, Any] | None:
+    """Return the synthetic upstream-backed entry for ``name``, if any."""
+    for entry in _synthesize_slots_from_upstreams(request):
+        if entry["name"] == name:
+            return entry
+    return None
+
+
+def _synthetic_logs_hint(entry: dict[str, Any]) -> str:
+    """Explain why a synthetic entry has no journal, worded by kind.
+
+    #1905 asked about the ``hal0`` composite, but remote upstreams reach
+    this path too — calling one of those a "composite" would be wrong,
+    so mirror the kind split ``_synthetic_reason`` already makes.
+    """
+    if entry.get("kind") == "slot":
+        return "synthetic composite slot has no journal of its own"
+    return "backed by a remote upstream; no local journal to read"
+
+
 @router.get("/{name}/logs")
 async def slot_logs(
     name: str, request: Request, lines: int = 200, quiet: bool = True
@@ -1496,17 +1517,21 @@ async def slot_logs(
     """
     sm = _get_slot_manager(request)
     # Validate slot exists so unknown names get the typed slot.not_found
-    # envelope instead of an empty 200.
+    # envelope instead of an empty 200. Catch ONLY SlotNotFound: every
+    # loaded container slot registers a same-name ``kind="slot"`` upstream
+    # (SlotManager._register_container_upstream), so a broad except here
+    # would convert a real slot's operational failure (e.g. SlotConfigError
+    # from a corrupt state.json) into a fake synthetic 200.
     try:
         await sm.status(name)
-    except Exception:
-        for entry in _synthesize_slots_from_upstreams(request):
-            if entry["name"] == name:
-                return {
-                    "name": name,
-                    "logs": "",
-                    "hint": "synthetic composite slot has no journal of its own",
-                }
+    except SlotNotFound:
+        entry = _find_synthetic_entry(request, name)
+        if entry is not None:
+            return {
+                "name": name,
+                "logs": "",
+                "hint": _synthetic_logs_hint(entry),
+            }
         raise
 
     text, hint = await _logs.read_tail(f"hal0-slot@{name}.service", lines, quiet)
@@ -1542,7 +1567,33 @@ async def slot_logs_stream(
     import shutil
 
     sm = _get_slot_manager(request)
-    await sm.status(name)  # 404 fast if unknown
+    try:
+        await sm.status(name)  # 404 fast if unknown
+    except SlotNotFound:
+        # #1905: same synthetic fall-through as the one-shot ``/logs`` route
+        # above — the dashboard log viewer and ``hal0 slot logs --follow``
+        # both drive THIS route, so fixing only the one-shot twin left the
+        # user-facing flow 404ing (EventSource.onerror → endless reconnect
+        # loop). Emit a terminal 'degraded' frame with the hint instead; the
+        # client already listens for 'degraded' (see B13 below). Only
+        # SlotNotFound falls through — other failures on a real slot must
+        # keep surfacing as errors.
+        entry = _find_synthetic_entry(request, name)
+        if entry is None:
+            raise
+
+        async def synthetic_source() -> Any:
+            yield (
+                "event: degraded\ndata: "
+                + json.dumps({"message": _synthetic_logs_hint(entry)})
+                + "\n\n"
+            )
+
+        return StreamingResponse(
+            synthetic_source(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
 
     async def event_source() -> Any:
         if shutil.which("journalctl") is None:

--- a/src/hal0/cli/_shared.py
+++ b/src/hal0/cli/_shared.py
@@ -108,16 +108,28 @@ def api_stream(
         yield resp
 
 
-def _iter_sse_payloads(resp: httpx.Response) -> Iterator[Any]:
-    """Parse an SSE response's ``data: ...`` lines into JSON (or raw text)."""
+def _iter_sse_payloads(resp: httpx.Response) -> Iterator[tuple[str | None, Any]]:
+    """Parse an SSE response into ``(event_name, payload)`` pairs.
+
+    ``event_name`` is the preceding ``event:`` field for named frames
+    (e.g. ``degraded``), ``None`` for plain ``data:`` frames. Payloads are
+    JSON-decoded when possible, raw text otherwise.
+    """
+    event: str | None = None
     for raw in resp.iter_lines():
-        if not raw or not raw.startswith("data:"):
+        if not raw:
+            event = None  # blank line terminates the frame
+            continue
+        if raw.startswith("event:"):
+            event = raw[len("event:") :].strip()
+            continue
+        if not raw.startswith("data:"):
             continue
         payload = raw[len("data:") :].strip()
         try:
-            yield json.loads(payload)
+            yield event, json.loads(payload)
         except ValueError:
-            yield payload
+            yield event, payload
 
 
 def follow_sse_logs(
@@ -132,13 +144,23 @@ def follow_sse_logs(
     stale credentials on an auth-enabled box) prints one actionable line via
     :func:`die` instead of silently echoing the JSON error envelope as if it
     were log output.
+
+    #1905: a ``degraded`` frame is terminal for the CLI. The server keeps
+    the stream open with keepalives after it (so a browser EventSource
+    doesn't error-reconnect), but a follow that can never produce log
+    lines (synthetic slot, journalctl missing) should print the
+    explanation and return rather than hang until Ctrl-C.
     """
     try:
         with api_stream("GET", path, timeout=None, params=params) as r:
             if r.status_code in (401, 403):
                 die(f"not authorized ({r.status_code}) — check HAL0_ADMIN_KEY/HAL0_CLIENT_KEY.")
                 return
-            for item in _iter_sse_payloads(r):
+            for event, item in _iter_sse_payloads(r):
+                if event == "degraded":
+                    message = item.get("message") if isinstance(item, dict) else item
+                    console.print(f"[dim]{message}[/dim]")
+                    return
                 console.print(item)
     except (httpx.HTTPError, KeyboardInterrupt):
         return

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -1359,25 +1359,53 @@ def agent_peers() -> None:
 
         #1905: on at least one upgraded box, a card's nested metadata
         fields (``hal0_state``, seen in the wild; ``endpoint`` shares the
-        same storage path) come back from the memory API as a
-        JSON-encoded *string* rather than an already-parsed object —
-        some write path serialized the nested value before persisting it
-        instead of leaving it as a nested JSON object. ``md.get("hal0_state")
-        or {}`` doesn't catch that: a non-empty string is truthy, so it
-        passes straight through and the next ``.get()`` call blows up with
-        ``AttributeError: 'str' object has no attribute 'get'``. Parse it
-        back into a dict here; any other shape (including malformed JSON)
-        degrades to an empty dict so the row still renders with "—".
+        same storage path) come back from the memory API as a *string*
+        rather than an already-parsed object — the Hindsight retain path
+        used to flatten nested values with ``str(v)``, i.e. a Python repr
+        with single quotes (``"{'registered_at': ...}"``), not JSON.
+        ``md.get("hal0_state") or {}`` doesn't catch that: a non-empty
+        string is truthy, so it passes straight through and the next
+        ``.get()`` call blows up with ``AttributeError: 'str' object has
+        no attribute 'get'``. The write path now emits real JSON, but
+        already-written cards on upgraded boxes still carry the repr
+        shape — try ``json.loads`` first, then ``ast.literal_eval`` as
+        the recovery path for those. Any other shape degrades to an
+        empty dict so the row still renders with "—".
         """
         if isinstance(value, dict):
             return value
         if isinstance(value, str):
-            try:
-                parsed = _json.loads(value)
-            except _json.JSONDecodeError:
-                return {}
+            parsed = _parse_stringified(value)
             return parsed if isinstance(parsed, dict) else {}
         return {}
+
+    def _parse_stringified(value: str) -> object:
+        """Decode a stringified metadata value: JSON first, repr second."""
+        try:
+            return _json.loads(value)
+        except _json.JSONDecodeError:
+            pass
+        import ast as _ast
+
+        try:
+            return _ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            return None
+
+    def _as_list(value: object) -> list[Any]:
+        """Coerce a metadata sub-field to a list.
+
+        #1905: ``roles`` shares the exact storage path (and therefore the
+        exact stringified-repr failure mode) as ``hal0_state`` above —
+        left uncoerced, ``", ".join(<str>)`` splits the repr into one
+        table cell per character.
+        """
+        if isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            parsed = _parse_stringified(value)
+            return parsed if isinstance(parsed, list) else []
+        return []
 
     table = Table(title=f"Agent peers ({len(items)})")
     table.add_column("Agent ID", style="bold")
@@ -1392,7 +1420,7 @@ def agent_peers() -> None:
         table.add_row(
             str(md.get("agent_id") or "—"),
             str(md.get("display_name") or "—"),
-            ", ".join(md.get("roles") or []) or "—",
+            ", ".join(str(r) for r in _as_list(md.get("roles"))) or "—",
             str(endpoint.get("url") or "—"),
             str(hal0_state.get("registered_at") or "—"),
         )

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -1354,6 +1354,31 @@ def agent_peers() -> None:
         console.print("[dim]No agent identity cards published yet.[/dim]")
         return
 
+    def _as_dict(value: object) -> dict[str, Any]:
+        """Coerce a metadata sub-field to a dict.
+
+        #1905: on at least one upgraded box, a card's nested metadata
+        fields (``hal0_state``, seen in the wild; ``endpoint`` shares the
+        same storage path) come back from the memory API as a
+        JSON-encoded *string* rather than an already-parsed object —
+        some write path serialized the nested value before persisting it
+        instead of leaving it as a nested JSON object. ``md.get("hal0_state")
+        or {}`` doesn't catch that: a non-empty string is truthy, so it
+        passes straight through and the next ``.get()`` call blows up with
+        ``AttributeError: 'str' object has no attribute 'get'``. Parse it
+        back into a dict here; any other shape (including malformed JSON)
+        degrades to an empty dict so the row still renders with "—".
+        """
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, str):
+            try:
+                parsed = _json.loads(value)
+            except _json.JSONDecodeError:
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        return {}
+
     table = Table(title=f"Agent peers ({len(items)})")
     table.add_column("Agent ID", style="bold")
     table.add_column("Display name")
@@ -1361,9 +1386,9 @@ def agent_peers() -> None:
     table.add_column("Endpoint")
     table.add_column("Registered")
     for item in items:
-        md = item.get("metadata") or {} if isinstance(item, dict) else {}
-        endpoint = md.get("endpoint") or {}
-        hal0_state = md.get("hal0_state") or {}
+        md = _as_dict(item.get("metadata") if isinstance(item, dict) else None)
+        endpoint = _as_dict(md.get("endpoint"))
+        hal0_state = _as_dict(md.get("hal0_state"))
         table.add_row(
             str(md.get("agent_id") or "—"),
             str(md.get("display_name") or "—"),

--- a/src/hal0/cli/capabilities_commands.py
+++ b/src/hal0/cli/capabilities_commands.py
@@ -102,6 +102,7 @@ def list_capabilities() -> None:
     table.add_column("Provider")
     table.add_column("Model")
     table.add_column("Enabled")
+    table.add_column("Status")
     for slot, children in sorted(selections.items()):
         if not isinstance(children, dict):
             continue
@@ -116,6 +117,7 @@ def list_capabilities() -> None:
                 str(sel.get("provider") or "—"),
                 str(sel.get("model") or "—"),
                 "[green]yes[/green]" if enabled else "[dim]no[/dim]",
+                str(sel.get("status") or "—"),
             )
     console.print(table)
 

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -407,7 +407,9 @@ def slot_logs(
         except CliApiError as exc:
             die(str(exc))
             return
-        console.print(data.get("logs") or "[dim]no logs[/dim]")
+        # #1905: an empty-logs response may carry the only explanation in
+        # ``hint`` (synthetic composite, journalctl missing, never started).
+        console.print(data.get("logs") or f"[dim]{data.get('hint') or 'no logs'}[/dim]")
         return
 
     # Stream SSE — line-buffered passthrough.

--- a/src/hal0/hardware/probe.py
+++ b/src/hal0/hardware/probe.py
@@ -212,23 +212,16 @@ def _read_hostname() -> str:
 def _read_uptime_s() -> int:
     """Return whole seconds since boot from /proc/uptime, 0 on failure.
 
-    /proc/uptime is "<uptime_seconds> <idle_seconds>"; we take the first
-    float and floor it. The UI formats this into "Nd HH:MM".
-
-    #1905: routes that must re-read uptime live on every request (rather
-    than trust the value cached in ``hardware.json`` at the last ``hal0
-    probe`` write) use :func:`hal0.hardware.uptime.read_uptime_s` instead
-    of this function, to avoid pulling in this module's private GPU/NPU
-    probe internals into the API route layer (#703). This is the same
-    read duplicated locally so this module's own ``_read_text`` test seam
-    keeps working unchanged.
+    #1905: the actual read lives in :mod:`hal0.hardware.uptime` so API
+    routes can re-read a live ``uptime_s`` per request without importing
+    this module's private GPU/NPU probe internals (#703). This alias
+    keeps the probe's call site local; the parse/failure branches are
+    tested against the shared implementation in
+    ``tests/hardware/test_uptime.py``.
     """
-    txt = _read_text(Path("/proc/uptime"))
-    if not txt:
-        return 0
-    with contextlib.suppress(IndexError, ValueError):
-        return int(float(txt.split()[0]))
-    return 0
+    from hal0.hardware.uptime import read_uptime_s
+
+    return read_uptime_s()
 
 
 def _read_distro() -> str:

--- a/src/hal0/hardware/probe.py
+++ b/src/hal0/hardware/probe.py
@@ -214,6 +214,14 @@ def _read_uptime_s() -> int:
 
     /proc/uptime is "<uptime_seconds> <idle_seconds>"; we take the first
     float and floor it. The UI formats this into "Nd HH:MM".
+
+    #1905: routes that must re-read uptime live on every request (rather
+    than trust the value cached in ``hardware.json`` at the last ``hal0
+    probe`` write) use :func:`hal0.hardware.uptime.read_uptime_s` instead
+    of this function, to avoid pulling in this module's private GPU/NPU
+    probe internals into the API route layer (#703). This is the same
+    read duplicated locally so this module's own ``_read_text`` test seam
+    keeps working unchanged.
     """
     txt = _read_text(Path("/proc/uptime"))
     if not txt:

--- a/src/hal0/hardware/uptime.py
+++ b/src/hal0/hardware/uptime.py
@@ -1,0 +1,37 @@
+"""Live host uptime — a single, cheap, dependency-free sysfs read.
+
+Split out of :mod:`hal0.hardware.probe` (#1905) so API routes can read a
+fresh ``uptime_s`` on every request without importing the probe module's
+private GPU/NPU internals — ``hal0.api.routes.hardware`` deliberately
+keeps zero imports from ``hal0.hardware.probe`` (see #703 and
+``test_route_module_has_no_private_probe_imports``), since GPU/NPU state
+there is meant to flow through the coalesced ``HardwareStats`` singleton,
+not per-request re-probes. Uptime has no such singleton and no expensive
+fanout — it's one file read — so it doesn't need that abstraction, but it
+still shouldn't drag in the rest of the probe module's surface.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+
+_UPTIME_PATH = Path("/proc/uptime")
+
+
+def read_uptime_s() -> int:
+    """Return whole seconds since boot from /proc/uptime, 0 on failure.
+
+    /proc/uptime is "<uptime_seconds> <idle_seconds>"; we take the first
+    float and floor it.
+    """
+    try:
+        txt = _UPTIME_PATH.read_text()
+    except OSError:
+        return 0
+    with contextlib.suppress(IndexError, ValueError):
+        return int(float(txt.split()[0]))
+    return 0
+
+
+__all__ = ["read_uptime_s"]

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -29,6 +29,7 @@ Maps hal0's engine-neutral MemoryProvider contract onto the shared
 
 from __future__ import annotations
 
+import json
 import re
 import time
 import uuid
@@ -953,7 +954,17 @@ class HindsightProvider(MemoryProvider):
                 content=text,
                 document_id=resolved_id,
                 context=context,
-                metadata={k: str(v) for k, v in meta.items()},
+                # #1905: nested structures must round-trip. ``str(v)`` on a
+                # dict/list produced a Python repr (single quotes) that no
+                # JSON reader on the way back out could decode — the peer
+                # registry's ``hal0_state``/``endpoint``/``roles`` cards on
+                # upgraded boxes were written exactly that way. ``json.dumps``
+                # keeps the value machine-readable; scalars stay ``str()``
+                # to preserve the wire shape existing readers expect.
+                metadata={
+                    k: (json.dumps(v) if isinstance(v, (dict, list)) else str(v))
+                    for k, v in meta.items()
+                },
                 tags=out_tags,
                 timestamp=timestamp,
                 **extra,

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -155,6 +155,32 @@ def _now() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _decode_metadata(md: dict[str, Any]) -> dict[str, Any]:
+    """Re-inflate nested metadata values the write path flattened (#1905).
+
+    ``retain`` stores nested dict/list values as JSON strings (Hindsight's
+    metadata is flat string→string). Callers of the engine-neutral surface
+    handed ``add`` a real dict, so read adapters must hand the same shape
+    back — otherwise every REST/MCP consumer gets ``metadata.x`` as a
+    string and nesting doesn't round-trip (only decoded case-by-case in
+    CLI commands). Only values that LOOK like JSON containers are decoded;
+    scalars were always stringified on this engine and stay strings, so
+    existing consumers see no change.
+    """
+    out: dict[str, Any] = {}
+    for k, v in md.items():
+        if isinstance(v, str) and v[:1] in "{[":
+            try:
+                parsed = json.loads(v)
+            except json.JSONDecodeError:
+                out[k] = v
+                continue
+            out[k] = parsed if isinstance(parsed, (dict, list)) else v
+            continue
+        out[k] = v
+    return out
+
+
 # ── time-window filtering + list cursors (#1471) ─────────────────────────────
 
 
@@ -1940,7 +1966,7 @@ class HindsightProvider(MemoryProvider):
             "dataset": bank.replace("__", ":"),
             "tags": list(fact.get("tags") or []),
             "source": (fact.get("metadata") or {}).get("source"),
-            "metadata": dict(fact.get("metadata") or {}),
+            "metadata": _decode_metadata(fact.get("metadata") or {}),
             "score": float(final_score) if isinstance(final_score, (int, float)) else None,
             "type": fact.get("type"),
             "entities": list(fact.get("entities") or []) or None,

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -801,11 +801,14 @@ def _synthetic_reason(u: Any) -> str:
     only masks that on the happy path (the synthetic fall-throughs in
     ``get_slot`` and ``/api/status`` can still surface these entries).
     The composite string must stay verbatim in sync with the UI's copy
-    (``ui/src/dash/data.jsx``).
+    (``ui/src/dash/data.jsx``). The reserved name alone isn't enough
+    either: an operator may define an explicit ``hal0`` entry in
+    ``upstreams.toml`` with ``kind="remote"`` — that one is genuinely
+    remote-backed, so require the local slot-kind stand-in too.
     """
     from hal0.upstreams.registry import RESERVED_UPSTREAM_NAME
 
-    if u.name == RESERVED_UPSTREAM_NAME:
+    if u.name == RESERVED_UPSTREAM_NAME and u.kind == "slot":
         return "Composite /v1 endpoint that fronts every chat model — not a lifecycle slot."
     if u.kind == "slot":
         return (

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -791,6 +791,30 @@ async def container_enrichment(
 # ── synthetic upstream entries ───────────────────────────────────────────────
 
 
+def _synthetic_reason(u: Any) -> str:
+    """Human-readable reason a synthetic entry exists, per upstream.
+
+    #1905 review nit: the composite string belongs to the reserved
+    ``hal0`` upstream by NAME, not to every ``kind="slot"`` upstream —
+    each loaded container slot registers a same-name slot-kind upstream
+    (``SlotManager._register_container_upstream``), and real-slot-wins
+    only masks that on the happy path (the synthetic fall-throughs in
+    ``get_slot`` and ``/api/status`` can still surface these entries).
+    The composite string must stay verbatim in sync with the UI's copy
+    (``ui/src/dash/data.jsx``).
+    """
+    from hal0.upstreams.registry import RESERVED_UPSTREAM_NAME
+
+    if u.name == RESERVED_UPSTREAM_NAME:
+        return "Composite /v1 endpoint that fronts every chat model — not a lifecycle slot."
+    if u.kind == "slot":
+        return (
+            f"Registered upstream for container slot {getattr(u, 'slot_name', None) or u.name!r}; "
+            "the real slot entry is authoritative."
+        )
+    return "Backed by remote upstream; install a local slot of the same name to take over."
+
+
 def synthesize_upstream_entries(
     upstreams: Any,
     model_cache: dict[str, Any],
@@ -859,14 +883,7 @@ def synthesize_upstream_entries(
                 "advertised_models": len(models),
                 "last_used_model": last_used_model.get(u.name) or None,
                 "_synthetic": True,
-                "_synthetic_reason": (
-                    "Composite /v1 endpoint that fronts every chat model — not a lifecycle slot."
-                    if u.kind == "slot"
-                    else (
-                        "Backed by remote upstream; install a local slot of the "
-                        "same name to take over."
-                    )
-                ),
+                "_synthetic_reason": _synthetic_reason(u),
             }
         )
     return out

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -860,7 +860,12 @@ def synthesize_upstream_entries(
                 "last_used_model": last_used_model.get(u.name) or None,
                 "_synthetic": True,
                 "_synthetic_reason": (
-                    "Backed by remote upstream; install a local slot of the same name to take over."
+                    "Composite /v1 endpoint that fronts every chat model — not a lifecycle slot."
+                    if u.kind == "slot"
+                    else (
+                        "Backed by remote upstream; install a local slot of the "
+                        "same name to take over."
+                    )
                 ),
             }
         )

--- a/tests/api/test_hardware_routes.py
+++ b/tests/api/test_hardware_routes.py
@@ -630,3 +630,21 @@ class TestLiveUptime:
         resp = client.get("/api/stats/hardware")
         assert resp.status_code == 200, resp.text
         assert resp.json()["uptime_s"] == 326305
+
+    def test_unreadable_proc_uptime_keeps_cached_value(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """#1905 review nit: read_uptime_s() returns 0 when /proc/uptime is
+        unreadable — a stale-but-plausible cached value degrades better
+        than clobbering it with a hard 0."""
+        from hal0.config.loader import save_hardware_info
+        from hal0.config.schema import HardwareInfo
+
+        save_hardware_info(HardwareInfo(hostname="ct150", uptime_s=4110))
+        monkeypatch.setattr(hw_mod, "read_uptime_s", lambda: 0)
+
+        resp = client.get("/api/hardware")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["uptime_s"] == 4110

--- a/tests/api/test_hardware_routes.py
+++ b/tests/api/test_hardware_routes.py
@@ -591,3 +591,42 @@ class TestStatsHardwareGpuSample:
         assert "_amd_drm_device" not in src
         assert "_read_sysfs_mb" not in src
         assert "from hal0.hardware.probe import" not in src
+
+
+class TestLiveUptime:
+    """#1905: uptime_s was frozen at the last ``hal0 probe`` write — a box
+    that never re-probes since an upgrade reports a stale value forever."""
+
+    def test_get_hardware_reports_live_uptime_not_cached_value(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from hal0.config import paths
+        from hal0.config.loader import save_hardware_info
+        from hal0.config.schema import HardwareInfo
+
+        # A hardware.json written long ago with a wildly stale uptime.
+        save_hardware_info(HardwareInfo(hostname="ct150", uptime_s=4110))
+        assert paths.hardware_json().exists()
+
+        monkeypatch.setattr(hw_mod, "read_uptime_s", lambda: 326305)
+
+        resp = client.get("/api/hardware")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["uptime_s"] == 326305
+
+    def test_stats_hardware_also_reports_live_uptime(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from hal0.config.loader import save_hardware_info
+        from hal0.config.schema import HardwareInfo
+
+        save_hardware_info(HardwareInfo(hostname="ct150", uptime_s=4110))
+        monkeypatch.setattr(hw_mod, "read_uptime_s", lambda: 326305)
+
+        resp = client.get("/api/stats/hardware")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["uptime_s"] == 326305

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -265,6 +265,68 @@ def test_logs_synthetic_hal0_composite_returns_hint_not_404(
     assert r2.json()["error"]["code"] == "slot.not_found"
 
 
+def test_logs_real_slot_config_error_not_masked_as_synthetic(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+    isolated_app: FastAPI,
+    tmp_hal0_home: str,
+) -> None:
+    """#1905 review (Codex, confirmed): the synthetic fall-through must catch
+    ONLY SlotNotFound. Every loaded container slot registers a same-name
+    ``kind="slot"`` upstream, so a broad ``except Exception`` converted a
+    real slot's SlotConfigError (corrupt state.json) into a fake synthetic
+    200 with "composite has no journal" — hiding a precise, actionable
+    config error from the operator.
+    """
+    from hal0.config import paths
+
+    # The same-name upstream _register_container_upstream would create.
+    isolated_app.state.upstreams.upsert(
+        Upstream(
+            name="chat",
+            kind="slot",
+            url="http://127.0.0.1:8081/v1",
+            auth_style="none",
+            slot_name="chat",
+        )
+    )
+    # Corrupt the slot's state.json so sm.status raises SlotConfigError.
+    state_file = paths.slot_data_dir("chat") / "state.json"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text("{'not': json}", encoding="utf-8")
+
+    r = isolated_client.get("/api/slots/chat/logs")
+    assert r.status_code != 200, (
+        f"config error must surface, not turn into a synthetic 200: {r.text}"
+    )
+    assert r.json()["error"]["code"] == "slot.config_error", r.text
+
+
+def test_logs_stream_synthetic_hal0_composite_emits_degraded_frame(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+    isolated_app: FastAPI,
+) -> None:
+    """#1905 review (Codex, confirmed): the dashboard log viewer and
+    ``hal0 slot logs --follow`` drive the STREAM route, which still 404'd
+    for the synthetic ``hal0`` composite after the one-shot route was
+    fixed. It must 200 with a terminal ``event: degraded`` frame (the
+    client already listens for 'degraded' — see B13) instead of feeding
+    EventSource.onerror an endless reconnect loop.
+    """
+    r = isolated_client.get("/api/slots/hal0/logs/stream")
+    assert r.status_code == 200, r.text
+    assert "event: degraded" in r.text
+    assert "journal" in r.text  # the explanatory hint payload
+
+    # A genuinely unknown slot name must still 404 with the typed envelope.
+    r2 = isolated_client.get("/api/slots/definitely-not-a-slot/logs/stream")
+    assert r2.status_code == 404
+    assert r2.json()["error"]["code"] == "slot.not_found"
+
+
 # ── lifespan auto-register ─────────────────────────────────────────────────
 
 

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -240,6 +240,31 @@ def test_list_real_wins_on_name_collision(
     assert primaries[0].get("_synthetic") is not True
 
 
+def test_logs_synthetic_hal0_composite_returns_hint_not_404(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+    isolated_app: FastAPI,
+) -> None:
+    """#1905: ``GET /api/slots/hal0/logs`` 404'd with the typed
+    ``slot.not_found`` envelope — identical to a genuinely nonexistent slot
+    name — even though ``hal0`` is a legitimate, listable synthetic
+    composite entry (see ``_UpstreamsWithHal0Composite``). It has no
+    journal of its own, so it should 200 with an explanatory hint instead
+    of looking indistinguishable from a typo.
+    """
+    r = isolated_client.get("/api/slots/hal0/logs")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["name"] == "hal0"
+    assert body.get("hint")
+
+    # A genuinely unknown slot name must still 404 with the typed envelope.
+    r2 = isolated_client.get("/api/slots/definitely-not-a-slot/logs")
+    assert r2.status_code == 404
+    assert r2.json()["error"]["code"] == "slot.not_found"
+
+
 # ── lifespan auto-register ─────────────────────────────────────────────────
 
 

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -303,10 +303,9 @@ def test_logs_real_slot_config_error_not_masked_as_synthetic(
     assert r.json()["error"]["code"] == "slot.config_error", r.text
 
 
-def test_logs_stream_synthetic_hal0_composite_emits_degraded_frame(
+async def test_logs_stream_synthetic_hal0_composite_emits_degraded_frame(
     slot_root: Path,
     container_stub: dict[str, Any],
-    isolated_client: TestClient,
     isolated_app: FastAPI,
 ) -> None:
     """#1905 review (Codex, confirmed): the dashboard log viewer and
@@ -316,15 +315,35 @@ def test_logs_stream_synthetic_hal0_composite_emits_degraded_frame(
     client already listens for 'degraded' — see B13) instead of feeding
     EventSource.onerror an endless reconnect loop.
     """
-    r = isolated_client.get("/api/slots/hal0/logs/stream")
-    assert r.status_code == 200, r.text
-    assert "event: degraded" in r.text
-    assert "journal" in r.text  # the explanatory hint payload
+    # The degraded stream stays OPEN after the frame (keepalives) so the
+    # browser's EventSource doesn't treat stream-end as an error and
+    # reconnect-loop — so consume the generator directly (same pattern as
+    # test_state_stream_emits_transition_event) instead of buffering the
+    # whole response.
+    with TestClient(isolated_app) as client:
+        from hal0.api.routes.slots import slot_logs_stream
 
-    # A genuinely unknown slot name must still 404 with the typed envelope.
-    r2 = isolated_client.get("/api/slots/definitely-not-a-slot/logs/stream")
-    assert r2.status_code == 404
-    assert r2.json()["error"]["code"] == "slot.not_found"
+        class _ReqShim:
+            class _AppShim:
+                state = isolated_app.state
+
+            app = _AppShim()
+
+        response = await slot_logs_stream("hal0", _ReqShim())  # type: ignore[arg-type]
+        assert response.status_code == 200
+        agen = response.body_iterator
+        frame = await asyncio.wait_for(agen.__anext__(), timeout=1.0)
+        if isinstance(frame, bytes):
+            frame = frame.decode("utf-8")
+        await agen.aclose()
+
+        assert frame.startswith("event: degraded\n"), f"bad SSE prefix: {frame!r}"
+        assert "journal" in frame  # the explanatory hint payload
+
+        # A genuinely unknown slot name must still 404, typed envelope.
+        r2 = client.get("/api/slots/definitely-not-a-slot/logs/stream")
+        assert r2.status_code == 404
+        assert r2.json()["error"]["code"] == "slot.not_found"
 
 
 # ── lifespan auto-register ─────────────────────────────────────────────────

--- a/tests/cli/test_agent_peers.py
+++ b/tests/cli/test_agent_peers.py
@@ -1,0 +1,131 @@
+"""Tests for ``hal0 agent peers`` (#1905).
+
+Observed on ct150 (upgraded box): the memory API sometimes returns a
+card's nested ``metadata.hal0_state`` as a JSON-encoded *string* instead
+of an already-parsed object. The old code did
+``md.get("hal0_state") or {}`` — a non-empty string is truthy, so the
+fallback never fires — and then called ``.get("registered_at")`` on that
+string, raising ``AttributeError: 'str' object has no attribute 'get'``.
+
+The HTTP layer is stubbed by monkey-patching ``urllib.request.urlopen``
+inside the module — same pattern as ``test_agent_uninstall_memory.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import agent_commands
+
+runner = CliRunner()
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._buf = BytesIO(json.dumps(payload).encode("utf-8"))
+
+    def read(self) -> bytes:
+        return self._buf.read()
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+
+@pytest.fixture
+def fake_urlopen(monkeypatch: pytest.MonkeyPatch):
+    import urllib.request as _urllib
+
+    def _install(payload: dict[str, Any]) -> None:
+        def _fake_urlopen(req: Any, timeout: float = 5.0) -> _FakeResponse:
+            return _FakeResponse(payload)
+
+        monkeypatch.setattr(_urllib, "urlopen", _fake_urlopen)
+
+    return _install
+
+
+@pytest.fixture(autouse=True)
+def _stub_reachability(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(agent_commands, "_api_unreachable", lambda _u: False)
+    monkeypatch.setenv("HAL0_API_URL", "http://127.0.0.1:8080")
+
+
+def test_peers_survives_hal0_state_as_json_string(fake_urlopen) -> None:
+    """#1905 regression: a stringified ``hal0_state`` must not crash the
+    command — it should render the row with "—" for that field."""
+    fake_urlopen(
+        {
+            "items": [
+                {
+                    "metadata": {
+                        "agent_id": "hermes-ct150",
+                        "display_name": "Hermes",
+                        "roles": ["chat"],
+                        "endpoint": {"url": "http://10.0.1.150:9000"},
+                        # The defect: a JSON string instead of a nested object.
+                        "hal0_state": json.dumps({"registered_at": "2026-08-10T00:00:00Z"}),
+                    }
+                }
+            ]
+        }
+    )
+
+    result = runner.invoke(agent_commands.app, ["peers"])
+
+    assert result.exit_code == 0, result.output
+    assert "hermes-ct150" in result.output
+    assert "2026-08-10" in result.output
+
+
+def test_peers_malformed_hal0_state_string_degrades_to_dash(fake_urlopen) -> None:
+    """A hal0_state string that isn't even valid JSON still must not crash."""
+    fake_urlopen(
+        {
+            "items": [
+                {
+                    "metadata": {
+                        "agent_id": "broken-card",
+                        "hal0_state": "not-json-at-all",
+                    }
+                }
+            ]
+        }
+    )
+
+    result = runner.invoke(agent_commands.app, ["peers"])
+
+    assert result.exit_code == 0, result.output
+    assert "broken-card" in result.output
+
+
+def test_peers_renders_normal_dict_shaped_cards(fake_urlopen) -> None:
+    """Precondition: the ordinary (already-parsed dict) shape still works."""
+    fake_urlopen(
+        {
+            "items": [
+                {
+                    "metadata": {
+                        "agent_id": "hermes-ct105",
+                        "display_name": "Hermes",
+                        "roles": ["chat", "voice"],
+                        "endpoint": {"url": "http://10.0.1.105:9000"},
+                        "hal0_state": {"registered_at": "2026-08-01T00:00:00Z"},
+                    }
+                }
+            ]
+        }
+    )
+
+    result = runner.invoke(agent_commands.app, ["peers"])
+
+    assert result.exit_code == 0, result.output
+    assert "hermes-ct105" in result.output
+    assert "2026-08-01" in result.output

--- a/tests/cli/test_agent_peers.py
+++ b/tests/cli/test_agent_peers.py
@@ -85,6 +85,49 @@ def test_peers_survives_hal0_state_as_json_string(fake_urlopen) -> None:
     assert "2026-08-10" in result.output
 
 
+def test_peers_recovers_python_repr_shaped_card(fake_urlopen) -> None:
+    """#1905 review: the REAL wire shape on ct150 is ``str(<dict>)`` — a
+    Python repr with single quotes, which ``json.loads`` can never parse
+    (the Hindsight retain path flattened nested metadata with ``str(v)``).
+    The reader must recover these via ``ast.literal_eval`` so the peer
+    registry is readable on exactly the box the issue was filed from, and
+    ``roles`` shares the same storage path and failure mode — left
+    uncoerced, ``", ".join(<str>)`` renders one cell entry per character.
+    """
+    fake_urlopen(
+        {
+            "items": [
+                {
+                    "metadata": {
+                        "agent_id": "hermes-ct150",
+                        # Every nested field in the repr shape str(v) produced.
+                        "roles": str(["chat", "voice"]),
+                        "endpoint": str({"url": "http://h:1"}),
+                        "hal0_state": str(
+                            {
+                                "registered_at": "2026-08-10T00:00:00Z",
+                                "bootstrap_version": 1,
+                            }
+                        ),
+                    }
+                }
+            ]
+        }
+    )
+
+    result = runner.invoke(agent_commands.app, ["peers"])
+
+    assert result.exit_code == 0, result.output
+    assert "hermes-ct150" in result.output
+    # Registered and Endpoint recover their data — not "—".
+    assert "2026-08-10" in result.output
+    assert "http://h:1" in result.output
+    # Roles render whole, not exploded per character.
+    assert "chat" in result.output
+    assert "voice" in result.output
+    assert "c, h, a, t" not in result.output
+
+
 def test_peers_malformed_hal0_state_string_degrades_to_dash(fake_urlopen) -> None:
     """A hal0_state string that isn't even valid JSON still must not crash."""
     fake_urlopen(

--- a/tests/cli/test_capabilities_commands.py
+++ b/tests/cli/test_capabilities_commands.py
@@ -125,6 +125,34 @@ def test_list_renders_selections(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "bge-small" in result.output
 
 
+def test_list_renders_status_column(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#1905: the API payload carries a per-selection ``status`` field
+    (e.g. "failed" after a botched apply) that the table used to drop
+    entirely, leaving a failed apply looking identical to a healthy one."""
+    monkeypatch.setattr(cc, "_api_unreachable", lambda _u: False)
+    monkeypatch.setattr(
+        cc,
+        "api_get",
+        lambda path, **_k: {
+            "selections": {
+                "embed": {
+                    "default": {
+                        "backend": "cpu",
+                        "provider": "",
+                        "model": "bge-small",
+                        "enabled": True,
+                        "status": "failed",
+                    }
+                }
+            }
+        },
+    )
+    result = runner.invoke(cc.app, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "Status" in result.output
+    assert "failed" in result.output
+
+
 def test_list_empty_selections(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cc, "_api_unreachable", lambda _u: False)
     monkeypatch.setattr(cc, "api_get", lambda path, **_k: {"selections": {}})

--- a/tests/cli/test_slot_commands.py
+++ b/tests/cli/test_slot_commands.py
@@ -212,3 +212,42 @@ def test_slot_logs_one_shot_prints_hint_when_logs_empty(
     assert result.exit_code == 0, result.output
     assert "synthetic composite" in result.output
     assert "no logs" not in result.output
+
+
+def test_slot_logs_follow_terminates_on_degraded_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1905 follow-up (Codex): the server keeps a synthetic slot's degraded
+    stream open with keepalives (so the browser EventSource doesn't
+    error-reconnect), which would leave ``hal0 slot logs hal0 --follow``
+    hanging until Ctrl-C. The CLI must treat ``event: degraded`` as
+    terminal: print the message and return."""
+    from contextlib import contextmanager
+
+    from hal0.cli import _shared
+
+    class _FakeStream:
+        status_code = 200
+
+        def iter_lines(self):
+            yield "event: degraded"
+            yield 'data: {"message":"synthetic composite slot has no journal of its own"}'
+            yield ""
+            # If the CLI does not stop at the degraded frame it would sit
+            # here forever on a real stream; bound it so the test fails
+            # loudly instead of hanging.
+            for _ in range(5):
+                yield ": keepalive"
+            raise AssertionError("CLI kept reading past the terminal degraded frame")
+
+    @contextmanager
+    def fake_api_stream(method, path, *, timeout=None, params=None):
+        yield _FakeStream()
+
+    monkeypatch.setattr(_shared, "api_stream", fake_api_stream)
+    monkeypatch.setattr(slot_commands, "_api_unreachable", lambda _u: False)
+
+    result = runner.invoke(slot_commands.app, ["logs", "hal0", "--follow"])
+
+    assert result.exit_code == 0, result.output
+    assert "synthetic composite" in result.output

--- a/tests/cli/test_slot_commands.py
+++ b/tests/cli/test_slot_commands.py
@@ -188,3 +188,27 @@ def test_restart_budget_charges_both_lock_acquisitions() -> None:
     # Two lock waits (each capped by a full load) plus the verb's own work.
     floor = 2 * load_phase + terminate + load_phase
     assert slot_lifecycle_timeout_s(loads=1, unloads=1) >= floor
+
+
+def test_slot_logs_one_shot_prints_hint_when_logs_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1905 follow-up (Codex): the one-shot ``hal0 slot logs hal0`` used to
+    print a generic "no logs" even when the response carried the only
+    explanation in ``hint`` (synthetic composite, journalctl missing)."""
+    monkeypatch.setattr(slot_commands, "_api_unreachable", lambda _u: False)
+    monkeypatch.setattr(
+        slot_commands,
+        "api_get",
+        lambda path, **kw: {
+            "name": "hal0",
+            "logs": "",
+            "hint": "synthetic composite slot has no journal of its own",
+        },
+    )
+
+    result = runner.invoke(slot_commands.app, ["logs", "hal0"])
+
+    assert result.exit_code == 0, result.output
+    assert "synthetic composite" in result.output
+    assert "no logs" not in result.output

--- a/tests/hardware/test_probe.py
+++ b/tests/hardware/test_probe.py
@@ -107,18 +107,21 @@ def test_read_hostname_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     assert probe_mod._read_hostname() == ""
 
 
-def test_read_uptime_s(monkeypatch: pytest.MonkeyPatch) -> None:
-    # /proc/uptime: "<uptime_seconds> <idle_seconds>"
-    monkeypatch.setattr(
-        probe_mod,
-        "_read_text",
-        lambda p: "123456.78 987654.32\n" if str(p) == "/proc/uptime" else None,
-    )
+def test_read_uptime_s(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # /proc/uptime: "<uptime_seconds> <idle_seconds>". _read_uptime_s
+    # delegates to hal0.hardware.uptime (#1905), so patch that seam.
+    from hal0.hardware import uptime as uptime_mod
+
+    fake = tmp_path / "uptime"
+    fake.write_text("123456.78 987654.32\n")
+    monkeypatch.setattr(uptime_mod, "_UPTIME_PATH", fake)
     assert probe_mod._read_uptime_s() == 123456
 
 
-def test_read_uptime_s_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(probe_mod, "_read_text", lambda _: None)
+def test_read_uptime_s_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from hal0.hardware import uptime as uptime_mod
+
+    monkeypatch.setattr(uptime_mod, "_UPTIME_PATH", tmp_path / "missing")
     assert probe_mod._read_uptime_s() == 0
 
 
@@ -438,6 +441,13 @@ def test_probe_assembles_hardware_info(monkeypatch: pytest.MonkeyPatch, tmp_path
         return None
 
     monkeypatch.setattr(probe_mod, "_read_text", fake_read_text)
+
+    # Uptime reads through hal0.hardware.uptime (#1905), not _read_text.
+    from hal0.hardware import uptime as uptime_mod
+
+    fake_uptime = tmp_path / "uptime"
+    fake_uptime.write_text("4242.0 9000.0\n")
+    monkeypatch.setattr(uptime_mod, "_UPTIME_PATH", fake_uptime)
 
     info = HardwareProbe().probe()
     assert isinstance(info, HardwareInfo)

--- a/tests/hardware/test_uptime.py
+++ b/tests/hardware/test_uptime.py
@@ -1,0 +1,44 @@
+"""Direct tests for :mod:`hal0.hardware.uptime` (#1905).
+
+The API-route tests monkeypatch ``read_uptime_s`` away, so the
+parse/failure branches need their own coverage here. ``probe._read_uptime_s``
+delegates to this module, so this is the single seam for both callers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.hardware import uptime as uptime_mod
+
+
+def _patch_path(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    monkeypatch.setattr(uptime_mod, "_UPTIME_PATH", path)
+
+
+def test_parses_first_float_and_floors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    f = tmp_path / "uptime"
+    f.write_text("326305.91 1234567.00\n")
+    _patch_path(monkeypatch, f)
+    assert uptime_mod.read_uptime_s() == 326305
+
+
+def test_missing_file_returns_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_path(monkeypatch, tmp_path / "does-not-exist")
+    assert uptime_mod.read_uptime_s() == 0
+
+
+def test_garbage_content_returns_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    f = tmp_path / "uptime"
+    f.write_text("not-a-number stuff\n")
+    _patch_path(monkeypatch, f)
+    assert uptime_mod.read_uptime_s() == 0
+
+
+def test_empty_file_returns_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    f = tmp_path / "uptime"
+    f.write_text("")
+    _patch_path(monkeypatch, f)
+    assert uptime_mod.read_uptime_s() == 0

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -49,6 +49,7 @@ class FakeHindsightClient:
                 "document_id": document_id,
                 "content": content,
                 "tags": list(tags or []),
+                "metadata": dict(metadata or {}),
                 **kwargs,
             }
         )
@@ -259,6 +260,39 @@ async def test_add_routes_to_retain_under_mapped_bank():
     assert fake.retained[0]["document_id"] == res["id"]
     # retain is async on this engine — the operation id surfaces for polling.
     assert res["operation_id"] == "op-test"
+
+
+@pytest.mark.asyncio
+async def test_add_serializes_nested_metadata_as_json_not_repr():
+    """#1905: ``str(v)`` on a nested dict/list produced a Python repr with
+    single quotes (``"{'registered_at': ...}"``) that no JSON reader could
+    decode — the peer registry's identity cards were unreadable on upgraded
+    boxes. Nested values must round-trip as JSON; scalars stay ``str()``.
+    """
+    import json
+
+    fake = FakeHindsightClient()
+    p = HindsightProvider(client=fake, client_id="hermes")
+    await p.add(
+        "identity card",
+        metadata={
+            "hal0_state": {"registered_at": "2026-08-10T00:00:00Z", "bootstrap_version": 1},
+            "roles": ["homelab-admin", "generalist-chat"],
+            "agent_id": "hermes-ct150",
+        },
+        client_id="hermes",
+    )
+    sent = fake.retained[0]["metadata"]
+    # Nested structures decode back to the original value via json.loads…
+    assert json.loads(sent["hal0_state"]) == {
+        "registered_at": "2026-08-10T00:00:00Z",
+        "bootstrap_version": 1,
+    }
+    assert json.loads(sent["roles"]) == ["homelab-admin", "generalist-chat"]
+    # …i.e. no single-quoted Python repr on the wire.
+    assert "'" not in sent["hal0_state"]
+    # Scalars keep the plain-string shape existing readers expect.
+    assert sent["agent_id"] == "hermes-ct150"
 
 
 class FakeReranker:

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -295,6 +295,35 @@ async def test_add_serializes_nested_metadata_as_json_not_repr():
     assert sent["agent_id"] == "hermes-ct150"
 
 
+def test_fact_to_item_decodes_nested_metadata_strings():
+    """#1905 follow-up (Codex): the write path stores nested dict/list
+    metadata as JSON strings, so the general read adapter must inflate
+    them back — otherwise only CLI-specific coercion sees dicts and every
+    other REST/MCP consumer gets strings. Scalars stay strings (that was
+    always this engine's wire shape)."""
+    import json
+
+    item = HindsightProvider._fact_to_item(
+        {
+            "text": "identity card",
+            "metadata": {
+                "hal0_state": json.dumps({"registered_at": "2026-08-10T00:00:00Z"}),
+                "roles": json.dumps(["chat", "voice"]),
+                "agent_id": "hermes-ct150",
+                "count": "1",
+                "not_json": "{broken",
+            },
+        },
+        "shared",
+    )
+    md = item["metadata"]
+    assert md["hal0_state"] == {"registered_at": "2026-08-10T00:00:00Z"}
+    assert md["roles"] == ["chat", "voice"]
+    assert md["agent_id"] == "hermes-ct150"
+    assert md["count"] == "1"
+    assert md["not_json"] == "{broken"  # undecodable passes through
+
+
 class FakeReranker:
     """Reverses input order so we can prove the merge re-ranked the union."""
 

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -1047,6 +1047,29 @@ class TestSyntheticEntries:
         assert e["model"] == "m-1"
         assert e["_synthetic"] is True
 
+    def test_synthetic_reason_differs_by_kind(self) -> None:
+        """#1905: the local ``hal0`` composite isn't "backed by a remote
+        upstream" — that reason string was copy-pasted onto every synthetic
+        entry regardless of kind, so the hal0 tile lied about why it's
+        synthetic. Only genuinely remote-backed entries get the "install a
+        local slot" reason; the local composite gets its own copy."""
+        upstreams = FakeUpstreams(
+            [
+                SimpleNamespace(name="hal0", kind="slot", url="http://l"),
+                SimpleNamespace(name="haloai", kind="remote", url="http://r"),
+            ]
+        )
+        entries = synthesize_upstream_entries(
+            upstreams,
+            model_cache={},
+            last_used_model={},
+            loaded_models=set(),
+        )
+        by_name = {e["name"]: e for e in entries}
+        assert "remote upstream" not in by_name["hal0"]["_synthetic_reason"]
+        assert "composite" in by_name["hal0"]["_synthetic_reason"].lower()
+        assert "remote upstream" in by_name["haloai"]["_synthetic_reason"]
+
 
 class TestSnapshotComposition:
     async def test_real_slots_win_over_synthetic_on_name_collision(self, no_mem: None) -> None:

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -1077,6 +1077,17 @@ class TestSyntheticEntries:
         assert "composite" not in by_name["chat"]["_synthetic_reason"].lower()
         assert "remote upstream" not in by_name["chat"]["_synthetic_reason"]
 
+    def test_synthetic_reason_explicit_remote_hal0_classified_by_kind(self) -> None:
+        """An operator may define an explicit ``hal0`` upstream with
+        ``kind="remote"`` in upstreams.toml — that entry is genuinely
+        remote-backed, so the reserved name alone must not earn it the
+        local-composite explanation."""
+        from hal0.slot_view import _synthetic_reason
+
+        reason = _synthetic_reason(SimpleNamespace(name="hal0", kind="remote"))
+        assert "remote upstream" in reason
+        assert "composite" not in reason.lower()
+
 
 class TestSnapshotComposition:
     async def test_real_slots_win_over_synthetic_on_name_collision(self, no_mem: None) -> None:

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -1057,6 +1057,11 @@ class TestSyntheticEntries:
             [
                 SimpleNamespace(name="hal0", kind="slot", url="http://l"),
                 SimpleNamespace(name="haloai", kind="remote", url="http://r"),
+                # Every loaded container slot registers a same-name
+                # kind="slot" upstream — it must NOT claim to be the
+                # composite (review nit: the composite string belongs to
+                # the reserved name, not the kind).
+                SimpleNamespace(name="chat", kind="slot", url="http://c"),
             ]
         )
         entries = synthesize_upstream_entries(
@@ -1069,6 +1074,8 @@ class TestSyntheticEntries:
         assert "remote upstream" not in by_name["hal0"]["_synthetic_reason"]
         assert "composite" in by_name["hal0"]["_synthetic_reason"].lower()
         assert "remote upstream" in by_name["haloai"]["_synthetic_reason"]
+        assert "composite" not in by_name["chat"]["_synthetic_reason"].lower()
+        assert "remote upstream" not in by_name["chat"]["_synthetic_reason"]
 
 
 class TestSnapshotComposition:


### PR DESCRIPTION
## Summary

Four small, independently-verified residues from rc.6 adversarial validation, rolled into issue #1905 and fixed here as one branch since it's one filed issue (each item is still independently tested):

1. **`hal0 capabilities list` drops the Status column** (`src/hal0/cli/capabilities_commands.py`) — the API payload already carries a per-selection `status` field; the CLI table just never rendered it, so a failed capability apply looked identical to a healthy one.

2. **Synthetic `hal0` composite slot has the wrong `_synthetic_reason` + its `/logs` route 404s like a nonexistent slot** (`src/hal0/slot_view/__init__.py`, `src/hal0/api/routes/slots.py`) — the reason string ("Backed by remote upstream; install a local slot...") was hardcoded for every synthetic entry regardless of kind, which is factually wrong for the local `hal0` composite. Fixed by branching on `u.kind`. Separately, `GET /api/slots/hal0/logs` raised the typed `slot.not_found` envelope even though `hal0` is a legitimate, listable synthetic entry (not a real slot, but not "not found" either) — it now 200s with an explanatory hint, mirroring how `get_slot`'s detail view already falls through to the synthetic entry. A genuinely unknown slot name still 404s.

3. **`uptime_s` frozen at `hardware.json` write time** (`src/hal0/hardware/uptime.py` new, `src/hal0/api/routes/hardware.py`) — `/api/hardware` and `/api/stats/hardware` served the cached probe's `uptime_s` as if it were live; on a box that's never re-probed since an upgrade this drifts by weeks (ct150 reported 4110s on a host up 326305s). Split the read into a standalone `hal0.hardware.uptime.read_uptime_s()` — deliberately outside `hal0.hardware.probe` so the API route layer doesn't pull in that module's private GPU/NPU probe internals (an existing test, `test_route_module_has_no_private_probe_imports`, guards the #703 architecture boundary that keeps GPU/NPU state flowing through the coalesced `HardwareStats` singleton instead of ad-hoc route-level probing) — and call it fresh on every serve.

4. **`hal0 agent peers` AttributeError** (`src/hal0/cli/agent_commands.py`) — crashed with `'str' object has no attribute 'get'` when a card's `metadata.hal0_state` came back from the memory API as a JSON-encoded string instead of an already-parsed dict (observed on an upgraded box). `md.get("hal0_state") or {}` doesn't catch this since a non-empty string is truthy. Added a small `_as_dict` coercion applied to `metadata`, `endpoint`, and `hal0_state` alike (same storage path, same failure mode) that parses a JSON string back to a dict and degrades anything else — including malformed JSON — to `{}` so the row still renders with "—".

## Test plan

- [x] Each item has its own regression test that fails on the pre-fix code and passes after.
- [x] Confirmed the `agent peers` regression by reverting just that hunk and re-running its tests — reproduces the original `AttributeError` crash.
- [x] `uv run pytest -q` — 10313 passed, 16 skipped, 1 xfailed, 0 failed
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean

## Out of scope

- `capability-apply-persists-intent-on-lifecycle-failure` (#697) — the `enabled=true` persistence-on-failure behavior itself is by-design per `known-issues.yaml`; this PR only adds visibility (the Status column), it doesn't change that behavior.
- Did not touch CHANGELOG.md per the fix-wave process rule (consolidated CHANGELOG PR lands at the end of the wave).

Closes #1905