### PR TITLE
fix(gpu): require /dev/kfd and retire the Vulkan LLM lane

### DIFF
--- a/docs/concepts/strix-halo.mdx
+++ b/docs/concepts/strix-halo.mdx
@@ -19,9 +19,10 @@ A Strix Halo machine gives hal0 three places to run a model:
 
 <CardGrid>
   <Card title="Radeon iGPU" icon="seti:default">
-    The integrated GPU runs LLM and image workloads through either ROCm
-    (`gpu-rocm`) or Vulkan (`gpu-vulkan`). It's detected as an AMD `amdgpu`
-    device; the marketing name comes from the system at probe time.
+    The integrated GPU runs LLM workloads through ROCm (`gpu-rocm`, which
+    requires `/dev/kfd`) and image/audio workloads through Vulkan
+    (`gpu-vulkan`). It's detected as an AMD `amdgpu` device; the marketing
+    name comes from the system at probe time.
   </Card>
   <Card title="XDNA NPU" icon="seti:config">
     The AMD XDNA NPU is driven by FastFlowLM (FLM) on the `npu` device. hal0
@@ -41,26 +42,28 @@ NVIDIA silicon.) A slot's `device` field is what picks one of these — see
 [Capabilities & profiles](/docs/concepts/capabilities-and-profiles) for why
 that ownership lives on the slot, not the profile, as of v1.0.
 
-## ROCm or Vulkan on the iGPU
+## ROCm is the LLM lane on the iGPU
 
-The iGPU can run through two backends, and hal0 treats them as distinct devices
-because they behave differently:
+- **ROCm** (`gpu-rocm`) — AMD's compute stack, and the only supported backend
+  for llama.cpp (LLM) slots on AMD hardware. It needs the `/dev/kfd` compute
+  node to be visible to hal0 and to the slot containers.
+- **Vulkan** (`gpu-vulkan`) — retained for the non-llama.cpp runtimes that
+  genuinely ship Vulkan images (Kokoro TTS, whisper.cpp, ComfyUI). It is **not**
+  a supported LLM backend.
 
-- **ROCm** (`gpu-rocm`) — AMD's compute stack. hal0 tests for it by probing for
-  the ROCm tooling; the GPU is marked compute-capable when it's present. ROCm
-  can deliver the best throughput, but it depends on a matching kernel and
-  user-space combination the installer can't easily verify on its own.
-- **Vulkan** (`gpu-vulkan`) — the broad-compatibility path via Mesa, which ships
-  with the `amdgpu` driver. It works on essentially any AMD GPU without extra
-  setup, which makes it the safe default for unified-memory APUs.
+<Aside type="caution">
+hal0's LLM slots all run the same unified ROCmFPX runner image, which is a
+single HIP + Vulkan build. llama.cpp picks ROCm when `/dev/kfd` is visible and
+silently falls back to that image's Vulkan backend when it is not — and that
+Vulkan backend emits invalid tokens for every model it serves, at full nominal
+speed, while HTTP 200, container health, `hal0 doctor` and the streaming `done`
+frame all read green.
 
-<Aside type="note">
-On Strix Halo-class unified-memory hardware, hal0's hardware recommender leans
-toward Vulkan as the safe default — ROCm requires a verified kernel and
-user-space stack the probe can't confirm on its own. You can still choose
-`gpu-rocm` explicitly when your stack supports it; the seed stacks
-([Stacks](/docs/concepts/stacks)) generally pair a ROCm agent with a Vulkan
-utility model as a middle ground.
+So `/dev/kfd` is a hard requirement, not an optimisation. The installer refuses
+to complete a GPU install without it, and a GPU LLM slot refuses to load. In a
+Proxmox LXC, forward it with a `dev1: /dev/kfd` line in
+`/etc/pve/lxc/<CTID>.conf`, then `pct stop` / `pct start`. Without it, run
+CPU-only.
 </Aside>
 
 ## Unified memory is the tuning target

--- a/docs/guides/manage-slots.mdx
+++ b/docs/guides/manage-slots.mdx
@@ -53,7 +53,7 @@ memory extraction); a custom slot is reachable only by its own name.
 hal0 slot create embed \
   --type embedding \
   --model nomic-embed-text-v1.5-q8_0 \
-  --hardware vulkan \
+  --hardware rocm \
   --ctx-size 8192
 ```
 
@@ -67,9 +67,15 @@ hal0 slot create embed \
 
 3. **`--model` / `-m`** (required) — the initial model ref to assign.
 
-4. **`--hardware`** — the compute backend: `vulkan`, `rocm`, or `cpu`.
-   When omitted it reads the cached hardware probe: `vulkan` if no probe
-   has run yet, `cpu` if the probe found no GPU. This sets the slot's
+4. **`--hardware`** — the compute backend: `rocm`, `cpu`, or `vulkan`.
+   When omitted it reads the cached hardware probe: `rocm` on any AMD GPU
+   (and if no probe has run yet), `cpu` if the probe found no GPU. `vulkan`
+   is **not a supported LLM backend** — llama.cpp slots run the unified
+   ROCmFPX runner image, whose Vulkan build emits invalid tokens for every
+   model, so it is reserved for the non-llama.cpp Vulkan runtimes and for
+   non-AMD GPUs. `rocm` requires the `/dev/kfd` compute node; a slot
+   without it refuses to load rather than serving garbage. This sets the
+   slot's
    `device` field directly (`vulkan → gpu-vulkan`, `rocm → gpu-rocm`,
    `cpu → cpu`) — as of v1.0, **the slot owns its hardware grid**
    (`device`, `n_gpu_layers`, `threads`, `binary`, `image_pin`), not the

--- a/docs/hal0-install-migration-guide.html
+++ b/docs/hal0-install-migration-guide.html
@@ -374,7 +374,7 @@ footer .mono{font-family:var(--jbm)}
 
   <h3>Inference backends</h3>
   <div class="grid c2">
-    <div class="card"><h4><span class="pill vulkan">Vulkan</span> recommended on Strix Halo</h4><p class="k">RADV/Vulkan benchmarked <strong>+40% prefill · +16% gen · −30% TTFT</strong> vs ROCm on the same weights (unified-memory APUs). v1.0 standardizes shared APU models on Vulkan.</p></div>
+    <div class="card"><h4><span class="pill vulkan">/dev/kfd</span> required on AMD</h4><p class="k">LLM slots run the unified ROCmFPX runner, which serves <strong>ROCm</strong> when <code>/dev/kfd</code> is visible and silently falls back to a Vulkan backend that emits <strong>invalid tokens for every model</strong> when it is not. v1.0 therefore requires <code>/dev/kfd</code>: the installer refuses a GPU install without it and GPU slots refuse to load. On Proxmox LXC add <code>dev1: /dev/kfd</code>; otherwise install CPU-only.</p></div>
     <div class="card"><h4><span class="pill rocm">ROCm</span> · <span class="pill npu">NPU</span> · <span class="pill cpu">CPU</span></h4><p class="k">ROCm/HIP for discrete AMD, AMDXDNA NPU via FastFlowLM (STT/embed/small LLMs), and a fully-supported CPU path (incl. Moonshine CPU STT). Devices are picked per-slot; you can pin any of them.</p></div>
   </div>
 

--- a/docs/reference/hardware-matrix.mdx
+++ b/docs/reference/hardware-matrix.mdx
@@ -41,7 +41,7 @@ across 5 call sites, now unified). `DEFAULT_DEVICE = "gpu-rocm"`.
 | Device id | Label | Recommended | Default profile | Notes |
 |---|---|---|---|---|
 | `gpu-rocm` | GPU (ROCm) | ✅ | `chat` | Best throughput on Strix Halo — the recommended default. |
-| `gpu-vulkan` | GPU (Vulkan) | — | `chat` | Runs anywhere Mesa Vulkan does; slower than ROCm on Strix Halo — fallback. |
+| `gpu-vulkan` | GPU (Vulkan) | ❌ for LLM | `chat` | **Not a supported LLM backend** (#1888) — the unified ROCmFPX runner's Vulkan build emits invalid tokens. Retained for the non-llama.cpp Vulkan runtimes (Kokoro, whisper.cpp, ComfyUI) and for non-AMD GPUs. |
 | `gpu-cuda` | GPU (CUDA) | — | `chat` | NVIDIA GPUs via llama.cpp CUDA — experimental on hal0. |
 | `cpu` | CPU | — | `cpu-chat` | Always available, slow but correct. |
 | `npu` | NPU (FLM) | — | `flm` | AMD XDNA NPU via FastFlowLM — chat/embed/ASR trio on one process. |
@@ -56,15 +56,19 @@ fallback rather than crashing config load.
 `hardware.recommend._backend_for()` — this is the actual logic the installer and
 dashboard use to pick a device for a new slot, given a probed `HardwareInfo`:
 
-1. **AMD**, unified memory ≥ 32 GB, and `vram_mb <= 4096` → **Vulkan** ("AMD UMA /
-   Strix Halo class" — small dedicated VRAM number is a UMA signal, not a real cap).
-2. **AMD**, `compute_capable` (rocm-smi reachable) → **ROCm**.
-3. **AMD**, no ROCm → **Vulkan** (Mesa).
-4. **NVIDIA**, NVIDIA Container Toolkit present (`nvidia-ctk` on `PATH` or a CDI spec
+1. **AMD**, `compute_capable` (rocm-smi reachable) *or* `/dev/kfd` present →
+   **ROCm**. The rationale string still names the "AMD UMA / Strix Halo class"
+   when unified memory ≥ 32 GB and `vram_mb <= 4096` (a small dedicated VRAM
+   number is a UMA signal, not a real cap).
+2. **AMD**, no ROCm compute node → **CPU**. Not Vulkan: LLM slots run the
+   unified ROCmFPX runner image on every AMD GPU device, and that image's
+   Vulkan backend emits invalid tokens for every model (#1888), so CPU is the
+   only lane that produces valid output on such a box.
+3. **NVIDIA**, NVIDIA Container Toolkit present (`nvidia-ctk` on `PATH` or a CDI spec
    under `/etc/cdi`/`/var/run/cdi`) → **CUDA**.
-5. **NVIDIA**, no CDI → **Vulkan** fallback.
-6. **Intel iGPU** / unknown-but-`vulkan_capable` → **Vulkan**.
-7. **No GPU detected** → **CPU** ("no GPU detected — CPU inference only, slow but
+4. **NVIDIA**, no CDI → **Vulkan** fallback.
+5. **Intel iGPU** / unknown-but-`vulkan_capable` → **Vulkan**.
+6. **No GPU detected** → **CPU** ("no GPU detected — CPU inference only, slow but
    correct").
 
 VRAM budget (`_vram_budget_gb()`): AMD UMA → half of the unified pool; discrete GPU →

--- a/installer/bench/suites/lane-matrix.toml
+++ b/installer/bench/suites/lane-matrix.toml
@@ -1,5 +1,5 @@
-# suites/lane-matrix.toml — feeds hal0-tune. Both lanes across the full
-# 2k/32k/128k depth axis, on a small set of profile-class representatives
+# suites/lane-matrix.toml — feeds hal0-tune. The supported GPU lane across
+# the full 2k/32k/128k depth axis, on a small set of profile-class representatives
 # — NOT the whole roster. This is a tuning signal, not a display board.
 # See the bench design handoff §4.
 
@@ -22,7 +22,7 @@ priority    = 40
 # is a judgment call. Update it when the profile-class lineup changes.
 #
 # include_only: with the list unset this suite selects NOTHING. Without it,
-# an empty include fell back to "every installed GGUF x 2 lanes x 3 depths" —
+# an empty include fell back to "every installed GGUF x every lane x 3 depths" —
 # an accidental multi-day exclusive GPU job.
 include_only = true
 include = [
@@ -32,7 +32,10 @@ include = [
 ]
 
 [matrix]
-lanes    = ["rocm", "vulkan_radv"]     # both lanes, unlike roster's "default"
+lanes    = ["rocm"]                    # explicit lane pin, unlike roster's "default".
+                                        # vulkan_radv is UNSUPPORTED (#1888): the ROCmFPX
+                                        # image's Vulkan backend emits invalid tokens, so
+                                        # its throughput numbers measure garbage.
 depths   = [2048, 32768, 131072]        # the full 2k/32k/128k ctx-fill axis
 samplers = ["greedy"]
 reps     = 3

--- a/installer/bench/suites/roster.toml
+++ b/installer/bench/suites/roster.toml
@@ -16,7 +16,7 @@ installed   = true               # only models present under /mnt/ai-models
 # explicit include/exclude lists also supported
 
 [matrix]                          # the axes; identity fields not listed are pinned to model defaults
-lanes    = ["default"]           # "default" = the model's preferred profile lane; or ["rocm","vulkan_radv"]
+lanes    = ["default"]           # "default" = the model's preferred profile lane; or an explicit ["rocm"]
 depths   = [2048]                # roster is the uniform 2k board; tune suites use [2048,32768,131072]
 samplers = ["greedy"]
 reps     = 3

--- a/installer/etc-hal0/slots/agent.toml
+++ b/installer/etc-hal0/slots/agent.toml
@@ -24,7 +24,11 @@
 # model family.
 name = "agent"
 type = "llm"
-device = "gpu-vulkan"
+# #1888: gpu-rocm, not gpu-vulkan. llama.cpp slots launch the unified
+# ROCmFPX runner on both GPU devices; that image's Vulkan backend emits
+# invalid tokens for every model, so gpu-vulkan named a lane no slot
+# could validly run. Requires /dev/kfd (preflight + load-time guard).
+device = "gpu-rocm"
 runtime = "container"
 profile = "chadrock-moe"
 port = 8081

--- a/installer/etc-hal0/slots/brain.toml
+++ b/installer/etc-hal0/slots/brain.toml
@@ -59,7 +59,11 @@
 # deliberately want a bigger steward voice.
 name = "brain"
 type = "llm"
-device = "gpu-vulkan"
+# #1888: gpu-rocm, not gpu-vulkan. llama.cpp slots launch the unified
+# ROCmFPX runner on both GPU devices; that image's Vulkan backend emits
+# invalid tokens for every model, so gpu-vulkan named a lane no slot
+# could validly run. Requires /dev/kfd (preflight + load-time guard).
+device = "gpu-rocm"
 runtime = "container"
 profile = "brain"
 port = 8089

--- a/installer/etc-hal0/slots/coder.toml
+++ b/installer/etc-hal0/slots/coder.toml
@@ -14,7 +14,11 @@
 # `[model].default` is what activates the slot (#1369).
 name = "coder"
 type = "llm"
-device = "gpu-vulkan"
+# #1888: gpu-rocm, not gpu-vulkan. llama.cpp slots launch the unified
+# ROCmFPX runner on both GPU devices; that image's Vulkan backend emits
+# invalid tokens for every model, so gpu-vulkan named a lane no slot
+# could validly run. Requires /dev/kfd (preflight + load-time guard).
+device = "gpu-rocm"
 runtime = "container"
 profile = "coding"
 port = 8082

--- a/installer/etc-hal0/slots/embed.toml
+++ b/installer/etc-hal0/slots/embed.toml
@@ -12,7 +12,11 @@
 # `[model].default` is what activates the slot (#1369).
 name = "embed"
 type = "embedding"
-device = "gpu-vulkan"
+# #1888: gpu-rocm, not gpu-vulkan. llama.cpp slots launch the unified
+# ROCmFPX runner on both GPU devices; that image's Vulkan backend emits
+# invalid tokens for every model, so gpu-vulkan named a lane no slot
+# could validly run. Requires /dev/kfd (preflight + load-time guard).
+device = "gpu-rocm"
 runtime = "container"
 profile = "embedding"
 port = 8083

--- a/installer/etc-hal0/slots/rerank.toml
+++ b/installer/etc-hal0/slots/rerank.toml
@@ -3,7 +3,7 @@
 # Clean seed (WS-E, #1107): no `[model].default` pin, so a model-less box
 # boots a GREY tile (no surprise download, no crash-loop). The operator picks
 # a reranker later; filling in `[model].default` activates it (#1369).
-# device/profile are the widest-compatible GPU-Vulkan tile defaults — the
+# device/profile are the supported GPU-ROCm tile defaults — the
 # guided / answer-file setup path derives them from the up-front preflight
 # (hardware.json, #1097).
 #
@@ -12,7 +12,11 @@
 # Existing installs keep their old port (seeds never overwrite).
 name = "rerank"
 type = "reranking"
-device = "gpu-vulkan"
+# #1888: gpu-rocm, not gpu-vulkan. llama.cpp slots launch the unified
+# ROCmFPX runner on both GPU devices; that image's Vulkan backend emits
+# invalid tokens for every model, so gpu-vulkan named a lane no slot
+# could validly run. Requires /dev/kfd (preflight + load-time guard).
+device = "gpu-rocm"
 runtime = "container"
 profile = "reranking"
 port = 8086

--- a/installer/etc-hal0/slots/utility.toml
+++ b/installer/etc-hal0/slots/utility.toml
@@ -14,7 +14,11 @@
 # profile pick.
 name = "utility"
 type = "llm"
-device = "gpu-vulkan"
+# #1888: gpu-rocm, not gpu-vulkan. llama.cpp slots launch the unified
+# ROCmFPX runner on both GPU devices; that image's Vulkan backend emits
+# invalid tokens for every model, so gpu-vulkan named a lane no slot
+# could validly run. Requires /dev/kfd (preflight + load-time guard).
+device = "gpu-rocm"
 runtime = "container"
 profile = "chat"
 # Port 8090: 8081 is the `agent` seed's canonical primary port (ADR-0023);

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -361,6 +361,10 @@ HAL0_CONTAINER_REQUIRED=1 preflight_container_runtime \
 #     inside this container (the #1 broken-install shape). HARD STOP with the
 #     dev0 remedy preflight_gpu just printed; the operator fixes the host dev0
 #     line and re-runs.
+#   HAL0_GPU_RC_NO_KFD     → AMD GPU visible but /dev/kfd (the ROCm compute
+#     node) missing. llama.cpp silently falls back to the runner image's Vulkan
+#     backend, which emits invalid tokens for every model while every health
+#     surface reads green (#1888). Same EXPLICIT CPU-only opt-in as below.
 #   HAL0_GPU_RC_NO_DEVICE  → no GPU devices inside an LXC. Allow an EXPLICIT
 #     CPU-only opt-in: HAL0_ALLOW_CPU_ONLY=1, or a y/N confirm on a real TTY;
 #     otherwise stop with the passthrough remedy.
@@ -433,6 +437,23 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
         err "GPU passthrough is broken: the render device is visible but its gid does not map to the render group in this container (no group, or the wrong one)."
         err "Every GPU slot would silently fall back to CPU. Apply the dev0/gid fix shown above on the Proxmox host, then re-run install.sh."
         exit 1
+    elif (( gpu_rc == HAL0_GPU_RC_NO_KFD )); then
+        # AMD GPU visible but no ROCm compute node: every GPU LLM slot would
+        # silently run the runner image's Vulkan backend, which emits invalid
+        # tokens for every model while every health surface reads green
+        # (#1888). Same opt-in shape as NO_DEVICE — a CPU-only install is a
+        # legitimate answer; a GPU install on this box is not.
+        if [[ "${HAL0_ALLOW_CPU_ONLY:-0}" == "1" ]]; then
+            warn "No /dev/kfd — proceeding CPU-only (HAL0_ALLOW_CPU_ONLY=1); GPU LLM slots will refuse to start."
+        elif [[ -r /dev/tty ]] && _confirm_cpu_only; then
+            warn "Proceeding with a CPU-only install (confirmed at the prompt)."
+        else
+            err "No /dev/kfd inside this container — the ROCm compute node GPU LLM slots require."
+            err "Without it the runner image falls back to Vulkan, which produces invalid output (#1888)."
+            err "Forward /dev/kfd (remedy above), then re-run install.sh."
+            err "To install CPU-only anyway, re-run with HAL0_ALLOW_CPU_ONLY=1."
+            exit 1
+        fi
     elif (( gpu_rc == HAL0_GPU_RC_NO_DEVICE )); then
         if [[ "${HAL0_ALLOW_CPU_ONLY:-0}" == "1" ]]; then
             warn "No GPU devices inside this container — proceeding CPU-only (HAL0_ALLOW_CPU_ONLY=1)."

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -912,10 +912,20 @@ preflight_podman_forward() {
 # like 'clock' instead of 'render') because getent still resolved a name.
 # Test seams (only consulted here, never set in production): HAL0_GPU_DRI_GLOB,
 # HAL0_GPU_CONTAINER_OVERRIDE, HAL0_GPU_RENDER_GID_OVERRIDE,
-# HAL0_GPU_RENDER_GROUP_OVERRIDE, HAL0_GPU_USER_OVERRIDE.
+# HAL0_GPU_RENDER_GROUP_OVERRIDE, HAL0_GPU_USER_OVERRIDE, HAL0_GPU_KFD_PATH,
+# HAL0_GPU_AMD_OVERRIDE.
 # See docs/getting-started/proxmox.mdx for the full walkthrough.
 HAL0_GPU_RC_BROKEN_GID=3
 HAL0_GPU_RC_NO_DEVICE=4
+#       HAL0_GPU_RC_NO_KFD(5)     → an AMD GPU render node is visible but
+#                                    /dev/kfd is NOT: the ROCm compute node is
+#                                    missing, so llama.cpp silently falls back
+#                                    to the runner image's Vulkan backend,
+#                                    which emits INVALID TOKENS for every
+#                                    model while every health surface reads
+#                                    green (#1888). Caller allows an explicit
+#                                    CPU-only opt-in, same as NO_DEVICE.
+HAL0_GPU_RC_NO_KFD=5
 preflight_gpu() {
     local gate="${HAL0_GPU_GATE:-0}"
 
@@ -928,15 +938,16 @@ preflight_gpu() {
     [[ -n "${HAL0_GPU_CONTAINER_OVERRIDE:-}" ]] && in_container="${HAL0_GPU_CONTAINER_OVERRIDE}"
 
     local dri_glob="${HAL0_GPU_DRI_GLOB:-/dev/dri/renderD*}"
+    local kfd_path="${HAL0_GPU_KFD_PATH:-/dev/kfd}"
     local have_render="" have_kfd="" have_accel=""
     compgen -G "${dri_glob}" >/dev/null 2>&1 && have_render=1
-    [[ -e /dev/kfd ]] && have_kfd=1
+    [[ -e "${kfd_path}" ]] && have_kfd=1
     [[ -e /dev/accel/accel0 ]] && have_accel=1
 
     if [[ -n "${have_render}" ]]; then
         info "gpu: $(compgen -G "${dri_glob}" 2>/dev/null | tr '\n' ' ')present"
     fi
-    [[ -n "${have_kfd}"   ]] && info "gpu: /dev/kfd present (ROCm compute)"
+    [[ -n "${have_kfd}"   ]] && info "gpu: ${kfd_path} present (ROCm compute)"
     [[ -n "${have_accel}" ]] && info "npu: /dev/accel/accel0 present (AMD XDNA)"
 
     if [[ -z "${have_render}" ]]; then
@@ -944,7 +955,7 @@ preflight_gpu() {
             warn "gpu: no /dev/dri/renderD* inside this container — GPU slots will run CPU-only"
             warn "  Forward the devices from the Proxmox HOST (/etc/pve/lxc/<CTID>.conf, PVE 8.2+):"
             warn "    dev0: /dev/dri/renderD128,gid=<render gid INSIDE this container>"
-            warn "    dev1: /dev/kfd                    # ROCm compute (optional)"
+            warn "    dev1: /dev/kfd                    # ROCm compute — REQUIRED for GPU LLM slots (#1888)"
             warn "    dev2: /dev/accel/accel0,gid=<render gid>   # XDNA NPU (Strix Halo only)"
             warn "  then: pct stop <CTID> && pct start <CTID>. Full guide: https://hal0.dev/docs/getting-started/proxmox/"
             # Gated install: no devices in an LXC is the opt-in CPU-only case.
@@ -1022,6 +1033,35 @@ preflight_gpu() {
                 fi
             fi
         fi
+    fi
+
+    # ── ROCm compute node (#1888) ────────────────────────────────────────
+    # A render node without /dev/kfd is NOT a working GPU box for LLM slots.
+    # The release-pinned ROCmFPX runner is one HIP+Vulkan build: llama.cpp
+    # runs ROCm when /dev/kfd is visible and SILENTLY falls back to that
+    # image's Vulkan backend when it is not — and that backend emits invalid
+    # tokens for every model, at full nominal speed, while HTTP 200,
+    # container health, `hal0 doctor` and the SSE done frame all read green.
+    # This is the exact shape a fresh unprivileged LXC install produces, so
+    # the gate refuses it instead of shipping a box that serves garbage.
+    # AMD-only: the defect is characterised on the AMD/HIP build, and a
+    # non-AMD GPU has no /dev/kfd to forward in the first place.
+    local is_amd="${HAL0_GPU_AMD_OVERRIDE:-}"
+    if [[ -z "${is_amd}" ]]; then
+        [[ -d /sys/module/amdgpu ]] && is_amd=1
+    fi
+    if [[ -n "${is_amd}" && "${is_amd}" != "0" && -z "${have_kfd}" ]]; then
+        warn "gpu: AMD GPU visible but /dev/kfd is MISSING — no ROCm compute node"
+        warn "  Every GPU LLM slot would fall back to the runner image's Vulkan backend,"
+        warn "  which emits INVALID TOKENS for every model while all health checks read green (#1888)."
+        if [[ "${in_container}" == "lxc" ]]; then
+            warn "  Forward it from the Proxmox HOST (/etc/pve/lxc/<CTID>.conf):"
+            warn "    dev1: /dev/kfd"
+            warn "  then: pct stop <CTID> && pct start <CTID>"
+        else
+            warn "  Load the amdkfd driver (it ships with amdgpu; check 'dmesg | grep -i kfd')."
+        fi
+        [[ "${gate}" == "1" ]] && return "${HAL0_GPU_RC_NO_KFD}"
     fi
     return 0
 }

--- a/src/hal0/api/routes/stacks.py
+++ b/src/hal0/api/routes/stacks.py
@@ -190,7 +190,10 @@ async def _create_missing_slots(
     for entry in cfg.slots:
         if not entry.model or _slot_toml_exists(entry.slot):
             continue
-        device = entry.device or "gpu-vulkan"
+        # #1888: an entry with no device lands on the ROCm lane, not Vulkan —
+        # llama.cpp slots run the ROCmFPX runner image on both GPU devices and
+        # that image's Vulkan backend emits invalid tokens for every model.
+        device = entry.device or "gpu-rocm"
         profile = entry.profile or DEVICE_TO_DEFAULT_PROFILE.get(device, "")
         # spec-hw-slot-ownership §1: vision/mtp/enable_thinking are model-owned
         # typed capabilities, so a stack-created slot must not be born carrying

--- a/src/hal0/api/routes/stacks.py
+++ b/src/hal0/api/routes/stacks.py
@@ -167,6 +167,28 @@ def _slot_toml_exists(slot: str) -> bool:
     return resolve_slot_stem(paths.slots_config_dir(), slot) is not None
 
 
+def _default_stack_slot_device() -> str:
+    """Device for a stack entry that names none — resolved from this host.
+
+    #1888: the old constant was ``"gpu-vulkan"``, a lane an llama.cpp slot
+    never validly runs. Swapping it for a ``"gpu-rocm"`` constant would strand
+    Intel/NVIDIA hosts on an AMD-only configuration instead, so the shared
+    install-time derivation decides. Falls back to the canonical
+    ``DEFAULT_DEVICE`` when the probe is unreadable — hal0's reference
+    platform is AMD, and a wrong ROCm label now fails loudly at slot load
+    rather than silently serving garbage.
+    """
+    from hal0.config.loader import load_hardware_info
+    from hal0.install.profile_derive import derive_device
+    from hal0.model_meta import DEFAULT_DEVICE
+
+    try:
+        hw = load_hardware_info()
+    except Exception:
+        return DEFAULT_DEVICE
+    return derive_device("chat", hw, npu_opt_in=False) or DEFAULT_DEVICE
+
+
 def _missing_slot_names(cfg: StackConfig) -> list[str]:
     """Stack slots (with a model) whose TOML doesn't exist yet."""
     return [e.slot for e in cfg.slots if e.model and not _slot_toml_exists(e.slot)]
@@ -190,10 +212,14 @@ async def _create_missing_slots(
     for entry in cfg.slots:
         if not entry.model or _slot_toml_exists(entry.slot):
             continue
-        # #1888: an entry with no device lands on the ROCm lane, not Vulkan —
-        # llama.cpp slots run the ROCmFPX runner image on both GPU devices and
-        # that image's Vulkan backend emits invalid tokens for every model.
-        device = entry.device or "gpu-rocm"
+        # #1888: an entry with no device is resolved from the HOST, not from a
+        # constant. The old constant was "gpu-vulkan" — a lane llama.cpp slots
+        # never validly run (they launch the ROCmFPX runner on both GPU
+        # devices, and its Vulkan backend emits invalid tokens for every
+        # model). Hardcoding "gpu-rocm" instead would just break the other
+        # direction, materialising an AMD-only slot on an Intel/NVIDIA box, so
+        # the host probe decides and gpu-rocm is only the last-resort default.
+        device = entry.device or _default_stack_slot_device()
         profile = entry.profile or DEVICE_TO_DEFAULT_PROFILE.get(device, "")
         # spec-hw-slot-ownership §1: vision/mtp/enable_thinking are model-owned
         # typed capabilities, so a stack-created slot must not be born carrying

--- a/src/hal0/bench/harness.py
+++ b/src/hal0/bench/harness.py
@@ -140,6 +140,26 @@ class LaneSpec:
     dev_args: tuple[tuple[str, str], ...]
 
 
+#: Lanes that still resolve to a :class:`LaneSpec` (historical records name
+#: them) but are NOT supported and never enter :func:`default_lanes`.
+#:
+#: ``vulkan_radv`` pins ``-dev Vulkan0`` on the unified ROCmFPX runner image,
+#: whose Vulkan backend emits invalid tokens for every model it serves
+#: (#1888) — a throughput number from it measures how fast the box produces
+#: non-language. Retained rather than deleted so old records/suites parse.
+UNSUPPORTED_LANES: frozenset[str] = frozenset({"vulkan_radv"})
+
+
+def lane_is_supported(lane: str) -> bool:
+    """Is ``lane`` a lane hal0 is willing to publish numbers for?
+
+    False for every entry in :data:`UNSUPPORTED_LANES`. Callers that run one
+    anyway (explicit ``--backends vulkan_radv``) must say so loudly rather
+    than let the record read like any other measurement.
+    """
+    return lane not in UNSUPPORTED_LANES
+
+
 def lane_specs() -> dict[str, LaneSpec]:
     """The fixed backend matrix (``config.sh`` ``BACKENDS``), ported verbatim.
 
@@ -158,6 +178,12 @@ def lane_specs() -> dict[str, LaneSpec]:
             env=("GGML_HIP_ENABLE_UNIFIED_MEMORY=1",),
             dev_args=(("-ngl", "99"), ("-dev", "ROCm0")),
         ),
+        # UNSUPPORTED (#1888) — kept only so historical records and an
+        # explicit `--backends vulkan_radv` still resolve to a spec. This
+        # lane pins ``-dev Vulkan0`` on the unified ROCmFPX image, whose
+        # Vulkan backend emits invalid tokens for every model: the numbers it
+        # produces are throughput measurements of garbage. Never in
+        # ``default_lanes``; callers must opt in and are warned.
         "vulkan_radv": LaneSpec(
             lane="vulkan_radv",
             image=DEFAULT_ROCMFPX_IMAGE,
@@ -181,8 +207,15 @@ def default_lanes(tier: str) -> list[str]:
     """The lanes a suite sweeps when it does not say ``--backends`` itself
     (``config.sh`` ``BACKEND_ORDER``): TIER-SCOPED, so a CPU-only box never
     queues the unrunnable GPU lanes, and a GPU box never silently pays for a
-    CPU lane's hours-long 27B/ctx65k cells by default."""
-    return ["cpu"] if tier == TIER_CPU else ["rocm", "vulkan_radv"]
+    CPU lane's hours-long 27B/ctx65k cells by default.
+
+    ``vulkan_radv`` was dropped from the GPU default in the #1888 wave: the
+    ROCmFPX runner's Vulkan backend emits invalid tokens for every model, so
+    publishing throughput for that lane means publishing tok/s for output
+    that is not language. The lane spec is retained (see
+    :data:`UNSUPPORTED_LANES`) so historical records still resolve, but it is
+    opt-in only and stamped unsupported in the record."""
+    return ["cpu"] if tier == TIER_CPU else ["rocm"]
 
 
 def dedupe_flags(pairs: list[tuple[str, str]]) -> list[tuple[str, str]]:

--- a/src/hal0/bench/planner.py
+++ b/src/hal0/bench/planner.py
@@ -158,7 +158,14 @@ def fetch_registry_models(api: str = DEFAULT_API, timeout: float = 10.0) -> list
 # hal0 /api/models backend token -> benchlab lane token. The registry reports a
 # model's runner backend as "vulkan"/"rocm"; benchlab's lanes are "vulkan_radv"/
 # "rocm" (the lane names harness.lane_specs() defines).
-_BACKEND_TO_LANE = {"vulkan": "vulkan_radv", "vulkan_radv": "vulkan_radv", "rocm": "rocm"}
+#
+# #1888: the registry's "vulkan" hint now resolves to the **rocm** lane. Both
+# GPU lanes share the unified ROCmFPX runner image, and llama.cpp runs ROCm on
+# it whenever /dev/kfd is visible — so a "vulkan"-labelled model was already
+# executing on ROCm in every serving path, and benching it on `-dev Vulkan0`
+# measured a backend that emits invalid tokens. An explicit "vulkan_radv"
+# still resolves to itself so a deliberate opt-in comparison remains possible.
+_BACKEND_TO_LANE = {"vulkan": "rocm", "vulkan_radv": "vulkan_radv", "rocm": "rocm"}
 
 
 def _model_caps(m: dict[str, Any]) -> set[str]:

--- a/src/hal0/bench/planner.py
+++ b/src/hal0/bench/planner.py
@@ -499,10 +499,24 @@ def plan(
             )
 
     stale: list[Cell] = []
+    warned_unsupported: set[str] = set()
     for model in selected_models:
         tokenizer = _resolve_tokenizer(model) or ""
         for lane_token in suite.matrix.lanes:
             lane = _resolve_lane(model, lane_token)
+            # #1888: an UNSUPPORTED lane is opt-in only and must never be
+            # planned silently — a vulkan_radv record is a throughput
+            # measurement of invalid output, and would otherwise be stored and
+            # published indistinguishably from a supported one.
+            if not harness.lane_is_supported(lane) and lane not in warned_unsupported:
+                warned_unsupported.add(lane)
+                print(
+                    f"WARNING: suite {suite.id!r} plans the UNSUPPORTED lane {lane!r} — "
+                    "the ROCmFPX runner's Vulkan backend emits invalid tokens for every "
+                    "model (#1888), so any throughput it reports measures garbage. "
+                    "Records from this lane must not be published.",
+                    file=sys.stderr,
+                )
             for kind in suite.cells.kinds:
                 if kind in _TIER_A_KINDS and lane not in known_lanes:
                     # Fail fast at plan time, not with a bare KeyError out of

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -416,8 +416,20 @@ def _backend_variants(entry: Any) -> list[str]:
             # Llama.cpp-compatible — fan out to every GPU/CPU backend
             # the host actually advertises so the picker shows what's
             # really runnable here.
+            #
+            # ROCm FIRST, and gpu-vulkan is SUPPRESSED entirely on a host
+            # that advertises gpu-rocm (#1888): both GPU devices run the same
+            # ROCmFPX runner image for llama.cpp, and that image's Vulkan
+            # backend emits invalid tokens for every model. Offering it in the
+            # picker would let an operator choose a lane whose slot reads
+            # ready, serves HTTP 200 and returns garbage. gpu-vulkan survives
+            # for the non-llama runtimes below (kokoro / whisper.cpp /
+            # ComfyUI), which run their own genuinely-Vulkan images.
             host_backends = {b["id"] for b in available_backends()}
-            for candidate in ("gpu-vulkan", "gpu-rocm", "cpu"):
+            candidates = (
+                ("gpu-rocm", "cpu") if "gpu-rocm" in host_backends else ("gpu-vulkan", "cpu")
+            )
+            for candidate in candidates:
                 if candidate in host_backends and candidate not in out:
                     out.append(candidate)
         elif low in {"rocm", "gpu-rocm"}:

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -28,6 +28,7 @@ from hal0.config.loader import load_hardware_info
 from hal0.errors import Hal0Error
 from hal0.model_fit import evaluate_model_fit
 from hal0.profiles import ProfileCatalog, ResolvedProfile
+from hal0.providers._gpu import host_is_amd_gpu
 from hal0.registry.curated import CURATED, CuratedModel, HaloaiModel
 from hal0.registry.store import ModelRegistry
 from hal0.runners import RUNNER_IMAGES
@@ -417,18 +418,20 @@ def _backend_variants(entry: Any) -> list[str]:
             # the host actually advertises so the picker shows what's
             # really runnable here.
             #
-            # ROCm FIRST, and gpu-vulkan is SUPPRESSED entirely on a host
-            # that advertises gpu-rocm (#1888): both GPU devices run the same
-            # ROCmFPX runner image for llama.cpp, and that image's Vulkan
-            # backend emits invalid tokens for every model. Offering it in the
-            # picker would let an operator choose a lane whose slot reads
-            # ready, serves HTTP 200 and returns garbage. gpu-vulkan survives
-            # for the non-llama runtimes below (kokoro / whisper.cpp /
-            # ComfyUI), which run their own genuinely-Vulkan images.
+            # ROCm FIRST, and gpu-vulkan is SUPPRESSED on any AMD host
+            # (#1888): both GPU devices run the same ROCmFPX runner image for
+            # llama.cpp, and that image's Vulkan backend emits invalid tokens
+            # for every model. Offering it in the picker would let an operator
+            # choose a lane whose slot reads ready, serves HTTP 200 and returns
+            # garbage — including on the no-/dev/kfd box, where the catalog
+            # advertises gpu-vulkan but NOT gpu-rocm, so keying the suppression
+            # off the gpu-rocm row alone would leave the trap in place. On an
+            # AMD box with no valid GPU lane the picker offers CPU only.
+            # gpu-vulkan survives for the non-llama runtimes below (kokoro /
+            # whisper.cpp / ComfyUI), which run genuinely-Vulkan images, and
+            # for non-AMD GPUs.
             host_backends = {b["id"] for b in available_backends()}
-            candidates = (
-                ("gpu-rocm", "cpu") if "gpu-rocm" in host_backends else ("gpu-vulkan", "cpu")
-            )
+            candidates = ("gpu-rocm", "cpu") if host_is_amd_gpu() else ("gpu-vulkan", "cpu")
             for candidate in candidates:
                 if candidate in host_backends and candidate not in out:
                     out.append(candidate)

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -120,30 +120,37 @@ _HARDWARE_TO_DEVICE: dict[str, str] = {
 def _detect_default_hardware() -> str:
     """Pick a sane default hardware backend from /etc/hal0/hardware.json.
 
-    Falls back to ``"vulkan"`` when the probe file is missing or
-    unreadable — that's the broadest match for AMD/NVIDIA/Intel GPUs and
-    preserves the historical hardcoded default for users without a probe.
+    Falls back to ``"rocm"`` when the probe file is missing or unreadable.
+    That used to be ``"vulkan"`` ("broadest match"), but the Vulkan backend of
+    the runner image llama.cpp slots actually launch emits invalid tokens for
+    every model (#1888) — so the broad default was a broadly-wrong one. ROCm
+    is the supported lane on hal0's reference (AMD) platform, and a box that
+    cannot run it gets a loud refusal at slot load instead of garbage output.
     """
     try:
         from hal0.config import paths as _paths
     except ImportError:
-        return "vulkan"
+        return "rocm"
     try:
         raw = _paths.hardware_json().read_text()
     except OSError:
-        return "vulkan"
+        return "rocm"
     try:
         data = jsonlib.loads(raw)
     except ValueError:
-        return "vulkan"
+        return "rocm"
     gpus = data.get("gpus") or []
     if not gpus:
         return "cpu"
     g = gpus[0] if isinstance(gpus[0], dict) else {}
     vendor = (g.get("vendor") or "").lower()
-    if vendor == "amd" and g.get("compute_capable"):
+    # AMD always defaults to ROCm (#1888): llama.cpp slots run the unified
+    # ROCmFPX runner image on every AMD GPU device, and that image's Vulkan
+    # backend emits invalid tokens for every model. A box without /dev/kfd
+    # gets a loud refusal at slot load rather than a silently-garbage lane.
+    if vendor == "amd":
         return "rocm"
-    if g.get("vulkan_capable") or vendor in ("amd", "nvidia", "intel"):
+    if g.get("vulkan_capable") or vendor in ("nvidia", "intel"):
         return "vulkan"
     return "cpu"
 
@@ -442,7 +449,7 @@ def slot_create(
         "--hardware",
         help=(
             "Hardware backend: vulkan | rocm | cpu. "
-            "Default: auto-detected from /etc/hal0/hardware.json (vulkan if no probe). "
+            "Default: auto-detected from /etc/hal0/hardware.json (rocm if no probe). "
             "The `device` field is derived: vulkan→gpu-vulkan, rocm→gpu-rocm, cpu→cpu."
         ),
         case_sensitive=False,

--- a/src/hal0/config/data/seed_stacks.toml
+++ b/src/hal0/config/data/seed_stacks.toml
@@ -21,7 +21,7 @@
 # saber -- max-throughput agentic MoE. Decode-per-GB leader on the board.
 [stack.saber]
 name = "Saber"
-description = "High-speed agentic MoE: a 35B-A3B agent on ROCm with a fast Vulkan utility helper, plus memory recall."
+description = "High-speed agentic MoE: a 35B-A3B agent on ROCm with a fast ROCm utility helper, plus memory recall."
 author = "hal0"
 icon = "⚡"
 tags = ["agentic", "moe", "fast"]
@@ -37,7 +37,7 @@ capabilities = "@embed_rerank"
 [[stack.saber.slots]]
 slot = "utility"
 model = "gemma-4-12b-it-ud-q4-k-xl"
-device = "gpu-vulkan"
+device = "gpu-rocm"
 profile = "chat"
 
 # forge -- coding-first developer loadout: a coder agent + a fast draft coder.
@@ -59,14 +59,14 @@ capabilities = "@embed_rerank"
 [[stack.forge.slots]]
 slot = "utility"
 model = "qwopus3-5-4b-coder-mtp-q6-k"
-device = "gpu-vulkan"
+device = "gpu-rocm"
 profile = "chat"
 mtp = true
 
 # pi -- always-on support: faithful compaction, memory recall (quality > speed).
 [stack.pi]
 name = "Pi"
-description = "Always-on support: a q-rich 27B utility for faithful compaction and recall, with a light Vulkan agent."
+description = "Always-on support: a q-rich 27B utility for faithful compaction and recall, with a light ROCm agent."
 author = "hal0"
 icon = "🥧"
 tags = ["support", "memory", "compaction"]
@@ -82,5 +82,5 @@ capabilities = "@embed_rerank"
 [[stack.pi.slots]]
 slot = "agent"
 model = "gemma-4-12b-it-ud-q4-k-xl"
-device = "gpu-vulkan"
+device = "gpu-rocm"
 profile = "chat"

--- a/src/hal0/hardware/recommend.py
+++ b/src/hal0/hardware/recommend.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from hal0.config.schema import HardwareInfo
 from hal0.model_meta import DEVICE_TO_DEFAULT_PROFILE, map_backend_to_device
+from hal0.providers._gpu import kfd_present
 from hal0.registry.curated import get_curated
 
 # Curated chat models suitable for the primary slot, ordered from
@@ -150,16 +151,24 @@ def _backend_for(hw: HardwareInfo) -> tuple[str, str]:
     gpus = hw.gpus
     primary = gpus[0] if gpus else None
 
-    # AMD UMA (Strix Halo et al.) — Vulkan is the safest default; ROCm
-    # works on the same parts but requires a kernel + userspace combo
-    # the installer can't easily verify. Vulkan ships in Mesa.
+    # AMD — ROCm is the ONLY supported llama.cpp GPU lane (#1888). The
+    # release-pinned ROCmFPX runner is a single HIP+Vulkan build whose Vulkan
+    # backend emits invalid tokens for every model, so recommending Vulkan
+    # here (which this ladder used to do for the whole Strix Halo class) hands
+    # the operator a lane that reads green and serves garbage. ROCm needs the
+    # /dev/kfd compute node; without it there is no valid GPU lane on this
+    # image and CPU is the honest answer.
     if primary and primary.vendor == "amd":
         unified_gb = hw.unified_memory_mb / 1024
-        if unified_gb >= _UMA_UNIFIED_GB_MIN and primary.vram_mb <= 4096:
-            return "vulkan", f"AMD UMA (Strix Halo class — {unified_gb:.0f} GB unified)"
-        if primary.compute_capable:
-            return "rocm", "AMD discrete GPU with rocm-smi reachable"
-        return "vulkan", "AMD GPU; ROCm not detected, Vulkan via Mesa"
+        if primary.compute_capable or kfd_present():
+            if unified_gb >= _UMA_UNIFIED_GB_MIN and primary.vram_mb <= 4096:
+                return "rocm", f"AMD UMA (Strix Halo class — {unified_gb:.0f} GB unified)"
+            return "rocm", "AMD GPU with ROCm compute reachable"
+        return "cpu", (
+            "AMD GPU but no ROCm compute (/dev/kfd absent, rocm-smi unreachable) — "
+            "the runner image's Vulkan lane is unsupported (#1888); forward /dev/kfd "
+            "for GPU inference"
+        )
 
     # NVIDIA — the CUDA path (gpu-cuda device, upstream llama.cpp CUDA
     # image via CDI) is preferred when the nvidia-container-toolkit is

--- a/src/hal0/install/profile_derive.py
+++ b/src/hal0/install/profile_derive.py
@@ -102,6 +102,14 @@ def derive_device(capability: str, hw: HardwareInfo, *, npu_opt_in: bool) -> str
     # FP4 signal; compute_capable means a ROCm/CUDA runtime was detected.
     if hw.platform == "strix-halo" or any(g.compute_capable for g in hw.gpus):
         return "gpu-rocm"
+    # AMD without ROCm compute is NOT a Vulkan lane: llama.cpp slots run the
+    # ROCmFPX runner image on both GPU devices, and that image's Vulkan
+    # backend emits invalid tokens for every model (#1888). CPU is the only
+    # honest fallback for AMD here. Non-AMD vulkan-capable GPUs (Intel iGPU,
+    # NVIDIA without CDI) keep the Vulkan lane — the defect is characterised
+    # on the AMD/HIP build; see the PR for the open question.
+    if any(g.vendor == "amd" for g in hw.gpus):
+        return "cpu"
     if any(g.vulkan_capable for g in hw.gpus):
         return "gpu-vulkan"
     return "cpu"

--- a/src/hal0/install/profile_derive.py
+++ b/src/hal0/install/profile_derive.py
@@ -14,6 +14,7 @@ The (device, profile) pairs this produces are backend-coherent per #807:
 from __future__ import annotations
 
 from hal0.config.schema import DEVICE_DEFAULT_PROFILES, HardwareInfo
+from hal0.providers._gpu import kfd_present
 
 #: NPU-trio capabilities (NPU chat agent + npu stt/embed passengers). Kept as a
 #: symbol because the trio code is left **dormant** (out of scope to remove,
@@ -100,18 +101,25 @@ def derive_device(capability: str, hw: HardwareInfo, *, npu_opt_in: bool) -> str
         return "npu" if (hw.npu.present and npu_opt_in) else None
     # chat / coder / embed → GPU lane. platform=="strix-halo" is the canonical
     # FP4 signal; compute_capable means a ROCm/CUDA runtime was detected.
-    if hw.platform == "strix-halo" or any(g.compute_capable for g in hw.gpus):
+    # #1888: the ROCm lane is the ONLY valid GPU LLM lane on AMD, and it needs
+    # the /dev/kfd compute node. The strix-halo / compute_capable signals are
+    # necessary but NOT sufficient — a Strix Halo box whose amdkfd node was
+    # never forwarded is exactly the fresh-LXC shape the blocker was found on,
+    # and deriving gpu-rocm there would hand every seeded slot a load-time
+    # refusal right after a deliberately CPU-only install.
+    rocm_ok = any(g.compute_capable for g in hw.gpus) or kfd_present()
+    if rocm_ok and (hw.platform == "strix-halo" or any(g.compute_capable for g in hw.gpus)):
         return "gpu-rocm"
-    # AMD without ROCm compute is NOT a Vulkan lane: llama.cpp slots run the
-    # ROCmFPX runner image on both GPU devices, and that image's Vulkan
-    # backend emits invalid tokens for every model (#1888). CPU is the only
-    # honest fallback for AMD here. Non-AMD vulkan-capable GPUs (Intel iGPU,
-    # NVIDIA without CDI) keep the Vulkan lane — the defect is characterised
-    # on the AMD/HIP build; see the PR for the open question.
-    if any(g.vendor == "amd" for g in hw.gpus):
-        return "cpu"
-    if any(g.vulkan_capable for g in hw.gpus):
+    # Non-AMD vulkan-capable GPUs (Intel iGPU, NVIDIA without CDI) keep the
+    # Vulkan lane — the defect is characterised on the AMD/HIP build. Checked
+    # BEFORE the AMD→CPU fallback so a mixed host with a dead AMD adapter and
+    # a usable Intel one still gets its GPU.
+    if any(g.vulkan_capable and g.vendor != "amd" for g in hw.gpus):
         return "gpu-vulkan"
+    # AMD without a ROCm compute node is NOT a Vulkan lane: llama.cpp slots
+    # run the ROCmFPX runner image on both GPU devices, and that image's
+    # Vulkan backend emits invalid tokens for every model. CPU is the only
+    # honest answer.
     return "cpu"
 
 

--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -59,15 +59,38 @@ class GpuPreflightError(RuntimeError):
     """
 
 
-def kfd_present(kfd_path: str = KFD_DEVICE_PATH) -> bool:
-    """Is the ROCm compute node visible to this process?
+#: sysfs marker for "the amdgpu kernel driver is bound on this host". Used to
+#: scope the ROCm requirement to AMD: an Intel or NVIDIA GPU has no
+#: ``/dev/kfd`` to forward in the first place, and its Vulkan lane is not what
+#: #1888 characterised.
+_AMDGPU_MODULE_DIR = "/sys/module/amdgpu"
 
-    Cheap ``os.path.exists`` — no ioctl, no driver probe. Inside an LXC this
-    is false unless the host forwarded ``/dev/kfd`` (a ``dev1:`` line on
-    Proxmox), which is exactly the fresh-unprivileged-install shape that
-    #1888 was found on.
+
+def kfd_present(kfd_path: str = KFD_DEVICE_PATH) -> bool:
+    """Is the ROCm compute node visible AND usable by this process?
+
+    Existence alone is not enough: an LXC passthrough with a mis-mapped gid
+    leaves ``/dev/kfd`` visible but unopenable, HIP still fails to initialise,
+    and llama.cpp still lands on the invalid Vulkan lane — the exact
+    false-pass shape ``preflight_gpu``'s gid check exists to catch on the
+    render node. So this also requires read+write access.
+
+    Still cheap — no ioctl, no driver probe, never raises. A genuinely
+    functional ROCm probe belongs in the output-sanity readiness gate
+    (#1922), not on the slot-load hot path.
     """
-    return os.path.exists(kfd_path)
+    return os.path.exists(kfd_path) and os.access(kfd_path, os.R_OK | os.W_OK)
+
+
+def host_is_amd_gpu(module_dir: str = _AMDGPU_MODULE_DIR) -> bool:
+    """Is the amdgpu kernel driver bound on this host?
+
+    Filesystem sniff only. Used to scope the ROCm requirement: on an Intel or
+    NVIDIA box there is no ``/dev/kfd`` by design, so demanding one there
+    would strand every GPU slot on hardware the defect was never characterised
+    on.
+    """
+    return os.path.isdir(module_dir)
 
 
 def require_kfd_for_gpu_slot(
@@ -76,6 +99,7 @@ def require_kfd_for_gpu_slot(
     device: str,
     kfd_path: str = KFD_DEVICE_PATH,
     env: dict[str, str] | None = None,
+    amd_host: bool | None = None,
 ) -> None:
     """Loud-fail an AMD-GPU llama.cpp slot that has no ROCm compute node.
 
@@ -90,12 +114,23 @@ def require_kfd_for_gpu_slot(
     image, not an optimisation: without it there is no lane that produces
     valid output, and the honest answer is to refuse the load and say why.
 
-    No-ops for devices that do not run on the ROCmFPX image — ``cpu``,
-    ``npu`` and ``gpu-cuda`` (CDI/NVIDIA, its own upstream CUDA image) — and
-    for a caller that has explicitly opted into the broken lane via
-    :data:`ENV_ALLOW_VULKAN_FALLBACK` (a warn, never a silent pass).
+    Scope, deliberately narrow:
+
+    * ``gpu-rocm`` — always gated. The device name IS the ROCm claim.
+    * ``gpu-vulkan`` — gated only on an **AMD** host (``amdgpu`` bound). A
+      legacy AMD slot still carrying the old label runs the same broken lane;
+      an Intel iGPU or an NVIDIA card without CDI has no ``/dev/kfd`` by
+      design and keeps working.
+    * ``cpu`` / ``npu`` / ``gpu-cuda`` — never gated: none of them can reach
+      the ROCmFPX image's Vulkan fallback.
+
+    An explicit :data:`ENV_ALLOW_VULKAN_FALLBACK` opt-in downgrades the
+    refusal to a warning — a warn, never a silent pass.
     """
-    if device not in ("gpu-rocm", "gpu-vulkan"):
+    if device == "gpu-vulkan":
+        if not (host_is_amd_gpu() if amd_host is None else amd_host):
+            return
+    elif device != "gpu-rocm":
         return
     if kfd_present(kfd_path):
         return

--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -38,6 +38,87 @@ log = structlog.get_logger(__name__)
 # see the fallback chain documented there.
 _GPU_GROUP_FALLBACK_GIDS: dict[str, int] = {"render": 993, "video": 44}
 
+#: The ROCm compute device node. Its presence inside the container is what
+#: decides which llama.cpp backend the unified ROCmFPX runner image actually
+#: executes on: ``ggml_rocm_init`` succeeds and the slot runs ROCm, or it
+#: fails and llama.cpp SILENTLY falls back to that image's Vulkan backend.
+KFD_DEVICE_PATH = "/dev/kfd"
+
+#: Escape hatch for the ROCm requirement below (#1888). Set to ``1`` only when
+#: you knowingly want the runner's Vulkan lane despite it emitting invalid
+#: tokens for every model — there is no supported configuration where this is
+#: the right answer; it exists so a box can be inspected, not run.
+ENV_ALLOW_VULKAN_FALLBACK = "HAL0_ALLOW_VULKAN_FALLBACK"
+
+
+class GpuPreflightError(RuntimeError):
+    """A GPU slot cannot be launched on this host as configured.
+
+    Raised loudly at slot-load time rather than letting the launch "succeed"
+    into a silently-degraded lane.
+    """
+
+
+def kfd_present(kfd_path: str = KFD_DEVICE_PATH) -> bool:
+    """Is the ROCm compute node visible to this process?
+
+    Cheap ``os.path.exists`` — no ioctl, no driver probe. Inside an LXC this
+    is false unless the host forwarded ``/dev/kfd`` (a ``dev1:`` line on
+    Proxmox), which is exactly the fresh-unprivileged-install shape that
+    #1888 was found on.
+    """
+    return os.path.exists(kfd_path)
+
+
+def require_kfd_for_gpu_slot(
+    slot_name: str,
+    *,
+    device: str,
+    kfd_path: str = KFD_DEVICE_PATH,
+    env: dict[str, str] | None = None,
+) -> None:
+    """Loud-fail an AMD-GPU llama.cpp slot that has no ROCm compute node.
+
+    The release-pinned ROCmFPX runner (``DEFAULT_ROCMFPX_IMAGE``) is a single
+    HIP+Vulkan build. llama.cpp picks ROCm when ``/dev/kfd`` is visible and
+    silently falls back to that image's **Vulkan** backend when
+    ``ggml_rocm_init`` fails. That Vulkan backend emits invalid tokens for
+    every model it serves, at full nominal speed, while HTTP 200, container
+    health, ``hal0 doctor`` and the SSE ``done`` frame all read green (#1888).
+
+    So ``/dev/kfd`` is a hard requirement for a GPU llama.cpp slot on this
+    image, not an optimisation: without it there is no lane that produces
+    valid output, and the honest answer is to refuse the load and say why.
+
+    No-ops for devices that do not run on the ROCmFPX image — ``cpu``,
+    ``npu`` and ``gpu-cuda`` (CDI/NVIDIA, its own upstream CUDA image) — and
+    for a caller that has explicitly opted into the broken lane via
+    :data:`ENV_ALLOW_VULKAN_FALLBACK` (a warn, never a silent pass).
+    """
+    if device not in ("gpu-rocm", "gpu-vulkan"):
+        return
+    if kfd_present(kfd_path):
+        return
+    environ = os.environ if env is None else env
+    if str(environ.get(ENV_ALLOW_VULKAN_FALLBACK, "")).strip() in ("1", "true", "yes"):
+        log.warning(
+            "gpu_slot_vulkan_fallback_allowed",
+            slot=slot_name,
+            device=device,
+            kfd_path=kfd_path,
+            detail="output will be invalid — see #1888",
+        )
+        return
+    raise GpuPreflightError(
+        f"slot {slot_name!r} (device={device}) needs the ROCm compute node "
+        f"{kfd_path}, which is not visible here. The runner image falls back to "
+        "its Vulkan backend without it, and that backend emits invalid tokens "
+        "for every model (#1888) — refusing to start rather than serve garbage. "
+        "Forward the device from the host (Proxmox LXC: add "
+        f"'dev1: {kfd_path}' to /etc/pve/lxc/<CTID>.conf, then pct stop/start), "
+        "or move this slot to device='cpu'."
+    )
+
 
 def resolve_gpu_device_paths(
     kfd_path: str = "/dev/kfd",

--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -117,10 +117,10 @@ def require_kfd_for_gpu_slot(
     Scope, deliberately narrow:
 
     * ``gpu-rocm`` — always gated. The device name IS the ROCm claim.
-    * ``gpu-vulkan`` — gated only on an **AMD** host (``amdgpu`` bound). A
-      legacy AMD slot still carrying the old label runs the same broken lane;
-      an Intel iGPU or an NVIDIA card without CDI has no ``/dev/kfd`` by
-      design and keeps working.
+    * ``gpu-vulkan`` — gated only on an **AMD** host (``amdgpu`` bound). An
+      older AMD slot still carrying that label runs the same broken lane; an
+      Intel iGPU or an NVIDIA card without CDI has no ``/dev/kfd`` by design
+      and keeps working.
     * ``cpu`` / ``npu`` / ``gpu-cuda`` — never gated: none of them can reach
       the ROCmFPX image's Vulkan fallback.
 

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -78,6 +78,7 @@ from hal0.providers._gpu import (
     gpu_visibility_env,
     is_nvidia_gpu_device,
     nvidia_cdi_devices,
+    require_kfd_for_gpu_slot,
     resolve_gpu_device_paths,
     resolve_gpu_group_ids,
 )
@@ -2319,10 +2320,21 @@ class ContainerProvider(Provider):
 
         Single launch path: unit text comes from the one renderer
         :meth:`_render_quadlet_text` (shared with the update-time re-render), and
-        this method layers on the install-only steps — the NPU loud-fail guard
-        plus writing the Quadlet file and starting the service.
+        this method layers on the install-only steps — the NPU and ROCm
+        loud-fail guards plus writing the Quadlet file and starting the service.
         """
         token = slot_instance_token(slot_cfg)
+
+        # Loud-fail for AMD-GPU llama.cpp slots with no /dev/kfd: the runner
+        # image would silently fall back to its Vulkan backend, which emits
+        # invalid tokens for every model while every health surface reads
+        # green (#1888). Enforced HERE (the load path) rather than in
+        # ``container_spec`` so unit rendering, previews and status renders
+        # stay host-independent.
+        require_kfd_for_gpu_slot(
+            str(slot_cfg.get("name", "") or token),
+            device=str(slot_cfg.get("device", "") or ""),
+        )
 
         # Loud-fail for NPU slots only: a missing FLM tag must not silently
         # fall through to FLM's legacy build_env default. Kokoro/ComfyUI are

--- a/tests/bench/test_harness.py
+++ b/tests/bench/test_harness.py
@@ -52,12 +52,14 @@ from hal0.bench.harness import (
     BENCHCTL,
     MAX_ATTEMPTS,
     SYSTEMCTL_SEAM,
+    UNSUPPORTED_LANES,
     CellResult,
     ExclusiveSlots,
     benchctl_exec_argv,
     compose_podman_argv,
     dedupe_flags,
     default_lanes,
+    lane_is_supported,
     lane_specs,
     run_cell,
     telemetry_argv,
@@ -166,11 +168,27 @@ class TestDefaultLanes:
     def test_cpu_tier_defaults_to_the_cpu_lane_only(self) -> None:
         assert default_lanes(TIER_CPU) == ["cpu"]
 
-    def test_amd_tier_defaults_to_rocm_and_vulkan(self) -> None:
-        assert default_lanes(TIER_AMD) == ["rocm", "vulkan_radv"]
+    def test_amd_tier_defaults_to_the_rocm_lane_only(self) -> None:
+        """#1888: vulkan_radv left the GPU default — the ROCmFPX image's
+        Vulkan backend emits invalid tokens, so its throughput numbers
+        measure garbage and must not be published by default."""
+        assert default_lanes(TIER_AMD) == ["rocm"]
 
-    def test_nvidia_tier_defaults_to_rocm_and_vulkan(self) -> None:
-        assert default_lanes(TIER_NVIDIA) == ["rocm", "vulkan_radv"]
+    def test_nvidia_tier_defaults_to_the_rocm_lane_only(self) -> None:
+        assert default_lanes(TIER_NVIDIA) == ["rocm"]
+
+    def test_no_default_lane_is_unsupported(self) -> None:
+        for tier in (TIER_CPU, TIER_AMD, TIER_NVIDIA):
+            for lane in default_lanes(tier):
+                assert lane_is_supported(lane), f"{tier} defaults to unsupported {lane}"
+
+    def test_vulkan_radv_is_flagged_unsupported(self) -> None:
+        """The lane spec is retained so old records resolve, but it must be
+        marked unsupported and stay out of every default sweep (#1888)."""
+        assert "vulkan_radv" in lane_specs()
+        assert "vulkan_radv" in UNSUPPORTED_LANES
+        assert not lane_is_supported("vulkan_radv")
+        assert lane_is_supported("rocm")
 
 
 # ── dedupe_flags ─────────────────────────────────────────────────────────────

--- a/tests/cli/test_slot_create_flags.py
+++ b/tests/cli/test_slot_create_flags.py
@@ -163,12 +163,19 @@ def test_default_hardware_reads_probe_json(monkeypatch: pytest.MonkeyPatch, tmp_
     assert slot_commands._detect_default_hardware() == "rocm"
 
 
-def test_default_hardware_vulkan_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Missing probe → vulkan (safe default that works on most GPUs)."""
+def test_default_hardware_rocm_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Missing probe → rocm (#1888).
+
+    This used to be ``vulkan`` ("safe default that works on most GPUs"), but
+    llama.cpp slots launch the unified ROCmFPX runner image on both GPU
+    devices and that image's Vulkan backend emits invalid tokens for every
+    model — so the broad default was a broadly-wrong one. A box that cannot
+    run ROCm gets a loud refusal at slot load, not silent garbage.
+    """
     from hal0.config import paths as _paths
 
     monkeypatch.setattr(_paths, "hardware_json", lambda: tmp_path / "missing.json")
-    assert slot_commands._detect_default_hardware() == "vulkan"
+    assert slot_commands._detect_default_hardware() == "rocm"
 
 
 def test_default_hardware_cpu_when_no_gpu(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -210,18 +217,20 @@ def test_invalid_hardware_value_rejected_by_typer(
     assert "body" not in captured_post
 
 
-def test_bare_create_on_strix_halo_resolves_to_vulkan(
+def test_bare_create_on_strix_halo_resolves_to_rocm(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """A bare ``slot create primary`` on a Strix Halo fixture auto-resolves
-    ``--hardware vulkan``.
+    ``--hardware rocm`` — even when the probe did not flag compute_capable.
 
-    Strix Halo presents as an AMD iGPU (vendor=amd) that is Vulkan-capable
-    but typically not flagged compute_capable in the probe output — the
-    iGPU runs llama.cpp via Vulkan, not ROCm. The auto-detect path must
-    pick ``vulkan`` so the user doesn't need to know about hardware flags
-    on the platform that hal0 v1 most cares about.
+    Regression for #1888: this used to resolve ``vulkan`` on exactly this
+    fixture, which is how a fresh install was born with slots labelled
+    ``gpu-vulkan``. On a box with ``/dev/kfd`` those slots actually executed
+    on ROCm (the label lied); without it they executed on the runner image's
+    Vulkan backend and emitted invalid tokens for every model. ROCm is the
+    only backend an AMD llama.cpp slot can validly run, so it is what the
+    auto-detect must write.
     """
     probe = tmp_path / "hardware.json"
     probe.write_text(
@@ -267,9 +276,9 @@ def test_bare_create_on_strix_halo_resolves_to_vulkan(
     )
     assert result.exit_code == 0, result.output
     # Bare invocation → provider defaults to llama-server, hardware
-    # auto-resolves to vulkan from the Strix Halo fixture.
+    # auto-resolves to rocm from the Strix Halo fixture.
     assert captured["body"]["provider"] == "llama-server"
-    assert captured["body"]["device"] == "gpu-vulkan"
+    assert captured["body"]["device"] == "gpu-rocm"
 
 
 # ── --profile (#1830) ────────────────────────────────────────────────────────

--- a/tests/config/test_schema_seeds_c5.py
+++ b/tests/config/test_schema_seeds_c5.py
@@ -18,7 +18,7 @@ def test_seed_rerank_toml_validates() -> None:
     slot = SlotConfig.model_validate(raw)
     assert slot.runtime == "container"
     assert slot.profile == "reranking"
-    assert slot.device == "gpu-vulkan"
+    assert slot.device == "gpu-rocm"  # #1888
     assert (
         slot.port == 8086
     )  # drifted from 8083 per spec §5.4 (port fix for _SETUP_SLOTS[embed] conflict)
@@ -37,7 +37,7 @@ def test_seed_utility_toml_validates() -> None:
     slot = SlotConfig.model_validate(raw)
     assert slot.runtime == "container"
     assert slot.profile == "chat"
-    assert slot.device == "gpu-vulkan"
+    assert slot.device == "gpu-rocm"  # #1888
     # 8090: 8081 was reclaimed as the `agent` seed's canonical primary port
     # (ADR-0023 LLM anchor); utility moved off it on new installs.
     assert slot.port == 8090

--- a/tests/config/test_seed_stack_devices.py
+++ b/tests/config/test_seed_stack_devices.py
@@ -32,12 +32,49 @@ def test_seed_stacks_still_ship_gpu_slots() -> None:
     assert "gpu-rocm" in devices
 
 
-def test_stack_apply_defaults_to_rocm_when_an_entry_omits_device() -> None:
-    """The apply path's fallback used to be ``gpu-vulkan`` (#1888)."""
-    import inspect
-
+def test_stack_apply_default_device_is_host_resolved_never_vulkan(monkeypatch) -> None:
+    """The apply path's fallback for a device-less entry used to be the
+    constant ``gpu-vulkan`` (#1888). It is now resolved from the host, and on
+    an AMD box with a reachable compute node that means ROCm.
+    """
     from hal0.api.routes import stacks as stacks_mod
 
-    src = inspect.getsource(stacks_mod)
-    assert 'entry.device or "gpu-rocm"' in src
-    assert 'entry.device or "gpu-vulkan"' not in src
+    monkeypatch.setattr("hal0.install.profile_derive.kfd_present", lambda *a, **k: True)
+    assert stacks_mod._default_stack_slot_device() != "gpu-vulkan"
+
+
+def test_stack_apply_default_device_falls_back_when_the_probe_is_unreadable(
+    monkeypatch,
+) -> None:
+    from hal0.api.routes import stacks as stacks_mod
+    from hal0.model_meta import DEFAULT_DEVICE
+
+    monkeypatch.setattr(
+        "hal0.config.loader.load_hardware_info",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("no probe")),
+    )
+    assert stacks_mod._default_stack_slot_device() == DEFAULT_DEVICE
+
+
+def test_no_static_slot_seed_declares_gpu_vulkan() -> None:
+    """The seeds a fresh install ACTUALLY receives (#1888).
+
+    ``installer/etc-hal0/slots/*.toml`` is what the installer copies onto a
+    box before auto-selection runs, and six of them declared
+    ``device = "gpu-vulkan"`` — the label ct151's garbage-serving slots wore.
+    The seed-stack check above does not cover this directory, so a fix that
+    only touched the stack catalog would have left the real default slots
+    untouched.
+    """
+    import tomllib
+    from pathlib import Path
+
+    slots_dir = Path(__file__).resolve().parents[2] / "installer" / "etc-hal0" / "slots"
+    offenders = [
+        p.name
+        for p in sorted(slots_dir.glob("*.toml"))
+        if tomllib.loads(p.read_text()).get("device") == "gpu-vulkan"
+    ]
+    assert not offenders, (
+        f"static slot seeds still name the unsupported Vulkan LLM lane: {offenders}"
+    )

--- a/tests/config/test_seed_stack_devices.py
+++ b/tests/config/test_seed_stack_devices.py
@@ -1,0 +1,43 @@
+"""#1888 — no shipped seed may label an LLM slot ``gpu-vulkan``.
+
+The seed stacks used to pair a ROCm agent with a ``device = "gpu-vulkan"``
+utility. On every box with ``/dev/kfd`` that slot actually executed on ROCm
+(the field simply lied); on every box without it, it executed on the runner
+image's Vulkan backend and emitted invalid tokens for every model. Either way
+the label named a backend the slot was not running, so the day-one catalog
+must not ship it.
+
+``gpu-vulkan`` itself stays a valid device id — Kokoro TTS, whisper.cpp and
+ComfyUI run genuinely-Vulkan images — this only pins the llama.cpp seeds.
+"""
+
+from __future__ import annotations
+
+from hal0.config.seeds import seed_stacks
+
+
+def test_no_seed_stack_slot_declares_gpu_vulkan() -> None:
+    offenders = [
+        (stack_id, slot.slot, slot.device)
+        for stack_id, stack in seed_stacks().items()
+        for slot in stack.slots
+        if slot.device == "gpu-vulkan"
+    ]
+    assert not offenders, f"seed stacks still name the unsupported Vulkan LLM lane: {offenders}"
+
+
+def test_seed_stacks_still_ship_gpu_slots() -> None:
+    """Guard against 'fixing' this by deleting every GPU slot."""
+    devices = {slot.device for stack in seed_stacks().values() for slot in stack.slots}
+    assert "gpu-rocm" in devices
+
+
+def test_stack_apply_defaults_to_rocm_when_an_entry_omits_device() -> None:
+    """The apply path's fallback used to be ``gpu-vulkan`` (#1888)."""
+    import inspect
+
+    from hal0.api.routes import stacks as stacks_mod
+
+    src = inspect.getsource(stacks_mod)
+    assert 'entry.device or "gpu-rocm"' in src
+    assert 'entry.device or "gpu-vulkan"' not in src

--- a/tests/hardware/test_recommend.py
+++ b/tests/hardware/test_recommend.py
@@ -20,8 +20,14 @@ from hal0.hardware.recommend import (
 from hal0.registry.curated import CURATED_BY_ID
 
 
-def _amd_uma_host(unified_gb: int) -> HardwareInfo:
-    """A Strix-Halo-class AMD UMA host with ``unified_gb`` of unified RAM."""
+def _amd_uma_host(unified_gb: int, *, compute_capable: bool = True) -> HardwareInfo:
+    """A Strix-Halo-class AMD UMA host with ``unified_gb`` of unified RAM.
+
+    ``compute_capable`` defaults True: since #1888 the ROCm compute path is the
+    only supported AMD LLM lane, so the representative Strix Halo host is one
+    where ROCm is reachable. Pass False for the no-``/dev/kfd`` box the blocker
+    was found on.
+    """
     mb = unified_gb * 1024
     return HardwareInfo(
         ram_mb=mb,
@@ -33,6 +39,7 @@ def _amd_uma_host(unified_gb: int) -> HardwareInfo:
                 name="Strix Halo",
                 vram_mb=512,  # UMA: no discrete carve-out
                 vulkan_capable=True,
+                compute_capable=compute_capable,
             )
         ],
     )
@@ -174,9 +181,40 @@ def test_cpu_only_host_seeds_chat_capable_profile(tmp_path) -> None:
 def test_seeded_slot_carries_container_runtime_and_profile() -> None:
     rec = recommend_primary_slot(_amd_uma_host(96))
     assert rec["runtime"] == "container"
-    # Strix-Halo-class AMD UMA → vulkan device → chat profile (device-agnostic).
-    assert rec["device"] == "gpu-vulkan"
+    # Strix-Halo-class AMD UMA with ROCm reachable → ROCm device (#1888: never
+    # gpu-vulkan — the runner image's Vulkan backend emits invalid tokens).
+    assert rec["device"] == "gpu-rocm"
     assert rec["profile"] == "chat"
+
+
+# ── #1888: the Vulkan lane is never recommended on AMD ───────────────────────
+
+
+def test_amd_uma_recommends_rocm_not_vulkan() -> None:
+    """A ROCm-capable Strix Halo box lands on gpu-rocm.
+
+    Regression for #1888: ``_backend_for`` used to return ``vulkan`` for the
+    whole "AMD UMA / Strix Halo class" branch, which labelled slots with a
+    backend they never executed on (with /dev/kfd) or executed on and emitted
+    garbage from (without it).
+    """
+    rec = recommend_primary_slot(_amd_uma_host(96))
+    assert rec["device"] == "gpu-rocm"
+    assert "vulkan" not in str(rec.get("backend", "")).lower()
+
+
+def test_amd_without_rocm_falls_back_to_cpu_not_vulkan(monkeypatch) -> None:
+    """No ROCm compute node → CPU, never the invalid Vulkan lane (#1888)."""
+    monkeypatch.setattr("hal0.hardware.recommend.kfd_present", lambda *a, **k: False)
+    rec = recommend_primary_slot(_amd_uma_host(96, compute_capable=False))
+    assert rec["device"] == "cpu"
+
+
+def test_amd_without_rocm_smi_but_with_kfd_is_rocm(monkeypatch) -> None:
+    """/dev/kfd alone is enough to call the box ROCm-capable (#1888)."""
+    monkeypatch.setattr("hal0.hardware.recommend.kfd_present", lambda *a, **k: True)
+    rec = recommend_primary_slot(_amd_uma_host(96, compute_capable=False))
+    assert rec["device"] == "gpu-rocm"
 
 
 def test_seeded_slot_profile_is_a_known_seed_profile() -> None:

--- a/tests/install/test_profile_derive.py
+++ b/tests/install/test_profile_derive.py
@@ -40,7 +40,7 @@ def test_chat_on_rocm_box_picks_rocm():
     assert derive_profile("chat", "gpu-rocm") == "chat"
 
 
-def test_chat_on_amd_box_without_rocm_picks_cpu_not_vulkan():
+def test_chat_on_amd_box_without_rocm_picks_cpu_not_vulkan(monkeypatch):
     """#1888: an AMD GPU with no ROCm compute is NOT a Vulkan lane.
 
     llama.cpp slots run the unified ROCmFPX runner image on every AMD GPU
@@ -49,6 +49,7 @@ def test_chat_on_amd_box_without_rocm_picks_cpu_not_vulkan():
     install with three slots that served garbage while reading green — CPU is
     the only honest fallback.
     """
+    monkeypatch.setattr("hal0.install.profile_derive.kfd_present", lambda *a, **k: False)
     hw = _hw(compute=False, vulkan=True)
     assert derive_device("chat", hw, npu_opt_in=False) == "cpu"
     assert derive_profile("chat", "cpu") == "cpu-chat"
@@ -148,10 +149,22 @@ def test_tts_is_cpu_kokoro():
     assert derive_profile("tts", "cpu") == "kokoro"
 
 
-def test_strix_platform_forces_rocm_even_if_compute_flag_missing():
-    # platform=strix-halo is the canonical FP4 signal.
+def test_strix_platform_forces_rocm_when_the_compute_node_is_there(monkeypatch):
+    """platform=strix-halo is the canonical FP4 signal — but since #1888 it is
+    necessary, not sufficient: /dev/kfd must actually be reachable."""
+    monkeypatch.setattr("hal0.install.profile_derive.kfd_present", lambda *a, **k: True)
     hw = _hw(platform="strix-halo", compute=False, vulkan=True)
     assert derive_device("chat", hw, npu_opt_in=False) == "gpu-rocm"
+
+
+def test_strix_platform_without_kfd_derives_cpu(monkeypatch):
+    """#1888: a Strix Halo box whose amdkfd node was never forwarded is the
+    exact fresh-LXC shape the blocker was found on. Deriving gpu-rocm there
+    would hand every seeded slot a load-time refusal immediately after a
+    deliberately CPU-only install."""
+    monkeypatch.setattr("hal0.install.profile_derive.kfd_present", lambda *a, **k: False)
+    hw = _hw(platform="strix-halo", compute=False, vulkan=True)
+    assert derive_device("chat", hw, npu_opt_in=False) == "cpu"
 
 
 # ── CPU-only host fixes (#834) ─────────────────────────────────────────────────

--- a/tests/install/test_profile_derive.py
+++ b/tests/install/test_profile_derive.py
@@ -40,10 +40,18 @@ def test_chat_on_rocm_box_picks_rocm():
     assert derive_profile("chat", "gpu-rocm") == "chat"
 
 
-def test_chat_on_vulkan_only_box_picks_vulkan():
+def test_chat_on_amd_box_without_rocm_picks_cpu_not_vulkan():
+    """#1888: an AMD GPU with no ROCm compute is NOT a Vulkan lane.
+
+    llama.cpp slots run the unified ROCmFPX runner image on every AMD GPU
+    device, and that image's Vulkan backend emits invalid tokens for every
+    model. Deriving ``gpu-vulkan`` here is what seeded a fresh unprivileged
+    install with three slots that served garbage while reading green — CPU is
+    the only honest fallback.
+    """
     hw = _hw(compute=False, vulkan=True)
-    assert derive_device("chat", hw, npu_opt_in=False) == "gpu-vulkan"
-    assert derive_profile("chat", "gpu-vulkan") == "chat"
+    assert derive_device("chat", hw, npu_opt_in=False) == "cpu"
+    assert derive_profile("chat", "cpu") == "cpu-chat"
 
 
 def test_embed_on_rocm_box_uses_embed_profile():

--- a/tests/installer/test_preflight_gpu_gate.py
+++ b/tests/installer/test_preflight_gpu_gate.py
@@ -29,6 +29,7 @@ PREFLIGHT = Path(__file__).resolve().parents[2] / "installer" / "lib" / "preflig
 RC_OK = 0
 RC_BROKEN_GID = 3
 RC_NO_DEVICE = 4
+RC_NO_KFD = 5
 
 # A gid with no matching group on any sane host — forces "maps to NO group".
 UNMAPPED_GID = "61999"
@@ -48,7 +49,10 @@ def _run_gpu_gate(env_overrides: dict[str, str]) -> int:
         "preflight_gpu >/dev/null 2>&1 || rc=$?\n"
         "exit $rc\n"
     )
-    env = {**os.environ, **env_overrides}
+    # HAL0_GPU_AMD_OVERRIDE defaults OFF here so the ROCm-compute check (#1888)
+    # stays hermetic: the box running the suite may itself be an AMD LXC with
+    # (or without) a real /dev/kfd. Tests that exercise that check set it.
+    env = {**os.environ, "HAL0_GPU_AMD_OVERRIDE": "0", **env_overrides}
     proc = subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
     return proc.returncode
 
@@ -235,6 +239,80 @@ def test_doctor_mode_no_device_lxc_is_soft(tmp_path: Path) -> None:
         {
             "HAL0_GPU_DRI_GLOB": str(tmp_path / "NONE*"),
             "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+        }
+    )
+    assert rc == RC_OK
+
+
+# ── #1888: /dev/kfd is required on AMD ───────────────────────────────────────
+# The release-pinned ROCmFPX runner is one HIP+Vulkan build: llama.cpp runs
+# ROCm when /dev/kfd is visible and SILENTLY falls back to that image's Vulkan
+# backend when it is not — and that backend emits invalid tokens for every
+# model, at full nominal speed, while every health surface reads green. A
+# render node without /dev/kfd is therefore not a working GPU box, and the
+# gate must say so instead of installing "successfully".
+
+
+def test_gate_amd_render_node_without_kfd_stops(render_glob: str, tmp_path: Path) -> None:
+    rc = _run_gpu_gate(
+        {
+            "HAL0_GPU_GATE": "1",
+            "HAL0_GPU_DRI_GLOB": render_glob,
+            "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+            "HAL0_GPU_RENDER_GID_OVERRIDE": "0",
+            "HAL0_GPU_RENDER_GROUP_OVERRIDE": "root",
+            "HAL0_GPU_AMD_OVERRIDE": "1",
+            "HAL0_GPU_KFD_PATH": str(tmp_path / "no-such-kfd"),
+        }
+    )
+    assert rc == RC_NO_KFD
+
+
+def test_gate_amd_render_node_with_kfd_proceeds(render_glob: str, tmp_path: Path) -> None:
+    kfd = tmp_path / "kfd"
+    kfd.touch()
+    rc = _run_gpu_gate(
+        {
+            "HAL0_GPU_GATE": "1",
+            "HAL0_GPU_DRI_GLOB": render_glob,
+            "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+            "HAL0_GPU_RENDER_GID_OVERRIDE": "0",
+            "HAL0_GPU_RENDER_GROUP_OVERRIDE": "root",
+            "HAL0_GPU_AMD_OVERRIDE": "1",
+            "HAL0_GPU_KFD_PATH": str(kfd),
+        }
+    )
+    assert rc == RC_OK
+
+
+def test_gate_non_amd_gpu_without_kfd_proceeds(render_glob: str, tmp_path: Path) -> None:
+    """The check is AMD-scoped: an NVIDIA/Intel box has no /dev/kfd to forward
+    and must not be blocked by it."""
+    rc = _run_gpu_gate(
+        {
+            "HAL0_GPU_GATE": "1",
+            "HAL0_GPU_DRI_GLOB": render_glob,
+            "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+            "HAL0_GPU_RENDER_GID_OVERRIDE": "0",
+            "HAL0_GPU_RENDER_GROUP_OVERRIDE": "root",
+            "HAL0_GPU_AMD_OVERRIDE": "0",
+            "HAL0_GPU_KFD_PATH": str(tmp_path / "no-such-kfd"),
+        }
+    )
+    assert rc == RC_OK
+
+
+def test_doctor_mode_missing_kfd_is_soft(render_glob: str, tmp_path: Path) -> None:
+    """`hal0 doctor` (no HAL0_GPU_GATE) stays advisory-only — it reports the
+    missing compute node but never aborts the report."""
+    rc = _run_gpu_gate(
+        {
+            "HAL0_GPU_DRI_GLOB": render_glob,
+            "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+            "HAL0_GPU_RENDER_GID_OVERRIDE": "0",
+            "HAL0_GPU_RENDER_GROUP_OVERRIDE": "root",
+            "HAL0_GPU_AMD_OVERRIDE": "1",
+            "HAL0_GPU_KFD_PATH": str(tmp_path / "no-such-kfd"),
         }
     )
     assert rc == RC_OK

--- a/tests/providers/test_container_chat_template.py
+++ b/tests/providers/test_container_chat_template.py
@@ -227,6 +227,9 @@ class TestLoadSyncChatTemplate:
 
         with (
             patch("hal0.providers.container._resolve_profile", return_value=profile),
+            # #1888 guard: these tests exercise UNIT RENDERING, not host GPU
+            # validity — the box running the suite has no /dev/kfd.
+            patch("hal0.providers.container.require_kfd_for_gpu_slot"),
             patch(
                 "hal0.providers.container.resolve_gpu_device_paths",
                 return_value=["/dev/kfd", "/dev/dri/renderD128"],
@@ -275,6 +278,9 @@ class TestLoadSyncChatTemplate:
 
         with (
             patch("hal0.providers.container._resolve_profile", return_value=profile),
+            # #1888 guard: these tests exercise UNIT RENDERING, not host GPU
+            # validity — the box running the suite has no /dev/kfd.
+            patch("hal0.providers.container.require_kfd_for_gpu_slot"),
             patch(
                 "hal0.providers.container.resolve_gpu_device_paths",
                 return_value=["/dev/kfd", "/dev/dri/renderD128"],

--- a/tests/providers/test_container_mmproj.py
+++ b/tests/providers/test_container_mmproj.py
@@ -161,6 +161,9 @@ class TestLoadSyncMmproj:
 
         with (
             patch("hal0.providers.container._resolve_profile", return_value=_moe_profile()),
+            # #1888 guard: these tests exercise UNIT RENDERING, not host GPU
+            # validity — the box running the suite has no /dev/kfd.
+            patch("hal0.providers.container.require_kfd_for_gpu_slot"),
             patch(
                 "hal0.providers.container.resolve_gpu_device_paths",
                 return_value=["/dev/kfd", "/dev/dri/renderD128"],

--- a/tests/providers/test_container_npu.py
+++ b/tests/providers/test_container_npu.py
@@ -222,6 +222,9 @@ class TestLoadSyncNpuBranch:
 
         with (
             patch("hal0.providers.container._resolve_profile", return_value=profile),
+            # #1888 guard: this test exercises UNIT RENDERING, not host GPU
+            # validity — the box running the suite has no /dev/kfd.
+            patch("hal0.providers.container.require_kfd_for_gpu_slot"),
             patch(
                 "hal0.providers.container.resolve_gpu_device_paths",
                 return_value=["/dev/kfd", "/dev/dri/renderD128"],

--- a/tests/providers/test_container_spec_dispatch.py
+++ b/tests/providers/test_container_spec_dispatch.py
@@ -252,6 +252,9 @@ def test_gpu_slot_unaffected_still_takes_llama_path(tmp_path: Any) -> None:
 
     with (
         patch("hal0.providers.container._resolve_profile", return_value=profile),
+        # #1888 guard: this test exercises UNIT RENDERING, not host GPU
+        # validity — the box running the suite has no /dev/kfd.
+        patch("hal0.providers.container.require_kfd_for_gpu_slot"),
         patch(
             "hal0.providers.container.resolve_gpu_device_paths",
             return_value=["/dev/kfd", "/dev/dri/renderD128"],

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -14,11 +14,14 @@ every text surface on the box was garbage for hours.
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from hal0.providers._gpu import (
     ENV_ALLOW_VULKAN_FALLBACK,
     GpuPreflightError,
+    host_is_amd_gpu,
     kfd_present,
     require_kfd_for_gpu_slot,
 )
@@ -33,12 +36,36 @@ class TestKfdPresent:
     def test_false_when_it_does_not(self, tmp_path) -> None:
         assert kfd_present(str(tmp_path / "kfd")) is False
 
+    def test_false_when_it_exists_but_is_not_accessible(self, tmp_path) -> None:
+        """An LXC passthrough with a mis-mapped gid leaves the node visible but
+        unopenable — HIP still fails and llama.cpp still lands on the invalid
+        Vulkan lane, so existence alone must not count as a pass."""
+        node = tmp_path / "kfd"
+        node.write_text("")
+        node.chmod(0o000)
+        try:
+            if os.access(str(node), os.R_OK):  # running as root — chmod is advisory
+                pytest.skip("root bypasses file permissions")
+            assert kfd_present(str(node)) is False
+        finally:
+            node.chmod(0o600)
+
+
+class TestHostIsAmdGpu:
+    def test_true_when_the_amdgpu_module_dir_exists(self, tmp_path) -> None:
+        assert host_is_amd_gpu(str(tmp_path)) is True
+
+    def test_false_otherwise(self, tmp_path) -> None:
+        assert host_is_amd_gpu(str(tmp_path / "nope")) is False
+
 
 class TestRequireKfdForGpuSlot:
     @pytest.mark.parametrize("device", ["gpu-rocm", "gpu-vulkan"])
     def test_amd_gpu_slot_without_kfd_is_refused(self, device, tmp_path) -> None:
         with pytest.raises(GpuPreflightError) as exc:
-            require_kfd_for_gpu_slot("agent", device=device, kfd_path=str(tmp_path / "kfd"), env={})
+            require_kfd_for_gpu_slot(
+                "agent", device=device, kfd_path=str(tmp_path / "kfd"), env={}, amd_host=True
+            )
         msg = str(exc.value)
         # The operator must be able to act on this without reading the source.
         assert "agent" in msg
@@ -49,13 +76,39 @@ class TestRequireKfdForGpuSlot:
     def test_passes_when_kfd_is_present(self, device, tmp_path) -> None:
         node = tmp_path / "kfd"
         node.write_text("")
-        require_kfd_for_gpu_slot("agent", device=device, kfd_path=str(node), env={})
+        require_kfd_for_gpu_slot("agent", device=device, kfd_path=str(node), env={}, amd_host=True)
+
+    def test_gpu_vulkan_on_a_non_amd_host_is_not_gated(self, tmp_path) -> None:
+        """An Intel iGPU / NVIDIA-without-CDI box has no /dev/kfd by design and
+        is not the hardware #1888 was characterised on — demanding one there
+        would strand every GPU slot on unaffected hardware."""
+        require_kfd_for_gpu_slot(
+            "utility",
+            device="gpu-vulkan",
+            kfd_path=str(tmp_path / "kfd"),
+            env={},
+            amd_host=False,
+        )
+
+    def test_gpu_rocm_is_gated_even_on_a_non_amd_host(self, tmp_path) -> None:
+        """The device name IS the ROCm claim — a gpu-rocm slot with no compute
+        node is broken regardless of what the host reports."""
+        with pytest.raises(GpuPreflightError):
+            require_kfd_for_gpu_slot(
+                "agent",
+                device="gpu-rocm",
+                kfd_path=str(tmp_path / "kfd"),
+                env={},
+                amd_host=False,
+            )
 
     @pytest.mark.parametrize("device", ["cpu", "npu", "gpu-cuda", "", "img"])
     def test_non_rocmfpx_devices_are_untouched(self, device, tmp_path) -> None:
         """CPU/NPU slots need no compute node, and gpu-cuda runs the upstream
         CUDA image via CDI — none of them can hit the Vulkan fallback."""
-        require_kfd_for_gpu_slot("x", device=device, kfd_path=str(tmp_path / "kfd"), env={})
+        require_kfd_for_gpu_slot(
+            "x", device=device, kfd_path=str(tmp_path / "kfd"), env={}, amd_host=True
+        )
 
     def test_explicit_opt_in_downgrades_to_a_warning(self, tmp_path) -> None:
         require_kfd_for_gpu_slot(
@@ -63,6 +116,7 @@ class TestRequireKfdForGpuSlot:
             device="gpu-rocm",
             kfd_path=str(tmp_path / "kfd"),
             env={ENV_ALLOW_VULKAN_FALLBACK: "1"},
+            amd_host=True,
         )
 
     def test_a_non_truthy_opt_in_still_refuses(self, tmp_path) -> None:
@@ -72,6 +126,7 @@ class TestRequireKfdForGpuSlot:
                 device="gpu-rocm",
                 kfd_path=str(tmp_path / "kfd"),
                 env={ENV_ALLOW_VULKAN_FALLBACK: "0"},
+                amd_host=True,
             )
 
 

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -1,0 +1,109 @@
+"""#1888 — /dev/kfd is a hard requirement for AMD-GPU llama.cpp slots.
+
+The release-pinned ROCmFPX runner is one HIP+Vulkan build. llama.cpp picks
+ROCm when ``/dev/kfd`` is visible and SILENTLY falls back to that image's
+Vulkan backend when ``ggml_rocm_init`` fails — and that Vulkan backend emits
+invalid tokens for every model it serves, at full nominal speed, while HTTP
+200, container health, ``hal0 doctor`` and the SSE ``done`` frame all read
+green. A box without ``/dev/kfd`` therefore has no valid GPU lane at all, and
+the only honest behaviour is to refuse the load and say why.
+
+Regression shape: before this, ``load_sync`` happily started such a slot and
+every text surface on the box was garbage for hours.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.providers._gpu import (
+    ENV_ALLOW_VULKAN_FALLBACK,
+    GpuPreflightError,
+    kfd_present,
+    require_kfd_for_gpu_slot,
+)
+
+
+class TestKfdPresent:
+    def test_true_when_the_node_exists(self, tmp_path) -> None:
+        node = tmp_path / "kfd"
+        node.write_text("")
+        assert kfd_present(str(node)) is True
+
+    def test_false_when_it_does_not(self, tmp_path) -> None:
+        assert kfd_present(str(tmp_path / "kfd")) is False
+
+
+class TestRequireKfdForGpuSlot:
+    @pytest.mark.parametrize("device", ["gpu-rocm", "gpu-vulkan"])
+    def test_amd_gpu_slot_without_kfd_is_refused(self, device, tmp_path) -> None:
+        with pytest.raises(GpuPreflightError) as exc:
+            require_kfd_for_gpu_slot("agent", device=device, kfd_path=str(tmp_path / "kfd"), env={})
+        msg = str(exc.value)
+        # The operator must be able to act on this without reading the source.
+        assert "agent" in msg
+        assert "/kfd" in msg
+        assert "1888" in msg
+
+    @pytest.mark.parametrize("device", ["gpu-rocm", "gpu-vulkan"])
+    def test_passes_when_kfd_is_present(self, device, tmp_path) -> None:
+        node = tmp_path / "kfd"
+        node.write_text("")
+        require_kfd_for_gpu_slot("agent", device=device, kfd_path=str(node), env={})
+
+    @pytest.mark.parametrize("device", ["cpu", "npu", "gpu-cuda", "", "img"])
+    def test_non_rocmfpx_devices_are_untouched(self, device, tmp_path) -> None:
+        """CPU/NPU slots need no compute node, and gpu-cuda runs the upstream
+        CUDA image via CDI — none of them can hit the Vulkan fallback."""
+        require_kfd_for_gpu_slot("x", device=device, kfd_path=str(tmp_path / "kfd"), env={})
+
+    def test_explicit_opt_in_downgrades_to_a_warning(self, tmp_path) -> None:
+        require_kfd_for_gpu_slot(
+            "agent",
+            device="gpu-rocm",
+            kfd_path=str(tmp_path / "kfd"),
+            env={ENV_ALLOW_VULKAN_FALLBACK: "1"},
+        )
+
+    def test_a_non_truthy_opt_in_still_refuses(self, tmp_path) -> None:
+        with pytest.raises(GpuPreflightError):
+            require_kfd_for_gpu_slot(
+                "agent",
+                device="gpu-rocm",
+                kfd_path=str(tmp_path / "kfd"),
+                env={ENV_ALLOW_VULKAN_FALLBACK: "0"},
+            )
+
+
+class TestLoadSyncGuard:
+    """The guard must fire on the LOAD path, not on unit rendering — a
+    preview/status render has to stay host-independent."""
+
+    def test_load_sync_refuses_a_gpu_slot_with_no_kfd(self, monkeypatch) -> None:
+        from hal0.providers import container as container_mod
+
+        monkeypatch.setattr(container_mod, "kfd_present_used", False, raising=False)
+        monkeypatch.setattr(container_mod, "require_kfd_for_gpu_slot", _raiser, raising=True)
+        provider = container_mod.ContainerProvider()
+        with pytest.raises(GpuPreflightError):
+            provider.load_sync({"name": "agent", "device": "gpu-rocm", "port": 8081}, {})
+
+    def test_load_sync_calls_the_guard_with_the_slots_device(self, monkeypatch) -> None:
+        from hal0.providers import container as container_mod
+
+        seen: dict[str, str] = {}
+
+        def _spy(slot_name: str, *, device: str, **_kw: object) -> None:
+            seen["slot"] = slot_name
+            seen["device"] = device
+            raise GpuPreflightError("stop here — the rest of load_sync writes units")
+
+        monkeypatch.setattr(container_mod, "require_kfd_for_gpu_slot", _spy)
+        provider = container_mod.ContainerProvider()
+        with pytest.raises(GpuPreflightError):
+            provider.load_sync({"name": "utility", "device": "gpu-vulkan", "port": 8082}, {})
+        assert seen == {"slot": "utility", "device": "gpu-vulkan"}
+
+
+def _raiser(*_a: object, **_kw: object) -> None:
+    raise GpuPreflightError("no /dev/kfd")

--- a/tests/slots/test_slot_schema.py
+++ b/tests/slots/test_slot_schema.py
@@ -18,16 +18,21 @@ SLOTS_DIR = Path(__file__).resolve().parents[2] / "installer/etc-hal0/slots"
 
 EXPECTED_MAPPING = {
     # slot name: (port, device, profile)
-    "brain": (8089, "gpu-vulkan", "brain"),
-    "agent": (8081, "gpu-vulkan", "chadrock-moe"),
-    "utility": (8090, "gpu-vulkan", "chat"),
+    #
+    # #1888: every llama.cpp seed is gpu-ROCM, never gpu-vulkan. Both GPU
+    # devices launch the same unified ROCmFPX runner image, whose Vulkan
+    # backend emits invalid tokens for every model — so the six seeds a fresh
+    # install actually receives named a lane no slot could validly run.
+    "brain": (8089, "gpu-rocm", "brain"),
+    "agent": (8081, "gpu-rocm", "chadrock-moe"),
+    "utility": (8090, "gpu-rocm", "chat"),
     "flm": (8088, "npu", "flm"),
     "img": (8188, "gpu-rocm", "comfyui"),
     "qwen3tts": (8095, "gpu-rocm", "qwen3-tts"),
     "tts": (8085, "cpu", "kokoro"),  # port drift fix (was 8084)
-    "rerank": (8086, "gpu-vulkan", "reranking"),  # port drift fix (was 8083)
-    "coder": (8082, "gpu-vulkan", "coding"),  # NEW static seed (Task 5)
-    "embed": (8083, "gpu-vulkan", "embedding"),  # NEW static seed (Task 5)
+    "rerank": (8086, "gpu-rocm", "reranking"),  # port drift fix (was 8083)
+    "coder": (8082, "gpu-rocm", "coding"),  # NEW static seed (Task 5)
+    "embed": (8083, "gpu-rocm", "embedding"),  # NEW static seed (Task 5)
 }
 
 


### PR DESCRIPTION
> ⚠️ **NEEDS OPERATOR REVIEW — release-shape change. Do not merge, do not enable automerge.**
> This changes fresh-install behaviour (a GPU install without `/dev/kfd` now stops) and retires an advertised backend lane. It must be validated on a real box before it lands.

## What

Closes out GA-blocker #1888 by taking the operator-approved direction — **drop/relabel the Vulkan lane** rather than repin or rebuild the runner image.

### 1. `/dev/kfd` is now an explicit, loud requirement

- `installer/lib/preflight.sh` — new classification `HAL0_GPU_RC_NO_KFD(5)`: an AMD render node visible with no ROCm compute node. New test seams `HAL0_GPU_KFD_PATH` / `HAL0_GPU_AMD_OVERRIDE`. Doctor mode stays soft/advisory; only the install gate returns the code. The Proxmox remedy line now says `dev1: /dev/kfd` is **REQUIRED**, not optional.
- `installer/install.sh` — hard-stops on that code with the remedy, with the same explicit CPU-only opt-in shape as the existing no-device case (`HAL0_ALLOW_CPU_ONLY=1` or a `/dev/tty` confirm).
- `src/hal0/providers/_gpu.py` — new `kfd_present()` / `require_kfd_for_gpu_slot()` / `GpuPreflightError`, with an `HAL0_ALLOW_VULKAN_FALLBACK=1` escape hatch that warns rather than silently passing.
- `src/hal0/providers/container.py` — `load_sync` refuses a `gpu-rocm`/`gpu-vulkan` slot with no `/dev/kfd`, alongside the existing NPU loud-fail guard. Enforced on the **load** path, not in `container_spec`, so unit rendering / previews / status renders stay host-independent.

### 2. The `device = "gpu-vulkan"` mislabel is gone from every llama.cpp surface

Both GPU device ids resolve to the same ROCmFPX image for llama.cpp slots, so `gpu-vulkan` never named the backend a slot executed on — it was ROCm wherever `/dev/kfd` existed, and garbage wherever it did not.

- `src/hal0/config/data/seed_stacks.toml` — the three `gpu-vulkan` utility/agent slots (saber, forge, pi) → `gpu-rocm`; stack descriptions no longer say "Vulkan utility helper" / "light Vulkan agent".
- `src/hal0/api/routes/stacks.py` — the stack-apply fallback for an entry with no device: `gpu-vulkan` → `gpu-rocm`.
- `src/hal0/install/profile_derive.py` — an AMD GPU with no ROCm compute derives **`cpu`**, not `gpu-vulkan`. Non-AMD vulkan-capable GPUs keep the lane (see open question).
- `src/hal0/hardware/recommend.py` — `_backend_for`'s AMD ladder: ROCm when `compute_capable` **or** `/dev/kfd` is present (the "AMD UMA / Strix Halo class" rationale string is preserved), else CPU. This branch used to return `vulkan` for the entire Strix Halo class — it is the root of the mislabel.
- `src/hal0/cli/slot_commands.py` — `--hardware` auto-detect: AMD always → `rocm`; the no-probe fallback moves from `vulkan` to `rocm`.
- `src/hal0/capabilities/catalog.py` — the llama.cpp backend fan-out suppresses `gpu-vulkan` entirely on a host that advertises `gpu-rocm`, so the picker cannot offer a lane whose slot reads ready and returns garbage. `gpu-vulkan` is untouched for Kokoro / whisper.cpp / ComfyUI, which run genuinely-Vulkan images.

### 3. The bench harness stops publishing the lane

- `src/hal0/bench/harness.py` — `vulkan_radv` leaves `default_lanes` (GPU tier is now `["rocm"]`), and is stamped in a new `UNSUPPORTED_LANES` / `lane_is_supported()`. The `LaneSpec` is retained so historical records and an explicit `--backends vulkan_radv` still resolve.
- `src/hal0/bench/planner.py` — the registry's `"vulkan"` backend hint now maps to the **rocm** lane, not `vulkan_radv`. An explicit `vulkan_radv` still resolves to itself.
- `installer/bench/suites/lane-matrix.toml` / `roster.toml` — shipped suites no longer sweep the lane.

### 4. Docs stop recommending it

- `docs/hal0-install-migration-guide.html` — the "**Vulkan** recommended on Strix Halo / v1.0 standardizes shared APU models on Vulkan" card is replaced with a "`/dev/kfd` required on AMD" card.
- `docs/concepts/strix-halo.mdx` — "ROCm or Vulkan on the iGPU" → "ROCm is the LLM lane on the iGPU", with a caution box explaining the silent fallback.
- `docs/reference/hardware-matrix.mdx` — device table + decision tree updated to the new ladder.
- `docs/guides/manage-slots.mdx` — `--hardware` guidance and the example command.

## Verification

```
uv run ruff format --check src tests   →  clean
make lint (ruff check src tests)        →  All checks passed!
```

Targeted suites (`env -u FORCE_COLOR HAL0_HOME=$(mktemp -d) uv run --extra dev pytest ... -q`):

```
tests/providers tests/capabilities tests/config tests/install tests/installer
tests/bench tests/hardware tests/registry tests/api/test_stacks_routes.py
tests/cli/test_slot_commands.py
  → 3105 passed, 10 skipped   (after fixing the 4 unit-render tests below)
tests/providers                → 549 passed
```

Full suite run recorded in the PR thread.

**Red-on-main proof** (same tests, with `src/` + `installer/` stashed back to `main`):

```
FAILED tests/config/test_seed_stack_devices.py::test_no_seed_stack_slot_declares_gpu_vulkan
FAILED tests/config/test_seed_stack_devices.py::test_stack_apply_defaults_to_rocm_when_an_entry_omits_device
FAILED tests/installer/test_preflight_gpu_gate.py::test_gate_amd_render_node_without_kfd_stops
FAILED tests/install/test_profile_derive.py::test_chat_on_amd_box_without_rocm_picks_cpu_not_vulkan
FAILED tests/hardware/test_recommend.py::test_seeded_slot_carries_container_runtime_and_profile
FAILED tests/hardware/test_recommend.py::test_amd_uma_recommends_rocm_not_vulkan
FAILED tests/hardware/test_recommend.py::test_amd_without_rocm_falls_back_to_cpu_not_vulkan
FAILED tests/hardware/test_recommend.py::test_amd_without_rocm_smi_but_with_kfd_is_rocm
8 failed, 50 passed
```
(`tests/providers/test_gpu_kfd_preflight.py` and `tests/bench/test_harness.py` fail at import on main — the symbols they assert on do not exist there.)

New tests: `tests/providers/test_gpu_kfd_preflight.py` (helper + `load_sync` guard, device scoping, escape hatch), `tests/config/test_seed_stack_devices.py` (no shipped seed names the lane), plus four new cases in `tests/installer/test_preflight_gpu_gate.py` (gate stops without kfd, proceeds with it, AMD-scoped, doctor mode stays soft).

Four pre-existing `load_sync` unit-render tests (`test_container_mmproj.py`, `test_container_chat_template.py`) now patch `require_kfd_for_gpu_slot` alongside the `resolve_gpu_device_paths` patch they already carried — they exercise unit rendering, not host GPU validity, and the CI box has no `/dev/kfd`.

## Not in scope

The **output-sanity slot-readiness gate** (`'The capital of France is'` → `'Paris'` probe) — the one-second check that would have collapsed five separately-reported rc.6 defects into one loud install-time failure. It drags `slots/manager.py` and `slots/watchdog.py` into the blast radius and would collide with #1911 / #1915, so it is filed with the full probe design as **#1922**.

Also out of scope by direction: repinning or rebuilding the runner image.

## Open questions for the operator

1. **Non-AMD Vulkan fallbacks.** `_backend_for` still returns `vulkan` for NVIDIA-without-CDI and Intel iGPU, and `derive_device` still returns `gpu-vulkan` for non-AMD vulkan-capable GPUs. Those slots resolve to the **same** ROCmFPX image, so they are plausibly equally broken — but the defect is only characterised on the AMD/HIP build, and routing them to CPU without evidence would regress a population that may be fine. Left alone deliberately. Want a follow-up issue to A/B a non-AMD box?
2. **Fresh-install blast radius.** A Strix Halo box whose probe reports `compute_capable=False` and has no `/dev/kfd` now installs **CPU-only** where it previously installed (garbage-serving) GPU slots. That is the intended behaviour change, but it is a visible one.
3. **Existing installs.** Slots already on disk with `device = "gpu-vulkan"` are not migrated — they will now refuse to load with the preflight message rather than being silently rewritten. Should an updater migration relabel them to `gpu-rocm`?

Refs #1888
Refs #1922

🤖 Generated with [Claude Code](https://claude.com/claude-code)
