### PR TITLE
fix(ui-e2e): key the voice-page copy specs on labelled rows, not ordinals

### DIFF
--- a/ui/src/dash/settings/pages/capabilities/TtsPanel.jsx
+++ b/ui/src/dash/settings/pages/capabilities/TtsPanel.jsx
@@ -75,16 +75,29 @@ export function TtsPanel({ registry }) {
   const resetAll = () => { sel.reset(); setVoice(origVoice); setSpeed(origSpeed); setFormat(origFormat) }
 
   const liveVoices = ttsVoicesQuery.data?.source === "live" ? (ttsVoicesQuery.data.voices || []) : []
-  const kokoroish = !sel.model || isKokoro
-  const options = liveVoices.length > 0
-    ? liveVoices.map(v => {
-        const seed = KOKORO_VOICES.find(k => k.id === v)
-        return { id: v, label: seed ? seed.label : v }
-      })
-    : (kokoroish ? KOKORO_VOICES : null)
-  const srcNote = liveVoices.length > 0
-    ? "voices reported live by the tts slot"
-    : (kokoroish ? "bundled voices (Kokoro v1) · slot offline — list is the seed pack" : "model-specific voice id")
+  // #1944: `!sel.model` used to stand in for "unconfigured slot", but it is
+  // equally true while GET /api/capabilities is still in flight (or has
+  // failed) — so a qwen3tts box rendered Kokoro's seed pack and its
+  // "(af_bella)" default for the whole load window. That is #1470's defect
+  // (Kokoro facts asserted as engine truth) scoped to the gap before the
+  // probe lands. Claim nothing until the provider is actually known; SttPanel
+  // already keys every string off `resolvedProvider` this way. An
+  // unconfigured slot still gets the seed pack once the probe has answered.
+  const providerKnown = !sel.loading && !sel.errored
+  const kokoroish = providerKnown && (!sel.model || isKokoro)
+  const options = !providerKnown
+    ? []
+    : liveVoices.length > 0
+      ? liveVoices.map(v => {
+          const seed = KOKORO_VOICES.find(k => k.id === v)
+          return { id: v, label: seed ? seed.label : v }
+        })
+      : (kokoroish ? KOKORO_VOICES : null)
+  const srcNote = !providerKnown
+    ? (sel.errored ? "capability probe failed — voice list unavailable" : "loading the tts slot's voice list…")
+    : liveVoices.length > 0
+      ? "voices reported live by the tts slot"
+      : (kokoroish ? "bundled voices (Kokoro v1) · slot offline — list is the seed pack" : "model-specific voice id")
   const defaultVoiceLabel = kokoroish
     ? "— use engine default (af_bella) —"
     : isQwen3 ? "— use engine default (Ryan) —" : "— use engine default —"

--- a/ui/tests/e2e/specs/voice-page-provider-copy-v3.spec.ts
+++ b/ui/tests/e2e/specs/voice-page-provider-copy-v3.spec.ts
@@ -14,9 +14,34 @@
  * These specs pin the qwen3tts selection getting qwen3tts-appropriate copy
  * (not Kokoro's), and the kokoro selection keeping the original Kokoro
  * facts as a regression guard.
+ *
+ * #1944 — two defects in this file, one cause. Every control was addressed
+ * by its ordinal inside the panel (`ttsPanel.locator('select option').first()`)
+ * and every assertion ran without waiting for the capabilities probe:
+ *
+ *   - The Model row renders a free-text <input> until GET /api/capabilities
+ *     delivers the catalog, and a <select> afterwards. So that one locator
+ *     pointed at the Default-voice picker before the probe landed (first
+ *     option "— use engine default (af_bella) —") and at the Model picker
+ *     after it landed (first option "— unset —"). The kokoro guard therefore
+ *     passed or failed purely on whether Playwright's first poll beat the
+ *     mocked probe — the intermittent CI red on #1923 and #1943.
+ *   - The same swap made the qwen3 guard permanently vacuous: post-probe it
+ *     only ever asked whether "— unset —" contains 'af_bella'. Reverting the
+ *     #1470 default-voice fix left the suite green.
+ *   - Two more qwen3 assertions were vacuous for a different reason: since
+ *     #1683 the sub-copy lives in a popup portalled to <body>, so a row's
+ *     own text can never contain "Kokoro" / "Kokoro clamps". Reverting those
+ *     two hints to hardcoded Kokoro copy also left the suite green.
+ *
+ * Rules this file now follows: address a control through its labelled row,
+ * never by ordinal; sync on the probe having been applied before asserting;
+ * read sub-copy through fieldInfoPopup; and pair every "must not claim X"
+ * with the positive statement of what the copy must say instead, so a blank
+ * or unrendered element cannot satisfy it.
  */
 import { test, expect, json } from '../fixtures/apiMock'
-import type { Locator } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 // #1683: FieldInfoIcon's description now portals to document.body (so
 // overflow:hidden panels can't clip it), so it's no longer a DOM descendant
@@ -28,14 +53,34 @@ async function fieldInfoPopup(row: Locator) {
   return row.page().locator(`[id="${id}"]`)
 }
 
+const capPanel = (page: Page, title: string) =>
+  page.locator('.s-panel').filter({ has: page.locator('.k > span', { hasText: new RegExp(`^${title}$`) }) })
+
+// #1944: rows are identified by their label, never by position. The set of
+// <select> elements in a panel changes as the capabilities probe resolves.
+const panelRow = (panel: Locator, label: string) =>
+  panel.locator('.s-row').filter({ has: panel.page().locator('.k > span', { hasText: new RegExp(`^${label}$`) }) })
+
+// #1944: the sync point every assertion in this file needs. The Model picker
+// only becomes a <select> holding the mocked id once GET /api/capabilities
+// has resolved AND useCapabilitySelection has pushed the selection into form
+// state — i.e. once `resolvedProvider` is the provider under test. Asserting
+// provider-keyed copy before this is meaningless: the provider is still ""
+// and none of the engine-specific strings are on screen yet.
+async function capabilitiesApplied(panel: Locator, model: string) {
+  await expect(panelRow(panel, 'Model').locator('select')).toHaveValue(model)
+}
+
 function capabilityRow(device: string, provider: string, model: string | null, slot: string, status: string) {
   return { device, backend: device, provider, model, enabled: !!model, slot, status }
 }
 
+type Sel = { model: string; provider: string; device: string }
+
 // Mirrors the real /api/capabilities envelope (orchestrator.py get_state /
 // catalogs_by_slot — catalog rows carry a flat `provider` field, see
 // catalog.py _entry_to_row / _tts_rows_for_capability).
-function capsWithTtsSelection(model: string, provider: string, device: string) {
+function capsWith(tts: Sel, stt: Sel = { model: 'moonshine-base', provider: 'moonshine', device: 'cpu' }) {
   return {
     backends: [
       { id: 'cpu', label: 'CPU', short: 'CPU', provider: 'llamacpp', multiplex: false },
@@ -45,6 +90,7 @@ function capsWithTtsSelection(model: string, provider: string, device: string) {
       voice: {
         stt: [
           { id: 'moonshine-base', capabilities: ['stt'], size_gb: 0.4, backend: 'cpu', provider: 'moonshine' },
+          { id: 'whisper-large-v3', capabilities: ['stt'], size_gb: 1.5, backend: 'npu', provider: 'flm' },
         ],
         tts: [
           { id: 'kokoro-v1', capabilities: ['tts'], size_gb: 0.3, backend: 'cpu', provider: 'kokoro' },
@@ -55,64 +101,148 @@ function capsWithTtsSelection(model: string, provider: string, device: string) {
     },
     selections: {
       voice: {
-        stt: capabilityRow('cpu', 'moonshine', 'moonshine-base', 'stt', 'serving'),
-        tts: capabilityRow(device, provider, model, 'tts', 'serving'),
+        stt: capabilityRow(stt.device, stt.provider, stt.model, 'stt', 'serving'),
+        tts: capabilityRow(tts.device, tts.provider, tts.model, 'tts', 'serving'),
       },
       img: { img: capabilityRow('', '', null, 'img', 'offline') },
     },
   }
 }
 
+const KOKORO: Sel = { model: 'kokoro-v1', provider: 'kokoro', device: 'cpu' }
+const QWEN3: Sel = { model: 'qwen3-tts', provider: 'qwen3tts', device: 'gpu-rocm' }
+
 test.describe('Voice page copy keyed on provider (#1470)', () => {
   test('qwen3tts selection gets qwen3tts-appropriate copy, not hardcoded Kokoro facts', async ({ page }) => {
-    await page.route('**/api/capabilities', (route) => json(route, capsWithTtsSelection('qwen3-tts', 'qwen3tts', 'gpu-rocm')))
+    await page.route('**/api/capabilities', (route) => json(route, capsWith(QWEN3)))
     await page.route('**/api/slots/tts/config', (route) => json(route, {}))
     await page.route('**/api/slots/tts/voices', (route) => json(route, { source: 'offline', voices: [] }))
     await page.goto('/#settings/voice')
     await expect(page.locator('.settings-content h2').first()).toHaveText('AI Capabilities')
 
-    const ttsPanel = page.locator('.s-panel').filter({ has: page.locator('.k span', { hasText: /^TTS$/ }) })
+    const ttsPanel = capPanel(page, 'TTS')
+    await capabilitiesApplied(ttsPanel, 'qwen3-tts')
 
-    // Default-voice placeholder must not claim Kokoro's af_bella default.
-    const voiceOption = ttsPanel.locator('select option').first()
-    await expect(voiceOption).not.toContainText('af_bella')
+    // Cold non-Kokoro slot: the Kokoro seed pack is not a legal fallback, so
+    // the row must degrade to the free-text id field rather than offering
+    // Bella & friends to an engine that has never heard of them.
+    const voiceRow = panelRow(ttsPanel, 'Default voice')
+    await expect(voiceRow.locator('input')).toHaveAttribute('placeholder', 'empty = engine default')
+    await expect(voiceRow.locator('option')).toHaveCount(0)
+    await expect(await fieldInfoPopup(voiceRow)).toContainText('model-specific voice id')
+    await expect(await fieldInfoPopup(voiceRow)).not.toContainText('Kokoro')
 
     // Sample-rate row must not claim a fixed 24 kHz — Qwen3-TTS reports
     // whatever the loaded model's codec produces at startup.
-    const sampleRateRow = ttsPanel.locator('.s-row').filter({ hasText: 'Sample rate' })
+    const sampleRateRow = panelRow(ttsPanel, 'Sample rate')
+    await expect(sampleRateRow).toContainText('engine-dependent')
     await expect(sampleRateRow).not.toContainText('24 kHz')
-    await expect(sampleRateRow).not.toContainText('Kokoro')
+    await expect(await fieldInfoPopup(sampleRateRow)).toContainText('Qwen3-TTS model at startup')
+    await expect(await fieldInfoPopup(sampleRateRow)).not.toContainText('Kokoro')
 
     // Speed hint must not attribute the clamp specifically to Kokoro.
-    const speedRow = ttsPanel.locator('.s-row').filter({ hasText: 'Default speed' })
-    await expect(speedRow).not.toContainText('Kokoro clamps')
+    const speedRow = panelRow(ttsPanel, 'Default speed')
+    await expect(await fieldInfoPopup(speedRow)).toContainText('the engine clamps to 0.5–2.0')
+    await expect(await fieldInfoPopup(speedRow)).not.toContainText('Kokoro clamps')
+  })
+
+  test('qwen3tts live voice list is labelled with the qwen3 engine default, not af_bella', async ({ page }) => {
+    // The placeholder <option> only exists when the picker renders a <select>,
+    // which for a non-Kokoro provider means the slot reported a live list.
+    // Without this case nothing asserts the #1470 default-voice label at all.
+    await page.route('**/api/capabilities', (route) => json(route, capsWith(QWEN3)))
+    await page.route('**/api/slots/tts/config', (route) => json(route, {}))
+    await page.route('**/api/slots/tts/voices', (route) => json(route, { source: 'live', voices: ['Ryan', 'Chelsie'] }))
+    await page.goto('/#settings/voice')
+
+    const ttsPanel = capPanel(page, 'TTS')
+    await capabilitiesApplied(ttsPanel, 'qwen3-tts')
+
+    const voiceOptions = panelRow(ttsPanel, 'Default voice').locator('option')
+    await expect(voiceOptions).toHaveCount(3)
+    await expect(voiceOptions.first()).toHaveText('— use engine default (Ryan) —')
+    await expect(voiceOptions.nth(1)).toHaveText('Ryan')
   })
 
   test('kokoro selection keeps the original Kokoro-specific copy (regression guard)', async ({ page }) => {
-    await page.route('**/api/capabilities', (route) => json(route, capsWithTtsSelection('kokoro-v1', 'kokoro', 'cpu')))
+    await page.route('**/api/capabilities', (route) => json(route, capsWith(KOKORO)))
     await page.route('**/api/slots/tts/config', (route) => json(route, {}))
     await page.route('**/api/slots/tts/voices', (route) => json(route, { source: 'offline', voices: [] }))
     await page.goto('/#settings/voice')
     await expect(page.locator('.settings-content h2').first()).toHaveText('AI Capabilities')
 
-    const ttsPanel = page.locator('.s-panel').filter({ has: page.locator('.k span', { hasText: /^TTS$/ }) })
+    const ttsPanel = capPanel(page, 'TTS')
+    await capabilitiesApplied(ttsPanel, 'kokoro-v1')
 
-    const voiceOption = ttsPanel.locator('select option').first()
-    await expect(voiceOption).toContainText('af_bella')
+    const voiceRow = panelRow(ttsPanel, 'Default voice')
+    await expect(voiceRow.locator('option').first()).toHaveText('— use engine default (af_bella) —')
+    await expect(await fieldInfoPopup(voiceRow)).toContainText('bundled voices (Kokoro v1)')
 
-    const sampleRateRow = ttsPanel.locator('.s-row').filter({ hasText: 'Sample rate' })
+    const sampleRateRow = panelRow(ttsPanel, 'Sample rate')
     await expect(sampleRateRow).toContainText('24 kHz')
     await expect(await fieldInfoPopup(sampleRateRow)).toContainText('Kokoro')
   })
 
-  test('moonshine STT selection keeps the English-only language copy, other providers do not claim it', async ({ page }) => {
-    await page.route('**/api/capabilities', (route) => json(route, capsWithTtsSelection('kokoro-v1', 'kokoro', 'cpu')))
+  test('moonshine STT selection keeps the English-only language copy', async ({ page }) => {
+    await page.route('**/api/capabilities', (route) => json(route, capsWith(KOKORO)))
     await page.route('**/api/slots/tts/config', (route) => json(route, {}))
     await page.route('**/api/slots/tts/voices', (route) => json(route, { source: 'offline', voices: [] }))
     await page.goto('/#settings/voice')
 
-    const languageRow = page.locator('.s-row').filter({ hasText: 'Language' })
+    const sttPanel = capPanel(page, 'STT')
+    await capabilitiesApplied(sttPanel, 'moonshine-base')
+
+    const languageRow = panelRow(sttPanel, 'Language')
     await expect(languageRow).toContainText('English')
     await expect(await fieldInfoPopup(languageRow)).toContainText('moonshine is English-only')
+  })
+
+  test('a non-moonshine STT provider does not claim the English-only fact', async ({ page }) => {
+    // The other half of the #1470 property, which the moonshine case above
+    // used to claim in its title but never exercised.
+    await page.route('**/api/capabilities', (route) =>
+      json(route, capsWith(KOKORO, { model: 'whisper-large-v3', provider: 'flm', device: 'npu' })))
+    await page.route('**/api/slots/tts/config', (route) => json(route, {}))
+    await page.route('**/api/slots/tts/voices', (route) => json(route, { source: 'offline', voices: [] }))
+    await page.goto('/#settings/voice')
+
+    const sttPanel = capPanel(page, 'STT')
+    await capabilitiesApplied(sttPanel, 'whisper-large-v3')
+
+    const languageRow = panelRow(sttPanel, 'Language')
+    await expect(languageRow).toContainText('engine-dependent')
+    await expect(languageRow).not.toContainText('English')
+    await expect(await fieldInfoPopup(languageRow)).toContainText('flm — language support is engine-specific')
+  })
+
+  test('the TTS voice picker claims no engine facts while the capabilities probe is in flight (#1944)', async ({ page }) => {
+    // TtsPanel's `kokoroish = !sel.model || isKokoro` conflated "no TTS model
+    // configured" with "the probe has not answered yet", so a qwen3tts box
+    // rendered Kokoro's seed pack and its "(af_bella)" default for the whole
+    // load window — #1470's defect, scoped to the gap before the probe lands.
+    // Gate the route so the in-flight state is a held, deterministic state
+    // rather than a race.
+    let releaseProbe: () => void = () => {}
+    const probeGate = new Promise<void>((resolve) => { releaseProbe = resolve })
+    await page.route('**/api/capabilities', async (route) => {
+      await probeGate
+      await json(route, capsWith(QWEN3))
+    })
+    await page.route('**/api/slots/tts/config', (route) => json(route, {}))
+    await page.route('**/api/slots/tts/voices', (route) => json(route, { source: 'offline', voices: [] }))
+    await page.goto('/#settings/voice')
+
+    const ttsPanel = capPanel(page, 'TTS')
+    const voiceRow = panelRow(ttsPanel, 'Default voice')
+    // Probe still held: no catalog, so the Model row is the free-text input.
+    await expect(panelRow(ttsPanel, 'Model').locator('select')).toHaveCount(0)
+    const options = voiceRow.locator('option')
+    await expect(options).toHaveCount(1)
+    await expect(options.first()).toHaveText('— use engine default —')
+    await expect(await fieldInfoPopup(voiceRow)).toContainText('loading the tts slot')
+
+    releaseProbe()
+    await capabilitiesApplied(ttsPanel, 'qwen3-tts')
+    await expect(voiceRow.locator('input')).toHaveAttribute('placeholder', 'empty = engine default')
   })
 })


### PR DESCRIPTION
Closes #1944

## Root cause

The flake and a second, larger defect share one cause: `voice-page-provider-copy-v3.spec.ts` addressed the TTS panel's controls **by position** and asserted **without waiting for the capabilities probe**.

```js
const voiceOption = ttsPanel.locator('select option').first()
```

`ModelRow` renders a free-text `<input>` while `sel.catalogItems` is empty and a `<select>` once `GET /api/capabilities` delivers the catalog. So that locator points at two different elements depending on timing:

| probe state | first `<select>` in the panel | its first `<option>` |
|---|---|---|
| in flight | Default voice picker | `— use engine default (af_bella) —` |
| resolved | **Model** picker | `— unset —` |

The spec's only wait was `expect(h2).toHaveText('AI Capabilities')`, and `CapabilitiesPage` renders that `<h2>` unconditionally — it is not a data-load gate. Whether the assertion sampled before or after the probe was a pure race, which is why the check went red on #1923 (backend-only) and #1943 (workflow YAML only) and green on re-run.

### Reproduced

Adding a real sync point (`Model` select holding `kokoro-v1`) before the existing assertion reproduces the CI failure verbatim, including the reported string:

```
Locator: …locator('select option').first()
Expected substring: "af_bella"
Received string:    "— unset —"
```

### The bigger half: the guard was not guarding

The same element swap made the qwen3 test **permanently vacuous** — after the probe lands it only ever asked whether `— unset —` contains `af_bella`. Verified by reverting the #1470 fix:

- hardcode `defaultVoiceLabel = "— use engine default (af_bella) —"` → old spec **9/9 green**
- additionally hardcode the speed hint to `Kokoro clamps to 0.5–2.0` and the sample-rate hint to the Kokoro sentence → old spec **6/6 green**

Two of those assertions were vacuous for a second reason: since #1683 the sub-copy is portalled to `<body>`, so a row's own `textContent` can never contain `Kokoro` / `Kokoro clamps`. Those two lines were never updated for the portal.

So the #1470 regression guard could be fully reverted without turning the suite red.

## What changed

**`ui/tests/e2e/specs/voice-page-provider-copy-v3.spec.ts`** — rules the file now follows:

- every control is reached through its labelled `.s-row`, never by ordinal;
- `capabilitiesApplied()` syncs on the Model picker holding the mocked id before any provider-keyed assertion (the provider is `""` until then, so the copy under test is not on screen yet);
- sub-copy is read through `fieldInfoPopup`, not row text;
- every "must not claim X" is paired with the positive statement of what the copy must say instead, so a blank or unrendered element cannot satisfy it.

Two cases added: the qwen3 **live** voice list (the only shape in which the qwen3 placeholder `<option>` renders at all — without it nothing asserts the #1470 default-voice label), and the non-moonshine STT case the old test's title claimed but never exercised.

**`ui/src/dash/settings/pages/capabilities/TtsPanel.jsx`** — the load race the issue suspected is real, just not the cause of the CI flake:

```js
const kokoroish = !sel.model || isKokoro
```

`!sel.model` stood in for "unconfigured slot", but it is equally true while the probe is in flight or has failed. A qwen3tts box therefore rendered Kokoro's seed pack and its `(af_bella)` default for the whole load window — #1470's defect scoped to the load gap. Now gated on `providerKnown = !sel.loading && !sel.errored`; an unconfigured slot still gets the seed pack once the probe has answered. This matches `SttPanel`, which already keys every string off `resolvedProvider` and says "select an STT model to see its language support" when it is unknown.

## Verification

- New in-flight test is **red before** the `TtsPanel` change (`Expected 1 / Received 10` options — the seed pack) and green after. The route is held behind a promise gate, so the in-flight state is a deterministic held state, not a timing window.
- New spec catches all three sabotages the old one missed: default-voice label → `Expected "(Ryan)" / Received "(af_bella)"`; sample-rate hint → `Expected "Qwen3-TTS model at startup"`; speed hint → `Expected "the engine clamps to 0.5–2.0"`.
- `npx playwright test specs/voice-page-provider-copy-v3.spec.ts --repeat-each=6` → 36/36 passed.
- Full γ-suite: **644 passed, 17 skipped, 0 failed** (4.0m) — includes `ui-sweep-a-v3` ("bundled voices (Kokoro v1)") and `capability-catalog-pickers-v3` (failed-probe branch), both of which the `TtsPanel` change touches.
- `npm run lint`, `npm run typecheck`, `npm run test:unit` (127 passed), `npm run build` — all green.
- `ruff check src tests` + `ruff format --check src tests` — clean (no Python touched).

## Out of scope

- No backend files, per the planning blast radius. Nothing here needs hermes; the γ-suite runs against mocked routes only.
- `CHANGELOG.md` untouched (#1545 — one consolidated entry lands at the end of the wave).
- #1926, the other γ-suite reliability tax, is a separate cause and is untouched.
- The same by-ordinal pattern (`panel.locator('select option')` without a row scope) appears in `capability-catalog-pickers-v3.spec.ts:136/174/210`. Those panels have a single select each today, so they are not currently ambiguous — left alone rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
