### PR TITLE
fix(updater): migrate gpu-vulkan slot TOMLs to gpu-rocm/cpu

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2417,22 +2417,27 @@ if status["due"]:
 PYEOF
 fi
 
-# ── post-activation migrations (schema + seed-profile/mtp/image-pin/extra-args) ─
+# ── post-activation migrations (schema + seed-profile/mtp/vulkan/image-pin/extra-args) ─
 # One shared sequence with Updater.commit()'s self-update path (GH #1475):
 # hal0.toml schema migrations, profiles.toml virtual-seed pruning (seeds live
 # in code and are overlaid on every load — an older install that materialised
 # them into profiles.toml froze stale definitions; this prunes them so the
 # code definition wins again), stale mtp=true slot-override clearing (a
 # force-on pointing at a model with no MTP heads crashes llama-server at load
-# once the unit re-renders under post-separation code), stale runner-image
-# pin retagging, and defaults.extra_args sanitizing. Every pass after the
-# schema migration is independently best-effort — a single pass failing never
-# aborts the others. Previously this block ran only the seed-profile and
-# stale-MTP passes directly, so a box upgraded by re-running install.sh (the
-# documented repair/upgrade path) kept a stale meta.schema_version, stale
-# runner-image pins, and unsanitised defaults.extra_args that `hal0 update`
-# would have fixed — two boxes on the same version with different on-disk
-# state. Operator edits and non-seed profiles are always left untouched.
+# once the unit re-renders under post-separation code), retired
+# device="gpu-vulkan" slot relabeling (#1924 — llama.cpp-backed GPU slots
+# left over from before #1923 retired the Vulkan LLM lane now refuse to load
+# under the new /dev/kfd preflight guard; relabeled to gpu-rocm/cpu, AMD
+# hosts only, non-llama runtimes like Kokoro/ComfyUI left untouched), stale
+# runner-image pin retagging, and defaults.extra_args sanitizing. Every pass
+# after the schema migration is independently best-effort — a single pass
+# failing never aborts the others. Previously this block ran only the
+# seed-profile and stale-MTP passes directly, so a box upgraded by
+# re-running install.sh (the documented repair/upgrade path) kept a stale
+# meta.schema_version, stale runner-image pins, and unsanitised
+# defaults.extra_args that `hal0 update` would have fixed — two boxes on the
+# same version with different on-disk state. Operator edits and non-seed
+# profiles are always left untouched.
 #
 # Ran through hal0_migration_step (not a bare heredoc): the schema migration
 # used to be able to abort this whole script under set -euo pipefail before
@@ -2445,7 +2450,7 @@ fi
 if [[ "${DEV_MODE}" -eq 1 ]]; then
     info "dev mode — skipping post-activation migrations (no system writes)"
 else
-    info "running post-activation migrations (schema + seed-profile/mtp/image-pin/extra-args)"
+    info "running post-activation migrations (schema + seed-profile/mtp/vulkan-slot/image-pin/extra-args)"
     hal0_migration_step "post-activation migrations" <<'PYEOF'
 from hal0.config.migrations.v2 import PROFILE_CATALOG_SCHEMA_VERSION
 from hal0.updater.updater import run_post_activation_migrations
@@ -2459,7 +2464,7 @@ if target != source:
     print(f"  hal0.toml schema migrated {source} -> {target}")
 else:
     print(f"  hal0.toml schema already at {target}")
-print("  seed-profile / stale-MTP / runner-image / extra-args cleanup passes ran (see log for any per-item detail)")
+print("  seed-profile / stale-MTP / vulkan-slot / runner-image / extra-args cleanup passes ran (see log for any per-item detail)")
 PYEOF
 fi
 

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -2864,7 +2864,7 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
 def relabel_stale_vulkan_slots(
     *, job_id: str | None = None, kfd_present: bool | None = None
 ) -> int:
-    """Relabel legacy ``device = "gpu-vulkan"`` slot TOMLs (upgrade migration).
+    """Relabel retired ``device = "gpu-vulkan"`` slot TOMLs (upgrade migration).
 
     #1888/PR #1923 retired the Vulkan LLM lane and switched ``load_sync`` to
     hard-refuse loading a GPU slot when the ROCm compute node (``/dev/kfd``)

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -2895,7 +2895,8 @@ def relabel_stale_vulkan_slots(
     On an AMD host, for every slot TOML with a literal ``device =
     "gpu-vulkan"`` (top-level or nested under ``[slot]``, the same two-shape
     handling :func:`retag_stale_slot_images` and
-    :func:`clear_stale_mtp_overrides` use), relabel ``device`` to:
+    :func:`clear_stale_mtp_overrides` use) that is ALSO llama.cpp-backed
+    (see runtime scope below), relabel ``device`` to:
 
     * ``"gpu-rocm"`` — when :func:`hal0.providers._gpu.kfd_present` reports
       the ROCm compute node present and usable. This is the same target PR
@@ -2906,12 +2907,40 @@ def relabel_stale_vulkan_slots(
       explicitly, so this is logged as its own WARNING-level breadcrumb,
       never folded silently into the routine "migrated" line.
 
-    Only the ``device`` key is ever written — narrow scope per the #1867
-    rails (no other field, comment, or slot is touched, and a slot whose
-    ``device`` is not literally ``"gpu-vulkan"`` is skipped entirely).
+    Runtime scope — llama.cpp-backed slots ONLY: ``device = "gpu-vulkan"``
+    is not exclusively an llama.cpp label. ``capabilities/catalog.py``
+    deliberately keeps it for the non-llama runtimes (Kokoro TTS,
+    whisper.cpp/Moonshine STT, ComfyUI), which run genuinely-Vulkan images —
+    #1923's Vulkan-lane retirement and its ``require_kfd_for_gpu_slot`` guard
+    are about llama.cpp's unified ROCmFPX runner specifically, not those.
+    Relabeling a non-llama slot here would be actively wrong on both kfd
+    axes: ``gpu-rocm`` is a label its image can't honor (and
+    ``gpu_visibility_env`` would silently swap
+    ``GGML_VK_VISIBLE_DEVICES`` for ``HIP_VISIBLE_DEVICES``, dropping any
+    ``gpu_index`` pin), and ``cpu`` would strip ``/dev/dri`` from a slot that
+    was working fine. So every candidate slot is resolved through
+    :func:`hal0.providers.container._spec_provider_for` — the same
+    authoritative runtime-family discriminator ``load_sync`` itself uses —
+    and skipped ENTIRELY (no relabel, no warning, no log line, on either kfd
+    axis) unless it resolves to ``None`` (the default llama-server GPU
+    provider). The kfd-absent non-llama case (``require_kfd_for_gpu_slot``
+    itself over-firing for non-llama runtimes) is a separate, already-filed
+    bug (#1941) and is deliberately NOT addressed by this migration.
+
+    Only the ``device`` key is ever changed in VALUE — narrow scope per the
+    #1867 rails (no other field or slot is touched, and a slot whose
+    ``device`` is not literally ``"gpu-vulkan"``, or that isn't
+    llama.cpp-backed, is skipped entirely). Note that "narrow scope" is
+    about which *keys* get new values, not byte-for-byte file preservation:
+    like every other pass in this module, the write goes through
+    :func:`~hal0.config.loader.write_toml_atomic`, which reserializes the
+    whole parsed document via ``tomli_w`` — so any comments in a touched
+    slot's TOML are dropped on that rewrite, exactly as they are for
+    :func:`retag_stale_slot_images` and :func:`clear_stale_mtp_overrides`.
     Idempotent: once a slot's ``device`` reads ``"gpu-rocm"`` or ``"cpu"`` it
     no longer matches the ``"gpu-vulkan"`` guard, so a second run touches
-    nothing and logs nothing new.
+    nothing and logs nothing
+    new.
 
     Args:
         job_id: Optional breadcrumb for structured-log tracing.
@@ -2932,6 +2961,7 @@ def relabel_stale_vulkan_slots(
     from hal0.config.paths import slots_config_dir
     from hal0.providers._gpu import host_is_amd_gpu as _probe_host_is_amd_gpu
     from hal0.providers._gpu import kfd_present as _probe_kfd_present
+    from hal0.providers.container import _spec_provider_for
 
     is_amd = _probe_host_is_amd_gpu() if amd_host is None else amd_host
     if not is_amd:
@@ -2956,6 +2986,22 @@ def relabel_stale_vulkan_slots(
         elif isinstance(raw.get("slot"), dict) and raw["slot"].get("device") == "gpu-vulkan":
             holder = raw["slot"]
         if holder is None:
+            continue
+        try:
+            provider = _spec_provider_for(holder)
+        except Exception as exc:
+            log.warning(
+                "updater.vulkan_migration_slot_runtime_unresolved",
+                slot=slot_name,
+                error=str(exc),
+            )
+            continue
+        if provider is not None:
+            # A non-llama runtime (Kokoro/Moonshine/ComfyUI/FLM/Qwen3TTS)
+            # genuinely runs a Vulkan image on this device string — #1923's
+            # guard is scoped to llama.cpp's unified ROCmFPX runner, not
+            # these. Leave completely untouched (see docstring; #1941 tracks
+            # the separate kfd-absent over-firing issue for this class).
             continue
         new_device = "gpu-rocm" if have_kfd else "cpu"
         holder["device"] = new_device

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -2961,6 +2961,11 @@ def relabel_stale_vulkan_slots(
     from hal0.config.paths import slots_config_dir
     from hal0.providers._gpu import host_is_amd_gpu as _probe_host_is_amd_gpu
     from hal0.providers._gpu import kfd_present as _probe_kfd_present
+
+    # Private import, deliberate: this must be the EXACT discriminator
+    # load_sync uses to pick a provider, not a re-implementation of it — do
+    # not "clean this up" into a public wrapper or a local re-derivation,
+    # that would risk drifting from the real dispatch logic it mirrors.
     from hal0.providers.container import _spec_provider_for
 
     is_amd = _probe_host_is_amd_gpu() if amd_host is None else amd_host

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -2862,7 +2862,10 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
 
 
 def relabel_stale_vulkan_slots(
-    *, job_id: str | None = None, kfd_present: bool | None = None
+    *,
+    job_id: str | None = None,
+    kfd_present: bool | None = None,
+    amd_host: bool | None = None,
 ) -> int:
     """Relabel retired ``device = "gpu-vulkan"`` slot TOMLs (upgrade migration).
 
@@ -2877,10 +2880,22 @@ def relabel_stale_vulkan_slots(
     updated install doesn't refuse to load slots it was serving fine
     yesterday.
 
-    For every slot TOML with a literal ``device = "gpu-vulkan"`` (top-level or
-    nested under ``[slot]``, the same two-shape handling
-    :func:`retag_stale_slot_images` and :func:`clear_stale_mtp_overrides`
-    use), relabel ``device`` to:
+    AMD-only, exactly matching :func:`~hal0.providers._gpu.require_kfd_for_gpu_slot`'s
+    own scope for a ``gpu-vulkan`` device: that guard only fires when the
+    amdgpu kernel driver is bound on THIS host
+    (:func:`hal0.providers._gpu.host_is_amd_gpu`). An Intel iGPU or an NVIDIA
+    card without CDI has no ``/dev/kfd`` by design, is never gated, and keeps
+    working post-#1923 exactly as it did before — relabeling its
+    ``gpu-vulkan`` slots here (which an unscoped ``kfd_present()`` check
+    would do, since none of those hosts has ``/dev/kfd`` either) would
+    silently downgrade a perfectly working GPU slot to CPU for no reason. On
+    a non-AMD host this function is therefore a full no-op: nothing is
+    inspected or written.
+
+    On an AMD host, for every slot TOML with a literal ``device =
+    "gpu-vulkan"`` (top-level or nested under ``[slot]``, the same two-shape
+    handling :func:`retag_stale_slot_images` and
+    :func:`clear_stale_mtp_overrides` use), relabel ``device`` to:
 
     * ``"gpu-rocm"`` — when :func:`hal0.providers._gpu.kfd_present` reports
       the ROCm compute node present and usable. This is the same target PR
@@ -2903,6 +2918,10 @@ def relabel_stale_vulkan_slots(
         kfd_present: Override for
             :func:`hal0.providers._gpu.kfd_present` — test seam. ``None``
             (the default) probes the real host's ``/dev/kfd``.
+        amd_host: Override for :func:`hal0.providers._gpu.host_is_amd_gpu` —
+            test seam, same shape as
+            :func:`~hal0.providers._gpu.require_kfd_for_gpu_slot`'s own
+            parameter. ``None`` (the default) probes the real host.
 
     Returns:
         Number of slot TOMLs relabeled.
@@ -2911,7 +2930,14 @@ def relabel_stale_vulkan_slots(
 
     from hal0.config.loader import write_toml_atomic
     from hal0.config.paths import slots_config_dir
+    from hal0.providers._gpu import host_is_amd_gpu as _probe_host_is_amd_gpu
     from hal0.providers._gpu import kfd_present as _probe_kfd_present
+
+    is_amd = _probe_host_is_amd_gpu() if amd_host is None else amd_host
+    if not is_amd:
+        # Not the hardware #1923's guard characterised or gates — a
+        # gpu-vulkan slot here was never broken by it. Leave it alone.
+        return 0
 
     have_kfd = _probe_kfd_present() if kfd_present is None else kfd_present
 

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1652,7 +1652,7 @@ def run_post_activation_migrations(
     the running code and the on-disk schema have diverged, which the
     caller must treat as fatal (``commit()`` nukes the staged tree and
     aborts; install.sh's ``set -euo pipefail`` aborts the script on a
-    non-zero exit). The four data-cleanup passes after it are each
+    non-zero exit). The five data-cleanup passes after it are each
     independently best-effort, exactly as before: one pass's exception is
     logged and never blocks the others or the caller's activation.
 
@@ -1679,6 +1679,13 @@ def run_post_activation_migrations(
         log.warning("updater.mtp_migration_failed", job_id=job_id, error=str(exc))
         # Non-fatal: the affected slot simply fails to load until the
         # operator flips MTP to Auto/Off in the drawer.
+
+    try:
+        relabel_stale_vulkan_slots(job_id=job_id)
+    except Exception as exc:
+        log.warning("updater.vulkan_migration_failed", job_id=job_id, error=str(exc))
+        # Non-fatal: an affected slot keeps refusing to load (the #1923
+        # preflight guard) until the operator manually relabels its device.
 
     try:
         retag_stale_slot_images(job_id=job_id)
@@ -2852,6 +2859,114 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
             except Exception as exc:
                 log.warning("updater.image_retag_profiles_write_failed", error=str(exc))
     return retagged
+
+
+def relabel_stale_vulkan_slots(
+    *, job_id: str | None = None, kfd_present: bool | None = None
+) -> int:
+    """Relabel legacy ``device = "gpu-vulkan"`` slot TOMLs (upgrade migration).
+
+    #1888/PR #1923 retired the Vulkan LLM lane and switched ``load_sync`` to
+    hard-refuse loading a GPU slot when the ROCm compute node (``/dev/kfd``)
+    is not visible (:func:`hal0.providers._gpu.require_kfd_for_gpu_slot`). PR
+    #1923 relabeled the SEED slot TOMLs the installer ships
+    (``installer/etc-hal0/slots/*.toml``) from ``gpu-vulkan`` to ``gpu-rocm``,
+    but deliberately did NOT touch slot TOMLs already materialised on an
+    existing install — see #1924. This is that follow-up: every EXISTING
+    on-disk slot TOML carrying the retired label is relabeled here, so an
+    updated install doesn't refuse to load slots it was serving fine
+    yesterday.
+
+    For every slot TOML with a literal ``device = "gpu-vulkan"`` (top-level or
+    nested under ``[slot]``, the same two-shape handling
+    :func:`retag_stale_slot_images` and :func:`clear_stale_mtp_overrides`
+    use), relabel ``device`` to:
+
+    * ``"gpu-rocm"`` — when :func:`hal0.providers._gpu.kfd_present` reports
+      the ROCm compute node present and usable. This is the same target PR
+      #1923 gave the seed TOMLs, and the slot keeps running on the GPU.
+    * ``"cpu"`` — when it is not. This is a genuine, operator-visible
+      behavior change (the slot drops off the GPU entirely and gets much
+      slower) — the #1867 rails require every mutation to be logged
+      explicitly, so this is logged as its own WARNING-level breadcrumb,
+      never folded silently into the routine "migrated" line.
+
+    Only the ``device`` key is ever written — narrow scope per the #1867
+    rails (no other field, comment, or slot is touched, and a slot whose
+    ``device`` is not literally ``"gpu-vulkan"`` is skipped entirely).
+    Idempotent: once a slot's ``device`` reads ``"gpu-rocm"`` or ``"cpu"`` it
+    no longer matches the ``"gpu-vulkan"`` guard, so a second run touches
+    nothing and logs nothing new.
+
+    Args:
+        job_id: Optional breadcrumb for structured-log tracing.
+        kfd_present: Override for
+            :func:`hal0.providers._gpu.kfd_present` — test seam. ``None``
+            (the default) probes the real host's ``/dev/kfd``.
+
+    Returns:
+        Number of slot TOMLs relabeled.
+    """
+    import tomllib
+
+    from hal0.config.loader import write_toml_atomic
+    from hal0.config.paths import slots_config_dir
+    from hal0.providers._gpu import kfd_present as _probe_kfd_present
+
+    have_kfd = _probe_kfd_present() if kfd_present is None else kfd_present
+
+    relabeled = 0
+    slots_dir = slots_config_dir()
+    for toml_path in sorted(slots_dir.glob("*.toml")) if slots_dir.is_dir() else []:
+        slot_name = toml_path.stem
+        try:
+            raw = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            log.warning("updater.vulkan_migration_slot_unreadable", slot=slot_name, error=str(exc))
+            continue
+        holder: dict | None = None
+        if raw.get("device") == "gpu-vulkan":
+            holder = raw
+        elif isinstance(raw.get("slot"), dict) and raw["slot"].get("device") == "gpu-vulkan":
+            holder = raw["slot"]
+        if holder is None:
+            continue
+        new_device = "gpu-rocm" if have_kfd else "cpu"
+        holder["device"] = new_device
+        try:
+            write_toml_atomic(toml_path, raw)
+        except Exception as exc:
+            log.warning("updater.vulkan_migration_write_failed", slot=slot_name, error=str(exc))
+            continue
+        relabeled += 1
+        if have_kfd:
+            log.warning(
+                "updater.slot_vulkan_relabeled_rocm",
+                job_id=job_id,
+                slot=slot_name,
+                old="gpu-vulkan",
+                new=new_device,
+                note=(
+                    "gpu-vulkan is retired for LLM slots (#1888/#1923); relabeled to "
+                    "gpu-rocm — /dev/kfd is present, slot keeps running on GPU"
+                ),
+            )
+        else:
+            log.warning(
+                "updater.slot_vulkan_relabeled_cpu_fallback",
+                job_id=job_id,
+                slot=slot_name,
+                old="gpu-vulkan",
+                new=new_device,
+                note=(
+                    "BEHAVIOR CHANGE: gpu-vulkan is retired for LLM slots (#1888/#1923) "
+                    "and /dev/kfd (the ROCm compute node) is not present on this host — "
+                    "relabeled to cpu. This slot no longer runs on the GPU and will be "
+                    "significantly slower until /dev/kfd is forwarded and the slot is "
+                    "re-pointed at gpu-rocm."
+                ),
+            )
+    return relabeled
 
 
 def rerender_slot_units(*, job_id: str | None = None) -> int:

--- a/tests/updater/test_post_activation_migrations.py
+++ b/tests/updater/test_post_activation_migrations.py
@@ -46,7 +46,7 @@ def _stub_every_pass(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
         calls["mtp"].append(job_id)
         return 0
 
-    def _vulkan_migration(*, job_id=None, kfd_present=None):
+    def _vulkan_migration(*, job_id=None, kfd_present=None, amd_host=None):
         calls["vulkan_migration"].append(job_id)
         return 0
 

--- a/tests/updater/test_post_activation_migrations.py
+++ b/tests/updater/test_post_activation_migrations.py
@@ -29,6 +29,7 @@ def _stub_every_pass(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
         "config_migrations": [],
         "seed_profiles": [],
         "mtp": [],
+        "vulkan_migration": [],
         "image_retag": [],
         "extra_args": [],
     }
@@ -45,6 +46,10 @@ def _stub_every_pass(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
         calls["mtp"].append(job_id)
         return 0
 
+    def _vulkan_migration(*, job_id=None, kfd_present=None):
+        calls["vulkan_migration"].append(job_id)
+        return 0
+
     def _image_retag(*, job_id=None):
         calls["image_retag"].append(job_id)
         return 0
@@ -56,17 +61,19 @@ def _stub_every_pass(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
     monkeypatch.setattr("hal0.updater.updater._maybe_run_config_migrations", _config_migrations)
     monkeypatch.setattr("hal0.updater.updater.ensure_seed_profiles", _seed_profiles)
     monkeypatch.setattr("hal0.updater.updater.clear_stale_mtp_overrides", _mtp)
+    monkeypatch.setattr("hal0.updater.updater.relabel_stale_vulkan_slots", _vulkan_migration)
     monkeypatch.setattr("hal0.updater.updater.retag_stale_slot_images", _image_retag)
     monkeypatch.setattr("hal0.updater.updater.sanitize_model_extra_args", _extra_args)
     return calls
 
 
-def test_runs_all_five_passes(_stub_every_pass: dict[str, list[Any]]) -> None:
+def test_runs_all_six_passes(_stub_every_pass: dict[str, list[Any]]) -> None:
     result = run_post_activation_migrations(job_id="j1")
     assert result == (1, 2)
     assert _stub_every_pass["config_migrations"] == [(1, "j1")]
     assert _stub_every_pass["seed_profiles"] == ["j1"]
     assert _stub_every_pass["mtp"] == ["j1"]
+    assert _stub_every_pass["vulkan_migration"] == ["j1"]
     assert _stub_every_pass["image_retag"] == ["j1"]
     assert _stub_every_pass["extra_args"] == ["j1"]
 
@@ -92,6 +99,7 @@ def test_a_failing_non_fatal_pass_does_not_block_the_others(
 
     assert result == (1, 2)  # schema migration still reported
     assert _stub_every_pass["seed_profiles"] == ["j2"]
+    assert _stub_every_pass["vulkan_migration"] == ["j2"]  # ran despite mtp's failure
     assert _stub_every_pass["image_retag"] == ["j2"]  # ran despite mtp's failure
     assert _stub_every_pass["extra_args"] == ["j2"]
 
@@ -99,7 +107,7 @@ def test_a_failing_non_fatal_pass_does_not_block_the_others(
 def test_schema_migration_failure_propagates(
     monkeypatch: pytest.MonkeyPatch, _stub_every_pass: dict[str, list[Any]]
 ) -> None:
-    """Unlike the four data-cleanup passes, a schema-migration failure is
+    """Unlike the five data-cleanup passes, a schema-migration failure is
     NOT swallowed — the caller (commit()'s install_dir cleanup, or
     install.sh's `set -euo pipefail`) must see it and abort the
     activation rather than proceed on an unmigrated schema."""
@@ -112,8 +120,9 @@ def test_schema_migration_failure_propagates(
     with pytest.raises(Hal0Error):
         run_post_activation_migrations(job_id="j3")
 
-    # None of the four data-cleanup passes ran — the schema must land first.
+    # None of the five data-cleanup passes ran — the schema must land first.
     assert _stub_every_pass["seed_profiles"] == []
     assert _stub_every_pass["mtp"] == []
+    assert _stub_every_pass["vulkan_migration"] == []
     assert _stub_every_pass["image_retag"] == []
     assert _stub_every_pass["extra_args"] == []

--- a/tests/updater/test_vulkan_slot_migration.py
+++ b/tests/updater/test_vulkan_slot_migration.py
@@ -84,6 +84,110 @@ def test_default_probes_real_amd_host(tmp_hal0_home: str, monkeypatch) -> None:
     assert _device_of("agent") == "gpu-vulkan"
 
 
+# ── runtime scope: only llama.cpp-backed slots, never Kokoro/ComfyUI/etc ── #
+#
+# capabilities/catalog.py:429-431 deliberately KEEPS gpu-vulkan for the
+# non-llama runtimes (Kokoro TTS, whisper.cpp/Moonshine STT, ComfyUI) — they
+# run genuinely-Vulkan images, unlike llama.cpp's unified ROCmFPX runner. A
+# migration that matches on the bare device string alone would relabel those
+# slots too:
+#   - kfd present: gpu-rocm is a label their image can't honor
+#     (gpu_visibility_env swaps GGML_VK_VISIBLE_DEVICES -> HIP_VISIBLE_DEVICES,
+#     dropping any gpu_index pin).
+#   - kfd absent: demoting to cpu strips /dev/dri from a working Vulkan slot.
+# container.py's _spec_provider_for is the authoritative "is this slot
+# llama.cpp-backed" discriminator (None == the default llama-server GPU
+# provider; non-None == Kokoro/Moonshine/ComfyUI/FLM/Qwen3TTS) — this
+# migration must gate on it and leave every non-llama slot COMPLETELY
+# untouched: no relabel, no warning, no log line, on EITHER kfd axis. The
+# kfd-absent non-llama case (require_kfd_for_gpu_slot itself over-firing for
+# non-llama runtimes) is tracked separately as #1941 and must NOT be
+# addressed here.
+
+
+def test_kokoro_slot_survives_untouched_kfd_present(tmp_hal0_home: str) -> None:
+    _write_slot(
+        "voice",
+        'name = "voice"\ntype = "tts"\ndevice = "gpu-vulkan"\nport = 8087\n',
+    )
+
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True) == 0
+    assert _device_of("voice") == "gpu-vulkan"
+
+
+def test_kokoro_slot_survives_untouched_kfd_absent(tmp_hal0_home: str) -> None:
+    _write_slot(
+        "voice",
+        'name = "voice"\ntype = "tts"\ndevice = "gpu-vulkan"\nport = 8087\n',
+    )
+
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=False) == 0
+    assert _device_of("voice") == "gpu-vulkan"
+
+
+def test_comfyui_slot_survives_untouched_kfd_present(tmp_hal0_home: str) -> None:
+    _write_slot(
+        "imggen",
+        'name = "imggen"\ntype = "image"\ndevice = "gpu-vulkan"\nport = 8188\n',
+    )
+
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True) == 0
+    assert _device_of("imggen") == "gpu-vulkan"
+
+
+def test_comfyui_slot_survives_untouched_kfd_absent(tmp_hal0_home: str) -> None:
+    _write_slot(
+        "imggen",
+        'name = "imggen"\ntype = "image"\ndevice = "gpu-vulkan"\nport = 8188\n',
+    )
+
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=False) == 0
+    assert _device_of("imggen") == "gpu-vulkan"
+
+
+def test_transcription_slot_survives_untouched(tmp_hal0_home: str) -> None:
+    """type=transcription with no NPU device dispatches to Moonshine
+    (whisper.cpp-shaped), never llama-server."""
+    _write_slot(
+        "stt",
+        'name = "stt"\ntype = "transcription"\ndevice = "gpu-vulkan"\nport = 8085\n',
+    )
+
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True) == 0
+    assert _device_of("stt") == "gpu-vulkan"
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=False) == 0
+    assert _device_of("stt") == "gpu-vulkan"
+
+
+def test_non_llama_slots_log_nothing_on_either_kfd_axis(tmp_hal0_home: str, monkeypatch) -> None:
+    import hal0.updater.updater as updater_mod
+
+    _write_slot("voice", 'name = "voice"\ntype = "tts"\ndevice = "gpu-vulkan"\n')
+    _write_slot("imggen", 'name = "imggen"\ntype = "image"\ndevice = "gpu-vulkan"\n')
+
+    calls: list[tuple[str, dict]] = []
+    monkeypatch.setattr(updater_mod.log, "warning", lambda event, **kw: calls.append((event, kw)))
+
+    relabel_stale_vulkan_slots(amd_host=True, kfd_present=True)
+    relabel_stale_vulkan_slots(amd_host=True, kfd_present=False)
+
+    assert calls == []
+
+
+def test_llama_slot_still_relabels_alongside_untouched_non_llama_slot(
+    tmp_hal0_home: str,
+) -> None:
+    """Sanity check that the runtime gate is scoped correctly: a genuine
+    llama.cpp slot (no profile, plain type=llm) in the SAME directory as a
+    non-llama slot still relabels, while its neighbor does not."""
+    _write_slot("agent", 'name = "agent"\ntype = "llm"\ndevice = "gpu-vulkan"\nport = 8081\n')
+    _write_slot("voice", 'name = "voice"\ntype = "tts"\ndevice = "gpu-vulkan"\nport = 8087\n')
+
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True) == 1
+    assert _device_of("agent") == "gpu-rocm"
+    assert _device_of("voice") == "gpu-vulkan"
+
+
 # ── kfd present → gpu-rocm (AMD host) ────────────────────────────────────── #
 
 

--- a/tests/updater/test_vulkan_slot_migration.py
+++ b/tests/updater/test_vulkan_slot_migration.py
@@ -188,6 +188,63 @@ def test_llama_slot_still_relabels_alongside_untouched_non_llama_slot(
     assert _device_of("voice") == "gpu-vulkan"
 
 
+def test_qwen3tts_profile_slot_survives_untouched(tmp_hal0_home: str) -> None:
+    """A slot dispatched to a non-llama runtime via its PROFILE rather than
+    its device/type (qwen3-tts resolves to the qwen3tts runtime_family
+    ahead of the generic type="tts" -> Kokoro fallback in
+    _spec_provider_for) must be left alone too, on both kfd axes. Reviewer
+    manually verified this path on the earlier fix; this pins it as a
+    regression guard."""
+    body = (
+        'name = "voice2"\ntype = "llm"\nprofile = "qwen3-tts"\ndevice = "gpu-vulkan"\nport = 8091\n'
+    )
+    _write_slot("voice2", body)
+
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True) == 0
+    assert _device_of("voice2") == "gpu-vulkan"
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=False) == 0
+    assert _device_of("voice2") == "gpu-vulkan"
+
+
+def test_runtime_resolution_error_leaves_slot_untouched_and_logs(
+    tmp_hal0_home: str, monkeypatch
+) -> None:
+    """If _spec_provider_for itself raises (an unrecognized runtime_family —
+    see UnknownRuntimeFamilyError in container.py), the migration must not
+    optimistically fall through to "must be llama.cpp, relabel it": the
+    slot is left byte-identical, the pass returns cleanly (no crash), and
+    the failure is visible in the log rather than swallowed. This is the
+    one branch none of the other tests exercise — a mutation that turned
+    the except's `continue` into a relabel would pass every other test in
+    this file."""
+    import hal0.updater.updater as updater_mod
+
+    body = 'name = "agent"\ntype = "llm"\ndevice = "gpu-vulkan"\nport = 8081\n'
+    _write_slot("agent", body)
+    toml_path = slots_config_dir() / "agent.toml"
+    before = toml_path.read_bytes()
+
+    def _boom(slot_cfg: dict) -> None:
+        raise RuntimeError("no provider registered for runtime family 'bogus'")
+
+    monkeypatch.setattr("hal0.providers.container._spec_provider_for", _boom)
+
+    calls: list[tuple[str, dict]] = []
+    monkeypatch.setattr(updater_mod.log, "warning", lambda event, **kw: calls.append((event, kw)))
+
+    result = relabel_stale_vulkan_slots(amd_host=True, kfd_present=True)
+
+    assert result == 0
+    assert toml_path.read_bytes() == before  # byte-identical — no write happened
+    assert _device_of("agent") == "gpu-vulkan"  # unchanged
+
+    unresolved = [c for c in calls if c[0] == "updater.vulkan_migration_slot_runtime_unresolved"]
+    assert len(unresolved) == 1
+    _event, fields = unresolved[0]
+    assert fields["slot"] == "agent"
+    assert "bogus" in fields["error"]
+
+
 # ── kfd present → gpu-rocm (AMD host) ────────────────────────────────────── #
 
 

--- a/tests/updater/test_vulkan_slot_migration.py
+++ b/tests/updater/test_vulkan_slot_migration.py
@@ -6,12 +6,16 @@ the SEED slot TOMLs the installer ships from ``gpu-vulkan`` to ``gpu-rocm``,
 but deliberately left slot TOMLs already materialised on an existing install
 untouched, so an updated box refuses to load them under the new
 ``require_kfd_for_gpu_slot`` preflight guard until an operator manually
-relabels them. This migration does that relabel automatically:
+relabels them. This migration does that relabel automatically, AMD-only
+(matching ``require_kfd_for_gpu_slot``'s own scope exactly):
 
-* ``/dev/kfd`` present (AMD host with a working ROCm compute node) →
-  ``gpu-rocm``, matching PR #1923's own seed relabel.
-* ``/dev/kfd`` absent → ``cpu``, logged loudly since it is a genuine
-  operator-visible behavior change (the slot drops off the GPU).
+* not an AMD host (no amdgpu kernel driver bound) → left alone entirely.
+  ``require_kfd_for_gpu_slot`` never gates a ``gpu-vulkan`` slot there either,
+  so it was never broken by #1923 and needs no migration.
+* AMD host, ``/dev/kfd`` present (working ROCm compute node) → ``gpu-rocm``,
+  matching PR #1923's own seed relabel.
+* AMD host, ``/dev/kfd`` absent → ``cpu``, logged loudly since it is a
+  genuine operator-visible behavior change (the slot drops off the GPU).
 
 Only the ``device`` key is ever touched (#1867 rails: narrow scope, log every
 mutation, idempotent).
@@ -43,13 +47,50 @@ def _device_of(name: str):
     return slot.get("device") if isinstance(slot, dict) else None
 
 
-# ── kfd present → gpu-rocm ──────────────────────────────────────────────── #
+# ── AMD-only scope ───────────────────────────────────────────────────────── #
+
+
+def test_non_amd_host_is_a_full_noop(tmp_hal0_home: str) -> None:
+    """require_kfd_for_gpu_slot never gates a gpu-vulkan slot on a non-AMD
+    host (Intel iGPU, NVIDIA without CDI) — it has no /dev/kfd by design and
+    keeps working post-#1923. Relabeling it here would be a pure regression:
+    a working GPU slot silently downgraded to CPU because kfd_present() is
+    (correctly) False on hardware that was never supposed to have kfd."""
+    _write_slot("intel-tts", 'name = "intel-tts"\ndevice = "gpu-vulkan"\nport = 8090\n')
+
+    assert relabel_stale_vulkan_slots(amd_host=False, kfd_present=False) == 0
+    assert _device_of("intel-tts") == "gpu-vulkan"
+
+
+def test_non_amd_host_logs_nothing(tmp_hal0_home: str, monkeypatch) -> None:
+    import hal0.updater.updater as updater_mod
+
+    _write_slot("intel-tts", 'name = "intel-tts"\ndevice = "gpu-vulkan"\n')
+
+    calls: list[tuple[str, dict]] = []
+    monkeypatch.setattr(updater_mod.log, "warning", lambda event, **kw: calls.append((event, kw)))
+
+    relabel_stale_vulkan_slots(amd_host=False, kfd_present=False)
+    assert calls == []
+
+
+def test_default_probes_real_amd_host(tmp_hal0_home: str, monkeypatch) -> None:
+    """With no ``amd_host`` override, the function calls the real
+    :func:`hal0.providers._gpu.host_is_amd_gpu` probe."""
+    _write_slot("agent", 'name = "agent"\ndevice = "gpu-vulkan"\n')
+    monkeypatch.setattr("hal0.providers._gpu.host_is_amd_gpu", lambda: False)
+
+    assert relabel_stale_vulkan_slots(kfd_present=True) == 0
+    assert _device_of("agent") == "gpu-vulkan"
+
+
+# ── kfd present → gpu-rocm (AMD host) ────────────────────────────────────── #
 
 
 def test_vulkan_slot_relabels_to_rocm_when_kfd_present(tmp_hal0_home: str) -> None:
     _write_slot("agent", 'name = "agent"\ntype = "llm"\ndevice = "gpu-vulkan"\nport = 8081\n')
 
-    assert relabel_stale_vulkan_slots(kfd_present=True) == 1
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True) == 1
     assert _device_of("agent") == "gpu-rocm"
 
 
@@ -59,19 +100,19 @@ def test_nested_slot_table_relabels_to_rocm_when_kfd_present(tmp_hal0_home: str)
         '[slot]\nname = "nested"\ndevice = "gpu-vulkan"\nport = 8082\n',
     )
 
-    assert relabel_stale_vulkan_slots(kfd_present=True) == 1
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True) == 1
     assert _device_of("nested") == "gpu-rocm"
     raw = _raw("nested")
     assert "slot" in raw and raw["slot"]["device"] == "gpu-rocm"
 
 
-# ── kfd absent → cpu, loud warning ──────────────────────────────────────── #
+# ── kfd absent → cpu, loud warning (AMD host) ────────────────────────────── #
 
 
 def test_vulkan_slot_relabels_to_cpu_when_kfd_absent(tmp_hal0_home: str) -> None:
     _write_slot("brain", 'name = "brain"\ntype = "llm"\ndevice = "gpu-vulkan"\nport = 8089\n')
 
-    assert relabel_stale_vulkan_slots(kfd_present=False) == 1
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=False) == 1
     assert _device_of("brain") == "cpu"
 
 
@@ -91,7 +132,7 @@ def test_cpu_fallback_logs_a_loud_warning(tmp_hal0_home: str, monkeypatch) -> No
 
     monkeypatch.setattr(updater_mod.log, "warning", _spy)
 
-    assert relabel_stale_vulkan_slots(kfd_present=False, job_id="job-cpu") == 1
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=False, job_id="job-cpu") == 1
 
     cpu_events = [c for c in calls if c[0] == "updater.slot_vulkan_relabeled_cpu_fallback"]
     assert len(cpu_events) == 1
@@ -113,7 +154,7 @@ def test_rocm_relabel_logs_a_distinct_breadcrumb(tmp_hal0_home: str, monkeypatch
     calls: list[tuple[str, dict]] = []
     monkeypatch.setattr(updater_mod.log, "warning", lambda event, **kw: calls.append((event, kw)))
 
-    assert relabel_stale_vulkan_slots(kfd_present=True, job_id="job-rocm") == 1
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True, job_id="job-rocm") == 1
 
     rocm_events = [c for c in calls if c[0] == "updater.slot_vulkan_relabeled_rocm"]
     assert len(rocm_events) == 1
@@ -142,7 +183,7 @@ def test_other_slot_fields_are_untouched(tmp_hal0_home: str) -> None:
     )
     _write_slot("agent", body)
 
-    assert relabel_stale_vulkan_slots(kfd_present=True) == 1
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True) == 1
 
     raw = _raw("agent")
     assert raw["device"] == "gpu-rocm"
@@ -164,7 +205,7 @@ def test_non_vulkan_devices_are_left_alone(tmp_hal0_home: str) -> None:
     _write_slot("npu-slot", 'name = "npu-slot"\ndevice = "npu"\n')
     _write_slot("no-device-slot", 'name = "no-device-slot"\n')
 
-    assert relabel_stale_vulkan_slots(kfd_present=True) == 0
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True) == 0
     assert _device_of("rocm-slot") == "gpu-rocm"
     assert _device_of("cpu-slot") == "cpu"
     assert _device_of("npu-slot") == "npu"
@@ -175,7 +216,7 @@ def test_unreadable_slot_is_skipped_not_fatal(tmp_hal0_home: str) -> None:
     _write_slot("broken", "not [ valid toml")
     _write_slot("agent", 'name = "agent"\ndevice = "gpu-vulkan"\n')
 
-    assert relabel_stale_vulkan_slots(kfd_present=True) == 1
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True) == 1
     assert _device_of("agent") == "gpu-rocm"
 
 
@@ -185,19 +226,19 @@ def test_unreadable_slot_is_skipped_not_fatal(tmp_hal0_home: str) -> None:
 def test_relabel_is_idempotent(tmp_hal0_home: str) -> None:
     _write_slot("agent", 'name = "agent"\ndevice = "gpu-vulkan"\n')
 
-    assert relabel_stale_vulkan_slots(kfd_present=True) == 1
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True) == 1
     assert _device_of("agent") == "gpu-rocm"
     # second run: device is now gpu-rocm, no longer matches the guard.
-    assert relabel_stale_vulkan_slots(kfd_present=True) == 0
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=True) == 0
     assert _device_of("agent") == "gpu-rocm"
 
 
 def test_relabel_is_idempotent_on_cpu_fallback(tmp_hal0_home: str) -> None:
     _write_slot("brain", 'name = "brain"\ndevice = "gpu-vulkan"\n')
 
-    assert relabel_stale_vulkan_slots(kfd_present=False) == 1
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=False) == 1
     assert _device_of("brain") == "cpu"
-    assert relabel_stale_vulkan_slots(kfd_present=False) == 0
+    assert relabel_stale_vulkan_slots(amd_host=True, kfd_present=False) == 0
     assert _device_of("brain") == "cpu"
 
 
@@ -209,21 +250,22 @@ def test_idempotent_second_run_logs_nothing_new(tmp_hal0_home: str, monkeypatch)
     calls: list[tuple[str, dict]] = []
     monkeypatch.setattr(updater_mod.log, "warning", lambda event, **kw: calls.append((event, kw)))
 
-    relabel_stale_vulkan_slots(kfd_present=True)
+    relabel_stale_vulkan_slots(amd_host=True, kfd_present=True)
     first_run_calls = len(calls)
     assert first_run_calls == 1
 
-    relabel_stale_vulkan_slots(kfd_present=True)
+    relabel_stale_vulkan_slots(amd_host=True, kfd_present=True)
     assert len(calls) == first_run_calls  # no new log entries on the no-op re-run
 
 
-# ── real host probe (no override) ───────────────────────────────────────── #
+# ── real host probes (no overrides) ──────────────────────────────────────── #
 
 
 def test_default_probes_real_kfd_present(tmp_hal0_home: str, monkeypatch) -> None:
     """With no ``kfd_present`` override, the function calls the real
     :func:`hal0.providers._gpu.kfd_present` probe."""
     _write_slot("agent", 'name = "agent"\ndevice = "gpu-vulkan"\n')
+    monkeypatch.setattr("hal0.providers._gpu.host_is_amd_gpu", lambda: True)
     monkeypatch.setattr("hal0.providers._gpu.kfd_present", lambda: True)
 
     assert relabel_stale_vulkan_slots() == 1

--- a/tests/updater/test_vulkan_slot_migration.py
+++ b/tests/updater/test_vulkan_slot_migration.py
@@ -1,0 +1,230 @@
+"""Upgrade migration: relabel legacy ``device = "gpu-vulkan"`` slot TOMLs.
+
+Covers :func:`hal0.updater.updater.relabel_stale_vulkan_slots` — the #1924
+follow-up to PR #1923 (#1888, Vulkan LLM lane retirement). PR #1923 relabeled
+the SEED slot TOMLs the installer ships from ``gpu-vulkan`` to ``gpu-rocm``,
+but deliberately left slot TOMLs already materialised on an existing install
+untouched, so an updated box refuses to load them under the new
+``require_kfd_for_gpu_slot`` preflight guard until an operator manually
+relabels them. This migration does that relabel automatically:
+
+* ``/dev/kfd`` present (AMD host with a working ROCm compute node) →
+  ``gpu-rocm``, matching PR #1923's own seed relabel.
+* ``/dev/kfd`` absent → ``cpu``, logged loudly since it is a genuine
+  operator-visible behavior change (the slot drops off the GPU).
+
+Only the ``device`` key is ever touched (#1867 rails: narrow scope, log every
+mutation, idempotent).
+"""
+
+from __future__ import annotations
+
+import tomllib
+
+from hal0.config.paths import slots_config_dir
+from hal0.updater.updater import relabel_stale_vulkan_slots
+
+
+def _write_slot(name: str, body: str) -> None:
+    d = slots_config_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{name}.toml").write_text(body, encoding="utf-8")
+
+
+def _raw(name: str) -> dict:
+    return tomllib.loads((slots_config_dir() / f"{name}.toml").read_text(encoding="utf-8"))
+
+
+def _device_of(name: str):
+    raw = _raw(name)
+    if "device" in raw:
+        return raw.get("device")
+    slot = raw.get("slot")
+    return slot.get("device") if isinstance(slot, dict) else None
+
+
+# ── kfd present → gpu-rocm ──────────────────────────────────────────────── #
+
+
+def test_vulkan_slot_relabels_to_rocm_when_kfd_present(tmp_hal0_home: str) -> None:
+    _write_slot("agent", 'name = "agent"\ntype = "llm"\ndevice = "gpu-vulkan"\nport = 8081\n')
+
+    assert relabel_stale_vulkan_slots(kfd_present=True) == 1
+    assert _device_of("agent") == "gpu-rocm"
+
+
+def test_nested_slot_table_relabels_to_rocm_when_kfd_present(tmp_hal0_home: str) -> None:
+    _write_slot(
+        "nested",
+        '[slot]\nname = "nested"\ndevice = "gpu-vulkan"\nport = 8082\n',
+    )
+
+    assert relabel_stale_vulkan_slots(kfd_present=True) == 1
+    assert _device_of("nested") == "gpu-rocm"
+    raw = _raw("nested")
+    assert "slot" in raw and raw["slot"]["device"] == "gpu-rocm"
+
+
+# ── kfd absent → cpu, loud warning ──────────────────────────────────────── #
+
+
+def test_vulkan_slot_relabels_to_cpu_when_kfd_absent(tmp_hal0_home: str) -> None:
+    _write_slot("brain", 'name = "brain"\ntype = "llm"\ndevice = "gpu-vulkan"\nport = 8089\n')
+
+    assert relabel_stale_vulkan_slots(kfd_present=False) == 1
+    assert _device_of("brain") == "cpu"
+
+
+def test_cpu_fallback_logs_a_loud_warning(tmp_hal0_home: str, monkeypatch) -> None:
+    """The cpu-fallback path must never be silent — it is a real
+    operator-visible behavior change (#1867 rails)."""
+    import hal0.updater.updater as updater_mod
+
+    _write_slot("coder", 'name = "coder"\ntype = "llm"\ndevice = "gpu-vulkan"\nport = 8082\n')
+
+    calls: list[tuple[str, dict]] = []
+    original_warning = updater_mod.log.warning
+
+    def _spy(event, **kwargs):
+        calls.append((event, kwargs))
+        return original_warning(event, **kwargs)
+
+    monkeypatch.setattr(updater_mod.log, "warning", _spy)
+
+    assert relabel_stale_vulkan_slots(kfd_present=False, job_id="job-cpu") == 1
+
+    cpu_events = [c for c in calls if c[0] == "updater.slot_vulkan_relabeled_cpu_fallback"]
+    assert len(cpu_events) == 1
+    _event, fields = cpu_events[0]
+    assert fields["slot"] == "coder"
+    assert fields["old"] == "gpu-vulkan"
+    assert fields["new"] == "cpu"
+    assert fields["job_id"] == "job-cpu"
+    assert "BEHAVIOR CHANGE" in fields["note"]
+
+
+def test_rocm_relabel_logs_a_distinct_breadcrumb(tmp_hal0_home: str, monkeypatch) -> None:
+    """The gpu-rocm relabel is also logged, distinct from the cpu-fallback
+    event so an operator scanning the journal can tell the two apart."""
+    import hal0.updater.updater as updater_mod
+
+    _write_slot("embed", 'name = "embed"\ntype = "embedding"\ndevice = "gpu-vulkan"\nport = 8083\n')
+
+    calls: list[tuple[str, dict]] = []
+    monkeypatch.setattr(updater_mod.log, "warning", lambda event, **kw: calls.append((event, kw)))
+
+    assert relabel_stale_vulkan_slots(kfd_present=True, job_id="job-rocm") == 1
+
+    rocm_events = [c for c in calls if c[0] == "updater.slot_vulkan_relabeled_rocm"]
+    assert len(rocm_events) == 1
+    _event, fields = rocm_events[0]
+    assert fields["slot"] == "embed"
+    assert fields["old"] == "gpu-vulkan"
+    assert fields["new"] == "gpu-rocm"
+    assert fields["job_id"] == "job-rocm"
+
+
+# ── narrow scope: other keys / other devices untouched ──────────────────── #
+
+
+def test_other_slot_fields_are_untouched(tmp_hal0_home: str) -> None:
+    body = (
+        'name = "agent"\n'
+        'type = "llm"\n'
+        'device = "gpu-vulkan"\n'
+        'runtime = "container"\n'
+        'profile = "chadrock-moe"\n'
+        "port = 8081\n"
+        "n_gpu_layers = 99\n"
+        "\n"
+        "[model]\n"
+        'default = "some-model"\n'
+    )
+    _write_slot("agent", body)
+
+    assert relabel_stale_vulkan_slots(kfd_present=True) == 1
+
+    raw = _raw("agent")
+    assert raw["device"] == "gpu-rocm"
+    # everything else survives byte-for-byte in value (structural comparison
+    # since write_toml_atomic round-trips through tomllib/tomli_w, same as
+    # every other migration pass in this module).
+    assert raw["name"] == "agent"
+    assert raw["type"] == "llm"
+    assert raw["runtime"] == "container"
+    assert raw["profile"] == "chadrock-moe"
+    assert raw["port"] == 8081
+    assert raw["n_gpu_layers"] == 99
+    assert raw["model"]["default"] == "some-model"
+
+
+def test_non_vulkan_devices_are_left_alone(tmp_hal0_home: str) -> None:
+    _write_slot("rocm-slot", 'name = "rocm-slot"\ndevice = "gpu-rocm"\n')
+    _write_slot("cpu-slot", 'name = "cpu-slot"\ndevice = "cpu"\n')
+    _write_slot("npu-slot", 'name = "npu-slot"\ndevice = "npu"\n')
+    _write_slot("no-device-slot", 'name = "no-device-slot"\n')
+
+    assert relabel_stale_vulkan_slots(kfd_present=True) == 0
+    assert _device_of("rocm-slot") == "gpu-rocm"
+    assert _device_of("cpu-slot") == "cpu"
+    assert _device_of("npu-slot") == "npu"
+    assert _device_of("no-device-slot") is None
+
+
+def test_unreadable_slot_is_skipped_not_fatal(tmp_hal0_home: str) -> None:
+    _write_slot("broken", "not [ valid toml")
+    _write_slot("agent", 'name = "agent"\ndevice = "gpu-vulkan"\n')
+
+    assert relabel_stale_vulkan_slots(kfd_present=True) == 1
+    assert _device_of("agent") == "gpu-rocm"
+
+
+# ── idempotency ──────────────────────────────────────────────────────────── #
+
+
+def test_relabel_is_idempotent(tmp_hal0_home: str) -> None:
+    _write_slot("agent", 'name = "agent"\ndevice = "gpu-vulkan"\n')
+
+    assert relabel_stale_vulkan_slots(kfd_present=True) == 1
+    assert _device_of("agent") == "gpu-rocm"
+    # second run: device is now gpu-rocm, no longer matches the guard.
+    assert relabel_stale_vulkan_slots(kfd_present=True) == 0
+    assert _device_of("agent") == "gpu-rocm"
+
+
+def test_relabel_is_idempotent_on_cpu_fallback(tmp_hal0_home: str) -> None:
+    _write_slot("brain", 'name = "brain"\ndevice = "gpu-vulkan"\n')
+
+    assert relabel_stale_vulkan_slots(kfd_present=False) == 1
+    assert _device_of("brain") == "cpu"
+    assert relabel_stale_vulkan_slots(kfd_present=False) == 0
+    assert _device_of("brain") == "cpu"
+
+
+def test_idempotent_second_run_logs_nothing_new(tmp_hal0_home: str, monkeypatch) -> None:
+    import hal0.updater.updater as updater_mod
+
+    _write_slot("agent", 'name = "agent"\ndevice = "gpu-vulkan"\n')
+
+    calls: list[tuple[str, dict]] = []
+    monkeypatch.setattr(updater_mod.log, "warning", lambda event, **kw: calls.append((event, kw)))
+
+    relabel_stale_vulkan_slots(kfd_present=True)
+    first_run_calls = len(calls)
+    assert first_run_calls == 1
+
+    relabel_stale_vulkan_slots(kfd_present=True)
+    assert len(calls) == first_run_calls  # no new log entries on the no-op re-run
+
+
+# ── real host probe (no override) ───────────────────────────────────────── #
+
+
+def test_default_probes_real_kfd_present(tmp_hal0_home: str, monkeypatch) -> None:
+    """With no ``kfd_present`` override, the function calls the real
+    :func:`hal0.providers._gpu.kfd_present` probe."""
+    _write_slot("agent", 'name = "agent"\ndevice = "gpu-vulkan"\n')
+    monkeypatch.setattr("hal0.providers._gpu.kfd_present", lambda: True)
+
+    assert relabel_stale_vulkan_slots() == 1
+    assert _device_of("agent") == "gpu-rocm"


### PR DESCRIPTION
## Summary

PR #1923 retired the Vulkan LLM lane (#1888) and made `container.py`'s `load_sync` refuse to load a GPU slot whose `device` is `gpu-vulkan` or `gpu-rocm` when `/dev/kfd` is not visible. It deliberately relabeled only the installer's *seed* slot TOMLs (`installer/etc-hal0/slots/*.toml`) from `gpu-vulkan` to `gpu-rocm`, and explicitly left slot TOMLs already materialised on an existing install untouched — so any pre-#1923 install with `device = "gpu-vulkan"` slots refuses to load them after updating, until an operator manually relabels the TOML (raised as open question 3 in #1923's report, filed as #1924).

This PR adds an updater migration that does that relabel automatically.

## Design

`relabel_stale_vulkan_slots` is a new sixth pass in `run_post_activation_migrations` (`src/hal0/updater/updater.py`) — the single sequence both `Updater.commit()` (self-update) and `install.sh`'s repair/upgrade-in-place path call, so both upgrade routes converge on the same on-disk state.

- **Trigger for `gpu-rocm`**: `/dev/kfd` present and usable (`hal0.providers._gpu.kfd_present()`, added in #1923) — matches PR #1923's own seed relabel exactly.
- **Trigger for `cpu`**: `/dev/kfd` not present. This is a genuine operator-visible behavior change (the slot drops off the GPU and gets much slower), so it is logged as its own distinct WARNING-level breadcrumb (`updater.slot_vulkan_relabeled_cpu_fallback`, note prefixed `BEHAVIOR CHANGE:`) — never folded silently into the routine relabel log line (`updater.slot_vulkan_relabeled_rocm`).
- **AMD-host scope**: only fires when the amdgpu kernel driver is bound on this host (`hal0.providers._gpu.host_is_amd_gpu()`), exactly matching `require_kfd_for_gpu_slot`'s own scope. A non-AMD host (Intel iGPU, NVIDIA without CDI) has no `/dev/kfd` by design, was never gated by #1923's guard, and is a full no-op here — no relabel, no log.
- **Runtime scope (llama.cpp-backed slots only)**: `device = "gpu-vulkan"` is not exclusively an llama.cpp label — `capabilities/catalog.py` deliberately keeps it for the non-llama runtimes (Kokoro TTS, whisper.cpp/Moonshine STT, ComfyUI), which run genuinely-Vulkan images. Every candidate slot is resolved through `hal0.providers.container._spec_provider_for` — the same discriminator `load_sync` itself uses — and is skipped ENTIRELY (no relabel, no warning, no log, on either kfd axis) unless it resolves to `None` (the default llama-server GPU provider). The kfd-absent non-llama case (`require_kfd_for_gpu_slot` itself over-firing for non-llama runtimes) is a separate, already-filed bug tracked as #1941 and is deliberately NOT addressed here.
- **Narrow scope (#1867 rails)**: raw `tomllib` load / `write_toml_atomic` dump, same convention as the existing `retag_stale_slot_images` / `clear_stale_mtp_overrides` passes in this module. Only the `device` key's *value* is ever changed (top-level or nested under `[slot]`, matching the two TOML shapes those passes already handle); every other field, and every slot whose `device` is not literally `"gpu-vulkan"` or that isn't llama.cpp-backed, is left untouched. Note this is narrow-scope-by-key, not byte-for-byte file preservation — like every other pass in this module, a touched file's comments are dropped on rewrite (`write_toml_atomic` reserializes the whole parsed document via `tomli_w`).
- **Idempotency**: once a slot's `device` reads `"gpu-rocm"` or `"cpu"` it no longer matches the `"gpu-vulkan"` guard, so a second run touches nothing and emits no new log lines (covered by `test_relabel_is_idempotent`, `test_relabel_is_idempotent_on_cpu_fallback`, `test_idempotent_second_run_logs_nothing_new`).
- **Journal breadcrumb**: every mutation logs `slot`, `old` (`"gpu-vulkan"`), `new` (`"gpu-rocm"` or `"cpu"`), and `job_id`, via `structlog` `log.warning` — same shape as the other post-activation passes.
- Non-fatal in the aggregate sequence, like the other four data-cleanup passes: a failure here logs and does not block the other migrations or the caller's activation.

This should ship in the **same release as #1923** — otherwise any pre-#1923 install with `gpu-vulkan` LLM slots hits the new load-time refusal with no automatic recovery path.

## Test plan

- [x] `tests/updater/test_vulkan_slot_migration.py` (new file, 22 tests) — TDD throughout, including the runtime-scope fix (RED first against the pre-fix code, confirmed the non-llama tests failed, then implementation). Covers: kfd-present → gpu-rocm relabel (flat + nested `[slot]` shape), kfd-absent → cpu relabel with a loud distinct breadcrumb, AMD-host scoping (non-AMD host is a full no-op, real-probe default), runtime scoping (Kokoro/ComfyUI/transcription-shaped slots survive completely untouched on both kfd axes, alongside a genuine llama.cpp slot that still relabels), narrow scope (other keys/slots untouched), unreadable-TOML is skipped not fatal, idempotent re-run (both branches, including "logs nothing new"), and the default (no override) probes the real `kfd_present()`/`host_is_amd_gpu()`.
- [x] `tests/updater/test_post_activation_migrations.py` (4 existing tests edited, stub signature updated for `amd_host`) to stub and assert the new sixth pass runs in order, alongside the others, and is skipped when the schema migration fails first.
- [x] `installer/install.sh`'s post-activation-migrations transcript/log updated to name the vulkan-slot pass alongside the other four.
- [x] `env -u FORCE_COLOR HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/updater tests/install -q` → 538 passed
- [x] `uv run ruff format --check src tests` → all formatted
- [x] `make lint` → all checks passed
- [x] `python scripts/check_sunset.py` → scar markers at baseline

Refs #1924 #1888. Related: #1941 (tracks `require_kfd_for_gpu_slot` itself over-firing for non-llama Vulkan runtimes on a kfd-absent AMD host — out of scope for this migration).
