### PR TITLE
fix(install): add ownership rows for model-pull-jobs/ and activity.db

### DIFF
--- a/src/hal0/install/perms.py
+++ b/src/hal0/install/perms.py
@@ -401,6 +401,64 @@ def ownership_table(
             0o644,
             role="hal0.db-shm (WAL shared-memory index)",
         ),
+        # activity.db — the durable audit trail (``paths.activity_db()`` ->
+        # ``var_lib/"activity.db"``, :class:`hal0.activity.AuditStore`). Same
+        # O13 birth-ownership class as ``hal0.db`` above: no row existed, so a
+        # box where the file's first writer was root (an install-time /
+        # doctor-invoked path) left it unreadable/unwritable to the
+        # User=hal0 daemon with no way for ``doctor perms --fix`` to heal it.
+        # ``AuditStore.__init__`` sets ``PRAGMA journal_mode=WAL``, so the
+        # ``-wal``/``-shm`` siblings need their own rows for the identical
+        # reason the ``hal0.db`` journal siblings do above.
+        PermRow(
+            var_lib / "activity.db",
+            state_owner,
+            service_group,
+            0o644,
+            role="activity.db (durable audit trail)",
+        ),
+        PermRow(
+            var_lib / "activity.db-wal",
+            state_owner,
+            service_group,
+            0o644,
+            role="activity.db-wal (WAL journal)",
+        ),
+        PermRow(
+            var_lib / "activity.db-shm",
+            state_owner,
+            service_group,
+            0o644,
+            role="activity.db-shm (WAL shared-memory index)",
+        ),
+        # model-pull-jobs/ — the durable pull-job snapshot store
+        # (``hal0.registry.pull._pull_jobs_dir()`` -> ``var_lib/"model-pull-jobs"``,
+        # the #626/#MR-1 restart-survival fallback). Same O13 birth-ownership
+        # class as ``models/`` above: the installer's root-run brain-model
+        # pull (bundle-tier auto-pull) calls ``persist_pull_job`` -> lazy
+        # ``path.parent.mkdir(parents=True, exist_ok=True)`` as root on a
+        # fresh install, so the dir is born ``root:root 0755`` with a
+        # root-only ``0600`` snapshot inside. ``hal0-api`` (``User=hal0``)
+        # then fails every pull-job snapshot write
+        # (``model.pull_job_persist_failed``, WARNING-only fail-soft — a
+        # write failure here must never break the pull itself) and cannot
+        # read the existing one, so ``GET /api/models/<id>/pull/status``
+        # 404s after a restart even though the pull succeeded (#1895). No
+        # row meant ``doctor perms --fix`` could not heal it either.
+        # ``persist_pull_job`` writes each snapshot via ``tempfile.mkstemp``
+        # + ``os.replace`` — mkstemp always creates its tempfile ``0600``
+        # regardless of umask, matching the ``registry.toml`` /
+        # ``slots/*/state.json`` convention above.
+        PermRow(
+            var_lib / "model-pull-jobs",
+            state_owner,
+            service_group,
+            0o2775,
+            glob="*.json",
+            child_mode=0o600,
+            optional=False,
+            role="model-pull-jobs/ (durable pull-job snapshots)",
+        ),
         # registry/ — the model registry, also born root:root from the same
         # install.sh mkdir and also written by the User=hal0 daemon. Same O13
         # birth-ownership class as slots/ above; heal the dir. registry/ is

--- a/tests/install/test_perms.py
+++ b/tests/install/test_perms.py
@@ -764,3 +764,101 @@ def test_upstreams_toml_is_not_world_readable(tmp_hal0_home: str) -> None:
     assert (row.owner, row.group) == ("hal0", "hal0")
     assert row.mode & 0o007 == 0, f"upstreams.toml is world-readable: {row.mode:o}"
     assert row.mode == 0o640
+
+
+# ── hal0-api write-path coverage (#1895) ───────────────────────────────────────
+#
+# ``hal0-api`` runs ``User=hal0``. Every ``var_lib()``-rooted path it can be
+# the FIRST writer of on a fresh install must carry a row here, or a
+# root-run installer step (a bundle-tier model pull, a schema migration, a
+# health check — anything that touches the path before the daemon's first
+# request) leaves it root-owned with no way for `doctor perms --fix` to
+# heal it (the O13 class: #1546 for hal0.db, #1895 for model-pull-jobs +
+# activity.db). This table is the durable form of that check: add a row
+# HERE whenever a new lazily-created ``var_lib()`` path is wired into
+# ``hal0-api``, matching the row(s) added to ``ownership_table`` in the
+# same change, so a future writer can't be missed the way model-pull-jobs
+# was.
+# Labels only at collection time — the concrete ``Path`` each label resolves
+# to depends on ``HAL0_HOME``, which ``tmp_hal0_home`` sets PER TEST FUNCTION
+# (after collection already ran). Resolving paths here instead of inside the
+# test body would race that fixture: the parametrize list would freeze
+# whatever ``HAL0_HOME`` was active at collection time, while
+# ``ownership_table()`` inside the test resolves against the per-test tmp
+# dir — two different tmp trees that would never compare equal.
+_HAL0_API_WRITE_LABELS = [
+    # primary database + WAL siblings (#1546)
+    "hal0.db",
+    "hal0.db-wal",
+    "hal0.db-shm",
+    # durable audit trail + WAL siblings (#1895)
+    "activity.db",
+    "activity.db-wal",
+    "activity.db-shm",
+    # durable pull-job snapshot store (#1895, the #626/#MR-1 fallback)
+    "model-pull-jobs/",
+    # pre-existing O13-class runtime trees, kept here as regression anchors
+    # so this test is the one place that answers "is hal0-api's write
+    # surface fully covered" rather than one more scattered check.
+    "registry/",
+    "slots/",
+    "models/",
+]
+
+
+def _resolve_hal0_api_write_target(label: str) -> Path:
+    from hal0.registry.pull import _pull_jobs_dir
+
+    var_lib = paths.var_lib()
+    targets = {
+        "hal0.db": paths.db_path(),
+        "hal0.db-wal": paths.db_path().with_name("hal0.db-wal"),
+        "hal0.db-shm": paths.db_path().with_name("hal0.db-shm"),
+        "activity.db": paths.activity_db(),
+        "activity.db-wal": paths.activity_db().with_name("activity.db-wal"),
+        "activity.db-shm": paths.activity_db().with_name("activity.db-shm"),
+        "model-pull-jobs/": _pull_jobs_dir(),
+        "registry/": var_lib / "registry",
+        "slots/": var_lib / "slots",
+        "models/": var_lib / "models",
+    }
+    return targets[label]
+
+
+@pytest.mark.parametrize("label", _HAL0_API_WRITE_LABELS)
+def test_every_hal0_api_write_path_has_an_ownership_row(tmp_hal0_home: str, label: str) -> None:
+    """Every path ``hal0-api`` (``User=hal0``) can write must have a table row.
+
+    A missing row is exactly the #1895 defect: the path is born from
+    whichever process touches it first (often root, during install), the
+    ``hal0`` daemon then can't write it, and ``doctor perms --fix`` has
+    nothing to reconcile because the table never declared an opinion.
+    """
+    target = _resolve_hal0_api_write_target(label)
+    table = perms.ownership_table(service_user="hal0")
+    by_target = {r.target: r for r in table}
+    assert target in by_target, f"no ownership row for {label} ({target}) — see #1895"
+    row = by_target[target]
+    assert row.owner == "hal0", f"{label} row is not hal0-owned: {row.owner}"
+    assert row.group == "hal0", f"{label} row is not hal0-grouped: {row.group}"
+
+
+def test_model_pull_jobs_dir_snapshot_files_get_hal0_owned_child_rows(
+    tmp_hal0_home: str,
+) -> None:
+    """The ``model-pull-jobs/`` dir row must also cover its ``*.json`` children.
+
+    ``persist_pull_job`` writes each snapshot via ``tempfile.mkstemp`` +
+    ``os.replace`` — mkstemp always births its tempfile ``0600`` regardless
+    of umask, so the row's ``child_mode`` must match that birth mode (not
+    fight it), the same convention as ``registry.toml`` /
+    ``slots/*/state.json`` above.
+    """
+    from hal0.registry.pull import _pull_jobs_dir
+
+    table = perms.ownership_table(service_user="hal0")
+    by_target = {r.target: r for r in table}
+    row = by_target[_pull_jobs_dir()]
+    assert row.glob == "*.json"
+    assert row.child_mode == 0o600
+    assert row.optional is False


### PR DESCRIPTION
## ⚠️ INSTALLER/PERMISSIONS CHANGE — operator review required

## Summary

Fixes #1895: `hal0-api` (`User=hal0`) failed every pull-job snapshot write (`model.pull_job_persist_failed`, WARNING-only fail-soft) and could not read an existing snapshot after a restart, because `/var/lib/hal0/model-pull-jobs` had no row in the `OwnershipStore` declarative table (`src/hal0/install/perms.py`). The installer's root-run brain-model pull (`installer/install.sh`'s bundle-tier auto-pull, before line 2809's `doctor perms --fix --force` backstop) is the first writer on a fresh install, lazily `mkdir`-ing the dir `root:root 0755` under root's umask — the same O13 birth-ownership bug class as #1546 (`hal0.db`). No row meant `doctor perms --fix` had nothing to reconcile.

The issue's "Expected" section also calls out `activity.db` (+ its `-wal`/`-shm` WAL siblings, `hal0.activity.AuditStore` runs `PRAGMA journal_mode=WAL`) as missing the identical row — added here too.

- **No `install.sh` change needed.** The bundle-tier brain-model pull (line ~1967) runs well before the `doctor perms --fix --force` backstop (line 2809), so the table-only fix is sufficient: the backstop now has a declared opinion to reconcile the root-owned dir against.
- Confirmed `runner-image-pull-jobs/` (the sibling runner-image pull store) is NOT affected — it's never touched at install time as root, only ever created by the `User=hal0` service itself, so it's born correctly already. Left out of scope.

## What changed

`src/hal0/install/perms.py`:
- `model-pull-jobs/` — `hal0:hal0 2775`, `glob="*.json"` children `0600` (matches `tempfile.mkstemp`'s birth mode, same convention as `registry.toml`/`slots/*/state.json`).
- `activity.db` / `activity.db-wal` / `activity.db-shm` — `hal0:hal0 0644`, mirroring the existing `hal0.db` rows exactly.

`tests/install/test_perms.py`:
- New `test_every_hal0_api_write_path_has_an_ownership_row` — parametrized over every `var_lib()` path `hal0-api` can be the first writer of (the two new ones + `hal0.db`/`registry/`/`slots/`/`models/` as regression anchors), so a future service-writable path can't go unrowed the same way `model-pull-jobs/` did. Confirmed RED against `main` (5 failures) before the `perms.py` change, GREEN after.
- New `test_model_pull_jobs_dir_snapshot_files_get_hal0_owned_child_rows` — asserts the `model-pull-jobs/` row's `child_mode` matches `persist_pull_job`'s actual `tempfile.mkstemp` birth mode (`0600`).

## Sequencing note

Kept minimal and confined to the missing rows + the coverage test — #1896 (`doctor perms` never-converges) also touches `perms.py` in unrelated areas (`STATE.md`, `secrets/`, recursive-mkdir modes) and is deliberately held until this lands, so it can rebase cleanly.

## Test plan

- [x] `env -u FORCE_COLOR HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/install tests/installer -q` → 748 passed, 1 skipped
- [x] Confirmed the 2 new pytest functions are RED on `main` (5 parametrized failures) before the `perms.py` fix, GREEN after
- [x] `make lint` → clean
- [x] `uv run ruff format --check src tests` → clean
- [ ] Operator: re-run `rc-validate` repro (`ls -ld /var/lib/hal0/model-pull-jobs && sudo -u hal0 test -w ...`) on a fresh install to confirm the end-to-end fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)