### PR TITLE
fix(updater): relay full child stderr to the journal on the failure path too

### DIFF
--- a/src/hal0/updater/privileged.py
+++ b/src/hal0/updater/privileged.py
@@ -155,14 +155,19 @@ class UpdateSeam:
 
         ``-n`` is load-bearing: a missing or broken grant fails immediately with
         a non-zero exit instead of prompting for a password inside a daemon.
-        The child's stderr (its structured log) is folded into the raised error
-        so a failure is diagnosable from the job result alone. On success the
-        same stderr is replayed into the parent's own log (see
-        :func:`_relay_child_log`) — the child's structlog output is captured,
-        not inherited, so without this replay every prepare/verify breadcrumb
-        (``sha256_ok``, ``cosign_verify_ok``, ``prepare_ok``, …) the root
-        helper emits is silently discarded on the happy path and never reaches
-        the journal (#1901).
+        The child's stderr (its structured log) is captured, not inherited, so
+        on BOTH the success and failure paths it is replayed in full into the
+        parent's own log (see :func:`_relay_child_log`) — without this replay
+        every prepare/verify breadcrumb (``sha256_ok``, ``cosign_verify_ok``,
+        ``prepare_ok``, …) the root helper emits is silently discarded and
+        never reaches the journal (#1901). A failure occurring AFTER those
+        breadcrumbs (e.g. during ``activate``, after a long cleanup/reaping
+        tail) still needs them in the durable journal, not just in a raised
+        error's details (#1940). The failure path additionally folds a
+        *bounded* stderr tail into the raised error so a failure is
+        diagnosable from the job result alone — that tail is a separate,
+        truncated sink for quick triage, not a substitute for the full
+        journal relay.
         """
         try:
             proc = self._run(  # nosec B603 — fixed argv; every arg re-validated as root
@@ -181,10 +186,20 @@ class UpdateSeam:
             raise _remediation(f"could not execute `sudo -n {self._seam_bin}`: {exc}") from exc
 
         full_stderr = proc.stderr or ""
+        # Relay the FULL stderr to the journal on EVERY outcome, not a
+        # truncated tail and not success-only: a run (successful or not) can
+        # emit many post-verification cleanup lines (stale quarantine/staging
+        # reaping in `_extract_tarball`) after the sha256/cosign breadcrumbs,
+        # and a 4000-char tail can push those breadcrumbs out of the relayed
+        # data — silently reopening the very audit gap this replay closes. A
+        # failure occurring after those breadcrumbs (e.g. during `activate`)
+        # is exactly the run where the evidence matters most (#1940).
+        _relay_child_log(full_stderr, verb=parts[0], job_id=self._job_id)
         if proc.returncode != 0:
-            # Bounded tail only for the error path — a raised error's details
-            # are a diagnostic breadcrumb, not the audit trail this exists to
-            # protect, so truncation here is fine.
+            # The bounded tail here is a SEPARATE sink from the journal relay
+            # above: a quick-triage breadcrumb folded into the raised error
+            # itself, not the durable audit trail. Truncating it is fine
+            # because the full record already reached the journal.
             raise UpdateError(
                 f"privileged update seam failed: {parts[0]} (rc={proc.returncode})",
                 details={
@@ -194,12 +209,6 @@ class UpdateSeam:
                     "seam_bin": self._seam_bin,
                 },
             )
-        # Relay the FULL stderr, not a truncated tail: a successful run can
-        # emit many post-verification cleanup lines (stale quarantine/staging
-        # reaping in `_extract_tarball`) after the sha256/cosign breadcrumbs,
-        # and a 4000-char tail can push those breadcrumbs out of the relayed
-        # data — silently reopening the very audit gap this replay closes.
-        _relay_child_log(full_stderr, verb=parts[0], job_id=self._job_id)
         return _parse_result(proc.stdout or "", verb=parts[0], stderr=full_stderr[-4000:])
 
     # ── preflight ──────────────────────────────────────────────────────────────

--- a/tests/updater/test_privileged_seam.py
+++ b/tests/updater/test_privileged_seam.py
@@ -247,19 +247,71 @@ def test_successful_stage_relay_survives_a_long_cleanup_tail() -> None:
     assert any("cosign_verify_ok" in e["line"] for e in relayed)
 
 
-def test_failed_stage_does_not_double_relay_stderr_as_breadcrumbs() -> None:
-    """A failure already folds stderr into the raised error's details — it
-    must not ALSO be replayed as a separate breadcrumb log (that would be a
-    second, redundant recording of the same failure content)."""
+def test_failed_stage_also_relays_full_stderr_to_the_journal() -> None:
+    """#1940: the failure path used to relay nothing, keeping only
+    ``full_stderr[-4000:]`` in the raised error's details — a diagnostic
+    breadcrumb, not the durable audit trail. Relaying to the journal and
+    folding a bounded tail into the error are different sinks, not a double
+    record of the same thing, so the failure path must do both: the full
+    stderr reaches the journal via ``_relay_child_log`` AND the raised
+    error still carries its own bounded tail for quick triage.
+    """
     from structlog.testing import capture_logs
 
     run = FakeRun(returncode=1, stderr="hal0-update: cosign verify-blob failed")
     seam = UpdateSeam(run=run, is_hal0_user=lambda: True, job_id="job-abc123")
 
-    with capture_logs() as logs, pytest.raises(UpdateError):
+    with capture_logs() as logs, pytest.raises(UpdateError) as exc:
         seam.discard("hal0-1.0.0")
 
-    assert not [e for e in logs if e.get("event") == "updater.privileged_child_log"]
+    relayed = [e for e in logs if e.get("event") == "updater.privileged_child_log"]
+    assert len(relayed) == 1
+    assert relayed[0]["job_id"] == "job-abc123"
+    assert relayed[0]["verb"] == "discard"
+    assert "cosign verify-blob failed" in relayed[0]["line"]
+    assert "cosign verify-blob failed" in exc.value.details["stderr"]
+
+
+def test_failed_activate_relay_survives_a_long_cleanup_tail_after_cosign() -> None:
+    """#1940: a failure occurring AFTER cosign passed (e.g. during activate)
+    with a long reaping tail must not push the sha256_ok/cosign_verify_ok
+    breadcrumbs out of the retained evidence — this is the run where that
+    evidence matters most. The bounded 4000-char tail kept in the raised
+    error's details can legitimately drop the early breadcrumbs; the journal
+    relay must not, because it sees the full, untruncated stderr.
+    """
+    from structlog.testing import capture_logs
+
+    breadcrumbs = (
+        "2026-08-17T00:00:00Z [info] updater.sha256_ok job_id=None digest=abc123\n"
+        "2026-08-17T00:00:01Z [info] updater.cosign_verify_ok job_id=None\n"
+    )
+    # Pad well past the old 4000-char truncation window with cleanup noise
+    # that runs AFTER the breadcrumbs and before the eventual failure.
+    cleanup_tail = "".join(
+        f"2026-08-17T00:00:{i:02d}Z [info] updater.quarantine_reaped path=/x/{i}\n"
+        for i in range(2, 400)
+    )
+    failure_line = "2026-08-17T00:07:00Z [error] updater.activate_failed reason=disk_full\n"
+    child_stderr = breadcrumbs + cleanup_tail + failure_line
+    assert len(child_stderr) > 4000
+    assert "sha256_ok" not in child_stderr[-4000:]
+
+    run = FakeRun(returncode=1, stderr=child_stderr)
+    seam = UpdateSeam(run=run, is_hal0_user=lambda: True, job_id="job-abc123")
+
+    import asyncio
+
+    with capture_logs() as logs, pytest.raises(UpdateError) as exc:
+        asyncio.run(seam.activate("hal0-1.0.0"))
+
+    relayed = [e for e in logs if e.get("event") == "updater.privileged_child_log"]
+    assert any("sha256_ok" in e["line"] for e in relayed)
+    assert any("cosign_verify_ok" in e["line"] for e in relayed)
+    # The bounded error detail is allowed to have lost the early breadcrumbs
+    # — that's exactly why the full relay above is the fix.
+    assert "sha256_ok" not in exc.value.details["stderr"]
+    assert "activate_failed" in exc.value.details["stderr"]
 
 
 # ── preflight: fail fast, with remediation, before any download ────────────────


### PR DESCRIPTION
## What changed

`UpdateSeam._invoke` (the sudo-seam wrapper around `stage`/`activate`/`discard`) now replays the root helper's **full** captured stderr into the parent's journal via `_relay_child_log` on **both** outcomes, not just success. The bounded `full_stderr[-4000:]` tail that's folded into the raised `UpdateError`'s `details["stderr"]` is unchanged — it's a separate, quick-triage sink, not the durable audit trail.

## Why

PR #1935 fixed the happy-path gap where the child's structured log (its `sha256_ok`/`cosign_verify_ok`/`prepare_ok`/`extract_ok` breadcrumbs) was captured but never relayed anywhere. The reviewer flagged (non-blocking, #1940) that the fix only covered success: a failure kept just the last 4000 chars in the raised error's details, with no journal relay at all. A failure occurring *after* cosign passed (e.g. during `activate`) with a long cleanup/reaping tail can push those verification breadcrumbs out of the retained 4000-char window — exactly the run where the evidence matters most, since it's the one an operator will actually go looking for.

The root cause was that `_relay_child_log(...)` was called only in the success branch, after the `if proc.returncode != 0: raise ...` block returned early. The fix moves the relay call ahead of that branch so it always runs, regardless of outcome.

## Verification

- Reproduced the gap first: `test_failed_stage_also_relays_full_stderr_to_the_journal` and `test_failed_activate_relay_survives_a_long_cleanup_tail_after_cosign` both fail against the pre-fix code (confirmed by stashing the source change and re-running) and pass after it.
- Rewrote `test_failed_stage_does_not_double_relay_stderr_as_breadcrumbs`, which cemented the old asymmetry, into `test_failed_stage_also_relays_full_stderr_to_the_journal` — it now asserts the failure path relays to the journal *and* still carries the bounded tail in the error details (different sinks, not a double-record of the same content).
- Added `test_failed_activate_relay_survives_a_long_cleanup_tail_after_cosign`, mirroring the existing success-path long-tail regression test but for a failure after a >4000-char cleanup tail following the sha256/cosign breadcrumbs.
- `uv run --extra dev pytest tests/updater/ -q` → 296 passed.
- `uv run --extra dev pytest -q` (full suite, `HAL0_HOME` override) → 10932 passed, 16 skipped, 1 xfailed.
- `uv run --extra dev ruff check src tests` → all checks passed.
- `uv run --extra dev ruff format --check src tests` → all files already formatted.
- `uv run --extra dev mypy src/hal0/updater/privileged.py` → no issues.

## Out of scope

CHANGELOG.md is deliberately untouched per the fix-wave convention (#1545) — a consolidated CHANGELOG PR lands at the end of the wave.

Closes #1940