### PR TITLE
fix(perms): make doctor perms converge on a fresh box

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1233,7 +1233,7 @@ if [[ -n "${HF_TOKEN_VAL}" ]]; then
     # an explicit rotate signal); with no token set, any existing file here is
     # left untouched — never deleted just because the env var was omitted on
     # a later run.
-    mkdir -p "${SECRETS_DIR}"
+    install -d -m 0700 -o root -g root "${SECRETS_DIR}"  # 0700: see #1896
     HF_SECRETS_TMP="$(mktemp "${HF_SECRETS_ENV}.XXXXXX")"
     cat > "${HF_SECRETS_TMP}" <<EOF
 # HuggingFace token for gated / large model pulls — gathered at install time
@@ -2706,7 +2706,14 @@ else
     # whole /etc/hal0 + /var/lib/hal0 tree to an unprivileged service user so a
     # dropped hal0-api could rewrite config — was removed. hal0-api runs as root,
     # so it writes config/state, applies updates, and restarts services directly.
-    mkdir -p "${ETC_DIR}/agents" "${VAR_DIR}/secrets/agents"
+    mkdir -p "${ETC_DIR}/agents"
+    # secrets/ + secrets/agents are born 0700 root:root, matching BOTH the
+    # ownership table (hal0.install.perms) and the hal0-agentenv seam's
+    # `install -d -m 0700`. A plain `mkdir -p` here births them 0755 under the
+    # installer's umask, which the `doctor perms --fix` backstop then had to
+    # tighten on every run — cosmetic drift the audit reported as a defect
+    # (#1896). Explicit mode = born correct, nothing to reconcile.
+    install -d -m 0700 -o root -g root "${VAR_DIR}/secrets" "${VAR_DIR}/secrets/agents"
 
 fi
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1233,7 +1233,15 @@ if [[ -n "${HF_TOKEN_VAL}" ]]; then
     # an explicit rotate signal); with no token set, any existing file here is
     # left untouched — never deleted just because the env var was omitted on
     # a later run.
-    install -d -m 0700 -o root -g root "${SECRETS_DIR}"  # 0700: see #1896
+    # -o/-g dropped from this `install -d`: in --dev this runs as an ordinary
+    # user (dev mode never elevates), so `install -o root -g root` would fail
+    # under `set -euo pipefail` and abort the install whenever HF_TOKEN /
+    # HUGGING_FACE_HUB_TOKEN is exported — the prod-only twin at the
+    # "hal0 system user" follow-up below stays root:root because it sits in
+    # the DEV_MODE=0 branch. Tolerant chown mirrors the HF_SECRETS_TMP idiom
+    # a few lines down: best-effort in --dev, real in a root prod install.
+    install -d -m 0700 "${SECRETS_DIR}"  # 0700: see #1896
+    chown root:root "${SECRETS_DIR}" 2>/dev/null || true
     HF_SECRETS_TMP="$(mktemp "${HF_SECRETS_ENV}.XXXXXX")"
     cat > "${HF_SECRETS_TMP}" <<EOF
 # HuggingFace token for gated / large model pulls — gathered at install time

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -61,7 +61,7 @@ from hal0.agents.anchor_window import (
     resolve_anchor_window,
 )
 from hal0.agents.role_slots import candidate_from_slot_mapping, resolve_role_slots
-from hal0.install.perms import ensure_shared_dir
+from hal0.install.perms import SECRETS_DIR_MODE, ensure_shared_dir
 from hal0.slot_lifecycle_budget import STACK_APPLY_SLOT_ALLOWANCE, slot_lifecycle_timeout_s
 from hal0.slots.state import SlotState, is_dispatchable_state, provider_requires_model
 from hal0.system import seam as _seam
@@ -4822,7 +4822,16 @@ def _merge_env_file(path: Path, updates: dict[str, str]) -> None:
 
     import contextlib
 
-    path.parent.mkdir(parents=True, exist_ok=True)
+    # #1942 review finding 3: a bare `path.parent.mkdir(parents=True,
+    # exist_ok=True)` births an absent parent at the process umask (0755
+    # under UMask=0022) — the sole caller is HERMES_SECRETS_ENV
+    # (secrets/agents/hermes.env), so an absent parent means a fresh box
+    # provisioning before install.sh (or a lost/never-created secrets/agents)
+    # would reintroduce the exact #1896 drift class this PR closed.
+    # `ensure_shared_dir` is umask-proof and only chmod's the components it
+    # creates, so a pre-existing parent (the common case — install.sh seeds
+    # it first) is left untouched.
+    ensure_shared_dir(path.parent, mode=SECRETS_DIR_MODE)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text("\n".join(out_lines) + "\n", encoding="utf-8")
     os.replace(tmp, path)

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -43,6 +43,7 @@ import pwd
 import re
 import shutil
 import sqlite3
+import stat
 import subprocess  # nosec B404 — needed to spawn python -m venv + pip
 import sys
 import tempfile
@@ -60,6 +61,7 @@ from hal0.agents.anchor_window import (
     resolve_anchor_window,
 )
 from hal0.agents.role_slots import candidate_from_slot_mapping, resolve_role_slots
+from hal0.install.perms import ensure_shared_dir
 from hal0.slot_lifecycle_budget import STACK_APPLY_SLOT_ALLOWANCE, slot_lifecycle_timeout_s
 from hal0.slots.state import SlotState, is_dispatchable_state, provider_requires_model
 from hal0.system import seam as _seam
@@ -2723,6 +2725,15 @@ ETC_HAL0_AGENT_SKILLS = ETC_HAL0_DIR / "agent-skills"
 # provision time as root.
 RUNTIME_SNAPSHOT_DIR = Path("/var/lib/hal0")
 
+#: Mode for the runtime snapshots rendered into RUNTIME_SNAPSHOT_DIR. This is
+#: the SAME value the ownership table declares for STATE.md
+#: (``hal0.install.perms.ownership_table``); the two are asserted equal by
+#: ``tests/install/test_perms_converge.py`` so they can never drift apart
+#: again (#1896). Group-writable because the file is written by the hal0
+#: daemon AND by a root-run ``hal0 hermes render-context``, and read by the
+#: session-start hook — one shared group, no owner-dependent access.
+RUNTIME_SNAPSHOT_MODE = 0o664
+
 
 def _latest_env_snapshot(hermes_home: Path) -> dict[str, Any]:
     """Load the env snapshot env_probe wrote (stable ``env.json``, or a legacy
@@ -2753,16 +2764,36 @@ def _render_template(name: str, **vars_: Any) -> str:
     return env.get_template(name).render(**vars_)
 
 
-def _atomic_write(path: Path, content: str) -> str:
-    """Tmp-write + rename for atomicity. Returns the sha256 of content."""
+def _atomic_write(path: Path, content: str, *, mode: int | None = None) -> str:
+    """Tmp-write + rename for atomicity. Returns the sha256 of content.
+
+    The replacement file inherits ``mode`` when given, else the mode of the
+    file it replaces, else the process umask (#1896). A tmp-write + ``rename``
+    otherwise silently RE-MODES its target: the new inode is born at the
+    umask, so the daemon's ``UMask=0022`` rewrote ``STATE.md`` back to ``0644``
+    after every render, discarding the ``0664`` the ownership table declares
+    and ``hal0 doctor perms --fix`` had just applied. That made the self-audit
+    unable to converge — a rewrite is a content change, not a posture change.
+
+    The chmod happens on the TMP file, before the rename, so the target is
+    never observable at the wrong mode.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
+    if mode is None:
+        with contextlib.suppress(OSError):
+            mode = stat.S_IMODE(path.stat().st_mode)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(content, encoding="utf-8")
+    if mode is not None:
+        with contextlib.suppress(OSError):
+            os.chmod(tmp, mode)
     os.replace(tmp, path)
     return content_hash(content)
 
 
-def _atomic_write_if_changed(path: Path, content: str) -> tuple[str, bool]:
+def _atomic_write_if_changed(
+    path: Path, content: str, *, mode: int | None = None
+) -> tuple[str, bool]:
     """Atomic write that skips a byte-identical file. Returns ``(sha256, wrote)``.
 
     The convergence signal for the rendered context files: a re-render that
@@ -2774,7 +2805,7 @@ def _atomic_write_if_changed(path: Path, content: str) -> tuple[str, bool]:
                 return content_hash(content), False
         except OSError:
             pass
-    return _atomic_write(path, content), True
+    return _atomic_write(path, content, mode=mode), True
 
 
 def _safe_symlink(target: Path, link: Path) -> bool:
@@ -4185,7 +4216,7 @@ def render_live_context(
     # STATE.md — content-hash gated (ignore the as_of line). Written under the
     # hal0-owned RUNTIME_SNAPSHOT_DIR so render-context works under the User=hal0
     # / ProtectSystem=strict hermes sandbox (#473).
-    RUNTIME_SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    ensure_shared_dir(RUNTIME_SNAPSHOT_DIR)
     state_path = RUNTIME_SNAPSHOT_DIR / "STATE.md"
     existing = ""
     if state_path.exists():
@@ -4199,7 +4230,7 @@ def render_live_context(
         return out  # state_written=False, hermes_written=False, degraded=True
 
     if _state_body_minus_timestamp(existing) != _state_body_minus_timestamp(new_state):
-        _atomic_write(state_path, new_state)
+        _atomic_write(state_path, new_state, mode=RUNTIME_SNAPSHOT_MODE)
         out["state_written"] = True
     elif reachable:
         # Content unchanged, but we just confirmed it current against a
@@ -4236,7 +4267,7 @@ def render_live_context(
         hpath = RUNTIME_SNAPSHOT_DIR / "HERMES.md"
         out["hermes_path"] = str(hpath)
         if not hpath.exists() or hpath.read_text(encoding="utf-8") != hermes_md:
-            _atomic_write(hpath, hermes_md)
+            _atomic_write(hpath, hermes_md, mode=RUNTIME_SNAPSHOT_MODE)
             out["hermes_written"] = True
     except Exception as exc:  # best-effort; STATE.md already written
         log.warning("hermes_provision.render_live_context_hermes_failed", error=str(exc))

--- a/src/hal0/install/perms.py
+++ b/src/hal0/install/perms.py
@@ -79,6 +79,13 @@ log = logging.getLogger(__name__)
 #: (the daemon, a root-run CLI, the wrapper seams) can write the same tree.
 SHARED_DIR_MODE = 0o2775
 
+#: The mode ``secrets/`` and ``secrets/agents/`` are declared at in the
+#: ownership table below (root:root, root-only traverse+list — #1896). NOT
+#: "shared": callers birthing either dir off the umask-proof path (root-run
+#: provisioners, not just install.sh) pass this explicitly to
+#: :func:`ensure_shared_dir` instead of the group-writable default.
+SECRETS_DIR_MODE = 0o700
+
 
 def ensure_shared_dir(path: Path | str, *, mode: int = SHARED_DIR_MODE) -> Path:
     """``mkdir -p`` whose result the process umask cannot narrow (#1896).
@@ -134,7 +141,14 @@ def ensure_shared_dir(path: Path | str, *, mode: int = SHARED_DIR_MODE) -> Path:
     for created in reversed(missing):
         resolved = created.resolve()
         if not any(_is_within(resolved, root) for root in roots):
-            log.warning(
+            # #1942 review finding 8: INFO, not WARNING — an operator model
+            # store outside every enumerated mount is a supported, expected
+            # configuration (see the CodeQL note above), and a migration or a
+            # multi-directory pull into one can log this once per component
+            # created. WARNING-per-directory on a routine path trains
+            # operators to ignore the log, same failure mode #1896 itself
+            # names for a self-audit that can never be green.
+            log.info(
                 "perms.ensure_shared_dir_outside_hal0_roots path=%s (created, not chmod'ed)",
                 resolved,
             )
@@ -666,24 +680,40 @@ def ownership_table(
         # never be durably green. Reconciled toward the RESTRICTIVE side
         # because nothing outside root has business here: systemd reads the
         # EnvironmentFile as root, the agentenv seam runs as root via
-        # /etc/sudoers.d, and every *.env inside is already 0600 root:root, so
-        # 0700 costs no reader any access it actually had. What it removes is
-        # agent-id ENUMERATION by any local user — small, but free (ADR-0002,
-        # agent credential isolation). See known-issues.yaml
-        # `doctor-perms-secrets-dir-0755-is-declared`, now superseded.
-        PermRow(var_lib / "secrets", "root", "root", 0o700, role="secrets/"),
+        # /etc/sudoers.d. The one non-root traverser, `installer/wrappers/
+        # hermes` (it re-execs as the unprivileged `hal0` user per the #843
+        # run-as-hal0 guard, then sources secrets/agents/hermes.env), is
+        # already blocked one level down — every *.env inside is 0600
+        # root:root, so `hal0` can `stat` the directory but still can't read
+        # the file. 0700 costs no reader any access it actually had. What it
+        # removes is agent-id ENUMERATION by any local user — small, but free
+        # (ADR-0002, agent credential isolation). See known-issues.yaml
+        # `doctor-perms-secrets-dir-0700-is-declared`.
+        PermRow(
+            var_lib / "secrets",
+            "root",
+            "root",
+            SECRETS_DIR_MODE,
+            optional=False,
+            role="secrets/",
+        ),
         # secrets/agents/ — per-agent secret .env files (written by the
         # hal0-agentenv seam, never by the service directly). Pinned root:root
         # like secrets/ itself; the dir mode is 0700 (root-only traverse+list,
         # matching the seam — see above), the per-agent .env files are 0600
-        # (owner-read-only tokens), unchanged by the tightening.
+        # (owner-read-only tokens), unchanged by the tightening. Non-optional
+        # (#1942 review finding 4): the default `optional=True` meant
+        # `_materialise_fresh_install` never created either secrets row, so
+        # the fresh-install convergence tests never exercised the 0700 change
+        # this PR makes — see test_fresh_install_tree_actually_exercises_the_secrets_mode.
         PermRow(
             var_lib / "secrets" / "agents",
             "root",
             "root",
-            0o700,
+            SECRETS_DIR_MODE,
             glob="*.env",
             child_mode=0o600,
+            optional=False,
             role="secrets/agents/ (+ <id>.env)",
         ),
         # benchmarks/ (+ runs/, logs/, server-ab/) — GPU bench artifacts,

--- a/src/hal0/install/perms.py
+++ b/src/hal0/install/perms.py
@@ -95,6 +95,16 @@ def ensure_shared_dir(path: Path | str, *, mode: int = SHARED_DIR_MODE) -> Path:
     through a deliberately tighter parent (``secrets/`` 0700, ``agents/`` 0711)
     can never widen it.
 
+    The ``chmod`` is CONTAINED: it only ever touches a path that resolves
+    inside one of hal0's own roots (:func:`_shared_dir_roots`). Callers derive
+    these paths from request-supplied ids (``persist_pull_job`` ->
+    ``pull_job_file(job.model_id)``, a slot's state dir, ...), and while each
+    caller sanitises its own component, a mode-changing sink must not depend on
+    that being true forever. Same shape as
+    :func:`hal0.config.store.assert_under_store` with ``severity="warn"``: an
+    out-of-tree path is still created (behaviour preserved for callers pointed
+    at an operator's own store) but never re-moded.
+
     Fail-soft on ``chmod``, like :func:`hal0.config.store.finalize_perms`: an
     operator's model store may live on an NFS export that refuses the call, and
     a permissions nice-to-have must never break a pull or a slot load.
@@ -111,12 +121,48 @@ def ensure_shared_dir(path: Path | str, *, mode: int = SHARED_DIR_MODE) -> Path:
 
     path.mkdir(parents=True, exist_ok=True)
 
+    roots = _shared_dir_roots()
     for created in reversed(missing):
+        resolved = created.resolve()
+        if not any(_is_within(resolved, root) for root in roots):
+            log.warning(
+                "perms.ensure_shared_dir_outside_hal0_roots path=%s (created, not chmod'ed)",
+                resolved,
+            )
+            continue
         try:
-            os.chmod(created, mode)
+            os.chmod(resolved, mode)
         except OSError as exc:  # pragma: no cover - exercised via monkeypatch
-            log.debug("perms.ensure_shared_dir_chmod_failed path=%s error=%s", created, exc)
+            log.debug("perms.ensure_shared_dir_chmod_failed path=%s error=%s", resolved, exc)
     return path
+
+
+def _is_within(candidate: Path, root: Path) -> bool:
+    """True when ``candidate`` (already resolved) sits at or under ``root``."""
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _shared_dir_roots() -> tuple[Path, ...]:
+    """Resolved roots :func:`ensure_shared_dir` is allowed to ``chmod`` inside.
+
+    hal0's own state + config trees, plus whatever model-store mounts the
+    operator configured (a pull stages and installs weights there). Root
+    discovery is best-effort: a config-load failure must degrade to the two
+    built-in trees, never raise into a pull.
+    """
+    roots: list[Path] = []
+    for probe in (paths.var_lib, paths.etc, paths.var_log):
+        with contextlib.suppress(OSError, ValueError):
+            roots.append(probe().resolve())
+    try:
+        roots.extend(Path(m).resolve() for m in paths.model_mount_roots())
+    except Exception as exc:  # config load is untrusted here; never raise into a pull
+        log.debug("perms.shared_dir_roots_model_mounts_failed error=%s", exc)
+    return tuple(roots)
 
 
 # ── the declarative table ─────────────────────────────────────────────────────

--- a/src/hal0/install/perms.py
+++ b/src/hal0/install/perms.py
@@ -110,6 +110,15 @@ def ensure_shared_dir(path: Path | str, *, mode: int = SHARED_DIR_MODE) -> Path:
     a permissions nice-to-have must never break a pull or a slot load.
     """
     path = Path(path)
+    # CodeQL note: the `exists()` probe and the `mkdir` below still carry the
+    # caller's taint (py/path-injection, the rule this repo already carries 71
+    # standing alerts for). They are byte-for-byte the operation each caller
+    # performed on the IDENTICAL path before this helper existed — no new
+    # capability, just relocated. The one genuinely new sink, `chmod`, is
+    # contained by the root check below. Containing the `mkdir` too was
+    # rejected: an operator's model store may sit outside every enumerated
+    # mount, and hard-failing a multi-GB pull to satisfy a static-analysis
+    # rule the tree already tolerates is a worse trade.
     # Deepest-first list of the components that do NOT exist yet.
     missing: list[Path] = []
     probe = path

--- a/src/hal0/install/perms.py
+++ b/src/hal0/install/perms.py
@@ -72,6 +72,53 @@ from hal0.config import paths
 log = logging.getLogger(__name__)
 
 
+# ── umask-proof directory creation (#1896) ────────────────────────────────────
+
+#: The mode every SHARED hal0 state directory is declared at below: setgid so
+#: children inherit the ``hal0`` group, group-writable so any hal0-group member
+#: (the daemon, a root-run CLI, the wrapper seams) can write the same tree.
+SHARED_DIR_MODE = 0o2775
+
+
+def ensure_shared_dir(path: Path | str, *, mode: int = SHARED_DIR_MODE) -> Path:
+    """``mkdir -p`` whose result the process umask cannot narrow (#1896).
+
+    ``Path.mkdir(mode=...)`` masks its mode with the umask, and the setgid bit
+    a parent passes down only carries GROUP OWNERSHIP, not the group-write bit.
+    So a daemon under the shipped ``UMask=0022`` births ``2755`` everywhere the
+    table declares ``2775`` — drift that regenerates after every ``--fix``,
+    once per slot loaded and once per model pulled. Creating the dir and then
+    ``chmod``-ing it is the only way to land the declared mode.
+
+    Only the components THIS call creates are chmod'ed. A dir that already
+    exists is left exactly as it is, so a lazy ``mkdir(parents=True)`` passing
+    through a deliberately tighter parent (``secrets/`` 0700, ``agents/`` 0711)
+    can never widen it.
+
+    Fail-soft on ``chmod``, like :func:`hal0.config.store.finalize_perms`: an
+    operator's model store may live on an NFS export that refuses the call, and
+    a permissions nice-to-have must never break a pull or a slot load.
+    """
+    path = Path(path)
+    # Deepest-first list of the components that do NOT exist yet.
+    missing: list[Path] = []
+    probe = path
+    while not probe.exists():
+        missing.append(probe)
+        if probe.parent == probe:
+            break
+        probe = probe.parent
+
+    path.mkdir(parents=True, exist_ok=True)
+
+    for created in reversed(missing):
+        try:
+            os.chmod(created, mode)
+        except OSError as exc:  # pragma: no cover - exercised via monkeypatch
+            log.debug("perms.ensure_shared_dir_chmod_failed path=%s error=%s", created, exc)
+    return path
+
+
 # ── the declarative table ─────────────────────────────────────────────────────
 
 
@@ -556,16 +603,30 @@ def ownership_table(
         # secrets/ stays root:root even under the flip: systemd reads the
         # EnvironmentFile here AS ROOT before dropping to the service user, so it
         # must not be service-writable (hardened-model decision).
-        PermRow(var_lib / "secrets", "root", "root", 0o755, role="secrets/"),
+        #
+        # 0700, NOT 0755 (#1896). The table used to declare 0755 while the
+        # shipped `hal0-agentenv` seam ran `install -d -m 0700` on the same two
+        # dirs on every merge-secrets — two shipped components asserting
+        # different truths, so the mode oscillated and `doctor perms` could
+        # never be durably green. Reconciled toward the RESTRICTIVE side
+        # because nothing outside root has business here: systemd reads the
+        # EnvironmentFile as root, the agentenv seam runs as root via
+        # /etc/sudoers.d, and every *.env inside is already 0600 root:root, so
+        # 0700 costs no reader any access it actually had. What it removes is
+        # agent-id ENUMERATION by any local user — small, but free (ADR-0002,
+        # agent credential isolation). See known-issues.yaml
+        # `doctor-perms-secrets-dir-0755-is-declared`, now superseded.
+        PermRow(var_lib / "secrets", "root", "root", 0o700, role="secrets/"),
         # secrets/agents/ — per-agent secret .env files (written by the
         # hal0-agentenv seam, never by the service directly). Pinned root:root
-        # like secrets/ itself; the dir mode is 0755 (traverse + list), the
-        # per-agent .env files are 0600 (owner-read-only tokens).
+        # like secrets/ itself; the dir mode is 0700 (root-only traverse+list,
+        # matching the seam — see above), the per-agent .env files are 0600
+        # (owner-read-only tokens), unchanged by the tightening.
         PermRow(
             var_lib / "secrets" / "agents",
             "root",
             "root",
-            0o755,
+            0o700,
             glob="*.env",
             child_mode=0o600,
             role="secrets/agents/ (+ <id>.env)",
@@ -930,12 +991,14 @@ def audit_rows(plan_: OwnershipPlan) -> list[dict[str, str]]:
 
 
 __all__ = [
+    "SHARED_DIR_MODE",
     "OwnershipPlan",
     "PermDiff",
     "PermObservation",
     "PermRow",
     "audit_rows",
     "commit",
+    "ensure_shared_dir",
     "observe",
     "ownership_table",
     "plan",

--- a/src/hal0/registry/model_store.py
+++ b/src/hal0/registry/model_store.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any
 
 from hal0.config import paths
+from hal0.install.perms import ensure_shared_dir
 
 log = logging.getLogger(__name__)
 
@@ -279,7 +280,7 @@ def execute_migration(plan: MigrationPlan) -> MigrationResult:
 
     src = Path(plan.source or "")
     dst = Path(plan.target)
-    dst.mkdir(parents=True, exist_ok=True)
+    ensure_shared_dir(dst)  # 2775, umask-proof (#1896)
     result = MigrationResult(source=str(src), target=str(dst))
 
     for entry in sorted(src.iterdir()):

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -39,6 +39,7 @@ from hal0.config import paths, store
 from hal0.db import repository
 from hal0.db.connection import connect, tx
 from hal0.errors import Hal0Error
+from hal0.install.perms import ensure_shared_dir
 from hal0.registry.fileset import FileSetEntry, FileSetPlan
 from hal0.registry.model import Model, ModelCapabilities, ModelDefaults
 from hal0.registry.store import ModelNotFound, ModelRegistry, _fsync_dir
@@ -448,7 +449,9 @@ def persist_pull_job(job: PullJob) -> None:
     """
     path = pull_job_file(job.model_id)
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
+        # model-pull-jobs/ is declared 2775; a bare mkdir under the daemon's
+        # UMask=0022 births 2755 and re-drifts the audit after every pull (#1896).
+        ensure_shared_dir(path.parent)
         fd, tmp_str = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
         tmp_path: Path | None = Path(tmp_str)
         try:
@@ -722,7 +725,7 @@ async def _download_one(
     headers = dict(base_headers)
 
     tmp_dir = _tmp_dir()
-    tmp_dir.mkdir(parents=True, exist_ok=True)
+    ensure_shared_dir(tmp_dir)  # 2775, umask-proof (#1896)
     # Deterministic staging name (MR-7) so a prior interrupted pull can be
     # found and resumed. The JSON sidecar next to it records the resume
     # coordinates (url, etag, bytes-on-disk, total). TRADEOFF: this is not
@@ -909,7 +912,7 @@ async def _download_one(
             )
 
         # Atomic install.
-        final.parent.mkdir(parents=True, exist_ok=True)
+        ensure_shared_dir(final.parent)  # 2775, umask-proof (#1896)
         os.replace(part, final)
         _discard_partial(part, sidecar)  # part is renamed away; drop the sidecar
         size_bytes = final.stat().st_size
@@ -1442,7 +1445,7 @@ def _maybe_hardlink_from_blob(sha256: str, dest: Path) -> bool:
         try:
             if not blob_path.is_file():
                 return False
-            dest.parent.mkdir(parents=True, exist_ok=True)
+            ensure_shared_dir(dest.parent)  # 2775, umask-proof (#1896)
             if os.stat(blob_path).st_dev != os.stat(dest.parent).st_dev:
                 # Cross-filesystem — hardlinks are impossible; degrade to a
                 # normal download rather than fail the pull (plan risk:

--- a/src/hal0/registry/runner_pull.py
+++ b/src/hal0/registry/runner_pull.py
@@ -33,6 +33,7 @@ from typing import Any
 
 from hal0.config import paths
 from hal0.errors import Hal0Error
+from hal0.install.perms import ensure_shared_dir
 from hal0.registry.runner_image_store import RunnerImageStore
 
 log = logging.getLogger(__name__)
@@ -134,7 +135,7 @@ def persist_pull_job(job: RunnerPullJob) -> None:
     """Atomically mirror a job snapshot to disk (best-effort, fail-soft)."""
     path = pull_job_file(job.image_id)
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_shared_dir(path.parent)  # 2775, umask-proof (#1896)
         fd, tmp_str = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
         tmp_path: Path | None = Path(tmp_str)
         try:
@@ -215,7 +216,7 @@ def local_marker_path(image_id: str) -> Path:
 def write_local_marker(image_id: str, image_ref: str) -> Path:
     """Record a completed pull. Returns the marker path (used as local_path)."""
     path = local_marker_path(image_id)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    ensure_shared_dir(path.parent)  # 2775, umask-proof (#1896)
     path.write_text(
         json.dumps(
             {"image_id": image_id, "image": image_ref, "pulled_at": datetime.now(UTC).isoformat()}

--- a/src/hal0/registry/store.py
+++ b/src/hal0/registry/store.py
@@ -48,6 +48,7 @@ import tomli_w
 
 from hal0.config import paths
 from hal0.errors import Hal0Error
+from hal0.install.perms import ensure_shared_dir
 from hal0.registry.model import Model
 
 try:  # POSIX advisory file locking. Absent on Windows; repo targets Linux.
@@ -119,7 +120,7 @@ def registry_write_lock(registry_dir: str | Path) -> Iterator[None]:
     if fcntl is None:  # pragma: no cover - non-POSIX fallback
         yield
         return
-    lock_dir.mkdir(parents=True, exist_ok=True)
+    ensure_shared_dir(lock_dir)  # 2775, umask-proof (#1896)
     lock_path = lock_dir / _PROCESS_LOCK_FILENAME
     fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
     try:
@@ -309,7 +310,7 @@ class TomlModelRegistry:
         the original file is left intact.
         """
         target = self.registry_file
-        target.parent.mkdir(parents=True, exist_ok=True)
+        ensure_shared_dir(target.parent)  # 2775, umask-proof (#1896)
 
         payload = {"models": {mid: _model_to_toml(m) for mid, m in sorted(models.items())}}
 

--- a/src/hal0/slots/arbiter.py
+++ b/src/hal0/slots/arbiter.py
@@ -60,6 +60,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from hal0.config import paths
 from hal0.errors import Hal0Error, NotFound
+from hal0.install.perms import ensure_shared_dir
 from hal0.slots.state import DISPATCHABLE_STATES, SlotState
 
 if TYPE_CHECKING:  # pragma: no cover — import cycle guard (manager owns us)
@@ -281,7 +282,7 @@ class GpuArbiter:
     def _persist(self) -> None:
         """Atomic same-directory tmpfile + os.replace (state.json pattern)."""
         st = self._load_state()
-        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_shared_dir(self.state_path.parent)  # 2775, umask-proof (#1896)
         tmp_path: Path | None = None
         try:
             fd, tmp_str = tempfile.mkstemp(

--- a/src/hal0/slots/migrate_id_keying.py
+++ b/src/hal0/slots/migrate_id_keying.py
@@ -45,6 +45,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
+from hal0.install.perms import ensure_shared_dir
 from hal0.slot_config import write_slot_toml
 from hal0.slots.identity import SlotIdentityStore
 
@@ -189,7 +190,7 @@ def _toml_id(raw: dict[str, Any]) -> int | None:
 
 
 def _write_json_atomic(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+    ensure_shared_dir(path.parent)  # 2775, umask-proof (#1896)
     payload = json.dumps(data, indent=2, sort_keys=True) + "\n"
     fd, tmp = tempfile.mkstemp(prefix=".hal0-state-", suffix=".tmp", dir=path.parent)
     try:

--- a/src/hal0/slots/state.py
+++ b/src/hal0/slots/state.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import Any
 
 from hal0.errors import Hal0Error
+from hal0.install.perms import ensure_shared_dir
 
 # ── Enum ─────────────────────────────────────────────────────────────────────
 
@@ -381,7 +382,9 @@ def write_state_atomic(path: Path | str, record: SlotStateRecord) -> None:
     truncated state.json.
     """
     path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    # 2775, umask-proof: the slots/ row declares the per-slot dir setgid +
+    # group-writable, and a bare mkdir under UMask=0022 births 2755 (#1896).
+    ensure_shared_dir(path.parent)
     payload = json.dumps(record.to_dict(), indent=2, sort_keys=True) + "\n"
 
     tmp_path: Path | None = None

--- a/tests/agents/test_hermes_env_seam.py
+++ b/tests/agents/test_hermes_env_seam.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 import pytest
 
 from hal0.agents import hermes_provision as hp
+from hal0.config import paths
 
 # ── secrets vault ────────────────────────────────────────────────────────────
 
@@ -48,6 +49,27 @@ def test_secrets_env_root_preserves_existing_lines(
     monkeypatch.setattr(hp.os, "geteuid", lambda: 0)
     hp._write_secrets_env({"A": "99", "C": "3"})
     assert vault.read_text() == "# operator note\nA=99\nKEEP=yes\nC=3\n"
+
+
+def test_secrets_env_root_births_absent_parent_at_0700(monkeypatch: pytest.MonkeyPatch) -> None:
+    """euid==0, secrets/agents/ absent (fresh box): the birthed dir is 0700.
+
+    #1942 review finding 3: ``_merge_env_file`` used a bare
+    ``path.parent.mkdir(parents=True, exist_ok=True)`` — no mode — so a
+    root-run provision on a box where ``secrets/agents`` doesn't exist yet
+    births it 0755 under the installer/daemon umask, reintroducing the exact
+    #1896 drift class this PR tightened the table and install.sh to close.
+    """
+    # Must sit under paths.var_lib() (not a bare tmp_path): ensure_shared_dir's
+    # containment check only chmod's paths inside hal0's own declared roots
+    # (see #1739 / #1896 in perms.py) — the autouse _isolate_hal0_home
+    # fixture points paths.var_lib() at tmp_path/var-lib for this test.
+    vault = paths.var_lib() / "secrets" / "agents" / "hermes.env"
+    assert not vault.parent.exists()
+    monkeypatch.setattr(hp, "HERMES_SECRETS_ENV", vault)
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 0)
+    hp._write_secrets_env({"A": "1"})
+    assert (vault.parent.stat().st_mode & 0o777) == 0o700
 
 
 def test_secrets_env_nonroot_routes_through_seam(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/install/test_perms_converge.py
+++ b/tests/install/test_perms_converge.py
@@ -234,6 +234,28 @@ def test_fresh_install_tree_is_green(tmp_hal0_home: str) -> None:
     assert _mode_drift(table) == []
 
 
+def test_fresh_install_tree_actually_exercises_the_secrets_mode(tmp_hal0_home: str) -> None:
+    """#1942 review finding 4: the 0700 change must be BOUND by a convergence test.
+
+    ``PermRow.optional`` defaults ``True``, and neither secrets row overrode
+    it, so ``_materialise_fresh_install`` (which skips optional rows) never
+    created ``secrets/`` — the fresh-install green check above passed
+    trivially by never looking at the path the whole PR is about. Both
+    secrets rows are now ``optional=False``; this asserts the fresh-install
+    tree actually contains them, born at the declared 0700, not merely that
+    the declaration table says 0700 (that's :func:`test_secrets_rows_declare_0700`).
+    """
+    table = perms.ownership_table(service_user="hal0")
+    _materialise_fresh_install(table)
+    var_lib = paths.var_lib()
+    secrets = var_lib / "secrets"
+    agents = var_lib / "secrets" / "agents"
+    assert secrets.is_dir(), "_materialise_fresh_install must create secrets/"
+    assert agents.is_dir(), "_materialise_fresh_install must create secrets/agents/"
+    assert os.stat(secrets).st_mode & 0o7777 == 0o700
+    assert os.stat(agents).st_mode & 0o7777 == 0o700
+
+
 def test_stays_green_after_slot_load_model_pull_and_state_render(
     tmp_hal0_home: str,
 ) -> None:

--- a/tests/install/test_perms_converge.py
+++ b/tests/install/test_perms_converge.py
@@ -1,0 +1,257 @@
+"""#1896 — ``hal0 doctor perms`` must be GREEN on a fresh box, and STAY green.
+
+The defect this file locks down is not a leak; it is a *contradiction* between
+three shipped components that each declared a different truth for the same
+paths, so the self-audit could never converge:
+
+  1. ``STATE.md`` — ``hermes_provision._atomic_write`` replaced the file with a
+     fresh tmp file born at the process umask (``0644`` under the daemon's
+     ``UMask=0022``), silently discarding the ``0664`` the table declares and
+     ``--fix`` had just applied.
+  2. ``secrets/`` + ``secrets/agents/`` — the ``hal0-agentenv`` privileged seam
+     re-tightens both to ``0700`` on every ``merge-secrets``, while the table
+     declared ``0755``. The two shipped components disagreed, so the mode
+     oscillated forever. Reconciled toward the RESTRICTIVE side (``0700``):
+     nothing but root ever traverses that tree.
+  3. Daemon-created dirs under the recursive ``slots/`` / ``models/`` /
+     ``model-pull-jobs/`` rows — ``Path.mkdir`` masks its mode with the umask,
+     so a ``UMask=0022`` daemon births ``2755`` where the table declares
+     ``2775`` (setgid survives inheritance; the group-write bit does not).
+
+Deliberately NOT asserted anywhere here: a drift ROW COUNT. The concrete path
+set grows with every slot loaded and every model pulled, so a count assertion
+is a false-failure generator. The invariant is *green after mutation*.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from hal0.config import paths
+from hal0.install import perms
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENTENV_WRAPPER = REPO_ROOT / "installer" / "wrappers" / "hal0-agentenv"
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _mode_drift(table: list[perms.PermRow]) -> list[tuple[str, str, str]]:
+    """Every existing path whose MODE differs from its declared mode.
+
+    Owner/group are deliberately out of scope: an unprivileged test process
+    cannot chown to ``hal0``/``root``, and the #1896 non-convergence is a
+    mode-only phenomenon. Returns ``(path, declared, observed)`` octal triples
+    so a failure names the offender instead of a bare count.
+    """
+    out: list[tuple[str, str, str]] = []
+    for diff in perms.plan(table).diffs:
+        before = diff.before
+        if not before.exists or before.is_symlink or before.mode is None:
+            continue
+        if before.mode != diff.mode:
+            out.append((str(diff.path), oct(diff.mode), oct(before.mode)))
+    return out
+
+
+def _materialise_fresh_install(table: list[perms.PermRow]) -> None:
+    """Build the on-disk tree a fresh install leaves AFTER ``--fix`` ran.
+
+    Every non-optional row's target is created and chmod'ed to its declared
+    mode — the state ``hal0 doctor perms`` is supposed to call green.
+    """
+    for row in table:
+        if row.optional:
+            continue
+        target = row.target
+        # A row's mode carries the file-type-independent permission bits; the
+        # non-optional rows in the table are all directories.
+        target.mkdir(parents=True, exist_ok=True)
+        os.chmod(target, row.mode)
+
+
+# ── component 2: the secrets/ mode contradiction ──────────────────────────────
+
+
+def test_secrets_rows_declare_0700(tmp_hal0_home: str) -> None:
+    """The table must declare the RESTRICTIVE mode the agentenv seam enforces."""
+    by_target = {r.target: r for r in perms.ownership_table(service_user="hal0")}
+    var_lib = paths.var_lib()
+
+    secrets = by_target[var_lib / "secrets"]
+    agents = by_target[var_lib / "secrets" / "agents"]
+
+    assert (secrets.owner, secrets.group, secrets.mode) == ("root", "root", 0o700)
+    assert (agents.owner, agents.group, agents.mode) == ("root", "root", 0o700)
+    # The secrecy contract one level down is untouched by the widening fix:
+    # the *.env files stay owner-read-only.
+    assert agents.glob == "*.env"
+    assert agents.child_mode == 0o600
+
+
+def test_agentenv_wrapper_and_table_agree_on_the_secrets_mode() -> None:
+    """The two shipped components may never disagree again.
+
+    ``hal0-agentenv`` runs ``install -d -m <mode>`` on both secrets dirs on
+    every ``merge-secrets``. If that mode and the table's ever diverge the
+    audit oscillates forever (#1896) — so parse the wrapper and compare.
+    """
+    body = AGENTENV_WRAPPER.read_text(encoding="utf-8")
+    match = re.search(
+        r"install\s+-d\s+-m\s+0?(?P<mode>[0-7]{3,4})\b[^\n]*/var/lib/hal0/secrets",
+        body,
+    )
+    assert match, "hal0-agentenv no longer creates the secrets dirs with an explicit mode"
+    wrapper_mode = int(match.group("mode"), 8)
+
+    table = perms.ownership_table(service_user="hal0")
+    by_target = {r.target: r for r in table}
+    declared = by_target[paths.var_lib() / "secrets"].mode
+    assert wrapper_mode == declared, (
+        f"hal0-agentenv installs secrets/ 0{wrapper_mode:o} but the ownership "
+        f"table declares 0{declared:o} — that disagreement IS #1896"
+    )
+
+
+# ── component 3: umask-proof shared state dirs ────────────────────────────────
+
+
+@pytest.mark.parametrize("umask", [0o022, 0o077, 0o002])
+def test_ensure_shared_dir_beats_the_process_umask(tmp_path: Path, umask: int) -> None:
+    """``mkdir`` masks its mode; the helper must not."""
+    old = os.umask(umask)
+    try:
+        made = perms.ensure_shared_dir(tmp_path / "models" / "org" / "repo")
+    finally:
+        os.umask(old)
+    assert made.is_dir()
+    for part in (tmp_path / "models", tmp_path / "models" / "org", made):
+        assert os.stat(part).st_mode & 0o7777 == perms.SHARED_DIR_MODE, part
+
+
+def test_ensure_shared_dir_never_widens_an_existing_dir(tmp_path: Path) -> None:
+    """Only components this call CREATES are chmod'ed.
+
+    An existing dir may be declared at a deliberately tighter mode elsewhere in
+    the table (``secrets/`` 0700, ``agents/`` 0711); a lazy mkdir passing
+    through it must never widen it.
+    """
+    tight = tmp_path / "secrets"
+    tight.mkdir(mode=0o700)
+    os.chmod(tight, 0o700)
+    perms.ensure_shared_dir(tight / "agents")
+    assert os.stat(tight).st_mode & 0o7777 == 0o700
+
+
+def test_ensure_shared_dir_is_fail_soft_on_chmod_refusal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A model store on NFS may refuse chmod — that must never break a pull."""
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise PermissionError("read-only export")
+
+    monkeypatch.setattr(perms.os, "chmod", _boom)
+    made = perms.ensure_shared_dir(tmp_path / "nfs" / "models")
+    assert made.is_dir()
+
+
+# ── component 1: the atomic-write mode discard ────────────────────────────────
+
+
+def test_atomic_write_preserves_an_existing_files_mode(tmp_path: Path) -> None:
+    """tmp-write + ``os.replace`` must not silently re-mode the target."""
+    from hal0.agents import hermes_provision
+
+    target = tmp_path / "STATE.md"
+    target.write_text("old\n", encoding="utf-8")
+    os.chmod(target, 0o664)
+
+    old = os.umask(0o022)
+    try:
+        hermes_provision._atomic_write(target, "new\n")
+    finally:
+        os.umask(old)
+
+    assert target.read_text(encoding="utf-8") == "new\n"
+    assert os.stat(target).st_mode & 0o7777 == 0o664
+
+
+def test_atomic_write_honours_an_explicit_mode(tmp_path: Path) -> None:
+    """A first render (no existing file) still lands the declared mode."""
+    from hal0.agents import hermes_provision
+
+    target = tmp_path / "STATE.md"
+    old = os.umask(0o022)
+    try:
+        hermes_provision._atomic_write(target, "fresh\n", mode=0o664)
+    finally:
+        os.umask(old)
+    assert os.stat(target).st_mode & 0o7777 == 0o664
+
+
+def test_state_md_row_matches_what_the_renderer_writes(tmp_hal0_home: str) -> None:
+    """The declared STATE.md mode and the renderer's write mode are one value."""
+    from hal0.agents import hermes_provision
+
+    by_target = {r.target: r for r in perms.ownership_table(service_user="hal0")}
+    declared = by_target[paths.var_lib() / "STATE.md"].mode
+    assert declared == hermes_provision.RUNTIME_SNAPSHOT_MODE
+
+
+# ── the whole point: green, and green again after real mutations ──────────────
+
+
+def test_fresh_install_tree_is_green(tmp_hal0_home: str) -> None:
+    table = perms.ownership_table(service_user="hal0")
+    _materialise_fresh_install(table)
+    assert _mode_drift(table) == []
+
+
+def test_stays_green_after_slot_load_model_pull_and_state_render(
+    tmp_hal0_home: str,
+) -> None:
+    """The #1896 acceptance criterion, verbatim from the issue.
+
+    "On a fresh install, ``hal0 doctor perms`` is green, and stays green after
+    a slot load, a model pull, and a hermes ``STATE.md`` render."
+
+    Each mutation runs through the REAL writer, under the daemon's own
+    ``UMask=0022``, and the audit is re-run after each one. No row count is
+    asserted — only that the drift set is empty.
+    """
+    from hal0.agents import hermes_provision
+    from hal0.registry import pull
+    from hal0.slots import state as slot_state
+
+    table = perms.ownership_table(service_user="hal0")
+    _materialise_fresh_install(table)
+    var_lib = paths.var_lib()
+
+    old_umask = os.umask(0o022)  # the shipped hal0-api unit's umask
+    try:
+        # 1. slot load -> slots/<id>/state.json (dir born by the writer)
+        slot_state.write_state_atomic(
+            var_lib / "slots" / "gpu-rocm-0" / "state.json",
+            slot_state.SlotStateRecord(name="gpu-rocm-0", state=slot_state.SlotState.READY),
+        )
+        assert _mode_drift(table) == [], "drift after a slot load"
+
+        # 2. model pull -> model-pull-jobs/<id>.json + models/<org>/<repo>/
+        pull.persist_pull_job(pull.PullJob(job_id="j1", model_id="org/repo", state="completed"))
+        perms.ensure_shared_dir(var_lib / "models" / "org" / "repo")
+        assert _mode_drift(table) == [], "drift after a model pull"
+
+        # 3. hermes STATE.md render
+        state_md = var_lib / "STATE.md"
+        hermes_provision._atomic_write(state_md, "# state\n", mode=0o664)
+        assert _mode_drift(table) == [], "drift after the first STATE.md render"
+        hermes_provision._atomic_write(state_md, "# state 2\n")
+        assert _mode_drift(table) == [], "drift after a STATE.md re-render"
+    finally:
+        os.umask(old_umask)

--- a/tests/install/test_perms_converge.py
+++ b/tests/install/test_perms_converge.py
@@ -122,34 +122,55 @@ def test_agentenv_wrapper_and_table_agree_on_the_secrets_mode() -> None:
 
 
 @pytest.mark.parametrize("umask", [0o022, 0o077, 0o002])
-def test_ensure_shared_dir_beats_the_process_umask(tmp_path: Path, umask: int) -> None:
+def test_ensure_shared_dir_beats_the_process_umask(tmp_hal0_home: str, umask: int) -> None:
     """``mkdir`` masks its mode; the helper must not."""
+    var_lib = paths.var_lib()
+    var_lib.mkdir(parents=True, exist_ok=True)
     old = os.umask(umask)
     try:
-        made = perms.ensure_shared_dir(tmp_path / "models" / "org" / "repo")
+        made = perms.ensure_shared_dir(var_lib / "models" / "org" / "repo")
     finally:
         os.umask(old)
     assert made.is_dir()
-    for part in (tmp_path / "models", tmp_path / "models" / "org", made):
+    for part in (var_lib / "models", var_lib / "models" / "org", made):
         assert os.stat(part).st_mode & 0o7777 == perms.SHARED_DIR_MODE, part
 
 
-def test_ensure_shared_dir_never_widens_an_existing_dir(tmp_path: Path) -> None:
+def test_ensure_shared_dir_never_widens_an_existing_dir(tmp_hal0_home: str) -> None:
     """Only components this call CREATES are chmod'ed.
 
     An existing dir may be declared at a deliberately tighter mode elsewhere in
     the table (``secrets/`` 0700, ``agents/`` 0711); a lazy mkdir passing
     through it must never widen it.
     """
-    tight = tmp_path / "secrets"
-    tight.mkdir(mode=0o700)
+    tight = paths.var_lib() / "secrets"
+    tight.mkdir(parents=True, exist_ok=True)
     os.chmod(tight, 0o700)
     perms.ensure_shared_dir(tight / "agents")
     assert os.stat(tight).st_mode & 0o7777 == 0o700
 
 
+def test_ensure_shared_dir_never_chmods_outside_hal0_roots(
+    tmp_hal0_home: str, tmp_path: Path
+) -> None:
+    """The chmod sink is contained; the mkdir behaviour is not.
+
+    Callers derive these paths from request-supplied ids. A path that escapes
+    every hal0 root is still created — the caller may legitimately be pointed
+    at an operator's own tree — but it is never re-moded.
+    """
+    outside = tmp_path / "elsewhere" / "not-hal0"
+    old = os.umask(0o022)
+    try:
+        made = perms.ensure_shared_dir(outside)
+    finally:
+        os.umask(old)
+    assert made.is_dir()
+    assert os.stat(made).st_mode & 0o7777 == 0o755  # umask default, untouched
+
+
 def test_ensure_shared_dir_is_fail_soft_on_chmod_refusal(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A model store on NFS may refuse chmod — that must never break a pull."""
 
@@ -157,7 +178,7 @@ def test_ensure_shared_dir_is_fail_soft_on_chmod_refusal(
         raise PermissionError("read-only export")
 
     monkeypatch.setattr(perms.os, "chmod", _boom)
-    made = perms.ensure_shared_dir(tmp_path / "nfs" / "models")
+    made = perms.ensure_shared_dir(paths.var_lib() / "nfs" / "models")
     assert made.is_dir()
 
 

--- a/tests/release-validation/known-issues.yaml
+++ b/tests/release-validation/known-issues.yaml
@@ -810,25 +810,26 @@ known_issues:
     review_at: v1.1.0
 
   - id: doctor-perms-secrets-dir-0755-is-declared
-    status: by-design      # partial — covers ONLY the mode value, not the non-convergence
+    status: fixed          # #1896, v1.0.0-rc.7 — the 0755 declaration is gone
     adjudicated: v1.0.0-rc.6
     summary: >-
       `hal0 doctor perms --fix` widens /var/lib/hal0/secrets and secrets/agents from 0700 to
       0755.
     why: >-
-      0755 IS the P3-perms table's declared want (perms.py:496-514): the directory needs
-      traverse+list only, secrecy is enforced one level down by child_mode=0o600 on the *.env
-      glob, and systemd reads the EnvironmentFile as root before dropping privilege. Widening
-      the DIRECTORY exposes agent-id enumeration, not credential content; 0755 is already the
-      live posture on production and ct150. Do not re-file as "doctor --fix leaks secrets". Also
-      never assert a drift ROW COUNT — the set grows with every slot loaded / model pulled. The
-      real unadjudicated defect is that perms.py (0755) and hal0-agentenv (`install -d -m 0700`)
-      DISAGREE, so the mode oscillates — that is regression `doctor-perms-never-converges`.
+      RESOLVED, not by-design any more. The rc.6 adjudication was correct that the widening was
+      not a credential leak (*.env stays 0600 root:root either way), but the underlying defect it
+      named — perms.py (0755) and hal0-agentenv (`install -d -m 0700`) DISAGREEING, so the mode
+      oscillates forever — was fixed in #1896 by moving the TABLE to the restrictive side: both
+      secrets rows now declare 0700, install.sh births them 0700, and the agentenv seam is
+      unchanged. Nothing outside root ever traversed the tree (systemd reads the EnvironmentFile
+      as root; the seam runs as root via /etc/sudoers.d), so 0700 costs no reader any access and
+      removes local agent-id enumeration. Still never assert a drift ROW COUNT — the set grows
+      with every slot loaded / model pulled.
     still_report_if: >-
-      A file under /var/lib/hal0/secrets/ is observed at a mode other than 0600, or owned by
-      anything but root:root, after `doctor perms --fix`; OR secrets/hal0-api.env is not covered
-      by a PermRow and lands group/world-readable; OR a caller other than the agentenv seam
-      tightens the directory.
+      /var/lib/hal0/secrets or secrets/agents is observed at any mode other than 0700 after
+      `doctor perms --fix`; OR a file under secrets/ is observed at a mode other than 0600, or
+      owned by anything but root:root; OR secrets/hal0-api.env is not covered by a PermRow and
+      lands group/world-readable.
     review_at: v1.1.0
 
   - id: pull-job-persist-fail-soft-scope

--- a/tests/release-validation/known-issues.yaml
+++ b/tests/release-validation/known-issues.yaml
@@ -809,7 +809,7 @@ known_issues:
       limit); OR `capabilities set --disabled` no longer recovers the box.
     review_at: v1.1.0
 
-  - id: doctor-perms-secrets-dir-0755-is-declared
+  - id: doctor-perms-secrets-dir-0700-is-declared
     status: fixed          # #1896, v1.0.0-rc.7 — the 0755 declaration is gone
     adjudicated: v1.0.0-rc.6
     summary: >-
@@ -821,10 +821,11 @@ known_issues:
       named — perms.py (0755) and hal0-agentenv (`install -d -m 0700`) DISAGREEING, so the mode
       oscillates forever — was fixed in #1896 by moving the TABLE to the restrictive side: both
       secrets rows now declare 0700, install.sh births them 0700, and the agentenv seam is
-      unchanged. Nothing outside root ever traversed the tree (systemd reads the EnvironmentFile
-      as root; the seam runs as root via /etc/sudoers.d), so 0700 costs no reader any access and
-      removes local agent-id enumeration. Still never assert a drift ROW COUNT — the set grows
-      with every slot loaded / model pulled.
+      unchanged. The one non-root traverser, `installer/wrappers/hermes` (it re-execs as the
+      unprivileged `hal0` user per the #843 run-as-hal0 guard, then sources
+      secrets/agents/hermes.env), is already blocked one level down — every *.env inside is 0600
+      root:root — so 0700 costs no reader any access and removes local agent-id enumeration.
+      Still never assert a drift ROW COUNT — the set grows with every slot loaded / model pulled.
     still_report_if: >-
       /var/lib/hal0/secrets or secrets/agents is observed at any mode other than 0700 after
       `doctor perms --fix`; OR a file under secrets/ is observed at a mode other than 0600, or

--- a/tests/release-validation/lanes/readonly/cli.md
+++ b/tests/release-validation/lanes/readonly/cli.md
@@ -51,8 +51,8 @@ command group is unfamiliar, run `--help` first and only run the verbs that clea
    not (regression `doctor-perms-never-converges`). Date any DRIFT row against the installer's
    own `--fix` backstop by **ctime** (chmod bumps ctime, not mtime) so install-time drift is
    distinguishable from lane damage. Never assert a drift row COUNT — it grows with every slot
-   load and model pull. The secrets-dir 0755 want is declared
-   (`known-issues: doctor-perms-secrets-dir-0755-is-declared`).
+   load and model pull. The secrets-dir mode is declared 0700 (#1896; was 0755, now fixed —
+   `known-issues: doctor-perms-secrets-dir-0700-is-declared`).
 8. **Service-user writability of state the daemon writes.** For each dir/db under
    /var/lib/hal0 that hal0-api writes (model-pull-jobs, activity.db, hal0.db, slots/, ...):
    `sudo -u hal0 test -w <path>` plus one journal grep for `persist_failed|init_failed`. A

--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -1124,7 +1124,7 @@ regressions:
       by hermes_provision._atomic_write (tmp-write, no chmod, UMask=0022) vs the table's 0664;
       hal0-agentenv re-tightens secrets/ to 0700 on every merge-secrets vs the table's 0755 (the
       two shipped components disagree — the contradiction is the defect, not a leak: *.env stays
-      0600 either way, see known-issues `doctor-perms-secrets-dir-0755-is-declared`); and every
+      0600 either way, see known-issues `doctor-perms-secrets-dir-0700-is-declared`); and every
       daemon-created dir under recursive rows lands 2755 vs 2775. A self-audit that can never be
       green trains operators to ignore it. Do not assert a drift ROW COUNT — it grows with every
       slot loaded and model pulled.

--- a/tests/systemd/test_hf_token_secrets.py
+++ b/tests/systemd/test_hf_token_secrets.py
@@ -163,6 +163,25 @@ class TestPersistence:
         assert re.search(r"mktemp \"\$\{HF_SECRETS_ENV\}", persist_block)
         assert "mv -f" in persist_block
 
+    def test_secrets_dir_birth_is_dev_mode_safe(self, persist_block: str) -> None:
+        # #1942 review finding 1: `install -d -m 0700 -o root -g root
+        # "${SECRETS_DIR}"` is NOT inside a DEV_MODE guard (unlike its prod
+        # twin in the "hal0 system user" follow-up). In `--dev`, this block
+        # runs as an ordinary user whenever HF_TOKEN/HUGGING_FACE_HUB_TOKEN is
+        # exported; `install -o root -g root` as non-root exits 1, and
+        # install.sh runs under `set -euo pipefail` (line 17) — a hard
+        # mid-install abort. The birth must drop -o/-g and chown tolerantly,
+        # like the HF_SECRETS_TMP idiom a few lines below.
+        assert re.search(r'install -d -m 0700 "\$\{SECRETS_DIR\}"', persist_block), (
+            "SECRETS_DIR must be created without -o/-g root — `install -o root` "
+            "as an unprivileged --dev user aborts the installer"
+        )
+        assert re.search(
+            r'chown root:root "\$\{SECRETS_DIR\}" 2>/dev/null \|\| true', persist_block
+        ), (
+            "the SECRETS_DIR chown must be the tolerant (best-effort) idiom, not baked into install -d"
+        )
+
     def test_token_value_written_to_secrets_file_only(self, persist_block: str) -> None:
         # HF_TOKEN=${HF_TOKEN_VAL} must appear inside the persistence
         # heredoc (targeting HF_SECRETS_TMP), not assigned anywhere that


### PR DESCRIPTION
## ⚠️ OPERATOR REVIEW REQUIRED

This PR touches three things that need a human eye before merge:

- **SECURITY-POSTURE DECISION** — the `secrets/` directory mode moves **0755 → 0700**. See "The decision point" below; this is the operator's call, not the agent's.
- **PERMISSIONS TABLE** — `hal0.install.perms.ownership_table()` is the declarative authority for every path hal0 owns; two rows change value.
- **PRIVILEGED WRAPPER** — the shipped `installer/wrappers/hal0-agentenv` seam (root via `/etc/sudoers.d`) is **NOT modified** by this PR, but it is now *coupled* to the table by a test. The chosen direction was picked specifically so the wrapper stays byte-identical.

## What was broken

`hal0 doctor perms` exited 1 with DRIFT rows on a **freshly installed box**, and its own remediation (`sudo hal0 doctor perms --fix`) could never produce a durably green audit. Three shipped components each declared a different truth for the same paths, so every repair was undone by the next write. A self-audit that can never be green trains operators to ignore it.

The contradiction *is* the defect — this was never a credential leak (`*.env` stays `0600 root:root` in every direction).

## The decision point — secrets/ 0700 vs 0755

Two shipped components disagreed:

| Component | Declared |
|---|---|
| `hal0.install.perms.ownership_table()` | `/var/lib/hal0/secrets` + `secrets/agents` = **0755** |
| `installer/wrappers/hal0-agentenv` (`install -d -m 0700`, run on every `merge-secrets`) | **0700** |

So `--fix` widened to 0755, the next agent secret write re-tightened to 0700, forever.

**Chosen direction: 0700 — move the TABLE to the restrictive side.** Evidence from the code, not preference:

- **systemd** reads the `EnvironmentFile` under `secrets/` **as root**, before dropping to the service user (that is the stated reason the rows are pinned `root:root` in the first place).
- The **`hal0-agentenv` seam** — the only writer of `secrets/agents/<id>.env` — runs **as root** via `/etc/sudoers.d/hal0-agentenv`.
- `hermes_provision._read_secrets_env()` is a **best-effort** read; the files are `0600 root:root`, so an unprivileged caller already failed on the *file*. The directory mode changes nothing for it.
- The one non-root traverser, `installer/wrappers/hermes` (it re-execs as the unprivileged `hal0` user per the #843 run-as-hal0 guard, then sources `secrets/agents/hermes.env`), is already blocked one level down: the file is `0600 root:root`, so `hal0` can `stat`/list the directory but still can't read the file. The directory mode changes nothing for it.

So 0700 costs no reader any access it actually had. What it removes is **local agent-id enumeration** by any unprivileged user on the box — small, but free, and aligned with ADR-0002 (agent credential isolation).

**Consequence of this choice:** the privileged wrapper needs **no change at all** — it was already right. `installer/install.sh` now births both dirs `install -d -m 0700 -o root -g root` instead of `mkdir -p` + leaning on the `--fix` backstop.

If the operator prefers 0755 instead, the reversal is: flip the two `PermRow` modes back, change `install -d -m 0700` → `0755` in the wrapper (**a privileged-wrapper edit**), and invert `test_agentenv_wrapper_and_table_agree_on_the_secrets_mode`. The coupling test keeps either direction honest.

## The three components reconciled

One direction throughout: **the ownership table is the authority; every writer is made to birth what it declares.**

1. **`secrets/` + `secrets/agents/` → 0700** (`perms.py`, `install.sh`). Wrapper untouched. Two follow-ups from review: `installer/install.sh`'s `HF_TOKEN` persistence block births `${SECRETS_DIR}` unconditionally (not `DEV_MODE`-guarded like its prod-only twin in the later "hal0 system user" follow-up) — `install -o root -g root` as an unprivileged `--dev` user aborted the installer under `set -euo pipefail` whenever `HF_TOKEN`/`HUGGING_FACE_HUB_TOKEN` was exported; fixed to the tolerant `install -d` + best-effort `chown` idiom already used a few lines down (review item 1, blocking). And `hermes_provision._merge_env_file`'s bare `path.parent.mkdir(parents=True, exist_ok=True)` would have re-introduced the exact #1896 drift class on a root-run provision hitting an absent `secrets/agents/` — routed through `perms.ensure_shared_dir(..., mode=perms.SECRETS_DIR_MODE)` instead (review item 3). Both secrets `PermRow`s are now `optional=False` so the fresh-install convergence tests actually materialise and check them — previously the default `optional=True` meant `_materialise_fresh_install` skipped both rows and the 0700 change was covered only by the declaration test, never the convergence one (review item 4; `optional` remains inert in `plan()`/`commit()`/`audit_rows()` in production — it only gates the test helper).

2. **`STATE.md` 0644 → declared 0664.** `hermes_provision._atomic_write` did tmp-write + `os.replace`, so the *new inode* was born at the process umask (`0644` under the daemon's `UMask=0022`), silently discarding the `0664` `--fix` had just applied. It now carries the target's existing mode across the rename, or an explicit `mode=`. The render sites pass a shared `RUNTIME_SNAPSHOT_MODE` constant. A rewrite is a content change, not a posture change. **Scope note (review item 7):** the mode-carry applies at all 6 `_atomic_write`/`_atomic_write_if_changed` call sites, not just `STATE.md` — `/etc/hal0/agents/hermes-terminal-tool`, the hermes `config.yaml`, an MCP hosts JSON, and the `SOUL.md`/`AGENTS.md`/`MCP-CLIENTS.md` writers. Previously every rewrite reset to the process umask on each write (a self-healing narrow); now an over-wide *existing* mode on any of those files is perpetuated instead of healed on the next rewrite. Deliberate: none of the six hold credentials, so this is not a leak, and "a rewrite is a content change, not a posture change" is the general principle — it just applies more broadly than the STATE.md example above.

3. **Daemon-created dirs `2755` → declared `2775`.** `Path.mkdir` masks its mode with the umask, and the setgid bit a parent passes down carries group *ownership*, not group-*write*. New `perms.ensure_shared_dir()` mkdirs then chmods **only the components it creates** (so a lazy `mkdir(parents=True)` through a deliberately tighter parent — `secrets/` 0700, `agents/` 0711 — can never widen it) and is **fail-soft on chmod** (an operator's model store may sit on an NFS export that refuses it; a permissions nice-to-have must never break a pull). Applied at every state-dir creation site under `slots/` and `registry/`.

## Known limits of the test coverage (review items 5, 6, 8)

- **Item 5 — one leg of the acceptance test is partly tautological.** `test_stays_green_after_slot_load_model_pull_and_state_render`'s `models/<org>/<repo>` leg calls `perms.ensure_shared_dir` directly rather than a real weights writer (`pull._download_one`'s `final.parent`), so it partly re-proves the helper's own unit test rather than a real call site. The `persist_pull_job` leg IS a real writer. Left as-is: wiring a real multi-GB-shaped download into a unit test isn't a good trade for the marginal coverage.
- **Item 6 — owner/group are out of scope for `_mode_drift`, so "green after mutation" is proved on the mode axis only.** An unprivileged test process can't chown to `hal0`/`root`, so this is a hard ceiling for a unit test, not a gap in this PR. Carried forward explicitly: the rc.7 ct151 validation brief should re-check the owner axis after a slot load and a `STATE.md` render on a real box — `os.replace` births a new inode owned by the writing process, and the table declares `state_owner="hal0"` while `install.sh` comments that `hal0-api` runs as root.
- **Item 8 — fixed.** `perms.ensure_shared_dir`'s out-of-root log line moved WARNING → INFO; a legitimate operator store outside every enumerated mount would otherwise emit one WARNING per directory created on a routine migration/pull, training operators to ignore it (the exact failure mode #1896 itself is about).

## How it was verified

TDD, red first — the red run reproduced the issue's exact drift, e.g. `('…/slots/gpu-rocm-0', '0o2775', '0o2755')`.

New `tests/install/test_perms_converge.py` (12 tests) asserts **green-after-mutation**, which is the issue's own acceptance criterion:

> On a fresh install, `hal0 doctor perms` is green, and stays green after a slot load, a model pull, and a hermes `STATE.md` render.

A fresh-install tree audits clean, then stays clean after a **real** `write_state_atomic` slot load, a **real** `persist_pull_job`, a `models/<org>/<repo>` creation and two `STATE.md` renders — every mutation run under `UMask=0022`, the shipped unit's umask, with the audit re-run after each.

**No drift ROW COUNT is asserted anywhere** (per the issue's trap): that set grows with every slot loaded and every model pulled. The helper reports `(path, declared, observed)` triples so a failure names the offender.

A coupling test parses `hal0-agentenv`'s `install -d -m <mode>` line out of the shipped wrapper and fails if it ever diverges from the table again — the specific way this bug was born.

```
make lint                                  All checks passed!
uv run ruff format --check src tests       1160 files already formatted
scripts/check_sunset.py                    scar markers 192 <= baseline 192; no overdue shims
full pytest suite                          10925 passed, 16 skipped, 1 xfailed (17m21s)
```

## Out of scope / follow-up

- No `CHANGELOG.md` entry — the rc.7 changelog wave collects merged PRs separately.
- `known-issues.yaml: doctor-perms-secrets-dir-0755-is-declared` moves `by-design` → `fixed`, with `still_report_if` inverted to expect 0700, and the entry `id` renamed to `doctor-perms-secrets-dir-0700-is-declared` — the old id asserted the pre-fix truth, and a validation agent pattern-matching it post-fix could mask a genuine 0755 regression as "known". The `regressions.yaml` probe `doctor-perms-never-converges` is left in place as the permanent regression watch.
- Not verified on a live box — this is unit-level evidence only; the rc.7 validation run on ct151 is the real confirmation.

Refs #1896

🤖 Generated with [Claude Code](https://claude.com/claude-code)

