### PR TITLE
fix(updater): thread job_id, relay child breadcrumbs, drop dead cosign_skipped

### DIFF
--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -348,7 +348,7 @@ async def _run_apply_job(
     job["updated_at"] = time.time()
     _persist_job(job)
     try:
-        updater = Updater(channel=channel)
+        updater = Updater(channel=channel, job_id=job_id)
         await updater.apply(version)
     except Exception as exc:
         job["state"] = "failed"
@@ -406,7 +406,7 @@ async def _run_prepare_job(
     job["updated_at"] = time.time()
     _persist_job(job)
     try:
-        updater = Updater(channel=channel)
+        updater = Updater(channel=channel, job_id=job_id)
         result = await updater.prepare(version)
     except Exception as exc:
         job["state"] = "failed"
@@ -415,7 +415,6 @@ async def _run_prepare_job(
     else:
         job["resolved_version"] = result.get("version")
         job["notes"] = result.get("notes")
-        job["cosign_skipped"] = result.get("cosign_skipped")
         # Read-only gate snapshot for the one-shot profile-catalog reset.
         # commit() runs in this daemon, which has no TTY, so the CLI has to be
         # told *here* whether a prompt is owed and what it would destroy.
@@ -454,7 +453,7 @@ async def _run_commit_job(
     job["updated_at"] = time.time()
     _persist_job(job)
     try:
-        updater = Updater(channel=channel)
+        updater = Updater(channel=channel, job_id=job_id)
         result = await updater.commit(version, reset_profiles=reset_profiles)
     except Exception as exc:
         job["state"] = "failed"

--- a/src/hal0/updater/privileged.py
+++ b/src/hal0/updater/privileged.py
@@ -156,7 +156,13 @@ class UpdateSeam:
         ``-n`` is load-bearing: a missing or broken grant fails immediately with
         a non-zero exit instead of prompting for a password inside a daemon.
         The child's stderr (its structured log) is folded into the raised error
-        so a failure is diagnosable from the job result alone.
+        so a failure is diagnosable from the job result alone. On success the
+        same stderr is replayed into the parent's own log (see
+        :func:`_relay_child_log`) — the child's structlog output is captured,
+        not inherited, so without this replay every prepare/verify breadcrumb
+        (``sha256_ok``, ``cosign_verify_ok``, ``prepare_ok``, …) the root
+        helper emits is silently discarded on the happy path and never reaches
+        the journal (#1901).
         """
         try:
             proc = self._run(  # nosec B603 — fixed argv; every arg re-validated as root
@@ -185,6 +191,7 @@ class UpdateSeam:
                     "seam_bin": self._seam_bin,
                 },
             )
+        _relay_child_log(stderr, verb=parts[0], job_id=self._job_id)
         return _parse_result(proc.stdout or "", verb=parts[0], stderr=stderr)
 
     # ── preflight ──────────────────────────────────────────────────────────────
@@ -293,6 +300,26 @@ def _validate_dir_name(dir_name: str) -> str:
         return assert_release_dir_name(dir_name)
     except ValueError as exc:
         raise UpdateError(str(exc), details={"dir_name": dir_name}) from exc
+
+
+def _relay_child_log(stderr: str, *, verb: str, job_id: str | None) -> None:
+    """Replay the root helper's captured stderr into the parent's own log.
+
+    ``_pin_logs_to_stderr`` sends the child's structured log to its stderr so
+    stdout carries nothing but the result envelope (see :data:`_RESULT_KEY`).
+    ``subprocess.run(capture_output=True)`` captures that stderr rather than
+    letting it inherit the parent's fd, so on success it was going nowhere —
+    the child's ``sha256_ok`` / ``cosign_verify_ok`` / ``prepare_ok`` /
+    ``extract_ok`` breadcrumbs never reached the journal (#1901). Each
+    non-empty line is re-emitted as its own parent-side event, tagged with the
+    verb and this seam's ``job_id``, so a durable prepare/verify trail exists
+    on the happy path and not only inside a failure's error details.
+    """
+    for line in stderr.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        log.info("updater.privileged_child_log", verb=verb, job_id=job_id, line=line)
 
 
 def _parse_result(stdout: str, *, verb: str, stderr: str = "") -> dict[str, Any]:

--- a/src/hal0/updater/privileged.py
+++ b/src/hal0/updater/privileged.py
@@ -180,19 +180,27 @@ class UpdateSeam:
         except OSError as exc:
             raise _remediation(f"could not execute `sudo -n {self._seam_bin}`: {exc}") from exc
 
-        stderr = (proc.stderr or "")[-4000:]
+        full_stderr = proc.stderr or ""
         if proc.returncode != 0:
+            # Bounded tail only for the error path — a raised error's details
+            # are a diagnostic breadcrumb, not the audit trail this exists to
+            # protect, so truncation here is fine.
             raise UpdateError(
                 f"privileged update seam failed: {parts[0]} (rc={proc.returncode})",
                 details={
                     "verb": parts[0],
                     "returncode": proc.returncode,
-                    "stderr": stderr,
+                    "stderr": full_stderr[-4000:],
                     "seam_bin": self._seam_bin,
                 },
             )
-        _relay_child_log(stderr, verb=parts[0], job_id=self._job_id)
-        return _parse_result(proc.stdout or "", verb=parts[0], stderr=stderr)
+        # Relay the FULL stderr, not a truncated tail: a successful run can
+        # emit many post-verification cleanup lines (stale quarantine/staging
+        # reaping in `_extract_tarball`) after the sha256/cosign breadcrumbs,
+        # and a 4000-char tail can push those breadcrumbs out of the relayed
+        # data — silently reopening the very audit gap this replay closes.
+        _relay_child_log(full_stderr, verb=parts[0], job_id=self._job_id)
+        return _parse_result(proc.stdout or "", verb=parts[0], stderr=full_stderr[-4000:])
 
     # ── preflight ──────────────────────────────────────────────────────────────
 

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -883,7 +883,6 @@ def test_prepare_job_reaches_prepared_with_notes(
             "version": "0.0.1",
             "install_dir": "/tmp/hal0-0.0.1",
             "cache_dir": "/tmp/cache/0.0.1",
-            "cosign_skipped": True,
             "notes": {
                 "markdown": "# 0.0.1\n- did xyz",
                 "highlights": ["h"],
@@ -908,6 +907,104 @@ def test_prepare_job_reaches_prepared_with_notes(
     assert final.get("state") == "prepared", final
     assert final.get("resolved_version") == "0.0.1"
     assert final.get("notes")
+
+
+def test_prepare_job_never_reports_cosign_skipped(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``cosign_skipped`` is a removed dead field (#1901) — cosign verification
+    is always mandatory (see ``_verify_cosign``'s "no bypass" docstring), so a
+    job must never surface a stale/structurally-null key for it, even if a
+    caller's ``prepare()`` stub still returns one.
+    """
+    from hal0.api.routes import updater as u_mod
+
+    async def fake_prepare(self: object, version: str | None = None) -> dict:
+        return {
+            "version": "0.0.1",
+            "install_dir": "/tmp/hal0-0.0.1",
+            "cache_dir": "/tmp/cache/0.0.1",
+            "cosign_skipped": True,  # a stray value from an old caller shape
+            "notes": {"markdown": "# 0.0.1", "highlights": [], "breaking": [], "migrations": []},
+        }
+
+    monkeypatch.setattr(u_mod.Updater, "prepare", fake_prepare)
+
+    r = isolated_client.post("/api/updates/prepare", json={})
+    job_id = r.json()["id"]
+
+    deadline = time.monotonic() + 6.0
+    final: dict = {}
+    while time.monotonic() < deadline:
+        final = isolated_client.get(f"/api/updates/status/{job_id}").json()
+        if final["state"] in ("prepared", "failed"):
+            break
+        time.sleep(0.05)
+
+    assert final.get("state") == "prepared", final
+    assert "cosign_skipped" not in final
+
+
+@pytest.mark.parametrize(
+    ("route", "phase", "body"),
+    [
+        ("/api/updates/apply", "apply", {}),
+        ("/api/updates/prepare", "prepare", {}),
+        ("/api/updates/commit", "commit", {"version": "0.0.1"}),
+    ],
+)
+def test_job_runners_thread_job_id_into_updater(
+    route: str,
+    phase: str,
+    body: dict,
+    isolated_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """apply/prepare/commit must construct ``Updater`` with the job's own id.
+
+    Regression for #1901 gap 1: every job runner built ``Updater(channel=...)``
+    without the ``job_id`` the parameter exists to thread, so every
+    parent-side ``updater.*`` journal line logged ``job_id=None`` regardless
+    of which job produced it.
+    """
+    from hal0.api.routes import updater as u_mod
+
+    captured: list[str | None] = []
+    real_init = u_mod.Updater.__init__
+
+    def spy_init(self: object, channel: str = "stable", job_id: str | None = None) -> None:
+        captured.append(job_id)
+        real_init(self, channel=channel, job_id=job_id)
+
+    monkeypatch.setattr(u_mod.Updater, "__init__", spy_init)
+
+    async def fake_apply(self: object, version: str | None = None) -> dict:
+        return {"version": "0.0.1"}
+
+    async def fake_prepare(self: object, version: str | None = None) -> dict:
+        return {"version": "0.0.1", "notes": {}}
+
+    async def fake_commit(self: object, version: str, reset_profiles: bool | None = None) -> dict:
+        return {"version": "0.0.1"}
+
+    monkeypatch.setattr(u_mod.Updater, "apply", fake_apply)
+    monkeypatch.setattr(u_mod.Updater, "prepare", fake_prepare)
+    monkeypatch.setattr(u_mod.Updater, "commit", fake_commit)
+
+    r = isolated_client.post(route, json=body)
+    assert r.status_code == 202, r.text
+    job_id = r.json()["id"]
+
+    deadline = time.monotonic() + 6.0
+    final: dict = {}
+    while time.monotonic() < deadline:
+        final = isolated_client.get(f"/api/updates/status/{job_id}").json()
+        if final["state"] not in ("queued", "running"):
+            break
+        time.sleep(0.05)
+
+    assert final.get("state") != "failed", final
+    assert job_id in captured, (job_id, captured)
 
 
 def test_commit_route_requires_version(isolated_client: TestClient) -> None:

--- a/tests/updater/test_privileged_seam.py
+++ b/tests/updater/test_privileged_seam.py
@@ -210,6 +210,43 @@ def test_successful_stage_relays_the_childs_breadcrumbs_into_the_journal() -> No
     assert any("prepare_ok" in e["line"] for e in relayed)
 
 
+def test_successful_stage_relay_survives_a_long_cleanup_tail() -> None:
+    """Codex review on #1901: ``_invoke`` used to truncate stderr to its last
+    4000 chars BEFORE deciding what to relay. A successful extraction can log
+    one cleanup line per stale quarantine/staging directory (see
+    ``_reap_stale_quarantines`` / ``_reap_stale_staging_dirs``) AFTER the
+    sha256/cosign breadcrumbs, so a long enough cleanup tail pushed those
+    breadcrumbs out of the relayed data — reopening the exact audit gap this
+    fix exists to close. The relay must see the full, untruncated stderr.
+    """
+    from structlog.testing import capture_logs
+
+    breadcrumbs = (
+        "2026-08-17T00:00:00Z [info] updater.sha256_ok job_id=None digest=abc123\n"
+        "2026-08-17T00:00:01Z [info] updater.cosign_verify_ok job_id=None\n"
+    )
+    # Pad well past the old 4000-char truncation window with cleanup noise.
+    cleanup_tail = "".join(
+        f"2026-08-17T00:00:{i:02d}Z [info] updater.quarantine_reaped path=/x/{i}\n"
+        for i in range(2, 400)
+    )
+    child_stderr = breadcrumbs + cleanup_tail
+    assert len(child_stderr) > 4000
+
+    run = FakeRun(stdout=_envelope({"version": "1.0.0"}), stderr=child_stderr)
+    seam = UpdateSeam(run=run, is_hal0_user=lambda: True, job_id="job-abc123")
+
+    import asyncio
+
+    with capture_logs() as logs:
+        result = asyncio.run(seam.stage("stable", "1.0.0"))
+
+    assert result["version"] == "1.0.0"
+    relayed = [e for e in logs if e.get("event") == "updater.privileged_child_log"]
+    assert any("sha256_ok" in e["line"] for e in relayed)
+    assert any("cosign_verify_ok" in e["line"] for e in relayed)
+
+
 def test_failed_stage_does_not_double_relay_stderr_as_breadcrumbs() -> None:
     """A failure already folds stderr into the raised error's details — it
     must not ALSO be replayed as a separate breadcrumb log (that would be a

--- a/tests/updater/test_privileged_seam.py
+++ b/tests/updater/test_privileged_seam.py
@@ -178,6 +178,53 @@ def test_seam_surfaces_the_root_helpers_stderr_on_failure() -> None:
     assert "cosign verify-blob failed" in exc.value.details["stderr"]
 
 
+def test_successful_stage_relays_the_childs_breadcrumbs_into_the_journal() -> None:
+    """#1901 gap 2: on success the root helper's stderr (its structured log)
+    was captured by ``subprocess.run`` and silently discarded — no
+    ``sha256_ok`` / ``cosign_verify_ok`` / ``prepare_ok`` breadcrumb ever
+    reached the parent's journal. Each captured line must now be replayed
+    into the parent's own log, tagged with the seam's job_id.
+    """
+    from structlog.testing import capture_logs
+
+    child_stderr = (
+        "2026-08-17T00:00:00Z [info] updater.sha256_ok job_id=None digest=abc123\n"
+        "2026-08-17T00:00:01Z [info] updater.cosign_verify_ok job_id=None\n"
+        "2026-08-17T00:00:02Z [info] updater.prepare_ok job_id=None version=1.0.0\n"
+    )
+    run = FakeRun(stdout=_envelope({"version": "1.0.0"}), stderr=child_stderr)
+    seam = UpdateSeam(run=run, is_hal0_user=lambda: True, job_id="job-abc123")
+
+    import asyncio
+
+    with capture_logs() as logs:
+        result = asyncio.run(seam.stage("stable", "1.0.0"))
+
+    assert result["version"] == "1.0.0"
+    relayed = [e for e in logs if e.get("event") == "updater.privileged_child_log"]
+    assert len(relayed) == 3
+    assert all(e["job_id"] == "job-abc123" for e in relayed)
+    assert all(e["verb"] == "stage" for e in relayed)
+    assert any("sha256_ok" in e["line"] for e in relayed)
+    assert any("cosign_verify_ok" in e["line"] for e in relayed)
+    assert any("prepare_ok" in e["line"] for e in relayed)
+
+
+def test_failed_stage_does_not_double_relay_stderr_as_breadcrumbs() -> None:
+    """A failure already folds stderr into the raised error's details — it
+    must not ALSO be replayed as a separate breadcrumb log (that would be a
+    second, redundant recording of the same failure content)."""
+    from structlog.testing import capture_logs
+
+    run = FakeRun(returncode=1, stderr="hal0-update: cosign verify-blob failed")
+    seam = UpdateSeam(run=run, is_hal0_user=lambda: True, job_id="job-abc123")
+
+    with capture_logs() as logs, pytest.raises(UpdateError):
+        seam.discard("hal0-1.0.0")
+
+    assert not [e for e in logs if e.get("event") == "updater.privileged_child_log"]
+
+
 # ── preflight: fail fast, with remediation, before any download ────────────────
 
 


### PR DESCRIPTION
## ⚠️ SELF-UPDATE PATH — operator review required, no automerge

Refs #1901

## Summary

Fixes the three observability gaps named in #1901 (found by `rc-validate` v1.0.0-rc.6, `update-audit-trail-gaps`). Verification logic itself is untouched — this is journal/logging only.

1. **`job_id=None` on every `updater.*` journal line.** The three background job runners (`_run_apply_job`, `_run_prepare_job`, `_run_commit_job`) constructed `Updater(channel=channel)` without the `job_id` the constructor already accepts and threads through to every log call. Now: `Updater(channel=channel, job_id=job_id)`.
2. **No prepare/verify breadcrumb reaches the journal on success.** The routed `hal0-update stage`/`activate`/`discard` child pins its structured log to stderr so stdout carries only the result envelope. `UpdateSeam._invoke` only folded that stderr into the raised error on *failure* — on success it was captured by `subprocess.run` and silently discarded, so `sha256_ok`/`cosign_verify_ok`/`prepare_ok`/etc. never reached the journal on a successful run. Added `_relay_child_log`, which replays each captured stderr line into the parent's own structured log (tagged with `verb` + `job_id`) once `_invoke` sees a zero return code.
3. **`cosign_skipped` is a dead job field.** `stage_release()` never emits it, and cosign verification has no bypass (`_verify_cosign`'s own docstring: "Verification is always mandatory — there is no bypass"), so the field always read `null`. Removed the producer-less consumer rather than inventing a fake producer.

## Explicitly out of scope (hard fences from the wave planner)

- `version:null` on a prepare job — that's the operator's pin, paired with `resolved_version`. Not touched.
- Absence of digest fields on the job record while the cached manifest exists. Not touched.
- Sha256 / cosign verification logic. Not touched — read-only investigation confirmed the cached manifest is written only after both checks pass (`stage_release`, steps 3–6 then cache write), consistent with the issue's own note. No new finding to escalate.

## Test plan

- [x] `make lint`
- [x] `uv run ruff format --check src tests`
- [x] `env -u FORCE_COLOR HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/updater tests/api/test_updater_routes.py -q` — 328 passed
- New/updated tests:
  - `test_job_runners_thread_job_id_into_updater` (parametrized apply/prepare/commit) — regression for gap 1
  - `test_successful_stage_relays_the_childs_breadcrumbs_into_the_journal` + `test_failed_stage_does_not_double_relay_stderr_as_breadcrumbs` — regression for gap 2
  - `test_prepare_job_never_reports_cosign_skipped` — regression for gap 3