### PR TITLE
fix(api): route slot image reads through the rootful podman seam

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1735,11 +1735,14 @@ PYEOF
         fi
     fi
 
-    # Privileged seam #5 (O12): hal0-podman-ro covers READ-ONLY podman
-    # introspection (image presence today) against ROOT's podman store — the
-    # store slots actually populate via Quadlet, NOT hal0-api's own rootless
-    # store. Narrow + hardcoded (no shell, no wildcards, no operator-supplied
-    # podman flags) — see the wrapper source.
+    # Privileged seam #5 (O12, extended in #1889): hal0-podman-ro covers
+    # READ-ONLY podman introspection — the local repo set, per-image presence,
+    # and a running slot container's image + argv — against ROOT's podman
+    # store, the store slots actually populate via Quadlet, NOT hal0-api's own
+    # rootless store. Narrow + hardcoded (no shell, no wildcards, no
+    # operator-supplied podman flags or --format); the three verbs that take
+    # an argument validate it root-side against a closed regex before exec.
+    # See the wrapper source for the full argument doctrine.
     PODMAN_RO_SRC="${REPO_ROOT}/installer/wrappers/hal0-podman-ro"
     if [[ -f "${PODMAN_RO_SRC}" ]]; then
         install -d "${LIB_DIR}/bin"

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1339,6 +1339,10 @@ _hal0_seam_probe() {
     case "$1" in
         hal0-systemctl) printf 'help\n' ;;
         hal0-update)    printf 'check\n' ;;
+        # #1889: podman-ro is now the only source of truth for a running
+        # slot's image_status/actual_image, so a silently-missing grant stops
+        # being cosmetic. `help` prints usage and touches nothing.
+        hal0-podman-ro) printf 'help\n' ;;
         *)              return 1 ;;
     esac
 }

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1341,8 +1341,12 @@ _hal0_seam_probe() {
         hal0-update)    printf 'check\n' ;;
         # #1889: podman-ro is now the only source of truth for a running
         # slot's image_status/actual_image, so a silently-missing grant stops
-        # being cosmetic. `help` prints usage and touches nothing.
-        hal0-podman-ro) printf 'help\n' ;;
+        # being cosmetic. NOT `help` — the pre-#1889 wrapper implements that
+        # too, so a failed wrapper refresh would probe green while every new
+        # verb was rejected. `check-slot-token` is release-specific and
+        # side-effect-free (validates, prints the name it would build, never
+        # calls podman). Keep in lock-step with src/hal0/system/seam_check.py.
+        hal0-podman-ro) printf 'check-slot-token hal0probe\n' ;;
         *)              return 1 ;;
     esac
 }
@@ -1382,11 +1386,17 @@ _preflight_seam() {
 
     local probe
     if probe="$(_hal0_seam_probe "${name}")" && (( rc == 0 )); then
+        # Probes are hardcoded above, never caller input, so splitting the
+        # line into argv words is safe — and #1889 needs a probe that takes an
+        # argument (a verb-only probe cannot tell a stale wrapper from a
+        # current one).
+        local -a probe_argv=()
+        read -r -a probe_argv <<< "${probe}"
         # The grant is written for the hal0 user, so the only honest test runs
         # AS that user. -n keeps it non-interactive: a missing grant fails
         # immediately instead of prompting.
-        if ! sudo -n -u hal0 sudo -n "${bin}" "${probe}" >/dev/null 2>&1; then
-            "${report}" "seam ${name}: 'sudo -n ${name} ${probe}' failed as the hal0 user — the ${grant} grant does not apply"
+        if ! sudo -n -u hal0 sudo -n "${bin}" "${probe_argv[@]}" >/dev/null 2>&1; then
+            "${report}" "seam ${name}: 'sudo -n ${name} ${probe}' failed as the hal0 user — the ${grant} grant does not apply, or the wrapper is stale"
             rc=1
         fi
     fi

--- a/installer/wrappers/hal0-podman-ro
+++ b/installer/wrappers/hal0-podman-ro
@@ -49,12 +49,23 @@
 # answer is negative" from "the seam itself is unusable", because the caller
 # must fall back to its rootless read only in the second case:
 #
-#   * rc 0   — podman ran. `image-exists` printed `present` or `missing`;
-#              `container-image` / `container-argv` printed the value, or
-#              nothing at all when no such container is running. An empty
-#              stdout on rc 0 is a real answer, not an error.
+#   * rc 0   — podman ran and gave a DEFINITIVE answer. `image-exists`
+#              printed `present` or `missing`; `container-image` /
+#              `container-argv` printed the value, or nothing at all when no
+#              such container exists. An empty stdout on rc 0 is a real
+#              answer, not an error.
 #   * rc 64  — this wrapper rejected the argument (validation) or the verb.
 #   * rc 65  — podman is not installed / not executable here.
+#   * rc 66  — podman ran but FAILED operationally (store corruption, lock
+#              contention, permission error, …). NOT a negative answer.
+#
+# rc 66 exists because conflating an operational podman failure with "the
+# image is absent" reproduces #1889 with extra steps: the API would report a
+# locally present image as missing and the caller would never know to
+# degrade. That is why the presence probes below use `podman image exists` /
+# `podman container exists`, whose contract is exactly rc 0 = yes, rc 1 = no,
+# anything else = error — `podman inspect` collapses "not found" and every
+# other failure into a single rc 125 and cannot make this distinction.
 #
 # A caller that gets rc 0 must trust stdout; anything else means "seam did
 # not answer" (including sudo's own rc 1 when the grant is missing).
@@ -88,8 +99,15 @@ SLOT_TOKEN_RE='^[A-Za-z0-9_-]{1,64}$'
 # would only convert a podman error into a wrapper rejection while risking a
 # false reject on a legitimate ref; a false reject is precisely the failure
 # mode #1889 is about (it degrades to image_status="missing" again).
-_REF_HOST='[A-Za-z0-9]+([.-][A-Za-z0-9]+)*(:[0-9]{1,5})?'
-_REF_PATH='[A-Za-z0-9]+([._-][A-Za-z0-9]+)*(/[A-Za-z0-9]+([._-][A-Za-z0-9]+)*)*'
+# The separator set is the distribution-reference grammar's, verbatim:
+#   separator := "." | "_" | "__" | "-"+
+# Getting this wrong is not a hardening nit — a legitimate ref that this
+# rejects never reaches the rootful store, so the caller degrades to the
+# rootless one and #1889 comes straight back for that image. `model__gpu` and
+# `model--gpu` are both legal repository names.
+_REF_SEP='(__|[._]|-+)'
+_REF_HOST="[A-Za-z0-9]+(([.]|-+)[A-Za-z0-9]+)*(:[0-9]{1,5})?"
+_REF_PATH="[A-Za-z0-9]+(${_REF_SEP}[A-Za-z0-9]+)*(/[A-Za-z0-9]+(${_REF_SEP}[A-Za-z0-9]+)*)*"
 _REF_TAG='(:[A-Za-z0-9_][A-Za-z0-9._-]{0,127})?'
 _REF_DIGEST='(@sha256:[0-9a-f]{64})?'
 IMAGE_REF_RE="^(${_REF_HOST}/)?${_REF_PATH}${_REF_TAG}${_REF_DIGEST}\$"
@@ -113,6 +131,10 @@ require_podman() {
   [[ -x "$PODMAN" ]] || { echo "hal0-podman-ro: podman not found at $PODMAN" >&2; exit 65; }
 }
 
+# An operational podman failure — distinct from a negative answer. See the
+# exit-code contract in the header.
+podman_failed() { echo "hal0-podman-ro: $1 (rc=$2)" >&2; exit 66; }
+
 # Run podman read-only, tolerating a non-zero rc (a missing image/container is
 # a legitimate NEGATIVE answer, not a seam failure). Sets PODMAN_RC/PODMAN_OUT.
 # stderr is dropped: podman emits benign device warnings under LXC.
@@ -120,6 +142,25 @@ run_podman() {
   PODMAN_OUT=""
   PODMAN_RC=0
   PODMAN_OUT="$("$PODMAN" "$@" 2>/dev/null)" || PODMAN_RC=$?
+}
+
+# Read one LITERAL --format field off a hal0 slot container.
+#   $1 = the format string (a literal from the case arm below, never caller
+#        input); $2 = the container name, already assembled from a validated
+#        token on this side of the boundary.
+# Prints the value and exits 0; prints nothing and exits 0 when the container
+# does not exist; exits 66 when podman itself failed.
+container_read() {
+  local fmt="$1" name="$2"
+  run_podman container exists -- "$name"
+  case "$PODMAN_RC" in
+    0) ;;
+    1) return 0 ;;   # no such container — a real negative answer
+    *) podman_failed "podman container exists failed" "$PODMAN_RC" ;;
+  esac
+  run_podman inspect --format "$fmt" -- "$name"
+  (( PODMAN_RC == 0 )) || podman_failed "podman inspect failed" "$PODMAN_RC"
+  printf '%s\n' "$PODMAN_OUT"
 }
 
 cmd="${1:-help}"; shift || true
@@ -133,11 +174,16 @@ case "$cmd" in
     [[ $# -eq 1 ]] || die "image-exists takes exactly one argument"
     validate_image_ref "$1"
     require_podman
-    # --format {{.Id}} is a LITERAL here: it keeps the inspect output to one
-    # short line instead of the full JSON manifest, and the value is
-    # discarded — only podman's rc decides presence.
-    run_podman image inspect --format '{{.Id}}' -- "$1"
-    if (( PODMAN_RC == 0 )); then echo present; else echo missing; fi
+    # `image exists` — NOT `image inspect`. Its contract is rc 0 = present,
+    # rc 1 = absent, anything else = operational failure, which is the only
+    # way to keep "podman is broken" from being reported as "the image is
+    # missing". `inspect` returns 125 for both.
+    run_podman image exists -- "$1"
+    case "$PODMAN_RC" in
+      0) echo present ;;
+      1) echo missing ;;
+      *) podman_failed "podman image exists failed" "$PODMAN_RC" ;;
+    esac
     ;;
 
   container-image)         # arg: slot token -> prints the running image ref
@@ -146,18 +192,19 @@ case "$cmd" in
     require_podman
     # #663 backend-of-record: the running container's image IS the backend.
     # The container NAME is built here from the validated token.
-    run_podman inspect --format '{{.ImageName}}' -- "hal0-slot-$1"
-    # A `(( … )) && printf` one-liner would make the "no such container" case
-    # exit non-zero under `set -e`, which the caller reads as "seam unusable".
-    if (( PODMAN_RC == 0 )); then printf '%s\n' "$PODMAN_OUT"; fi
+    #
+    # Two podman calls in ONE sudo hop: `container exists` first, because it
+    # is the only call that can say "absent" without also meaning "podman
+    # broke", then the inspect whose failure is therefore unambiguously
+    # operational.
+    container_read '{{.ImageName}}' "hal0-slot-$1"
     ;;
 
   container-argv)          # arg: slot token -> prints the live command argv
     [[ $# -eq 1 ]] || die "container-argv takes exactly one argument"
     validate_slot_token "$1"
     require_podman
-    run_podman inspect --format '{{json .Config.Cmd}}' -- "hal0-slot-$1"
-    if (( PODMAN_RC == 0 )); then printf '%s\n' "$PODMAN_OUT"; fi
+    container_read '{{json .Config.Cmd}}' "hal0-slot-$1"
     ;;
 
   check-image-ref)         # arg: image ref — side-effect-free validator probe

--- a/installer/wrappers/hal0-podman-ro
+++ b/installer/wrappers/hal0-podman-ro
@@ -106,7 +106,13 @@ SLOT_TOKEN_RE='^[A-Za-z0-9_-]{1,64}$'
 # rootless one and #1889 comes straight back for that image. `model__gpu` and
 # `model--gpu` are both legal repository names.
 _REF_SEP='(__|[._]|-+)'
-_REF_HOST="[A-Za-z0-9]+(([.]|-+)[A-Za-z0-9]+)*(:[0-9]{1,5})?"
+# A registry host is a dotted/dashed name OR a bracketed IPv6 literal
+# ([2001:db8::1]:5000/...), which the reference grammar permits and which a
+# rejection here would silently turn back into image_status="missing". The
+# bracket body is hex-and-colons only, so it still cannot carry a path,
+# whitespace, a metacharacter or a second word.
+_REF_IPV6='\[[0-9A-Fa-f:]{2,45}\]'
+_REF_HOST="([A-Za-z0-9]+(([.]|-+)[A-Za-z0-9]+)*|${_REF_IPV6})(:[0-9]{1,5})?"
 _REF_PATH="[A-Za-z0-9]+(${_REF_SEP}[A-Za-z0-9]+)*(/[A-Za-z0-9]+(${_REF_SEP}[A-Za-z0-9]+)*)*"
 _REF_TAG='(:[A-Za-z0-9_][A-Za-z0-9._-]{0,127})?'
 _REF_DIGEST='(@sha256:[0-9a-f]{64})?'

--- a/installer/wrappers/hal0-podman-ro
+++ b/installer/wrappers/hal0-podman-ro
@@ -8,19 +8,119 @@
 # store than the one slots actually populate: backends report "installable"
 # even when the image is present, in root's store (halo143/halo150).
 #
-# This script is the ENTIRE privileged surface, modeled exactly on
-# hal0-agentenv / hal0-benchctl / hal0-systemctl: every verb is a single
-# HARDCODED podman invocation (no operator-supplied flags ever reach podman's
-# argv), no shell is ever evaluated, no wildcards. Only read-only
-# introspection is exposed — rm/run/build/exec are never wired in. Add a new
-# verb here (never widen an existing one with caller-supplied args) the day a
-# call site needs one; see src/hal0/providers/podman_introspect.py.
+# ARGUMENT DOCTRINE (#1889). Until #1889 this script accepted exactly one
+# verb (`images`) with zero caller-supplied argv, and the header said no
+# caller args may ever reach podman. That doctrine bought its safety by
+# leaving the #663 image-drift detector permanently inert: `image_present`
+# and `running_image` need a *specific* image ref / container name, so they
+# stayed on a bare rootless `podman` call and answered from the wrong store —
+# `image_status` was "missing" for every running slot and `actual_image` was
+# always null.
+#
+# The doctrine is therefore refined, not abandoned, and lands exactly where
+# hal0-systemctl's slot/agent verbs already put it: a caller-supplied value
+# may reach podman's argv ONLY as a single positional operand that has been
+# validated on the ROOT side of the boundary against a closed regex, and only
+# for a verb whose podman subcommand, flags and --format string are literals
+# written here. Specifically:
+#
+#   * every podman invocation is still a hardcoded exec array — no shell, no
+#     eval, no word splitting, no wildcards, no operator-supplied flags;
+#   * `image-exists` takes an image REFERENCE, matched against the OCI ref
+#     grammar (optional host[:port]/, path segments with single ._-
+#     separators, optional :tag, optional @sha256:<64 hex>) and length-capped.
+#     A validated ref cannot contain whitespace, a shell metacharacter, a
+#     leading '-' (so it can never be read as a flag), '..', or a second argv
+#     word;
+#   * `container-image` / `container-argv` DO NOT take a container name at
+#     all. They take the slot's bare INSTANCE TOKEN, validated with the same
+#     charset hal0-systemctl's validate_slot_id uses, and the container name
+#     `hal0-slot-<token>` is assembled HERE, on the root side. The caller can
+#     therefore only ever name a hal0 slot container — never an arbitrary
+#     container, and never a podman option.
+#
+# Still read-only: rm/run/build/exec/pull are never wired in. Add a new verb
+# here (never widen an existing one with an unvalidated arg, and never accept
+# a caller-supplied --format) the day a call site needs one; see
+# src/hal0/providers/podman_introspect.py, which mirrors every regex below so
+# the unprivileged side fails fast instead of burning a sudo round-trip.
+#
+# EXIT-CODE CONTRACT. The read verbs distinguish "podman answered, and the
+# answer is negative" from "the seam itself is unusable", because the caller
+# must fall back to its rootless read only in the second case:
+#
+#   * rc 0   — podman ran. `image-exists` printed `present` or `missing`;
+#              `container-image` / `container-argv` printed the value, or
+#              nothing at all when no such container is running. An empty
+#              stdout on rc 0 is a real answer, not an error.
+#   * rc 64  — this wrapper rejected the argument (validation) or the verb.
+#   * rc 65  — podman is not installed / not executable here.
+#
+# A caller that gets rc 0 must trust stdout; anything else means "seam did
+# not answer" (including sudo's own rc 1 when the grant is missing).
 
 set -euo pipefail
 
 PODMAN=/usr/bin/podman
 
 die() { echo "hal0-podman-ro: $1" >&2; exit 64; }
+
+# ── argument validators (root side of the privilege boundary) ──────────────
+#
+# Both are closed allow-lists: they say what IS accepted and reject
+# everything else, rather than trying to enumerate dangerous characters.
+
+# The slot instance token — the "<token>" in hal0-slot@<token>.service and in
+# the container name hal0-slot-<token> (see src/hal0/slots/naming.py).
+# Deliberately byte-identical to hal0-systemctl's validate_slot_id: a bounded
+# identifier charset with NO '.', '/', ':', '@' or whitespace, so a validated
+# token can never carry a path traversal, a second argv word, or an
+# option-looking token ('-x' is a legal token but is only ever concatenated
+# into hal0-slot-<token>, never passed as a bare argv word).
+SLOT_TOKEN_RE='^[A-Za-z0-9_-]{1,64}$'
+
+# An OCI image reference: [host[:port]/]path[/path...][:tag][@sha256:<hex>].
+#
+# Structure-strict, case-permissive. The security properties come from the
+# STRUCTURE — no whitespace, no shell metacharacter, no leading '-', no '..',
+# no second word, bounded length — none of which depend on letter case.
+# Podman itself rejects uppercase repository names, so folding case in here
+# would only convert a podman error into a wrapper rejection while risking a
+# false reject on a legitimate ref; a false reject is precisely the failure
+# mode #1889 is about (it degrades to image_status="missing" again).
+_REF_HOST='[A-Za-z0-9]+([.-][A-Za-z0-9]+)*(:[0-9]{1,5})?'
+_REF_PATH='[A-Za-z0-9]+([._-][A-Za-z0-9]+)*(/[A-Za-z0-9]+([._-][A-Za-z0-9]+)*)*'
+_REF_TAG='(:[A-Za-z0-9_][A-Za-z0-9._-]{0,127})?'
+_REF_DIGEST='(@sha256:[0-9a-f]{64})?'
+IMAGE_REF_RE="^(${_REF_HOST}/)?${_REF_PATH}${_REF_TAG}${_REF_DIGEST}\$"
+
+validate_slot_token() {  # arg: slot instance token
+  local token="${1-}"
+  [[ -n "$token" ]] || die "missing slot token"
+  [[ "$token" =~ $SLOT_TOKEN_RE ]] || die "bad slot token: $token"
+}
+
+validate_image_ref() {   # arg: image reference
+  local ref="${1-}"
+  [[ -n "$ref" ]] || die "missing image ref"
+  # Length cap first: a pathological input should never be handed to the
+  # regex engine, and no real ref approaches this.
+  (( ${#ref} <= 512 )) || die "image ref too long (${#ref} > 512)"
+  [[ "$ref" =~ $IMAGE_REF_RE ]] || die "bad image ref: $ref"
+}
+
+require_podman() {
+  [[ -x "$PODMAN" ]] || { echo "hal0-podman-ro: podman not found at $PODMAN" >&2; exit 65; }
+}
+
+# Run podman read-only, tolerating a non-zero rc (a missing image/container is
+# a legitimate NEGATIVE answer, not a seam failure). Sets PODMAN_RC/PODMAN_OUT.
+# stderr is dropped: podman emits benign device warnings under LXC.
+run_podman() {
+  PODMAN_OUT=""
+  PODMAN_RC=0
+  PODMAN_OUT="$("$PODMAN" "$@" 2>/dev/null)" || PODMAN_RC=$?
+}
 
 cmd="${1:-help}"; shift || true
 
@@ -29,10 +129,61 @@ case "$cmd" in
     exec "$PODMAN" images --format '{{.Repository}}'
     ;;
 
+  image-exists)            # arg: image ref -> prints "present" | "missing"
+    [[ $# -eq 1 ]] || die "image-exists takes exactly one argument"
+    validate_image_ref "$1"
+    require_podman
+    # --format {{.Id}} is a LITERAL here: it keeps the inspect output to one
+    # short line instead of the full JSON manifest, and the value is
+    # discarded — only podman's rc decides presence.
+    run_podman image inspect --format '{{.Id}}' -- "$1"
+    if (( PODMAN_RC == 0 )); then echo present; else echo missing; fi
+    ;;
+
+  container-image)         # arg: slot token -> prints the running image ref
+    [[ $# -eq 1 ]] || die "container-image takes exactly one argument"
+    validate_slot_token "$1"
+    require_podman
+    # #663 backend-of-record: the running container's image IS the backend.
+    # The container NAME is built here from the validated token.
+    run_podman inspect --format '{{.ImageName}}' -- "hal0-slot-$1"
+    # A `(( … )) && printf` one-liner would make the "no such container" case
+    # exit non-zero under `set -e`, which the caller reads as "seam unusable".
+    if (( PODMAN_RC == 0 )); then printf '%s\n' "$PODMAN_OUT"; fi
+    ;;
+
+  container-argv)          # arg: slot token -> prints the live command argv
+    [[ $# -eq 1 ]] || die "container-argv takes exactly one argument"
+    validate_slot_token "$1"
+    require_podman
+    run_podman inspect --format '{{json .Config.Cmd}}' -- "hal0-slot-$1"
+    if (( PODMAN_RC == 0 )); then printf '%s\n' "$PODMAN_OUT"; fi
+    ;;
+
+  check-image-ref)         # arg: image ref — side-effect-free validator probe
+    # Exists so the validation regexes can be exercised by the test suite (and
+    # by an operator debugging a rejection) without podman, without root and
+    # without a provisioned box. Never touches podman.
+    [[ $# -eq 1 ]] || die "check-image-ref takes exactly one argument"
+    validate_image_ref "$1"
+    printf '%s\n' "$1"
+    ;;
+
+  check-slot-token)        # arg: slot token — side-effect-free validator probe
+    [[ $# -eq 1 ]] || die "check-slot-token takes exactly one argument"
+    validate_slot_token "$1"
+    printf 'hal0-slot-%s\n' "$1"
+    ;;
+
   help|"")
     cat <<EOF
-usage: hal0-podman-ro <command>
-  images    podman images --format {{.Repository}}   (root's image store)
+usage: hal0-podman-ro <command> [arg]
+  images                     podman images --format {{.Repository}}   (root's image store)
+  image-exists <ref>         "present" | "missing" for a validated image ref
+  container-image <token>    running image of hal0-slot-<token>, or nothing
+  container-argv <token>     live command argv of hal0-slot-<token>, or nothing
+  check-image-ref <ref>      validate an image ref only (no podman call)
+  check-slot-token <token>   validate a slot token only (no podman call)
 EOF
     ;;
 

--- a/installer/wrappers/hal0-podman-ro
+++ b/installer/wrappers/hal0-podman-ro
@@ -72,6 +72,17 @@
 
 set -euo pipefail
 
+# LOCALE PIN — load-bearing for the validators below, not a tidiness nit.
+# bash's `[[ =~ ]]` bracket expressions use the CURRENT locale's collation, so
+# under a UTF-8 locale `[A-Za-z0-9]` matches accented letters: `alpiné` was
+# accepted here while the Python mirror rejected it — the wrapper LOOSER than
+# its mirror, the dangerous direction. This is reachable in production because
+# sudo's default `env_keep` passes LANG/LC_* straight through from the calling
+# process. Pinning to C makes every character class below mean exactly the
+# ASCII bytes it spells, in any caller's environment. Set before any validator
+# can run. (Security review of #1889, finding 1.)
+export LC_ALL=C
+
 PODMAN=/usr/bin/podman
 
 die() { echo "hal0-podman-ro: $1" >&2; exit 64; }
@@ -164,8 +175,12 @@ container_read() {
     1) return 0 ;;   # no such container — a real negative answer
     *) podman_failed "podman container exists failed" "$PODMAN_RC" ;;
   esac
-  run_podman inspect --format "$fmt" -- "$name"
-  (( PODMAN_RC == 0 )) || podman_failed "podman inspect failed" "$PODMAN_RC"
+  # `container inspect`, not bare `inspect`: the bare form also resolves
+  # images, volumes, networks and pods, so a name collision could return a
+  # different object's fields entirely. Type-safety by construction, even
+  # though the name is already pinned to the hal0-slot- prefix here.
+  run_podman container inspect --format "$fmt" -- "$name"
+  (( PODMAN_RC == 0 )) || podman_failed "podman container inspect failed" "$PODMAN_RC"
   printf '%s\n' "$PODMAN_OUT"
 }
 

--- a/packaging/sudoers/hal0-podman-ro
+++ b/packaging/sudoers/hal0-podman-ro
@@ -4,10 +4,17 @@
 # root's image store). hal0-api runs as the unprivileged `hal0` system user,
 # so its own podman calls hit hal0's ROOTLESS store — a different store from
 # the one slots actually populate, producing false "installable" backend
-# states (halo143/halo150). It delegates exactly the read-only introspection
-# ops to /usr/lib/hal0/bin/hal0-podman-ro, which is the entire privileged
-# surface: today just `images`, each a single hardcoded podman invocation —
-# no operator-supplied argv, no shell. rm/run/build/exec are never exposed.
+# states (halo143/halo150) and — until #1889 — an `image_status` of "missing"
+# for every running, healthy slot. It delegates exactly the read-only
+# introspection ops to /usr/lib/hal0/bin/hal0-podman-ro, which is the entire
+# privileged surface: `images`, `image-exists <ref>`, `container-image
+# <slot-token>`, `container-argv <slot-token>` plus two side-effect-free
+# validator probes. Every podman subcommand, flag and --format string is a
+# literal in the wrapper; no shell is ever evaluated. The three verbs that
+# take an argument accept exactly ONE positional operand, validated ROOT-side
+# against a closed regex before exec (#1889) — the container verbs take the
+# bare slot token and build `hal0-slot-<token>` themselves, so the caller can
+# never name a non-hal0 container. rm/run/build/exec/pull are never exposed.
 #
 # Install (as root):
 #   install -m 0755 -o root -g root hal0-podman-ro /usr/lib/hal0/bin/hal0-podman-ro
@@ -15,6 +22,13 @@
 #   visudo -cf /etc/sudoers.d/hal0-podman-ro
 #
 # Keep this grant pinned to the helper binary; a broader grant would let the
-# API run arbitrary root commands. Revoke with: rm /etc/sudoers.d/hal0-podman-ro
+# API run arbitrary root commands. Note the grant deliberately does NOT
+# enumerate argv (a bare command path in sudoers permits any arguments): the
+# wrapper itself is the control surface, exactly as for hal0-systemctl, whose
+# slot/agent verbs have taken a validated id since P3-perms. Constraining argv
+# in sudoers instead would be a second, silently-drifting copy of the verb
+# list, and sudoers wildcards are a well-known footgun. Every new verb is
+# gated by a ROOT-side validator in the wrapper (#1889).
+# Revoke with: rm /etc/sudoers.d/hal0-podman-ro
 
 hal0 ALL=(root) NOPASSWD: /usr/lib/hal0/bin/hal0-podman-ro

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -3040,10 +3040,14 @@ def _image_mismatch(running_image: str | None, declared_image: str | None) -> bo
     shorthand a profile declares compares equal to the fully-qualified name
     podman reports — see that function for why #1889 makes this load-bearing.
 
-    Digest-pinned vs tag-pinned is compared on the REPOSITORY alone: deciding
-    whether ``ghcr.io/x/y:v2`` and ``ghcr.io/x/y@sha256:…`` are the same image
-    needs a registry round-trip this hot path will never make, and guessing
-    "drifted" there is the same cry-wolf failure the docstring above forbids.
+    Digests decide identity whenever both sides carry one: a digest IS the
+    immutable image id, so ``ghcr.io/x/y:v1@sha256:D`` and
+    ``ghcr.io/x/y@sha256:D`` are the same image and the tag text is noise.
+    When only ONE side is digest-pinned the comparison falls back to the
+    REPOSITORY alone — deciding whether ``ghcr.io/x/y:v2`` and
+    ``ghcr.io/x/y@sha256:…`` match needs a registry round-trip this hot path
+    will never make, and guessing "drifted" there is the same cry-wolf
+    failure the docstring above forbids.
     """
     if not running_image or not declared_image:
         return False
@@ -3055,7 +3059,12 @@ def _image_mismatch(running_image: str | None, declared_image: str | None) -> bo
 
     running_repo, _, running_digest = running.partition("@")
     declared_repo, _, declared_digest = declared.partition("@")
-    if bool(running_digest) != bool(declared_digest):
-        return _split_image_tag(running_repo)[0] != _split_image_tag(declared_repo)[0]
+    running_name = _split_image_tag(running_repo)[0]
+    declared_name = _split_image_tag(declared_repo)[0]
+
+    if running_digest and declared_digest:
+        return running_name != declared_name or running_digest != declared_digest
+    if running_digest or declared_digest:
+        return running_name != declared_name
 
     return True

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -93,7 +93,7 @@ from hal0.slots.naming import (
     slot_quadlet_name,
     slot_unit_name,
 )
-from hal0.system.seam import SystemCtlSeam
+from hal0.system.seam import SystemCtlSeam, is_hal0_service_user
 
 # ``ContainerSpec`` is the back-compat alias for ``RuntimeLaunchPlan``; some
 # callers/tests still import the old name from this module.
@@ -2585,9 +2585,21 @@ class ContainerProvider(Provider):
         ROOTLESS store — a different store, which never contains a slot image.
         That is why ``image_status`` was ``"missing"`` for every running,
         healthy slot on every standard install. The seam returns ``None`` when
-        it cannot answer (dev/CI box, grant not installed, podman absent), and
-        only then do we fall back to the rootless read, which is still the
-        right answer in a dev checkout where hal0-api runs as the operator.
+        it cannot answer, and only then do we fall back to the rootless read —
+        and only when this process is NOT the hal0 service user. On a
+        provisioned box the rootless store is definitionally the wrong store,
+        so consulting it after a seam failure would collapse "podman is
+        broken / the grant is missing" (wrapper rc 66 / sudo rc 1) back into
+        an authoritative-looking "missing", which is #1889 with extra steps.
+        We log instead, so an operator gets a diagnosable signal.
+
+        (The seam-failed-as-hal0 case still has to answer ``False`` because
+        this method's contract is a bool and ``image_status`` has no
+        "unknown" member. Surfacing a distinct unknown state is an API-schema
+        change, deliberately out of scope here — see the PR notes.)
+
+        In a dev checkout, where hal0-api runs as the operator, the rootless
+        store IS the store slots use, so the fallback is correct there.
 
         Runs synchronously — callers must dispatch to a thread executor when
         called from an async context.
@@ -2595,6 +2607,14 @@ class ContainerProvider(Provider):
         seam_answer = podman_introspect.image_exists(image)
         if seam_answer is not None:
             return seam_answer
+        if is_hal0_service_user():
+            log.warning(
+                "hal0.podman_ro.image_present_unanswered image=%s — the rootful seam "
+                "did not answer (grant missing, podman failure, or rejected ref); "
+                "reporting missing without consulting the unrelated rootless store",
+                image,
+            )
+            return False
         try:
             runtime = _container_runtime()
         except RuntimeError:
@@ -2631,6 +2651,13 @@ class ContainerProvider(Provider):
         seam_ref = podman_introspect.container_image(token)
         if seam_ref:
             return seam_ref
+        if is_hal0_service_user():
+            # Same reasoning as image_present: on a provisioned box the
+            # rootless store cannot hold this container, so asking it is a
+            # wasted spawn in the status hot path that can only ever answer
+            # None — or, worse, answer about a same-named container that is
+            # not this slot's.
+            return None
         try:
             runtime = _container_runtime()
         except RuntimeError:
@@ -2669,6 +2696,8 @@ class ContainerProvider(Provider):
             parsed = _decode_argv_json(seam_json)
             if parsed is not None:
                 return parsed
+        if is_hal0_service_user():
+            return None
         try:
             runtime = _container_runtime()
         except RuntimeError:
@@ -2957,10 +2986,13 @@ def canonical_image_ref(ref: str) -> str:
     Applies exactly the two implicit rules the OCI/distribution reference
     grammar defines, and nothing else:
 
-      * a name with no registry component gets ``docker.io/`` (plus the
-        ``library/`` namespace when it is a single bare component). A first
+      * a name with no registry component gets ``docker.io/``. A first
         component is a registry only if it contains ``.`` or ``:``, or is
         literally ``localhost`` — the standard heuristic;
+      * a Docker Hub name whose repository is a single component gets the
+        implicit ``library/`` namespace. This is applied AFTER the registry
+        rule so it also catches an explicitly-qualified ``docker.io/alpine``,
+        which podman likewise reports as ``docker.io/library/alpine``;
       * a name with neither tag nor digest gets ``:latest``.
 
     Never raises and never invents: anything it cannot parse is returned
@@ -2978,7 +3010,15 @@ def canonical_image_ref(ref: str) -> str:
     first, slash, _rest = name.partition("/")
     has_registry = bool(slash) and ("." in first or ":" in first or first == "localhost")
     if not has_registry:
-        name = f"docker.io/library/{name}" if not slash else f"docker.io/{name}"
+        name = f"docker.io/{name}"
+
+    # Docker Hub's implicit `library/` namespace, applied to the repository
+    # portion regardless of how the registry got there — `alpine`,
+    # `docker.io/alpine` and `docker.io/library/alpine` all name one image,
+    # and podman reports the last form.
+    registry, _, repository = name.partition("/")
+    if registry == "docker.io" and "/" not in repository:
+        name = f"docker.io/library/{repository}"
 
     if not tag and not digest:
         tag = "latest"

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -74,6 +74,7 @@ from hal0.errors import Hal0Error, UnprocessableEntity
 from hal0.http_client import async_client
 from hal0.model_meta import model_is_mtp_eligible
 from hal0.profiles import ProfileCatalog
+from hal0.providers import podman_introspect
 from hal0.providers._gpu import (
     gpu_visibility_env,
     is_nvidia_gpu_device,
@@ -489,6 +490,23 @@ def _container_runtime() -> str:
         if found:
             return found
     raise RuntimeError("no podman runtime found; install podman or set HAL0_CONTAINER_RUNTIME")
+
+
+def _decode_argv_json(raw: str) -> list[str] | None:
+    """Decode a podman ``{{json .Config.Cmd}}`` payload into an argv list.
+
+    Shared by :meth:`ContainerProvider.running_argv`'s two read paths (the
+    ``hal0-podman-ro`` seam and the rootless fallback) so both apply the same
+    shape check. ``None`` on anything that is not a JSON array — status
+    callers treat missing data as "unknown", never as drift.
+    """
+    try:
+        payload = json.loads(raw.strip())
+    except ValueError:
+        return None
+    if not isinstance(payload, list):
+        return None
+    return [str(part) for part in payload]
 
 
 def _slot_publish_host() -> str:
@@ -2558,12 +2576,25 @@ class ContainerProvider(Provider):
         self._run("systemctl", "reset-failed", self._unit_name(_artefact_token(slot)), check=False)
 
     def image_present(self, image: str) -> bool:
-        """Return True if ``image`` is in the local container image store.
+        """Return True if ``image`` is in the container image store slots use.
 
-        Uses ``<runtime> image inspect`` (exit 0 = present, non-zero = missing).
+        #1889: asks ROOT's store first, through the ``hal0-podman-ro``
+        ``image-exists`` seam. Slots run ROOTFUL podman (Quadlet), while
+        hal0-api runs as the unprivileged ``hal0`` user with no subuid ranges,
+        so the bare ``<runtime> image inspect`` below reads hal0's own
+        ROOTLESS store — a different store, which never contains a slot image.
+        That is why ``image_status`` was ``"missing"`` for every running,
+        healthy slot on every standard install. The seam returns ``None`` when
+        it cannot answer (dev/CI box, grant not installed, podman absent), and
+        only then do we fall back to the rootless read, which is still the
+        right answer in a dev checkout where hal0-api runs as the operator.
+
         Runs synchronously — callers must dispatch to a thread executor when
         called from an async context.
         """
+        seam_answer = podman_introspect.image_exists(image)
+        if seam_answer is not None:
+            return seam_answer
         try:
             runtime = _container_runtime()
         except RuntimeError:
@@ -2588,12 +2619,23 @@ class ContainerProvider(Provider):
         when the container is not running or inspect fails. Reads stdout only —
         podman emits benign device warnings to stderr under LXC. Never raises;
         callers dispatch to a thread executor from the async status path.
+
+        #1889: routed through the ``hal0-podman-ro`` ``container-image`` seam
+        first, for the same reason as :meth:`image_present` — the slot's
+        container lives in ROOT's podman store, so hal0-api's own rootless
+        inspect never found it and ``actual_image`` was always ``null``. The
+        seam takes the bare instance TOKEN and builds ``hal0-slot-<token>``
+        root-side; the rootless path below is the dev/CI fallback.
         """
+        token = _artefact_token(slot)
+        seam_ref = podman_introspect.container_image(token)
+        if seam_ref:
+            return seam_ref
         try:
             runtime = _container_runtime()
         except RuntimeError:
             return None
-        container_name = slot_container_name(_artefact_token(slot))
+        container_name = slot_container_name(token)
         try:
             result = subprocess.run(
                 [runtime, "inspect", container_name, "--format", "{{.ImageName}}"],
@@ -2617,12 +2659,21 @@ class ContainerProvider(Provider):
         as :meth:`running_image` (#1417). Returns None when the container is
         not running, inspect fails, or the runtime returns an unexpected shape.
         Never raises; status callers treat missing data as "unknown", not drift.
+
+        #1889: routed through the ``hal0-podman-ro`` ``container-argv`` seam
+        first, same rationale as :meth:`running_image`.
         """
+        token = _artefact_token(slot)
+        seam_json = podman_introspect.container_argv(token)
+        if seam_json is not None:
+            parsed = _decode_argv_json(seam_json)
+            if parsed is not None:
+                return parsed
         try:
             runtime = _container_runtime()
         except RuntimeError:
             return None
-        container_name = slot_container_name(_artefact_token(slot))
+        container_name = slot_container_name(token)
         try:
             result = subprocess.run(
                 [runtime, "inspect", container_name, "--format", "{{json .Config.Cmd}}"],
@@ -2635,13 +2686,7 @@ class ContainerProvider(Provider):
             return None
         if result.returncode != 0:
             return None
-        try:
-            payload = json.loads(result.stdout.strip())
-        except ValueError:
-            return None
-        if not isinstance(payload, list):
-            return None
-        return [str(part) for part in payload]
+        return _decode_argv_json(result.stdout)
 
     async def pull_image_stream(self, image: str):
         """Async generator that runs ``<runtime> pull <image>`` and yields

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -2927,16 +2927,95 @@ __all__ = [
 ]
 
 
+def _split_image_tag(name: str) -> tuple[str, str]:
+    """Split ``repo[:tag]`` on the tag colon only.
+
+    A registry port (``localhost:5000/foo``) puts a colon BEFORE the last
+    ``/``; a naive ``split(":")`` would amputate the host and silently compare
+    two different repositories as equal.
+    """
+    last_slash = name.rfind("/")
+    last_colon = name.rfind(":")
+    if last_colon > last_slash:
+        return name[:last_colon], name[last_colon + 1 :]
+    return name, ""
+
+
+def canonical_image_ref(ref: str) -> str:
+    """Expand an image ref to its fully-qualified form for comparison (#1889).
+
+    Podman reports a container's ``ImageName`` in canonical form —
+    ``docker.io/library/alpine:latest`` — while hal0 profiles routinely
+    declare the shorthand an operator would type (``alpine``,
+    ``alpine:latest``, ``myorg/img``). Before #1889 that never mattered:
+    :meth:`ContainerProvider.running_image` read the wrong podman store and
+    returned ``None`` on every deployed box, so :func:`_image_mismatch` was
+    unreachable. Making it reachable without this normalisation would have
+    turned a literal string compare into a drift alarm on every correctly
+    running slot — trading an inert detector for a lying one.
+
+    Applies exactly the two implicit rules the OCI/distribution reference
+    grammar defines, and nothing else:
+
+      * a name with no registry component gets ``docker.io/`` (plus the
+        ``library/`` namespace when it is a single bare component). A first
+        component is a registry only if it contains ``.`` or ``:``, or is
+        literally ``localhost`` — the standard heuristic;
+      * a name with neither tag nor digest gets ``:latest``.
+
+    Never raises and never invents: anything it cannot parse is returned
+    stripped but otherwise untouched.
+    """
+    ref = ref.strip()
+    if not ref:
+        return ""
+
+    name, sep, digest = ref.partition("@")
+    digest = f"@{digest}" if sep else ""
+
+    name, tag = _split_image_tag(name)
+
+    first, slash, _rest = name.partition("/")
+    has_registry = bool(slash) and ("." in first or ":" in first or first == "localhost")
+    if not has_registry:
+        name = f"docker.io/library/{name}" if not slash else f"docker.io/{name}"
+
+    if not tag and not digest:
+        tag = "latest"
+
+    return f"{name}{f':{tag}' if tag else ''}{digest}"
+
+
 def _image_mismatch(running_image: str | None, declared_image: str | None) -> bool:
     """Return True iff both image refs are known AND differ (#663).
 
     The deterministic replacement for the /proc ``actual_backend`` sniff on
-    container slots: the running backend IS the image tag, so drift is a plain
-    ref comparison (the running container's image vs the slot profile's
-    declared image). Returns False whenever the running image can't be
-    determined (container down / inspect failed) - never cry wolf on missing
-    data, same omit-don't-guess contract as ``resolve_actual_backend``.
+    container slots: the running backend IS the image tag, so drift is a ref
+    comparison (the running container's image vs the slot profile's declared
+    image). Returns False whenever the running image can't be determined
+    (container down / inspect failed) - never cry wolf on missing data, same
+    omit-don't-guess contract as ``resolve_actual_backend``.
+
+    Both sides are canonicalised first (:func:`canonical_image_ref`) so the
+    shorthand a profile declares compares equal to the fully-qualified name
+    podman reports — see that function for why #1889 makes this load-bearing.
+
+    Digest-pinned vs tag-pinned is compared on the REPOSITORY alone: deciding
+    whether ``ghcr.io/x/y:v2`` and ``ghcr.io/x/y@sha256:…`` are the same image
+    needs a registry round-trip this hot path will never make, and guessing
+    "drifted" there is the same cry-wolf failure the docstring above forbids.
     """
     if not running_image or not declared_image:
         return False
-    return running_image.strip() != declared_image.strip()
+
+    running = canonical_image_ref(running_image)
+    declared = canonical_image_ref(declared_image)
+    if running == declared:
+        return False
+
+    running_repo, _, running_digest = running.partition("@")
+    declared_repo, _, declared_digest = declared.partition("@")
+    if bool(running_digest) != bool(declared_digest):
+        return _split_image_tag(running_repo)[0] != _split_image_tag(declared_repo)[0]
+
+    return True

--- a/src/hal0/providers/podman_introspect.py
+++ b/src/hal0/providers/podman_introspect.py
@@ -98,8 +98,13 @@ SLOT_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 #: (no whitespace, no shell metacharacter, no leading ``-``, no ``..``, no
 #: second word) and case-permissive; see the wrapper header for why case is
 #: not folded here.
-_REF_HOST = r"[A-Za-z0-9]+([.-][A-Za-z0-9]+)*(:[0-9]{1,5})?"
-_REF_PATH = r"[A-Za-z0-9]+([._-][A-Za-z0-9]+)*(/[A-Za-z0-9]+([._-][A-Za-z0-9]+)*)*"
+# Separator set straight from the distribution-reference grammar:
+# ``"." | "_" | "__" | "-"+``. ``__`` is listed FIRST because Python's ``re``
+# is leftmost-FIRST (unlike POSIX ERE's leftmost-longest), so ``_|__`` would
+# match only the first underscore of ``model__gpu`` and then fail.
+_REF_SEP = r"(__|[._]|-+)"
+_REF_HOST = r"[A-Za-z0-9]+(([.]|-+)[A-Za-z0-9]+)*(:[0-9]{1,5})?"
+_REF_PATH = rf"[A-Za-z0-9]+({_REF_SEP}[A-Za-z0-9]+)*(/[A-Za-z0-9]+({_REF_SEP}[A-Za-z0-9]+)*)*"
 _REF_TAG = r"(:[A-Za-z0-9_][A-Za-z0-9._-]{0,127})?"
 _REF_DIGEST = r"(@sha256:[0-9a-f]{64})?"
 IMAGE_REF_RE = re.compile(rf"^({_REF_HOST}/)?{_REF_PATH}{_REF_TAG}{_REF_DIGEST}$")

--- a/src/hal0/providers/podman_introspect.py
+++ b/src/hal0/providers/podman_introspect.py
@@ -23,9 +23,9 @@ so nobody hand-rolls the ``sudo -n`` argv::
     if result is not None:
         repos, context = result.repos, result.context
 
-Privileged seam: ``sudo -n /usr/lib/hal0/bin/hal0-podman-ro <verb>`` — a
-tiny, argument-free wrapper (``installer/wrappers/hal0-podman-ro``) that
-hardcodes each read-only podman invocation; see
+Privileged seam: ``sudo -n /usr/lib/hal0/bin/hal0-podman-ro <verb> [arg]`` —
+a tiny wrapper (``installer/wrappers/hal0-podman-ro``) that hardcodes each
+read-only podman subcommand, flag and ``--format`` string; see
 ``packaging/sudoers/hal0-podman-ro`` for the grant. Mirrors the gating
 :class:`hal0.system.seam.SystemCtlSeam` already uses: the seam is only
 ATTEMPTED when this process is literally the ``hal0`` service account
@@ -42,10 +42,39 @@ come from a different store than the one slots actually use. Returns
 ``None`` only when NEITHER context produced usable output (podman absent
 entirely, or both invocations failed) — the pre-existing graceful-degrade
 contract (§21.4 HARD REQUIREMENT #5) callers already rely on.
+
+#1889 — argument-taking verbs
+============================
+
+O12 shipped one argument-free verb (``images``), which left the sibling call
+sites in :mod:`hal0.providers.container` (``image_present`` /
+``running_image`` / ``running_argv``) on a bare rootless ``podman`` call
+against the wrong store. Consequence: ``GET /api/slots`` reported
+``image_status="missing"`` for every running, healthy slot, ``actual_image``
+was always ``null``, and the #663 image-drift detector could never fire.
+
+Fixing that needs a *specific* image ref / container name to reach podman, so
+the wrapper now takes one validated positional operand for three read verbs.
+The validation is authoritative on the ROOT side (see the wrapper header);
+:data:`IMAGE_REF_RE` and :data:`SLOT_TOKEN_RE` below are mirrors of the
+wrapper's regexes so the unprivileged side fails fast with a readable error
+instead of burning a sudo round-trip — exactly the role
+:func:`hal0.system.seam.agent_unit_name` plays for ``hal0-systemctl``. Keep
+the two in lock-step; ``tests/installer/test_podman_ro_validation.py``
+asserts they agree by running the real wrapper.
+
+The three read helpers (:func:`image_exists`, :func:`container_image`,
+:func:`container_argv`) are TRI-STATE and deliberately do NOT fall back to a
+rootless call themselves: they return ``None`` for "the rootful seam did not
+answer" and let the caller decide, because a rootless answer for a *named*
+image or container is not merely stale, it is an answer about a different
+object. ``images()`` keeps its original fall-back behaviour (a repo *set* is
+still useful, and it self-labels via ``context``).
 """
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from collections.abc import Callable
@@ -57,6 +86,27 @@ from hal0.system.seam import is_hal0_service_user
 #: Installed path of the read-only podman introspection seam (O12). See
 #: installer/wrappers/hal0-podman-ro + packaging/sudoers/hal0-podman-ro.
 SEAM_BIN = "/usr/lib/hal0/bin/hal0-podman-ro"
+
+#: Mirror of the wrapper's ``SLOT_TOKEN_RE`` (#1889). Same charset as
+#: ``hal0-systemctl``'s ``validate_slot_id`` / :data:`hal0.system.seam._AGENT_ID_RE`:
+#: no ``.``, ``/``, ``:``, ``@`` or whitespace, so a validated token can never
+#: carry a path traversal, a second argv word or an option-looking value.
+SLOT_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+#: Mirror of the wrapper's ``IMAGE_REF_RE`` (#1889) —
+#: ``[host[:port]/]path[/path...][:tag][@sha256:<64 hex>]``. Structure-strict
+#: (no whitespace, no shell metacharacter, no leading ``-``, no ``..``, no
+#: second word) and case-permissive; see the wrapper header for why case is
+#: not folded here.
+_REF_HOST = r"[A-Za-z0-9]+([.-][A-Za-z0-9]+)*(:[0-9]{1,5})?"
+_REF_PATH = r"[A-Za-z0-9]+([._-][A-Za-z0-9]+)*(/[A-Za-z0-9]+([._-][A-Za-z0-9]+)*)*"
+_REF_TAG = r"(:[A-Za-z0-9_][A-Za-z0-9._-]{0,127})?"
+_REF_DIGEST = r"(@sha256:[0-9a-f]{64})?"
+IMAGE_REF_RE = re.compile(rf"^({_REF_HOST}/)?{_REF_PATH}{_REF_TAG}{_REF_DIGEST}$")
+
+#: Longest image ref the wrapper will look at before it even reaches the
+#: regex engine. Mirrors the wrapper's cap.
+IMAGE_REF_MAX_LEN = 512
 
 #: Which store a result actually came from: "rootful" is the store slots
 #: populate (via the sudo -n seam); "rootless" is hal0-api's own store,
@@ -126,4 +176,138 @@ def images(
     return PodmanImagesResult(repos=_parse_repos(proc.stdout), context="rootless")
 
 
-__all__ = ["SEAM_BIN", "PodmanContext", "PodmanImagesResult", "images"]
+# ── #1889: argument-taking read verbs ──────────────────────────────────────
+
+
+def is_valid_image_ref(image: str) -> bool:
+    """Would the wrapper accept ``image`` as an image reference?
+
+    Unprivileged mirror of the wrapper's ``validate_image_ref``. The ROOT-side
+    check is the authoritative one; this exists so a bad ref fails fast and
+    readably here instead of costing a sudo round-trip and coming back as an
+    opaque rc 64.
+    """
+    return bool(image) and len(image) <= IMAGE_REF_MAX_LEN and IMAGE_REF_RE.match(image) is not None
+
+
+def is_valid_slot_token(token: str) -> bool:
+    """Would the wrapper accept ``token`` as a slot instance token?
+
+    Unprivileged mirror of the wrapper's ``validate_slot_token``. Note the
+    caller passes the bare TOKEN, never a container name: the wrapper builds
+    ``hal0-slot-<token>`` itself on the root side, so this seam can only ever
+    name a hal0 slot container.
+    """
+    return bool(token) and SLOT_TOKEN_RE.match(token) is not None
+
+
+def _seam_read(
+    verb: str,
+    arg: str,
+    *,
+    run: _RunFn,
+    is_hal0_user: Callable[[], bool],
+    timeout: float,
+) -> str | None:
+    """Run one argument-taking read verb; ``None`` when the seam didn't answer.
+
+    "Didn't answer" covers every non-``rc 0`` outcome: the gate said this
+    process is not the ``hal0`` service account, ``sudo -n`` was denied (grant
+    not installed / mid-upgrade race), the wrapper rejected the argument
+    (rc 64), podman is absent on the box (rc 65), or the call raised. Only
+    ``rc 0`` is an answer — and on ``rc 0`` an EMPTY stdout is a real negative
+    answer (no such container), not a failure, which is why this returns
+    ``""`` rather than ``None`` in that case.
+    """
+    if not is_hal0_user():
+        return None
+    proc = _run(run, _seam_argv(verb, arg), timeout=timeout)
+    if proc is None or proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def image_exists(
+    image: str,
+    *,
+    run: _RunFn = subprocess.run,
+    is_hal0_user: Callable[[], bool] = is_hal0_service_user,
+    timeout: float = 10.0,
+) -> bool | None:
+    """Is ``image`` present in ROOT's image store? ``None`` if unanswerable.
+
+    ``True``/``False`` mean the rootful seam actually answered. ``None`` means
+    it did not (not the hal0 service user, no grant, podman absent, or the ref
+    was rejected) — the caller must then decide, and deliberately is NOT given
+    a silent rootless fallback here: hal0-api's own rootless store is a
+    different store, so a "missing" from it about a *named* image is not a
+    stale answer but an answer about a different object. That conflation is
+    exactly #1889.
+    """
+    if not is_valid_image_ref(image):
+        return None
+    answer = _seam_read("image-exists", image, run=run, is_hal0_user=is_hal0_user, timeout=timeout)
+    if answer == "present":
+        return True
+    if answer == "missing":
+        return False
+    return None
+
+
+def container_image(
+    token: str,
+    *,
+    run: _RunFn = subprocess.run,
+    is_hal0_user: Callable[[], bool] = is_hal0_service_user,
+    timeout: float = 10.0,
+) -> str | None:
+    """The running image ref of ``hal0-slot-<token>`` in ROOT's store (#663).
+
+    Returns the ref when the seam answered and a container is running, and
+    ``None`` both when the seam did not answer AND when it answered "no such
+    container" — the two are indistinguishable to every caller of this value
+    (both mean "no actual_image to report"), so they are collapsed here rather
+    than pushing a tri-state nobody branches on into the status hot path.
+    """
+    if not is_valid_slot_token(token):
+        return None
+    answer = _seam_read(
+        "container-image", token, run=run, is_hal0_user=is_hal0_user, timeout=timeout
+    )
+    return answer or None
+
+
+def container_argv(
+    token: str,
+    *,
+    run: _RunFn = subprocess.run,
+    is_hal0_user: Callable[[], bool] = is_hal0_service_user,
+    timeout: float = 10.0,
+) -> str | None:
+    """Raw ``{{json .Config.Cmd}}`` for ``hal0-slot-<token>`` from ROOT's store.
+
+    Returns the undecoded JSON text (the caller owns parsing, as it already
+    did), or ``None`` when the seam did not answer / no such container.
+    """
+    if not is_valid_slot_token(token):
+        return None
+    answer = _seam_read(
+        "container-argv", token, run=run, is_hal0_user=is_hal0_user, timeout=timeout
+    )
+    return answer or None
+
+
+__all__ = [
+    "IMAGE_REF_MAX_LEN",
+    "IMAGE_REF_RE",
+    "SEAM_BIN",
+    "SLOT_TOKEN_RE",
+    "PodmanContext",
+    "PodmanImagesResult",
+    "container_argv",
+    "container_image",
+    "image_exists",
+    "images",
+    "is_valid_image_ref",
+    "is_valid_slot_token",
+]

--- a/src/hal0/providers/podman_introspect.py
+++ b/src/hal0/providers/podman_introspect.py
@@ -103,7 +103,10 @@ SLOT_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 # is leftmost-FIRST (unlike POSIX ERE's leftmost-longest), so ``_|__`` would
 # match only the first underscore of ``model__gpu`` and then fail.
 _REF_SEP = r"(__|[._]|-+)"
-_REF_HOST = r"[A-Za-z0-9]+(([.]|-+)[A-Za-z0-9]+)*(:[0-9]{1,5})?"
+#: A registry host is a dotted/dashed name OR a bracketed IPv6 literal
+#: (``[2001:db8::1]:5000/…``), which the reference grammar permits.
+_REF_IPV6 = r"\[[0-9A-Fa-f:]{2,45}\]"
+_REF_HOST = rf"([A-Za-z0-9]+(([.]|-+)[A-Za-z0-9]+)*|{_REF_IPV6})(:[0-9]{{1,5}})?"
 _REF_PATH = rf"[A-Za-z0-9]+({_REF_SEP}[A-Za-z0-9]+)*(/[A-Za-z0-9]+({_REF_SEP}[A-Za-z0-9]+)*)*"
 _REF_TAG = r"(:[A-Za-z0-9_][A-Za-z0-9._-]{0,127})?"
 _REF_DIGEST = r"(@sha256:[0-9a-f]{64})?"

--- a/src/hal0/system/seam_check.py
+++ b/src/hal0/system/seam_check.py
@@ -89,10 +89,20 @@ SEAMS: tuple[SeamSpec, ...] = (
     SeamSpec("hal0-benchctl", probe=None, required=False, role="benchmark harness"),
     # #1889: podman-ro is now the ONLY source of truth for a running slot's
     # image_status/actual_image, so a silently-missing grant is no longer
-    # cosmetic — probe it. `help` prints usage and touches nothing.
+    # cosmetic — probe it.
+    #
+    # The probe is `check-slot-token`, NOT `help`, deliberately: `help` exists
+    # on the PRE-#1889 wrapper too, so a box whose best-effort wrapper refresh
+    # failed would keep the old one-verb wrapper, pass a `help` probe, and
+    # report the seam healthy from `hal0 doctor` while image_status stayed
+    # "missing" and actual_image stayed null — the exact undiagnosable-green
+    # failure #1465 exists to prevent. `check-slot-token` is release-specific
+    # (the old wrapper rejects it with rc 64) and side-effect-free: it
+    # validates the token and prints the container name it WOULD build,
+    # touching neither podman nor the filesystem.
     SeamSpec(
         "hal0-podman-ro",
-        probe=("help",),
+        probe=("check-slot-token", "hal0probe"),
         required=False,
         role="podman image introspection (slot image_status / actual_image)",
     ),

--- a/src/hal0/system/seam_check.py
+++ b/src/hal0/system/seam_check.py
@@ -87,7 +87,15 @@ SEAMS: tuple[SeamSpec, ...] = (
     ),
     SeamSpec("hal0-agentenv", probe=None, required=False, role="bundled-agent env files"),
     SeamSpec("hal0-benchctl", probe=None, required=False, role="benchmark harness"),
-    SeamSpec("hal0-podman-ro", probe=None, required=False, role="podman image introspection"),
+    # #1889: podman-ro is now the ONLY source of truth for a running slot's
+    # image_status/actual_image, so a silently-missing grant is no longer
+    # cosmetic — probe it. `help` prints usage and touches nothing.
+    SeamSpec(
+        "hal0-podman-ro",
+        probe=("help",),
+        required=False,
+        role="podman image introspection (slot image_status / actual_image)",
+    ),
 )
 
 

--- a/tests/installer/test_podman_ro_validation.py
+++ b/tests/installer/test_podman_ro_validation.py
@@ -36,6 +36,14 @@ WRAPPER = REPO / "installer" / "wrappers" / "hal0-podman-ro"
 # A minimal PATH: the wrapper must not depend on the caller's environment.
 _ENV = {"PATH": "/usr/bin:/bin"}
 
+#: The env a REAL invocation gets. sudo's default `env_keep` passes LANG and
+#: LC_* straight through, so the wrapper runs under whatever locale the
+#: calling process had — and bash's `[[ =~ ]]` bracket expressions are
+#: locale-sensitive: under a UTF-8 locale `[A-Za-z0-9]` collates accented
+#: letters INTO the range. `_ENV` above strips those vars, so the rest of this
+#: file would never have seen it.
+_UTF8_ENV = {**_ENV, "LANG": "en_US.UTF-8", "LC_ALL": "en_US.UTF-8"}
+
 _DIGEST = "a" * 64
 
 #: Refs that MUST be accepted — a false rejection degrades straight back to
@@ -142,13 +150,13 @@ MALICIOUS_TOKENS = [
 ]
 
 
-def _run(*argv: str) -> subprocess.CompletedProcess[str]:
+def _run(*argv: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [str(WRAPPER), *argv],
         capture_output=True,
         text=True,
         check=False,
-        env=_ENV,
+        env=env or _ENV,
     )
 
 
@@ -293,6 +301,17 @@ def test_presence_probes_use_exists_not_inspect() -> None:
     assert not [ln for ln in code if "image inspect" in ln]
 
 
+def test_inspect_calls_are_type_qualified() -> None:
+    """Bare `podman inspect` also resolves images, volumes, networks and pods,
+    so a name collision could return a different object's fields. Every
+    inspect names its type (security review of #1889, finding 3)."""
+    src = WRAPPER.read_text()
+    code = [ln for ln in src.splitlines() if not ln.lstrip().startswith("#")]
+    for line in code:
+        if "inspect" in line and "run_podman" in line:
+            assert "container inspect" in line or "image inspect" in line, line
+
+
 def test_operational_podman_failure_exits_66() -> None:
     src = WRAPPER.read_text()
     assert "exit 66" in src
@@ -306,3 +325,49 @@ def test_no_caller_supplied_format_string() -> None:
     for line in src.splitlines():
         if "--format" in line and not line.lstrip().startswith("#"):
             assert '"$1"' not in line and '"$2"' not in line, line
+
+
+# ── locale independence (security review, finding 1) ───────────────────────
+#
+# bash's `[[ =~ ]]` uses the current locale's collation, so under a UTF-8
+# locale `[A-Za-z0-9]` matches accented letters and the wrapper accepted refs
+# its Python mirror rejects — a wrapper-LOOSER-than-mirror parity break, the
+# dangerous direction. sudo's default `env_keep` passes LANG/LC_* through, so
+# this was reachable in production; only this file's stripped `_ENV` hid it.
+
+
+@pytest.mark.parametrize("ref", ["alpiné", "alpine\u202eid", "ALPINÉ", "café/img:tag"])
+def test_unicode_refs_rejected_under_a_utf8_locale(ref: str) -> None:
+    proc = _run("check-image-ref", ref, env=_UTF8_ENV)
+    assert proc.returncode == 64, f"ACCEPTED {ref!r} under UTF-8 (rc={proc.returncode})"
+
+
+@pytest.mark.parametrize("token", ["braîn", "tokén"])
+def test_unicode_tokens_rejected_under_a_utf8_locale(token: str) -> None:
+    proc = _run("check-slot-token", token, env=_UTF8_ENV)
+    assert proc.returncode == 64, f"ACCEPTED {token!r} under UTF-8 (rc={proc.returncode})"
+
+
+@pytest.mark.parametrize("ref", [*LEGITIMATE_REFS, *MALICIOUS_REFS])
+def test_validation_is_identical_under_a_utf8_locale(ref: str) -> None:
+    """The whole corpus must decide the same way in any locale, and must still
+    agree with the Python mirror there."""
+    assert (
+        _run("check-image-ref", ref, env=_UTF8_ENV).returncode
+        == _run("check-image-ref", ref, env=_ENV).returncode
+    ), f"locale changed the verdict on {ref!r}"
+    assert is_valid_image_ref(ref) == (
+        _run("check-image-ref", ref, env=_UTF8_ENV).returncode == 0
+    ), f"mirror disagrees with the wrapper under UTF-8 on {ref!r}"
+
+
+def test_wrapper_pins_the_locale_itself() -> None:
+    """Structural backstop: the tests above prove nothing on a box where
+    en_US.UTF-8 is not generated (bash silently falls back to C), so also
+    assert the pin is present and set before any validator can run."""
+    src = WRAPPER.read_text()
+    assert "export LC_ALL=C" in src
+    lines = [ln.strip() for ln in src.splitlines()]
+    assert lines.index("export LC_ALL=C") < lines.index(
+        "validate_slot_token() {  # arg: slot instance token"
+    )

--- a/tests/installer/test_podman_ro_validation.py
+++ b/tests/installer/test_podman_ro_validation.py
@@ -57,6 +57,9 @@ LEGITIMATE_REFS = [
     "registry.example/team/model__gpu:v1",
     "team/model--gpu:v1",
     "my--registry.example.com/a__b/c.d-e_f:tag",
+    # bracketed IPv6 registry literals are legal reference hosts
+    "[2001:db8::1]:5000/team/model:v1",
+    "[::1]/local/img",
 ]
 
 #: Argv that must never reach podman. Each is a shape that would either run a
@@ -92,6 +95,11 @@ MALICIOUS_REFS = [
     "/etc/passwd",
     # malformed digests
     "alpine@sha256:zzzz",
+    # IPv6 brackets must not become a hole: only hex+colons inside
+    "[2001:db8::1;id]:5000/foo",
+    "[../etc]/foo",
+    "[]/foo",
+    "[2001:db8::1]extra/foo",
     "alpine@sha512:" + _DIGEST,
     "alpine@sha256:" + "a" * 63,
     "alpine@sha256:" + "A" * 64,

--- a/tests/installer/test_podman_ro_validation.py
+++ b/tests/installer/test_podman_ro_validation.py
@@ -53,6 +53,10 @@ LEGITIMATE_REFS = [
     f"ghcr.io/x/y@sha256:{_DIGEST}",
     f"ghcr.io/x/y:tag@sha256:{_DIGEST}",
     "rocm/vllm-dev:nightly_main_20260101",
+    # distribution-reference separators: "." | "_" | "__" | "-"+
+    "registry.example/team/model__gpu:v1",
+    "team/model--gpu:v1",
+    "my--registry.example.com/a__b/c.d-e_f:tag",
 ]
 
 #: Argv that must never reach podman. Each is a shape that would either run a
@@ -94,7 +98,6 @@ MALICIOUS_REFS = [
     # separators the OCI grammar does not allow
     "-alpine",
     "alpine-",
-    "alpine__x",
     "foo//bar",
     "foo/",
     "/foo",
@@ -260,3 +263,38 @@ def test_python_slot_token_mirror_agrees_with_the_wrapper(token: str) -> None:
     assert is_valid_slot_token(token) == (_run("check-slot-token", token).returncode == 0), (
         f"mirror disagrees with the wrapper on {token!r}"
     )
+
+
+# ── exit-code contract: operational failure ≠ negative answer ───────────────
+#
+# Podman's own rc cannot be exercised here without injecting a fake podman
+# path, and making PODMAN overridable would be a hole in the very boundary
+# this file defends. These assert the contract structurally instead; the
+# consuming half (rc 66 → "seam did not answer", never "missing") is pinned in
+# tests/providers/test_podman_introspect.py.
+
+
+def test_presence_probes_use_exists_not_inspect() -> None:
+    """`podman inspect` collapses "not found" and every other failure into a
+    single rc 125, so it cannot tell a missing image from a broken store.
+    `image exists` / `container exists` are rc 0 / rc 1 / error."""
+    src = WRAPPER.read_text()
+    assert "run_podman image exists --" in src
+    assert "run_podman container exists --" in src
+    code = [ln for ln in src.splitlines() if not ln.lstrip().startswith("#")]
+    assert not [ln for ln in code if "image inspect" in ln]
+
+
+def test_operational_podman_failure_exits_66() -> None:
+    src = WRAPPER.read_text()
+    assert "exit 66" in src
+    # every podman call site routes its non-{0,1} rc into podman_failed
+    assert src.count("podman_failed") >= 4
+
+
+def test_no_caller_supplied_format_string() -> None:
+    """Every --format is a literal in this file; none is read from argv."""
+    src = WRAPPER.read_text()
+    for line in src.splitlines():
+        if "--format" in line and not line.lstrip().startswith("#"):
+            assert '"$1"' not in line and '"$2"' not in line, line

--- a/tests/installer/test_podman_ro_validation.py
+++ b/tests/installer/test_podman_ro_validation.py
@@ -1,0 +1,262 @@
+"""#1889 — root-side argument allow-list for the hal0-podman-ro read verbs.
+
+``installer/wrappers/hal0-podman-ro`` is reachable as root by the unprivileged
+``hal0`` service account (packaging/sudoers/hal0-podman-ro), so its argv is
+attacker-controlled at a privilege boundary. Before #1889 the wrapper dodged
+that by accepting zero caller arguments — at the cost of leaving
+``image_present`` / ``running_image`` on a bare rootless ``podman`` call
+against the wrong store, which is why ``image_status`` was ``"missing"`` for
+every running slot and ``actual_image`` was always ``null``.
+
+Three verbs now take exactly one positional operand. These tests pin the
+validators that stand between that operand and podman's argv, and they do it
+through the *real* bash wrapper's side-effect-free ``check-image-ref`` /
+``check-slot-token`` verbs — no root, no sudo, no podman, no provisioned box
+(the ``hal0-systemctl`` drop-in suite's posture).
+
+They also assert PARITY with the Python mirrors in
+:mod:`hal0.providers.podman_introspect`: those exist so the unprivileged side
+fails fast, and a mirror that drifts looser than the wrapper turns a fast
+rejection into an opaque ``rc 64``, while one that drifts stricter silently
+re-creates #1889 for the refs it wrongly rejects.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hal0.providers.podman_introspect import is_valid_image_ref, is_valid_slot_token
+
+REPO = Path(__file__).resolve().parents[2]
+WRAPPER = REPO / "installer" / "wrappers" / "hal0-podman-ro"
+
+# A minimal PATH: the wrapper must not depend on the caller's environment.
+_ENV = {"PATH": "/usr/bin:/bin"}
+
+_DIGEST = "a" * 64
+
+#: Refs that MUST be accepted — a false rejection degrades straight back to
+#: image_status="missing", the bug this issue is about.
+LEGITIMATE_REFS = [
+    "alpine",
+    "alpine:latest",
+    "alpine:3.19",
+    "docker.io/library/alpine:3.19",
+    "ghcr.io/thinmintdev/hal0-rocmfpx:latest",
+    "quay.io/hal0/runner:v1.0.0-rc.6",
+    "localhost/hal0-toolbox:dev",
+    "localhost:5000/team/img:v1.2.3",
+    "registry.example.com:443/a/b/c/deep:tag",
+    f"ghcr.io/x/y@sha256:{_DIGEST}",
+    f"ghcr.io/x/y:tag@sha256:{_DIGEST}",
+    "rocm/vllm-dev:nightly_main_20260101",
+]
+
+#: Argv that must never reach podman. Each is a shape that would either run a
+#: second command, smuggle a podman flag, escape the intended object, or
+#: exhaust the box.
+MALICIOUS_REFS = [
+    "alpine; rm -rf /",
+    "alpine && id",
+    "alpine || id",
+    "alpine | id",
+    "alpine $(id)",
+    "alpine `id`",
+    "alpine\nid",
+    "alpine\tid",
+    "alpine id",
+    "$(id)",
+    ";id",
+    "&id",
+    ">/etc/passwd",
+    "<(id)",
+    "alpine:tag;whoami",
+    # flag smuggling — a leading '-' must never be readable as an option
+    "-v/:/host",
+    "--format={{.Config}}",
+    "--rm",
+    "-",
+    # path traversal shapes
+    "../../../etc/shadow",
+    "foo/../../etc/passwd",
+    "foo..bar",
+    "..",
+    "./alpine",
+    "/etc/passwd",
+    # malformed digests
+    "alpine@sha256:zzzz",
+    "alpine@sha512:" + _DIGEST,
+    "alpine@sha256:" + "a" * 63,
+    "alpine@sha256:" + "A" * 64,
+    # separators the OCI grammar does not allow
+    "-alpine",
+    "alpine-",
+    "alpine__x",
+    "foo//bar",
+    "foo/",
+    "/foo",
+    ":latest",
+    "alpine:",
+    "",
+    # unicode / control bytes
+    "alpine\rid",
+    "alpine\x1b[31m",
+    "alpine\x7f",
+    "alpiné",
+    "alpine‮id",
+]
+
+#: Slot tokens that must be accepted (see src/hal0/slots/naming.py — the token
+#: is either the slot's opaque numeric id or its name).
+LEGITIMATE_TOKENS = ["brain", "1", "42", "my_slot", "my-slot", "A_b-9", "x" * 64]
+
+MALICIOUS_TOKENS = [
+    "",
+    "../root",
+    "foo bar",
+    "foo;id",
+    "foo$(id)",
+    "foo/bar",
+    "foo.bar",
+    "foo@bar",
+    "foo:bar",
+    "foo\nbar",
+    "x" * 65,
+    "brain'",
+    'brain"',
+    "brain\\",
+]
+
+
+def _run(*argv: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(WRAPPER), *argv],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_ENV,
+    )
+
+
+# ── the wrapper is syntactically sound and self-describing ─────────────────
+
+
+def test_wrapper_parses() -> None:
+    proc = subprocess.run(["bash", "-n", str(WRAPPER)], capture_output=True, text=True, check=False)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_help_lists_every_verb() -> None:
+    proc = _run("help")
+    assert proc.returncode == 0, proc.stderr
+    for verb in (
+        "images",
+        "image-exists",
+        "container-image",
+        "container-argv",
+        "check-image-ref",
+        "check-slot-token",
+    ):
+        assert verb in proc.stdout, f"{verb} missing from usage"
+
+
+def test_unknown_verb_is_rejected() -> None:
+    proc = _run("rm")
+    assert proc.returncode == 64
+    assert "bad cmd" in proc.stderr
+
+
+@pytest.mark.parametrize("verb", ["image-exists", "container-image", "container-argv"])
+def test_write_verbs_are_not_reachable(verb: str) -> None:
+    """The seam stays READ-ONLY: no verb spells a mutation, and the three
+    argument-taking verbs refuse a second argv word outright (so a validated
+    operand can never be followed by a smuggled one)."""
+    proc = _run(verb, "alpine", "extra")
+    assert proc.returncode == 64
+    assert "exactly one argument" in proc.stderr
+
+
+@pytest.mark.parametrize("verb", ["image-exists", "container-image", "container-argv"])
+def test_argument_verbs_require_an_argument(verb: str) -> None:
+    proc = _run(verb)
+    assert proc.returncode == 64
+
+
+# ── image refs ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("ref", LEGITIMATE_REFS)
+def test_wrapper_accepts_legitimate_image_ref(ref: str) -> None:
+    proc = _run("check-image-ref", ref)
+    assert proc.returncode == 0, f"rejected {ref!r}: {proc.stderr}"
+    # Echoed verbatim: what podman receives is exactly what was validated.
+    assert proc.stdout == f"{ref}\n"
+
+
+@pytest.mark.parametrize("ref", MALICIOUS_REFS)
+def test_wrapper_rejects_malicious_image_ref(ref: str) -> None:
+    proc = _run("check-image-ref", ref)
+    assert proc.returncode == 64, f"ACCEPTED {ref!r} (rc={proc.returncode})"
+    assert "hal0-podman-ro:" in proc.stderr
+
+
+def test_wrapper_rejects_overlong_image_ref() -> None:
+    proc = _run("check-image-ref", "a" * 513)
+    assert proc.returncode == 64
+    assert "too long" in proc.stderr
+    # ...and the cap is not off-by-one against a legitimate long ref.
+    assert _run("check-image-ref", "a" * 512).returncode == 0
+
+
+@pytest.mark.parametrize("ref", MALICIOUS_REFS)
+def test_malicious_ref_is_rejected_by_the_real_verb_too(ref: str) -> None:
+    """The validator runs BEFORE podman is even located, so this holds on a
+    box with no podman installed (CI) as well as on a provisioned one."""
+    proc = _run("image-exists", ref)
+    assert proc.returncode == 64, f"ACCEPTED {ref!r} (rc={proc.returncode})"
+
+
+# ── slot tokens ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("token", LEGITIMATE_TOKENS)
+def test_wrapper_accepts_legitimate_slot_token(token: str) -> None:
+    proc = _run("check-slot-token", token)
+    assert proc.returncode == 0, f"rejected {token!r}: {proc.stderr}"
+    # The container NAME is assembled on the root side from the bare token —
+    # the caller never supplies a container name, so it can only ever address
+    # a hal0 slot container.
+    assert proc.stdout == f"hal0-slot-{token}\n"
+
+
+@pytest.mark.parametrize("token", MALICIOUS_TOKENS)
+def test_wrapper_rejects_malicious_slot_token(token: str) -> None:
+    proc = _run("check-slot-token", token)
+    assert proc.returncode == 64, f"ACCEPTED {token!r} (rc={proc.returncode})"
+
+
+@pytest.mark.parametrize("token", MALICIOUS_TOKENS)
+def test_malicious_token_is_rejected_by_the_real_verbs_too(token: str) -> None:
+    for verb in ("container-image", "container-argv"):
+        proc = _run(verb, token)
+        assert proc.returncode == 64, f"{verb} ACCEPTED {token!r} (rc={proc.returncode})"
+
+
+# ── wrapper ↔ Python-mirror parity ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize("ref", [*LEGITIMATE_REFS, *MALICIOUS_REFS, "a" * 513])
+def test_python_image_ref_mirror_agrees_with_the_wrapper(ref: str) -> None:
+    assert is_valid_image_ref(ref) == (_run("check-image-ref", ref).returncode == 0), (
+        f"mirror disagrees with the wrapper on {ref!r}"
+    )
+
+
+@pytest.mark.parametrize("token", [*LEGITIMATE_TOKENS, *MALICIOUS_TOKENS])
+def test_python_slot_token_mirror_agrees_with_the_wrapper(token: str) -> None:
+    assert is_valid_slot_token(token) == (_run("check-slot-token", token).returncode == 0), (
+        f"mirror disagrees with the wrapper on {token!r}"
+    )

--- a/tests/providers/test_container_podman_ro_routing.py
+++ b/tests/providers/test_container_podman_ro_routing.py
@@ -376,3 +376,24 @@ def test_container_reads_still_fall_back_off_the_service_account(
 
     expected = IMAGE if method == "running_image" else ["llama-server"]
     assert getattr(ContainerProvider(), method)(SLOT) == expected
+
+
+def test_both_digest_pinned_compares_digest_not_tag_text() -> None:
+    """A digest IS the immutable image id, so the tag text alongside it is
+    noise — `repo:v1@sha256:D` and `repo@sha256:D` are the same image."""
+    digest = "@sha256:" + "a" * 64
+    other = "@sha256:" + "b" * 64
+    repo = "ghcr.io/team/model"
+
+    assert container_mod._image_mismatch(f"{repo}:v1{digest}", f"{repo}{digest}") is False
+    assert container_mod._image_mismatch(f"{repo}:v1{digest}", f"{repo}:v2{digest}") is False
+    # a genuinely different digest, or a different repository, is real drift
+    assert container_mod._image_mismatch(f"{repo}{digest}", f"{repo}{other}") is True
+    assert container_mod._image_mismatch(f"{repo}{digest}", f"ghcr.io/team/x{digest}") is True
+
+
+def test_ipv6_registry_refs_canonicalise_and_compare() -> None:
+    ref = "[2001:db8::1]:5000/team/model:v1"
+    assert container_mod.canonical_image_ref(ref) == ref
+    assert container_mod._image_mismatch(ref, ref) is False
+    assert container_mod._image_mismatch(ref, "[2001:db8::2]:5000/team/model:v1") is True

--- a/tests/providers/test_container_podman_ro_routing.py
+++ b/tests/providers/test_container_podman_ro_routing.py
@@ -1,0 +1,229 @@
+"""#1889 — ContainerProvider's image reads go through the ROOTFUL seam.
+
+The bug this pins: ``image_present`` / ``running_image`` / ``running_argv``
+shelled out to a bare ``podman`` as the unprivileged ``hal0`` service user,
+which has no subuid ranges at all, so they read hal0-api's own ROOTLESS image
+store. Slots run ROOTFUL podman (Quadlet, root's store), so that store by
+construction never holds a slot image. Result on every standard install:
+``GET /api/slots`` reported ``image_status: "missing"`` for every running,
+healthy slot, ``actual_image`` was always ``null``, and the #663 image-drift
+detector could never fire.
+
+The seam (``hal0-podman-ro``) and the ``is_hal0_service_user()`` gate already
+existed — commit ``cbc8e94d`` wired them into ``/api/system-info``. These
+tests assert the three sibling call sites are now on the same seam, and that
+the fallback to the rootless read survives for the dev/CI case where the
+process is NOT the hal0 service user (there is no grant there, and the
+operator's own store IS the right one).
+
+``podman_introspect`` is patched rather than ``subprocess`` so these never
+touch sudo, a real ``hal0`` account, or podman.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hal0.providers import container as container_mod
+from hal0.providers.container import ContainerProvider
+
+SLOT: dict[str, Any] = {"id": 7, "name": "gpu-chat"}
+IMAGE = "ghcr.io/thinmintdev/hal0-runner:v1.0.0-rc.6"
+
+
+@pytest.fixture
+def no_rootless(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    """Fail loudly if anything reaches the rootless podman path.
+
+    A test that "passes" by silently falling through to ``subprocess.run``
+    would prove nothing about the seam, so the fallback is booby-trapped
+    rather than merely unused.
+    """
+    calls: list[list[str]] = []
+
+    def _boom(argv: list[str], **_kw: object) -> None:
+        calls.append(list(argv))
+        raise AssertionError(f"rootless podman was invoked: {argv}")
+
+    monkeypatch.setattr(container_mod.subprocess, "run", _boom)
+    return calls
+
+
+# ── image_present: the "always missing" bug ────────────────────────────────
+
+
+def test_image_present_true_from_rootful_seam(
+    monkeypatch: pytest.MonkeyPatch, no_rootless: list[list[str]]
+) -> None:
+    """The whole point of #1889: a slot image that IS in root's store now
+    reports present, so slot_view renders image_status="present"."""
+    seen: list[str] = []
+
+    def _exists(image: str) -> bool:
+        seen.append(image)
+        return True
+
+    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", _exists)
+
+    assert ContainerProvider().image_present(IMAGE) is True
+    assert seen == [IMAGE]
+
+
+def test_image_present_false_is_an_honest_rootful_negative(
+    monkeypatch: pytest.MonkeyPatch, no_rootless: list[list[str]]
+) -> None:
+    """A seam that answered "missing" is authoritative — we must NOT then
+    re-ask the rootless store and let its (also wrong) answer stand in."""
+    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: False)
+
+    assert ContainerProvider().image_present(IMAGE) is False
+
+
+def test_image_present_falls_back_to_rootless_when_seam_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dev checkout / CI / no grant: the seam returns None and the operator's
+    own store is the right one to read."""
+    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: None)
+    monkeypatch.setattr(container_mod, "_container_runtime", lambda: "/usr/bin/podman")
+
+    calls: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+
+    def _run(argv: list[str], **_kw: object) -> _Proc:
+        calls.append(list(argv))
+        return _Proc()
+
+    monkeypatch.setattr(container_mod.subprocess, "run", _run)
+
+    assert ContainerProvider().image_present(IMAGE) is True
+    assert calls == [["/usr/bin/podman", "image", "inspect", IMAGE]]
+
+
+def test_image_present_false_when_seam_silent_and_no_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: None)
+
+    def _no_runtime() -> str:
+        raise RuntimeError("no podman runtime found")
+
+    monkeypatch.setattr(container_mod, "_container_runtime", _no_runtime)
+
+    assert ContainerProvider().image_present(IMAGE) is False
+
+
+# ── running_image: the "actual_image is always null" bug ───────────────────
+
+
+def test_running_image_from_rootful_seam(
+    monkeypatch: pytest.MonkeyPatch, no_rootless: list[list[str]]
+) -> None:
+    seen: list[str] = []
+
+    def _container_image(token: str) -> str:
+        seen.append(token)
+        return IMAGE
+
+    monkeypatch.setattr(container_mod.podman_introspect, "container_image", _container_image)
+
+    assert ContainerProvider().running_image(SLOT) == IMAGE
+    # The bare INSTANCE TOKEN crosses the boundary (#1417: id-keyed slots), not
+    # a container name — the wrapper builds hal0-slot-<token> root-side.
+    assert seen == ["7"]
+
+
+def test_running_image_falls_back_to_rootless_when_seam_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(container_mod.podman_introspect, "container_image", lambda _t: None)
+    monkeypatch.setattr(container_mod, "_container_runtime", lambda: "/usr/bin/podman")
+
+    calls: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+        stdout = f"{IMAGE}\n"
+
+    def _run(argv: list[str], **_kw: object) -> _Proc:
+        calls.append(list(argv))
+        return _Proc()
+
+    monkeypatch.setattr(container_mod.subprocess, "run", _run)
+
+    assert ContainerProvider().running_image(SLOT) == IMAGE
+    assert calls == [["/usr/bin/podman", "inspect", "hal0-slot-7", "--format", "{{.ImageName}}"]]
+
+
+# ── running_argv ───────────────────────────────────────────────────────────
+
+
+def test_running_argv_from_rootful_seam(
+    monkeypatch: pytest.MonkeyPatch, no_rootless: list[list[str]]
+) -> None:
+    monkeypatch.setattr(
+        container_mod.podman_introspect,
+        "container_argv",
+        lambda _t: '["llama-server", "--port", "8080"]',
+    )
+
+    assert ContainerProvider().running_argv(SLOT) == ["llama-server", "--port", "8080"]
+
+
+def test_running_argv_falls_back_when_seam_returns_unparseable_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A seam answer that is not a JSON array is treated as no answer, not as
+    "the slot has no command" — status callers must never read garbage as
+    drift."""
+    monkeypatch.setattr(container_mod.podman_introspect, "container_argv", lambda _t: "null")
+    monkeypatch.setattr(container_mod, "_container_runtime", lambda: "/usr/bin/podman")
+
+    class _Proc:
+        returncode = 0
+        stdout = '["llama-server"]'
+
+    monkeypatch.setattr(container_mod.subprocess, "run", lambda *_a, **_k: _Proc())
+
+    assert ContainerProvider().running_argv(SLOT) == ["llama-server"]
+
+
+def test_running_argv_none_when_neither_context_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(container_mod.podman_introspect, "container_argv", lambda _t: None)
+
+    def _no_runtime() -> str:
+        raise RuntimeError("no podman runtime found")
+
+    monkeypatch.setattr(container_mod, "_container_runtime", _no_runtime)
+
+    assert ContainerProvider().running_argv(SLOT) is None
+
+
+# ── the promoted regression test (issue #1889, "Test to promote") ──────────
+
+
+def test_slot_view_reports_present_for_a_running_slot(
+    monkeypatch: pytest.MonkeyPatch, no_rootless: list[list[str]]
+) -> None:
+    """End of the chain: the value slot_view puts in ``image_status``.
+
+    slot_view reaches ``ContainerProvider.image_present`` through its TTL
+    cache helper; this drives the real provider through that same helper so a
+    future regression anywhere on the path re-fails here.
+    """
+    from hal0 import slot_view
+
+    slot_view._image_present_cache.clear()
+    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: True)
+
+    present = slot_view._image_present_cached(ContainerProvider(), IMAGE)
+
+    assert present is True
+    assert ("present" if present else "missing") == "present"
+    slot_view._image_present_cache.clear()

--- a/tests/providers/test_container_podman_ro_routing.py
+++ b/tests/providers/test_container_podman_ro_routing.py
@@ -87,6 +87,7 @@ def test_image_present_falls_back_to_rootless_when_seam_silent(
     """Dev checkout / CI / no grant: the seam returns None and the operator's
     own store is the right one to read."""
     monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: None)
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: False)
     monkeypatch.setattr(container_mod, "_container_runtime", lambda: "/usr/bin/podman")
 
     calls: list[list[str]] = []
@@ -108,6 +109,7 @@ def test_image_present_false_when_seam_silent_and_no_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: None)
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: False)
 
     def _no_runtime() -> str:
         raise RuntimeError("no podman runtime found")
@@ -141,6 +143,7 @@ def test_running_image_falls_back_to_rootless_when_seam_silent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(container_mod.podman_introspect, "container_image", lambda _t: None)
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: False)
     monkeypatch.setattr(container_mod, "_container_runtime", lambda: "/usr/bin/podman")
 
     calls: list[list[str]] = []
@@ -181,6 +184,7 @@ def test_running_argv_falls_back_when_seam_returns_unparseable_json(
     "the slot has no command" — status callers must never read garbage as
     drift."""
     monkeypatch.setattr(container_mod.podman_introspect, "container_argv", lambda _t: "null")
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: False)
     monkeypatch.setattr(container_mod, "_container_runtime", lambda: "/usr/bin/podman")
 
     class _Proc:
@@ -196,6 +200,7 @@ def test_running_argv_none_when_neither_context_answers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(container_mod.podman_introspect, "container_argv", lambda _t: None)
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: False)
 
     def _no_runtime() -> str:
         raise RuntimeError("no podman runtime found")
@@ -245,6 +250,10 @@ def test_slot_view_reports_present_for_a_running_slot(
         ("alpine:3.19", "docker.io/library/alpine:3.19"),
         ("myorg/img", "docker.io/myorg/img:latest"),
         ("docker.io/library/alpine:latest", "docker.io/library/alpine:latest"),
+        # Docker Hub's implicit library/ namespace, however the registry
+        # got there — podman reports the fully-expanded form for all three.
+        ("docker.io/alpine", "docker.io/library/alpine:latest"),
+        ("docker.io/alpine:3.19", "docker.io/library/alpine:3.19"),
         ("ghcr.io/team/model", "ghcr.io/team/model:latest"),
         ("localhost/hal0-toolbox", "localhost/hal0-toolbox:latest"),
         ("localhost:5000/foo:v1", "localhost:5000/foo:v1"),
@@ -264,6 +273,8 @@ def test_canonical_image_ref(ref: str, expected: str) -> None:
         # what podman actually reports vs what a profile actually declares
         ("docker.io/library/alpine:latest", "alpine"),
         ("docker.io/library/alpine:latest", "alpine:latest"),
+        ("docker.io/library/alpine:latest", "docker.io/alpine"),
+        ("docker.io/library/alpine:3.19", "docker.io/alpine:3.19"),
         ("docker.io/myorg/img:latest", "myorg/img"),
         ("ghcr.io/team/model:latest", "ghcr.io/team/model"),
         ("localhost:5000/foo:v1", "localhost:5000/foo:v1"),
@@ -299,3 +310,69 @@ def test_digest_vs_tag_compares_repository_only() -> None:
 def test_unknown_running_image_is_never_drift() -> None:
     assert container_mod._image_mismatch(None, "alpine") is False
     assert container_mod._image_mismatch("alpine", None) is False
+
+
+# ── the rootless store is never consulted ON a provisioned box ─────────────
+#
+# rc 66 ("podman ran but failed") and a missing sudo grant both surface as a
+# None from the seam. Falling through to the rootless store there would
+# collapse that distinction straight back into an authoritative-looking
+# "missing" — #1889 with extra steps — because on a provisioned box that store
+# definitionally cannot hold a slot image.
+
+
+def test_image_present_does_not_consult_rootless_store_as_service_user(
+    monkeypatch: pytest.MonkeyPatch, no_rootless: list[list[str]]
+) -> None:
+    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: None)
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: True)
+
+    # `no_rootless` raises if subprocess.run is reached at all.
+    assert ContainerProvider().image_present(IMAGE) is False
+
+
+def test_image_present_logs_when_the_seam_does_not_answer(
+    monkeypatch: pytest.MonkeyPatch,
+    no_rootless: list[list[str]],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The False above is a bool-contract limitation, not a silent one — an
+    operator must be able to tell it apart from a genuinely absent image."""
+    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: None)
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: True)
+
+    with caplog.at_level("WARNING"):
+        ContainerProvider().image_present(IMAGE)
+
+    assert "image_present_unanswered" in caplog.text
+
+
+@pytest.mark.parametrize("method", ["running_image", "running_argv"])
+def test_container_reads_do_not_consult_rootless_store_as_service_user(
+    monkeypatch: pytest.MonkeyPatch, no_rootless: list[list[str]], method: str
+) -> None:
+    monkeypatch.setattr(container_mod.podman_introspect, "container_image", lambda _t: None)
+    monkeypatch.setattr(container_mod.podman_introspect, "container_argv", lambda _t: None)
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: True)
+
+    assert getattr(ContainerProvider(), method)(SLOT) is None
+
+
+@pytest.mark.parametrize("method", ["running_image", "running_argv"])
+def test_container_reads_still_fall_back_off_the_service_account(
+    monkeypatch: pytest.MonkeyPatch, method: str
+) -> None:
+    """Dev checkout: the operator's own store IS the store slots use."""
+    monkeypatch.setattr(container_mod.podman_introspect, "container_image", lambda _t: None)
+    monkeypatch.setattr(container_mod.podman_introspect, "container_argv", lambda _t: None)
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: False)
+    monkeypatch.setattr(container_mod, "_container_runtime", lambda: "/usr/bin/podman")
+
+    class _Proc:
+        returncode = 0
+        stdout = IMAGE if method == "running_image" else '["llama-server"]'
+
+    monkeypatch.setattr(container_mod.subprocess, "run", lambda *_a, **_k: _Proc())
+
+    expected = IMAGE if method == "running_image" else ["llama-server"]
+    assert getattr(ContainerProvider(), method)(SLOT) == expected

--- a/tests/providers/test_container_podman_ro_routing.py
+++ b/tests/providers/test_container_podman_ro_routing.py
@@ -227,3 +227,75 @@ def test_slot_view_reports_present_for_a_running_slot(
     assert present is True
     assert ("present" if present else "missing") == "present"
     slot_view._image_present_cache.clear()
+
+
+# ── #663 drift comparison, now that running_image is finally reachable ──────
+#
+# Before #1889 running_image() returned None on every deployed box, so
+# _image_mismatch was dead code. Making it live without normalising both sides
+# would trade an inert detector for a LYING one: podman reports the canonical
+# `docker.io/library/alpine:latest` while hal0 profiles declare the shorthand
+# an operator types.
+
+
+@pytest.mark.parametrize(
+    ("ref", "expected"),
+    [
+        ("alpine", "docker.io/library/alpine:latest"),
+        ("alpine:3.19", "docker.io/library/alpine:3.19"),
+        ("myorg/img", "docker.io/myorg/img:latest"),
+        ("docker.io/library/alpine:latest", "docker.io/library/alpine:latest"),
+        ("ghcr.io/team/model", "ghcr.io/team/model:latest"),
+        ("localhost/hal0-toolbox", "localhost/hal0-toolbox:latest"),
+        ("localhost:5000/foo:v1", "localhost:5000/foo:v1"),
+        ("registry.example.com:443/a/b:t", "registry.example.com:443/a/b:t"),
+        ("alpine@sha256:" + "a" * 64, "docker.io/library/alpine@sha256:" + "a" * 64),
+        ("  alpine:3.19  ", "docker.io/library/alpine:3.19"),
+        ("", ""),
+    ],
+)
+def test_canonical_image_ref(ref: str, expected: str) -> None:
+    assert container_mod.canonical_image_ref(ref) == expected
+
+
+@pytest.mark.parametrize(
+    ("running", "declared"),
+    [
+        # what podman actually reports vs what a profile actually declares
+        ("docker.io/library/alpine:latest", "alpine"),
+        ("docker.io/library/alpine:latest", "alpine:latest"),
+        ("docker.io/myorg/img:latest", "myorg/img"),
+        ("ghcr.io/team/model:latest", "ghcr.io/team/model"),
+        ("localhost:5000/foo:v1", "localhost:5000/foo:v1"),
+    ],
+)
+def test_no_false_drift_on_equivalent_refs(running: str, declared: str) -> None:
+    assert container_mod._image_mismatch(running, declared) is False
+
+
+@pytest.mark.parametrize(
+    ("running", "declared"),
+    [
+        ("docker.io/library/alpine:3.19", "alpine:3.20"),
+        ("ghcr.io/team/model:v1", "ghcr.io/team/other:v1"),
+        ("docker.io/library/alpine:latest", "ghcr.io/team/model:latest"),
+        # a registry port must not be amputated into a false match
+        ("localhost:5000/foo:v1", "localhost:6000/foo:v1"),
+    ],
+)
+def test_real_drift_still_fires(running: str, declared: str) -> None:
+    assert container_mod._image_mismatch(running, declared) is True
+
+
+def test_digest_vs_tag_compares_repository_only() -> None:
+    """Deciding whether a tag and a digest name the same image needs a
+    registry round-trip the status hot path will never make; guessing
+    "drifted" there is the cry-wolf failure #663's contract forbids."""
+    digest = "ghcr.io/team/model@sha256:" + "a" * 64
+    assert container_mod._image_mismatch(digest, "ghcr.io/team/model:v1") is False
+    assert container_mod._image_mismatch(digest, "ghcr.io/team/other:v1") is True
+
+
+def test_unknown_running_image_is_never_drift() -> None:
+    assert container_mod._image_mismatch(None, "alpine") is False
+    assert container_mod._image_mismatch("alpine", None) is False

--- a/tests/providers/test_podman_introspect.py
+++ b/tests/providers/test_podman_introspect.py
@@ -325,3 +325,31 @@ def test_is_valid_image_ref_accepts_real_refs(ref: str) -> None:
 @pytest.mark.parametrize("token", ["brain", "1", "my_slot", "my-slot", "x" * 64])
 def test_is_valid_slot_token_accepts_real_tokens(token: str) -> None:
     assert is_valid_slot_token(token) is True
+
+
+def test_image_exists_none_on_operational_podman_failure() -> None:
+    """rc 66 = podman ran but broke (store corruption, lock contention). That
+    is NOT "the image is missing" — reporting it as such would recreate #1889
+    with extra steps, so it must read as "the seam did not answer"."""
+    _calls, run = _seam_recorder(returncode=66, stdout="")
+    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is None
+
+
+def test_container_image_none_on_operational_podman_failure() -> None:
+    _calls, run = _seam_recorder(returncode=66, stdout="")
+    assert container_image("brain", run=run, is_hal0_user=lambda: True) is None
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        # distribution-reference separators: "." | "_" | "__" | "-"+
+        "registry.example/team/model__gpu:v1",
+        "team/model--gpu:v1",
+        "my--registry.example.com/a__b/c.d-e_f:tag",
+    ],
+)
+def test_is_valid_image_ref_accepts_double_separators(ref: str) -> None:
+    """A ref this wrongly rejects never reaches the rootful store, so the
+    caller degrades to the rootless one and #1889 returns for that image."""
+    assert is_valid_image_ref(ref) is True

--- a/tests/providers/test_podman_introspect.py
+++ b/tests/providers/test_podman_introspect.py
@@ -19,7 +19,18 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from hal0.providers.podman_introspect import SEAM_BIN, PodmanImagesResult, images
+import pytest
+
+from hal0.providers.podman_introspect import (
+    SEAM_BIN,
+    PodmanImagesResult,
+    container_argv,
+    container_image,
+    image_exists,
+    images,
+    is_valid_image_ref,
+    is_valid_slot_token,
+)
 
 
 def _completed(returncode: int = 0, stdout: str = "") -> MagicMock:
@@ -140,3 +151,177 @@ def test_images_returns_none_on_rootless_nonzero_exit() -> None:
     result = images(run=_run, which=lambda _n: "/usr/bin/podman", is_hal0_user=lambda: False)
 
     assert result is None
+
+
+# ── #1889: argument-taking read verbs ───────────────────────────────────────
+#
+# The bug: image_present/running_image never used the seam at all, so on every
+# standard install they read hal0-api's own ROOTLESS store — a store that by
+# construction never contains a slot image. image_status was "missing" for
+# every running, healthy slot and actual_image was always null, leaving the
+# #663 drift detector permanently inert.
+
+
+def _seam_recorder(*, returncode: int = 0, stdout: str = ""):
+    calls: list[list[str]] = []
+
+    def _run(argv: object, **kwargs: object) -> MagicMock:
+        calls.append(list(argv))  # type: ignore[arg-type]
+        return _completed(returncode, stdout)
+
+    return calls, _run
+
+
+# ── the gate: still never touches sudo off the hal0 service account ─────────
+
+
+def test_image_exists_skips_seam_when_not_hal0_user() -> None:
+    calls, run = _seam_recorder(stdout="present\n")
+
+    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: False) is None
+    # Crucially NO rootless fallback here either: a "missing" from hal0's own
+    # store about a NAMED image is not a stale answer, it is an answer about a
+    # different object. container.py owns that fallback decision.
+    assert calls == []
+
+
+def test_container_image_skips_seam_when_not_hal0_user() -> None:
+    calls, run = _seam_recorder(stdout="ghcr.io/x/y:1\n")
+
+    assert container_image("brain", run=run, is_hal0_user=lambda: False) is None
+    assert calls == []
+
+
+# ── exact argv (the operand is positional, never a flag) ────────────────────
+
+
+def test_image_exists_seam_argv() -> None:
+    calls, run = _seam_recorder(stdout="present\n")
+
+    assert image_exists("ghcr.io/hal0/runner:rc6", run=run, is_hal0_user=lambda: True) is True
+    assert calls == [["sudo", "-n", SEAM_BIN, "image-exists", "ghcr.io/hal0/runner:rc6"]]
+
+
+def test_container_image_seam_argv_passes_the_bare_token() -> None:
+    """The caller never supplies a container NAME — the wrapper builds
+    hal0-slot-<token> on the root side, so this seam can only ever address a
+    hal0 slot container."""
+    calls, run = _seam_recorder(stdout="ghcr.io/hal0/runner:rc6\n")
+
+    assert container_image("42", run=run, is_hal0_user=lambda: True) == "ghcr.io/hal0/runner:rc6"
+    assert calls == [["sudo", "-n", SEAM_BIN, "container-image", "42"]]
+    assert "hal0-slot-42" not in str(calls)
+
+
+def test_container_argv_seam_argv() -> None:
+    calls, run = _seam_recorder(stdout='["llama-server","--port","8080"]\n')
+
+    out = container_argv("brain", run=run, is_hal0_user=lambda: True)
+
+    assert out == '["llama-server","--port","8080"]'
+    assert calls == [["sudo", "-n", SEAM_BIN, "container-argv", "brain"]]
+
+
+# ── the actual #1889 fix: "present" is reachable ────────────────────────────
+
+
+def test_image_exists_true_on_present() -> None:
+    _calls, run = _seam_recorder(stdout="present\n")
+    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is True
+
+
+def test_image_exists_false_on_missing() -> None:
+    _calls, run = _seam_recorder(stdout="missing\n")
+    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is False
+
+
+# ── tri-state: "seam did not answer" is never confused with a real answer ───
+
+
+def test_image_exists_none_when_seam_denied() -> None:
+    """sudo -n rc 1 (grant not installed / mid-upgrade race) is NOT 'missing'."""
+    _calls, run = _seam_recorder(returncode=1, stdout="")
+    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is None
+
+
+def test_image_exists_none_when_wrapper_rejects_the_ref() -> None:
+    """rc 64 (root-side validation) must not read as 'the image is missing'."""
+    _calls, run = _seam_recorder(returncode=64, stdout="")
+    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is None
+
+
+def test_image_exists_none_when_podman_absent_on_the_box() -> None:
+    """rc 65 (no podman) is not an answer about the image."""
+    _calls, run = _seam_recorder(returncode=65, stdout="")
+    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is None
+
+
+def test_image_exists_none_on_unexpected_stdout() -> None:
+    _calls, run = _seam_recorder(stdout="yes\n")
+    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is None
+
+
+def test_image_exists_none_on_subprocess_error() -> None:
+    def _run(argv: object, **kwargs: object) -> MagicMock:
+        raise OSError("boom")
+
+    assert image_exists("alpine:3.19", run=_run, is_hal0_user=lambda: True) is None
+
+
+def test_container_image_none_when_no_such_container() -> None:
+    """rc 0 with empty stdout is a real negative answer, not a failure."""
+    _calls, run = _seam_recorder(stdout="\n")
+    assert container_image("brain", run=run, is_hal0_user=lambda: True) is None
+
+
+def test_container_argv_none_when_no_such_container() -> None:
+    _calls, run = _seam_recorder(stdout="")
+    assert container_argv("brain", run=run, is_hal0_user=lambda: True) is None
+
+
+# ── unprivileged-side validation: a bad operand never costs a sudo hop ──────
+
+
+@pytest.mark.parametrize(
+    "ref",
+    ["alpine; rm -rf /", "--rm", "-v/:/host", "../../etc/passwd", "", "a" * 513, "foo bar"],
+)
+def test_image_exists_rejects_bad_ref_without_calling_sudo(ref: str) -> None:
+    calls, run = _seam_recorder(stdout="present\n")
+
+    assert image_exists(ref, run=run, is_hal0_user=lambda: True) is None
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "token", ["../root", "foo bar", "foo;id", "foo/bar", "", "x" * 65, "foo.bar"]
+)
+def test_container_verbs_reject_bad_token_without_calling_sudo(token: str) -> None:
+    calls, run = _seam_recorder(stdout="ghcr.io/x/y:1\n")
+
+    assert container_image(token, run=run, is_hal0_user=lambda: True) is None
+    assert container_argv(token, run=run, is_hal0_user=lambda: True) is None
+    assert calls == []
+
+
+# ── the mirrors themselves ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "alpine",
+        "alpine:latest",
+        "docker.io/library/alpine:3.19",
+        "ghcr.io/thinmintdev/hal0-rocmfpx:latest",
+        "localhost:5000/team/img:v1.2.3",
+        "ghcr.io/x/y@sha256:" + "a" * 64,
+    ],
+)
+def test_is_valid_image_ref_accepts_real_refs(ref: str) -> None:
+    assert is_valid_image_ref(ref) is True
+
+
+@pytest.mark.parametrize("token", ["brain", "1", "my_slot", "my-slot", "x" * 64])
+def test_is_valid_slot_token_accepts_real_tokens(token: str) -> None:
+    assert is_valid_slot_token(token) is True


### PR DESCRIPTION
> [!IMPORTANT]
> **SUDOERS + INSTALLER CHANGE — operator review required.** This PR widens a root sudo seam (`hal0-podman-ro`) from zero caller-supplied argv to three verbs that each accept one validated positional operand. Please review the validation regexes and the argument doctrine in the wrapper header before merging. **Do not automerge.**

Refs #1889.

## The bug

`ContainerProvider.image_present` / `running_image` / `running_argv` shelled out to a bare `podman` as the unprivileged `hal0` service user, which has no subuid ranges at all, so they read hal0-api's **own rootless** image store. Slots run **rootful** podman (Quadlet units under `/etc/containers/systemd/`, root's store), so that store by construction never holds a slot image.

On every standard install (reproduced on ct151, ct150 and ct105/rc.5 — pre-existing, not an rc.6 regression):

- `GET /api/slots` reported `image_status: "missing"` for every running, healthy slot
- `GET /api/slots/{name}/pull/status` read "missing" for a present image
- `actual_image` was always `null`, so the **#663 image-drift detector could never fire**

The `hal0-podman-ro` seam and its `is_hal0_service_user()` gate already existed — `cbc8e94d` wired them into `/api/system-info`, which answers correctly — but the wrapper exposed only the argument-free `images` verb, and its header doctrine forbade caller args reaching podman's argv. The three call sites that need a *specific* image ref or container name therefore could not use it.

## The privilege boundary

The doctrine is **refined, not abandoned**, and lands exactly where `hal0-systemctl`'s slot/agent verbs have had it since P3-perms: a caller-supplied value may reach podman's argv only as a **single positional operand validated on the root side against a closed regex**, for a verb whose podman subcommand, flags and `--format` string are literals in the wrapper.

| verb | operand | root-side validation |
|---|---|---|
| `image-exists <ref>` | OCI image reference | `^([A-Za-z0-9]+([.-][A-Za-z0-9]+)*(:[0-9]{1,5})?/)?[A-Za-z0-9]+([._-][A-Za-z0-9]+)*(/…)*(:tag)?(@sha256:[0-9a-f]{64})?$`, length ≤ 512 |
| `container-image <slot-token>` | slot **instance token** | `^[A-Za-z0-9_-]{1,64}$` — byte-identical to `hal0-systemctl`'s `validate_slot_id` |
| `container-argv <slot-token>` | slot **instance token** | same |

Deliberate design points:

- **The container verbs do not take a container name.** They take the bare instance token and the wrapper assembles `hal0-slot-<token>` itself, root-side. The caller can therefore only ever address a hal0 slot container — never an arbitrary one, and never a podman option.
- A validated ref cannot contain whitespace, a shell metacharacter, a leading `-` (no flag smuggling), `..`, or a second argv word. Each verb rejects a second argv word outright.
- Exec arrays only. No shell, no `eval`, no word splitting, no wildcards, no caller-supplied `--format`. `rm`/`run`/`build`/`exec`/`pull` remain unreachable.
- The image-ref regex is **structure-strict, case-permissive**: the security properties come from the structure, and podman itself rejects uppercase repo names, so folding case here would only convert a podman error into a wrapper rejection — while risking a false reject, which is *literally the bug this PR fixes* (a rejected ref degrades to `image_status: "missing"` again).
- The **sudoers grant is unchanged** (`hal0 ALL=(root) NOPASSWD: /usr/lib/hal0/bin/hal0-podman-ro`). A bare command path in sudoers already permits any argv; the wrapper is the control surface. Enumerating verbs in sudoers instead would be a second, silently-drifting copy of the verb list, and sudoers wildcards are a known footgun. Only the explanatory comment changed.

### Exit-code contract

`0` = podman answered (empty stdout on a container verb is a real "no such container"); `64` = wrapper rejected the argument or verb; `65` = podman absent. This is what lets the Python side tell **"the seam did not answer"** from **"the answer is negative"**. The named-object reads deliberately do **not** silently fall back to the rootless store: a rootless answer about a *named* image is not a stale answer, it is an answer about a *different object* — that conflation is #1889. The fallback survives only for the dev/CI case where the process is not the hal0 service user (no grant exists there, and the operator's own store is the right one).

## Files changed

| file | change |
|---|---|
| `installer/wrappers/hal0-podman-ro` | 3 new read verbs + 2 side-effect-free validator probes (`check-image-ref`, `check-slot-token`), 2 validators, exit-code contract, rewritten argument doctrine |
| `packaging/sudoers/hal0-podman-ro` | comment only — documents the new surface and why argv is not enumerated in sudoers |
| `installer/install.sh` | seam #5 comment updated to the new surface |
| `installer/lib/preflight.sh` | `hal0-podman-ro` gains a `help` probe — the grant is now load-bearing for slot status, so presence-only checking was no longer enough |
| `src/hal0/system/seam_check.py` | same probe, kept in lock-step (the `#1465` inventory) |
| `src/hal0/providers/podman_introspect.py` | `image_exists` / `container_image` / `container_argv` (tri-state), `is_valid_image_ref` / `is_valid_slot_token` mirrors |
| `src/hal0/providers/container.py` | the three methods route through the seam first; shared `_decode_argv_json` helper |
| `tests/installer/test_podman_ro_validation.py` | **new** — 220 tests |
| `tests/providers/test_container_podman_ro_routing.py` | **new** — 10 tests |
| `tests/providers/test_podman_introspect.py` | +26 tests |

## Test evidence

The wrapper tests run the **real bash wrapper** (no root, no sudo, no podman, no provisioned box — the `hal0-systemctl` drop-in suite's posture) over ~40 malicious argv shapes: command chaining (`;`/`&&`/`||`/`|`), substitution (`$(…)`/backticks), flag smuggling (`--rm`, `-v/:/host`, `--format={{.Config}}`, bare `-`), traversal (`../../../etc/shadow`, `foo/../../etc/passwd`), malformed digests, control bytes and RTL-override unicode, plus 12 legitimate refs that must **not** be rejected. They also assert **parity** between the wrapper and the Python mirrors — a mirror that drifts looser turns a fast rejection into an opaque `rc 64`; one that drifts stricter silently re-creates #1889.

```
tests/installer/test_podman_ro_validation.py ....... 220 passed
tests/providers/test_podman_introspect.py ........... 47 passed
tests/providers/test_container_podman_ro_routing.py . 10 passed

tests/installer tests/providers tests/slot_view tests/install tests/system
                                                     1811 passed, 1 skipped
tests/api/test_slots_container_state.py tests/api/test_slots_image_pull.py
tests/api/test_system_info_route.py tests/updater/test_wrapper_refresh.py
                                                       48 passed

make lint                                            All checks passed
uv run ruff format --check src tests                 1149 files already formatted
uv run python scripts/check_sunset.py                scar markers 192 <= baseline 192
```

The issue's "test to promote" is `test_slot_view_reports_present_for_a_running_slot`, which drives the real `ContainerProvider` through `slot_view`'s TTL cache helper — the exact path that produces `image_status`. The seam-routing tests booby-trap `subprocess.run` so a test cannot pass by silently falling through to the rootless read.

## Not covered / follow-ups

- The full `tests/api` suite was not run locally (it exceeds a 10-minute local budget); the relevant slot/system-info files were. CI covers the rest.
- `shellcheck` is not installed on this box, so `tests/installer/test_platform_gate_hardening.py` skipped its shellcheck arm as it does on main. `bash -n` passes and is asserted by a test.
- Verifying the fix end-to-end on a provisioned box (`image_status: "present"` for a running slot on ct151) needs a deploy and is left to RC validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)