### PR TITLE
fix(gpu): scope the /dev/kfd guard to the llama.cpp lane

### DIFF
--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -428,11 +428,15 @@ def _backend_variants(entry: Any) -> list[str]:
             # off the gpu-rocm row alone would leave the trap in place. On an
             # AMD box with no valid GPU lane the picker offers CPU only.
             # gpu-vulkan survives for the non-llama runtimes below (kokoro /
-            # whisper.cpp / ComfyUI), which run genuinely-Vulkan images, and
-            # for non-AMD GPUs. That survival is only real because the load
-            # path agrees: ``require_kfd_for_gpu_slot``'s gpu-vulkan gate is
-            # scoped to the llama.cpp lane (#1941), so a slot this branch
-            # keeps on gpu-vulkan is not refused at load on a kfd-less box.
+            # whisper.cpp / ComfyUI) and for non-AMD GPUs.
+            #
+            # For those non-llama runtimes "gpu-vulkan" is this picker's GPU
+            # ROW, NOT a claim about the image (#1941). Kokoro and Moonshine
+            # are CPU ONNX images that forward no GPU node at all; ComfyUI's
+            # Strix Halo build and Qwen3-TTS are ROCm images that DO need
+            # /dev/kfd. Nothing derived from this device string can tell them
+            # apart — the load-path guard keys off the provider's own
+            # ``gpu_runtime_needs_rocm`` declaration instead.
             host_backends = {b["id"] for b in available_backends()}
             candidates = ("gpu-rocm", "cpu") if host_is_amd_gpu() else ("gpu-vulkan", "cpu")
             for candidate in candidates:

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -429,7 +429,10 @@ def _backend_variants(entry: Any) -> list[str]:
             # AMD box with no valid GPU lane the picker offers CPU only.
             # gpu-vulkan survives for the non-llama runtimes below (kokoro /
             # whisper.cpp / ComfyUI), which run genuinely-Vulkan images, and
-            # for non-AMD GPUs.
+            # for non-AMD GPUs. That survival is only real because the load
+            # path agrees: ``require_kfd_for_gpu_slot``'s gpu-vulkan gate is
+            # scoped to the llama.cpp lane (#1941), so a slot this branch
+            # keeps on gpu-vulkan is not refused at load on a kfd-less box.
             host_backends = {b["id"] for b in available_backends()}
             candidates = ("gpu-rocm", "cpu") if host_is_amd_gpu() else ("gpu-vulkan", "cpu")
             for candidate in candidates:

--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -199,6 +199,30 @@ def require_kfd_for_gpu_slot(
         return
     if kfd_present(kfd_path):
         return
+    # Computed once and reused on both the warn and raise paths below, so
+    # neither can drift from the lane it is actually describing (#1952
+    # review): #1888 is llama.cpp's failure mode specifically, and quoting
+    # it at a non-llama operator sends them chasing the wrong defect.
+    if runtime_lane == "llama":
+        why = (
+            "The runner image falls back to its Vulkan backend without it, and "
+            "that backend emits invalid tokens for every model (#1888) — "
+            "refusing to start rather than serve garbage."
+        )
+    elif runtime_lane == "rocm":
+        why = (
+            "This slot's runtime image resolves ROCm at launch and cannot "
+            "initialise HIP without it."
+        )
+    else:
+        # "no-rocm" only reaches this far via device == "gpu-rocm" — the
+        # gpu-vulkan branch above already returned for this lane. The image
+        # never touches HIP, so the actual problem is the device
+        # declaration, not the runtime.
+        why = (
+            "This runtime's image never touches ROCm/HIP — the slot's device "
+            "is declared 'gpu-rocm' but doesn't need to be."
+        )
     environ = os.environ if env is None else env
     if str(environ.get(ENV_ALLOW_VULKAN_FALLBACK, "")).strip() in ("1", "true", "yes"):
         log.warning(
@@ -207,19 +231,9 @@ def require_kfd_for_gpu_slot(
             device=device,
             kfd_path=kfd_path,
             runtime_lane=runtime_lane,
-            detail="output will be invalid — see #1888",
+            detail=why,
         )
         return
-    why = (
-        "The runner image falls back to its Vulkan backend without it, and that "
-        "backend emits invalid tokens for every model (#1888) — refusing to start "
-        "rather than serve garbage."
-        if runtime_lane == "llama"
-        # #1888 is llama.cpp's failure mode; quoting it at a ComfyUI or
-        # Qwen3-TTS operator would send them chasing the wrong defect.
-        else "This slot's runtime image resolves ROCm at launch and cannot "
-        "initialise HIP without it."
-    )
     raise GpuPreflightError(
         f"slot {slot_name!r} (device={device}) needs the ROCm compute node "
         f"{kfd_path}, which is not visible here. {why} "

--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -97,11 +97,12 @@ def require_kfd_for_gpu_slot(
     slot_name: str,
     *,
     device: str,
+    llama_lane: bool = True,
     kfd_path: str = KFD_DEVICE_PATH,
     env: dict[str, str] | None = None,
     amd_host: bool | None = None,
 ) -> None:
-    """Loud-fail an AMD-GPU llama.cpp slot that has no ROCm compute node.
+    """Loud-fail a GPU slot that claims ROCm but has no ROCm compute node.
 
     The release-pinned ROCmFPX runner (``DEFAULT_ROCMFPX_IMAGE``) is a single
     HIP+Vulkan build. llama.cpp picks ROCm when ``/dev/kfd`` is visible and
@@ -116,18 +117,43 @@ def require_kfd_for_gpu_slot(
 
     Scope, deliberately narrow:
 
-    * ``gpu-rocm`` — always gated. The device name IS the ROCm claim.
-    * ``gpu-vulkan`` — gated only on an **AMD** host (``amdgpu`` bound). An
-      older AMD slot still carrying that label runs the same broken lane; an
-      Intel iGPU or an NVIDIA card without CDI has no ``/dev/kfd`` by design
-      and keeps working.
+    * ``gpu-rocm`` — always gated, in every runtime. The device name IS the
+      ROCm claim: llama.cpp lands on the poisoned Vulkan fallback without the
+      node, and a genuinely-ROCm non-llama image (Qwen3-TTS) cannot
+      initialise HIP without it either. Only the *explanation* in the refusal
+      differs by lane — #1888's silent-garbage story is llama.cpp's alone.
+    * ``gpu-vulkan`` — gated only on an **AMD** host (``amdgpu`` bound) AND
+      only for the llama.cpp lane (``llama_lane``). An older AMD llama slot
+      still carrying that label runs the same broken ROCmFPX lane; an Intel
+      iGPU or an NVIDIA card without CDI has no ``/dev/kfd`` by design and
+      keeps working.
     * ``cpu`` / ``npu`` / ``gpu-cuda`` — never gated: none of them can reach
       the ROCmFPX image's Vulkan fallback.
+
+    ``llama_lane`` (#1941) is the caller's answer to "does this slot actually
+    launch the unified ROCmFPX llama.cpp runner?", because ``gpu-vulkan`` is
+    not an llama.cpp-only label. :mod:`hal0.capabilities.catalog` deliberately
+    keeps that device for the non-llama runtimes — Kokoro TTS,
+    whisper.cpp/Moonshine STT, ComfyUI — which run genuinely-Vulkan images and
+    never had the #1888 defect; gating them here refused working STT/TTS/image
+    slots at load on every AMD box without the compute node. The one authority
+    on the question is
+    :func:`hal0.providers.container._spec_provider_for` (``None`` == the
+    default llama-server GPU provider), which is what the sole call site
+    passes and what
+    :func:`hal0.updater.updater.relabel_stale_vulkan_slots` uses for the same
+    split. Defaults to ``True`` on purpose: a caller that forgets gets the
+    fail-closed pre-#1941 behaviour, never a silent pass into the poisoned
+    lane.
 
     An explicit :data:`ENV_ALLOW_VULKAN_FALLBACK` opt-in downgrades the
     refusal to a warning — a warn, never a silent pass.
     """
     if device == "gpu-vulkan":
+        if not llama_lane:
+            # A genuinely-Vulkan image (Kokoro / whisper.cpp / ComfyUI). It
+            # never touches HIP, so /dev/kfd is irrelevant to it (#1941).
+            return
         if not (host_is_amd_gpu() if amd_host is None else amd_host):
             return
     elif device != "gpu-rocm":
@@ -141,14 +167,22 @@ def require_kfd_for_gpu_slot(
             slot=slot_name,
             device=device,
             kfd_path=kfd_path,
+            llama_lane=llama_lane,
             detail="output will be invalid — see #1888",
         )
         return
+    why = (
+        "The runner image falls back to its Vulkan backend without it, and that "
+        "backend emits invalid tokens for every model (#1888) — refusing to start "
+        "rather than serve garbage."
+        if llama_lane
+        # #1888 is llama.cpp's failure mode; quoting it at a Qwen3-TTS operator
+        # would send them chasing the wrong defect.
+        else "This slot's runtime image cannot initialise ROCm without it."
+    )
     raise GpuPreflightError(
         f"slot {slot_name!r} (device={device}) needs the ROCm compute node "
-        f"{kfd_path}, which is not visible here. The runner image falls back to "
-        "its Vulkan backend without it, and that backend emits invalid tokens "
-        "for every model (#1888) — refusing to start rather than serve garbage. "
+        f"{kfd_path}, which is not visible here. {why} "
         "Forward the device from the host (Proxmox LXC: add "
         f"'dev1: {kfd_path}' to /etc/pve/lxc/<CTID>.conf, then pct stop/start), "
         "or move this slot to device='cpu'."

--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -28,10 +28,43 @@ from __future__ import annotations
 import json
 import os
 import stat
+from typing import Any, Literal
 
 import structlog
 
 log = structlog.get_logger(__name__)
+
+#: What a slot's runtime does with a GPU device, for
+#: :func:`require_kfd_for_gpu_slot`. Deliberately NOT the slot's ``device``
+#: string, which cannot answer the question — see that function's docstring
+#: and :func:`runtime_lane_for_provider` (#1941).
+#:
+#: * ``"llama"``   — the unified ROCmFPX llama.cpp runner (#1888's lane).
+#: * ``"rocm"``    — a non-llama runtime whose image resolves ROCm/HIP.
+#: * ``"no-rocm"`` — a runtime that never touches HIP.
+RuntimeLane = Literal["llama", "rocm", "no-rocm"]
+
+
+def runtime_lane_for_provider(spec_provider: Any | None) -> RuntimeLane:
+    """Translate a resolved spec provider into a :data:`RuntimeLane`.
+
+    ``spec_provider`` is exactly what
+    :func:`hal0.providers.container._spec_provider_for` returns: ``None`` for
+    the default llama-server GPU provider, else the single-purpose runtime's
+    provider. The ROCm question is answered by the provider's own
+    :attr:`~hal0.providers.base.Provider.gpu_runtime_needs_rocm` declaration
+    rather than by anything derived from the device string, because the
+    catalog labels every non-llama GPU runtime ``gpu-vulkan`` regardless of
+    what its image actually runs (#1941).
+
+    Reads the attribute defensively (``getattr``) so a duck-typed test double
+    standing in for a provider is treated as a plain non-ROCm runtime instead
+    of raising on the load path.
+    """
+    if spec_provider is None:
+        return "llama"
+    return "rocm" if getattr(spec_provider, "gpu_runtime_needs_rocm", False) else "no-rocm"
+
 
 # Linux-convention GID fallbacks (Strix Halo LXC values; also the historical
 # hal0 defaults). Used only as the LAST resort in resolve_gpu_group_ids —
@@ -97,12 +130,12 @@ def require_kfd_for_gpu_slot(
     slot_name: str,
     *,
     device: str,
-    llama_lane: bool = True,
+    runtime_lane: RuntimeLane = "llama",
     kfd_path: str = KFD_DEVICE_PATH,
     env: dict[str, str] | None = None,
     amd_host: bool | None = None,
 ) -> None:
-    """Loud-fail a GPU slot that claims ROCm but has no ROCm compute node.
+    """Loud-fail a GPU slot whose runtime needs ROCm but has no compute node.
 
     The release-pinned ROCmFPX runner (``DEFAULT_ROCMFPX_IMAGE``) is a single
     HIP+Vulkan build. llama.cpp picks ROCm when ``/dev/kfd`` is visible and
@@ -115,44 +148,50 @@ def require_kfd_for_gpu_slot(
     image, not an optimisation: without it there is no lane that produces
     valid output, and the honest answer is to refuse the load and say why.
 
-    Scope, deliberately narrow:
+    ``runtime_lane`` is what makes that decision correct for the OTHER
+    runtimes (#1941). The slot's ``device`` string cannot answer it:
+    :mod:`hal0.capabilities.catalog` labels every non-llama GPU runtime
+    ``gpu-vulkan``, and that label means "the GPU row in the picker", not
+    "this image runs Vulkan". Two of those runtimes are ROCm builds
+    (``ComfyUI``'s Strix Halo image and ``Qwen3-TTS`` — the latter reachable
+    on a ``gpu-vulkan`` slot because ``tts_profile_for_device`` maps ANY GPU
+    device to the ``qwen3-tts`` profile), and two are CPU ONNX images that
+    forward no GPU node at all (Kokoro, Moonshine). Only the provider knows
+    which, so it declares
+    :attr:`~hal0.providers.base.Provider.gpu_runtime_needs_rocm` and the sole
+    call site (``ContainerProvider.load_sync``) translates:
 
-    * ``gpu-rocm`` — always gated, in every runtime. The device name IS the
-      ROCm claim: llama.cpp lands on the poisoned Vulkan fallback without the
-      node, and a genuinely-ROCm non-llama image (Qwen3-TTS) cannot
-      initialise HIP without it either. Only the *explanation* in the refusal
-      differs by lane — #1888's silent-garbage story is llama.cpp's alone.
-    * ``gpu-vulkan`` — gated only on an **AMD** host (``amdgpu`` bound) AND
-      only for the llama.cpp lane (``llama_lane``). An older AMD llama slot
-      still carrying that label runs the same broken ROCmFPX lane; an Intel
-      iGPU or an NVIDIA card without CDI has no ``/dev/kfd`` by design and
-      keeps working.
+    * ``"llama"`` — the default llama-server provider, i.e. the unified
+      ROCmFPX runner. Gated, with #1888's silent-garbage explanation.
+    * ``"rocm"`` — a non-llama runtime whose image resolves ROCm/HIP.
+      Gated, but the refusal does not blame llama.cpp's fallback: quoting
+      #1888 at a ComfyUI operator sends them chasing the wrong defect.
+    * ``"no-rocm"`` — a runtime that never touches HIP (Kokoro / Moonshine,
+      and any genuinely-Vulkan image). Its ``gpu-vulkan`` slots are NOT
+      gated; this is the class #1941 was filed for.
+
+    Scope by device, given that lane:
+
+    * ``gpu-rocm`` — always gated, in every lane. The device name IS the ROCm
+      claim, whatever the runtime does with it.
+    * ``gpu-vulkan`` — gated only on an **AMD** host (``amdgpu`` bound) and
+      only when the lane needs ROCm. An Intel iGPU or an NVIDIA card without
+      CDI has no ``/dev/kfd`` by design and keeps working.
     * ``cpu`` / ``npu`` / ``gpu-cuda`` — never gated: none of them can reach
       the ROCmFPX image's Vulkan fallback.
 
-    ``llama_lane`` (#1941) is the caller's answer to "does this slot actually
-    launch the unified ROCmFPX llama.cpp runner?", because ``gpu-vulkan`` is
-    not an llama.cpp-only label. :mod:`hal0.capabilities.catalog` deliberately
-    keeps that device for the non-llama runtimes — Kokoro TTS,
-    whisper.cpp/Moonshine STT, ComfyUI — which run genuinely-Vulkan images and
-    never had the #1888 defect; gating them here refused working STT/TTS/image
-    slots at load on every AMD box without the compute node. The one authority
-    on the question is
-    :func:`hal0.providers.container._spec_provider_for` (``None`` == the
-    default llama-server GPU provider), which is what the sole call site
-    passes and what
-    :func:`hal0.updater.updater.relabel_stale_vulkan_slots` uses for the same
-    split. Defaults to ``True`` on purpose: a caller that forgets gets the
-    fail-closed pre-#1941 behaviour, never a silent pass into the poisoned
-    lane.
+    ``runtime_lane`` defaults to ``"llama"`` on purpose: a caller that forgets
+    gets the fail-closed pre-#1941 behaviour, never a silent pass into the
+    poisoned lane.
 
     An explicit :data:`ENV_ALLOW_VULKAN_FALLBACK` opt-in downgrades the
     refusal to a warning — a warn, never a silent pass.
     """
     if device == "gpu-vulkan":
-        if not llama_lane:
-            # A genuinely-Vulkan image (Kokoro / whisper.cpp / ComfyUI). It
-            # never touches HIP, so /dev/kfd is irrelevant to it (#1941).
+        if runtime_lane == "no-rocm":
+            # A runtime that never touches HIP (Kokoro / Moonshine). The
+            # gpu-vulkan label is the picker's GPU row, not a ROCm claim, so
+            # /dev/kfd is irrelevant to it (#1941).
             return
         if not (host_is_amd_gpu() if amd_host is None else amd_host):
             return
@@ -167,7 +206,7 @@ def require_kfd_for_gpu_slot(
             slot=slot_name,
             device=device,
             kfd_path=kfd_path,
-            llama_lane=llama_lane,
+            runtime_lane=runtime_lane,
             detail="output will be invalid — see #1888",
         )
         return
@@ -175,10 +214,11 @@ def require_kfd_for_gpu_slot(
         "The runner image falls back to its Vulkan backend without it, and that "
         "backend emits invalid tokens for every model (#1888) — refusing to start "
         "rather than serve garbage."
-        if llama_lane
-        # #1888 is llama.cpp's failure mode; quoting it at a Qwen3-TTS operator
-        # would send them chasing the wrong defect.
-        else "This slot's runtime image cannot initialise ROCm without it."
+        if runtime_lane == "llama"
+        # #1888 is llama.cpp's failure mode; quoting it at a ComfyUI or
+        # Qwen3-TTS operator would send them chasing the wrong defect.
+        else "This slot's runtime image resolves ROCm at launch and cannot "
+        "initialise HIP without it."
     )
     raise GpuPreflightError(
         f"slot {slot_name!r} (device={device}) needs the ROCm compute node "

--- a/src/hal0/providers/base.py
+++ b/src/hal0/providers/base.py
@@ -235,6 +235,25 @@ class Provider(ABC):
     """Short backend identifier, e.g. "llama-server".  Used in slot configs
     and structured logs."""
 
+    gpu_runtime_needs_rocm: bool = False
+    """Does this runtime's toolbox image resolve ROCm/HIP at launch, and so
+    need ``/dev/kfd`` forwarded when the slot sits on a GPU device?
+
+    Declared per provider because a slot's ``device`` string does NOT answer
+    it (#1941). ``hal0.capabilities.catalog`` labels every non-llama GPU
+    runtime ``gpu-vulkan`` — that label means "the GPU row in the picker",
+    not "this image runs Vulkan". ComfyUI's Strix Halo image and Qwen3-TTS
+    are ROCm builds that reach the GPU through HIP and forward ``/dev/kfd``
+    in their specs; Kokoro and Moonshine are CPU ONNX images that forward no
+    GPU nodes at all. Only the provider knows which of those its image is, so
+    it says so here and :func:`hal0.providers._gpu.require_kfd_for_gpu_slot`
+    stops having to guess from the device string.
+
+    Default ``False`` covers the CPU/NPU runtimes. The llama.cpp lane is not
+    expressed here: it is the ``spec_provider is None`` default in
+    ``ContainerProvider.load_sync`` and carries its own #1888 refusal wording.
+    """
+
     @abstractmethod
     def build_env(
         self,

--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -121,6 +121,15 @@ class ComfyUIProvider(Provider):
 
     name = "comfyui"
 
+    #: The kyuz0 Strix Halo image is a PyTorch-**ROCm** build (see the module
+    #: docstring's "Backend default: rocm", ``RUNNER_IMAGES["comfyui"]
+    #: .supported_backends == ("rocm",)``, and ``container_spec`` forwarding
+    #: ``resolve_gpu_device_paths()`` — which includes ``/dev/kfd``). The
+    #: catalog labels img slots ``gpu-vulkan``, but that is the picker's GPU
+    #: row, not the image's backend: without the compute node this slot has no
+    #: GPU at all (#1941).
+    gpu_runtime_needs_rocm = True
+
     # ── Env / argv ─────────────────────────────────────────────────────────────
 
     def build_env(

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -82,6 +82,7 @@ from hal0.providers._gpu import (
     require_kfd_for_gpu_slot,
     resolve_gpu_device_paths,
     resolve_gpu_group_ids,
+    runtime_lane_for_provider,
 )
 from hal0.providers.base import HealthCheck, Mount, Provider, RuntimeLaunchPlan
 from hal0.slot_lifecycle_budget import HEALTH_TIMEOUT_S
@@ -2006,6 +2007,13 @@ class ContainerProvider(Provider):
 
     name = "container"
 
+    #: The unified ROCmFPX runner: HIP first, poisoned Vulkan fallback second
+    #: (#1888). ``runtime_lane_for_provider`` never actually sees this class —
+    #: ``_spec_provider_for`` returns ``None`` for the llama-server default and
+    #: that maps to the richer ``"llama"`` lane — but declaring it keeps every
+    #: possible input to that translation fail-CLOSED rather than fail-open.
+    gpu_runtime_needs_rocm = True
+
     # ── Provider ABC stubs (not used in the container path) ──────────────────
 
     def build_env(self, slot_cfg: dict[str, Any], model_info: dict[str, Any]) -> dict[str, str]:
@@ -2359,23 +2367,24 @@ class ContainerProvider(Provider):
         # dispatch). ``None`` means the default llama-server GPU provider.
         spec_provider = _spec_provider_for(slot_cfg)
 
-        # Loud-fail for AMD-GPU llama.cpp slots with no /dev/kfd: the runner
-        # image would silently fall back to its Vulkan backend, which emits
-        # invalid tokens for every model while every health surface reads
-        # green (#1888). Enforced HERE (the load path) rather than in
-        # ``container_spec`` so unit rendering, previews and status renders
-        # stay host-independent.
+        # Loud-fail for AMD-GPU slots with no /dev/kfd whose runtime needs it:
+        # the ROCmFPX runner would silently fall back to its Vulkan backend,
+        # which emits invalid tokens for every model while every health
+        # surface reads green (#1888). Enforced HERE (the load path) rather
+        # than in ``container_spec`` so unit rendering, previews and status
+        # renders stay host-independent.
         #
-        # ``llama_lane`` scopes the gpu-vulkan half of that guard to the
-        # ROCmFPX runner (#1941): Kokoro / whisper.cpp / ComfyUI keep
-        # device="gpu-vulkan" and run genuinely-Vulkan images that never had
-        # the #1888 defect, so demanding /dev/kfd refused working STT/TTS/
-        # image slots on kfd-less AMD boxes. Same discriminator the updater's
-        # ``relabel_stale_vulkan_slots`` migration uses, so the two agree.
+        # The lane — not the device string — decides (#1941). ``device =
+        # "gpu-vulkan"`` is the catalog's GPU-row label for EVERY non-llama
+        # runtime, so it says nothing about the image: Kokoro and Moonshine
+        # are CPU ONNX images that need no compute node, while ComfyUI and
+        # Qwen3-TTS are ROCm builds that do. Each provider declares
+        # ``gpu_runtime_needs_rocm``; ``runtime_lane_for_provider`` turns that
+        # into the lane.
         require_kfd_for_gpu_slot(
             str(slot_cfg.get("name", "") or token),
             device=str(slot_cfg.get("device", "") or ""),
-            llama_lane=spec_provider is None,
+            runtime_lane=runtime_lane_for_provider(spec_provider),
         )
 
         # Loud-fail for NPU slots only: a missing FLM tag must not silently

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -2354,22 +2354,35 @@ class ContainerProvider(Provider):
         """
         token = slot_instance_token(slot_cfg)
 
+        # The slot's runtime family, resolved ONCE for both loud-fail guards
+        # below (and re-resolved inside _render_quadlet_text, which owns the
+        # dispatch). ``None`` means the default llama-server GPU provider.
+        spec_provider = _spec_provider_for(slot_cfg)
+
         # Loud-fail for AMD-GPU llama.cpp slots with no /dev/kfd: the runner
         # image would silently fall back to its Vulkan backend, which emits
         # invalid tokens for every model while every health surface reads
         # green (#1888). Enforced HERE (the load path) rather than in
         # ``container_spec`` so unit rendering, previews and status renders
         # stay host-independent.
+        #
+        # ``llama_lane`` scopes the gpu-vulkan half of that guard to the
+        # ROCmFPX runner (#1941): Kokoro / whisper.cpp / ComfyUI keep
+        # device="gpu-vulkan" and run genuinely-Vulkan images that never had
+        # the #1888 defect, so demanding /dev/kfd refused working STT/TTS/
+        # image slots on kfd-less AMD boxes. Same discriminator the updater's
+        # ``relabel_stale_vulkan_slots`` migration uses, so the two agree.
         require_kfd_for_gpu_slot(
             str(slot_cfg.get("name", "") or token),
             device=str(slot_cfg.get("device", "") or ""),
+            llama_lane=spec_provider is None,
         )
 
         # Loud-fail for NPU slots only: a missing FLM tag must not silently
         # fall through to FLM's legacy build_env default. Kokoro/ComfyUI are
         # self-managed and need no registry tag — the check fires ONLY when
         # device == "npu" and the slot resolves to a spec provider.
-        if str(slot_cfg.get("device", "")) == "npu" and _spec_provider_for(slot_cfg) is not None:
+        if str(slot_cfg.get("device", "")) == "npu" and spec_provider is not None:
             model_table = slot_cfg.get("model") or {}
             tag = (
                 model_info.get("flm_tag")

--- a/src/hal0/providers/qwen3tts.py
+++ b/src/hal0/providers/qwen3tts.py
@@ -108,6 +108,14 @@ class Qwen3TTSProvider(Provider):
 
     name = "qwen3tts"
 
+    #: ROCm-only image (``RUNNER_IMAGES["qwen3tts"].supported_backends ==
+    #: ("rocm",)``; ``container_spec`` forwards ``resolve_gpu_device_paths()``,
+    #: which includes ``/dev/kfd``). Reachable on a ``gpu-vulkan`` slot too:
+    #: ``tts_profile_for_device`` maps ANY GPU device — including
+    #: ``gpu-vulkan`` — to the ``qwen3-tts`` profile, so the device string
+    #: cannot be trusted to mean "Vulkan image" here (#1941).
+    gpu_runtime_needs_rocm = True
+
     # ── Provider ABC stubs ─────────────────────────────────────────────────────
 
     def build_env(

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -2924,8 +2924,10 @@ def relabel_stale_vulkan_slots(
     and skipped ENTIRELY (no relabel, no warning, no log line, on either kfd
     axis) unless it resolves to ``None`` (the default llama-server GPU
     provider). The kfd-absent non-llama case (``require_kfd_for_gpu_slot``
-    itself over-firing for non-llama runtimes) is a separate, already-filed
-    bug (#1941) and is deliberately NOT addressed by this migration.
+    itself over-firing for non-llama runtimes) was a separate bug, fixed in
+    the guard itself (#1941): it now takes a ``llama_lane`` flag derived from
+    this same ``_spec_provider_for`` discriminator, so a non-llama
+    ``gpu-vulkan`` slot is neither relabeled here nor refused there.
 
     Only the ``device`` key is ever changed in VALUE — narrow scope per the
     #1867 rails (no other field or slot is touched, and a slot whose

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -2910,9 +2910,10 @@ def relabel_stale_vulkan_slots(
     Runtime scope — llama.cpp-backed slots ONLY: ``device = "gpu-vulkan"``
     is not exclusively an llama.cpp label. ``capabilities/catalog.py``
     deliberately keeps it for the non-llama runtimes (Kokoro TTS,
-    whisper.cpp/Moonshine STT, ComfyUI), which run genuinely-Vulkan images —
-    #1923's Vulkan-lane retirement and its ``require_kfd_for_gpu_slot`` guard
-    are about llama.cpp's unified ROCmFPX runner specifically, not those.
+    whisper.cpp/Moonshine STT, ComfyUI), where it means "the picker's GPU
+    row", not "this image runs Vulkan" (#1941) — #1923's Vulkan-lane
+    retirement and its ``require_kfd_for_gpu_slot`` guard are about
+    llama.cpp's unified ROCmFPX runner specifically, not those.
     Relabeling a non-llama slot here would be actively wrong on both kfd
     axes: ``gpu-rocm`` is a label its image can't honor (and
     ``gpu_visibility_env`` would silently swap
@@ -2925,9 +2926,14 @@ def relabel_stale_vulkan_slots(
     axis) unless it resolves to ``None`` (the default llama-server GPU
     provider). The kfd-absent non-llama case (``require_kfd_for_gpu_slot``
     itself over-firing for non-llama runtimes) was a separate bug, fixed in
-    the guard itself (#1941): it now takes a ``llama_lane`` flag derived from
-    this same ``_spec_provider_for`` discriminator, so a non-llama
-    ``gpu-vulkan`` slot is neither relabeled here nor refused there.
+    the guard itself (#1941): it now takes a ``runtime_lane`` derived from
+    the resolved provider's own ``gpu_runtime_needs_rocm`` declaration, so a
+    Kokoro/Moonshine ``gpu-vulkan`` slot is neither relabeled here nor
+    refused there — while a ComfyUI or Qwen3-TTS slot, whose image really is
+    ROCm, keeps its refusal. Note the two scopes are deliberately NOT the
+    same predicate: this migration skips every non-llama slot (relabeling
+    one would break its device passthrough regardless of backend), the guard
+    keys on what the image needs at launch.
 
     Only the ``device`` key is ever changed in VALUE — narrow scope per the
     #1867 rails (no other field or slot is touched, and a slot whose

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -24,6 +24,7 @@ from hal0.providers._gpu import (
     host_is_amd_gpu,
     kfd_present,
     require_kfd_for_gpu_slot,
+    runtime_lane_for_provider,
 )
 
 
@@ -148,28 +149,98 @@ class TestLoadSyncGuard:
 
         seen: dict[str, object] = {}
 
-        def _spy(slot_name: str, *, device: str, llama_lane: bool = True, **_kw: object) -> None:
+        def _spy(
+            slot_name: str, *, device: str, runtime_lane: str = "llama", **_kw: object
+        ) -> None:
             seen["slot"] = slot_name
             seen["device"] = device
-            seen["llama_lane"] = llama_lane
+            seen["runtime_lane"] = runtime_lane
             raise GpuPreflightError("stop here — the rest of load_sync writes units")
 
         monkeypatch.setattr(container_mod, "require_kfd_for_gpu_slot", _spy)
         provider = container_mod.ContainerProvider()
         with pytest.raises(GpuPreflightError):
             provider.load_sync({"name": "utility", "device": "gpu-vulkan", "port": 8082}, {})
-        assert seen == {"slot": "utility", "device": "gpu-vulkan", "llama_lane": True}
+        assert seen == {"slot": "utility", "device": "gpu-vulkan", "runtime_lane": "llama"}
 
 
-class TestNonLlamaVulkanRuntimesAreNotGated:
-    """#1941 — the guard is about llama.cpp's unified ROCmFPX runner, not the
-    device string on its own.
+class TestRuntimeLaneForProvider:
+    """#1941 — the lane comes from the PROVIDER's declared image backend, not
+    from the slot's device string.
 
-    ``device = "gpu-vulkan"`` is NOT an llama.cpp-only label: ``capabilities/
-    catalog.py`` deliberately keeps it for Kokoro TTS, whisper.cpp/Moonshine
-    STT and ComfyUI, which run genuinely-Vulkan images and never had #1888's
-    silent-fallback defect. Gating those on ``/dev/kfd`` refused working
-    STT/TTS/image slots at load on every AMD box without the compute node.
+    ``capabilities/catalog.py`` labels every non-llama GPU runtime
+    ``gpu-vulkan``; that is the picker's GPU row, not a statement about the
+    image. Two of those runtimes are ROCm builds and two are CPU ONNX images,
+    so the device string cannot answer "does this need /dev/kfd".
+    """
+
+    def test_none_is_the_llama_lane(self) -> None:
+        """``_spec_provider_for`` returns None for the default llama-server
+        GPU provider — #1888's lane."""
+        assert runtime_lane_for_provider(None) == "llama"
+
+    @pytest.mark.parametrize(
+        ("module", "cls_name"),
+        [
+            ("hal0.providers.comfyui", "ComfyUIProvider"),
+            ("hal0.providers.qwen3tts", "Qwen3TTSProvider"),
+        ],
+    )
+    def test_rocm_image_runtimes_declare_the_rocm_lane(self, module, cls_name) -> None:
+        """Both forward ``resolve_gpu_device_paths()`` (which includes
+        /dev/kfd) and are registered ``supported_backends=("rocm",)`` — they
+        genuinely cannot initialise HIP without the compute node."""
+        import importlib
+
+        provider = getattr(importlib.import_module(module), cls_name)()
+        assert provider.gpu_runtime_needs_rocm is True
+        assert runtime_lane_for_provider(provider) == "rocm"
+
+    @pytest.mark.parametrize(
+        ("module", "cls_name"),
+        [
+            ("hal0.providers.kokoro", "KokoroProvider"),
+            ("hal0.providers.moonshine", "MoonshineProvider"),
+            ("hal0.providers.flm", "FLMProvider"),
+        ],
+    )
+    def test_non_rocm_runtimes_declare_the_no_rocm_lane(self, module, cls_name) -> None:
+        """CPU ONNX / NPU images: they forward no GPU device node at all, so
+        /dev/kfd is irrelevant to them."""
+        import importlib
+
+        provider = getattr(importlib.import_module(module), cls_name)()
+        assert provider.gpu_runtime_needs_rocm is False
+        assert runtime_lane_for_provider(provider) == "no-rocm"
+
+    def test_the_declaration_matches_the_runner_registry(self) -> None:
+        """Cross-check the per-provider flag against the OTHER place that
+        records the same fact (``RUNNER_IMAGES[...].supported_backends``), so
+        the two cannot drift apart silently."""
+        import importlib
+
+        from hal0.runners import RUNNER_IMAGES
+
+        for runner_key, module, cls_name in (
+            ("comfyui", "hal0.providers.comfyui", "ComfyUIProvider"),
+            ("qwen3tts", "hal0.providers.qwen3tts", "Qwen3TTSProvider"),
+            ("kokoro", "hal0.providers.kokoro", "KokoroProvider"),
+            ("moonshine", "hal0.providers.moonshine", "MoonshineProvider"),
+            ("flm", "hal0.providers.flm", "FLMProvider"),
+        ):
+            runner = RUNNER_IMAGES[runner_key]
+            registry_says_rocm = "rocm" in runner.supported_backends or runner.backend == "rocm"
+            provider = getattr(importlib.import_module(module), cls_name)()
+            assert provider.gpu_runtime_needs_rocm is registry_says_rocm, runner_key
+
+
+class TestNonRocmRuntimesAreNotGated:
+    """#1941 — a ``gpu-vulkan`` slot whose runtime never touches HIP must load
+    on a kfd-less AMD box, exactly as it did before #1923.
+
+    Kokoro TTS and Moonshine STT run CPU ONNX images and forward no GPU node,
+    so ``/dev/kfd`` is irrelevant to them — but the pre-fix guard saw only
+    ``device == "gpu-vulkan"`` and refused them with a llama.cpp error.
     """
 
     @staticmethod
@@ -203,12 +274,8 @@ class TestNonLlamaVulkanRuntimesAreNotGated:
         "slot_cfg",
         [
             pytest.param(
-                {"name": "imagegen", "type": "image", "device": "gpu-vulkan", "port": 8188},
-                id="comfyui",
-            ),
-            pytest.param(
                 {"name": "stt", "type": "transcription", "device": "gpu-vulkan", "port": 8092},
-                id="whispercpp-stt",
+                id="moonshine-stt",
             ),
             pytest.param(
                 {"name": "voice", "type": "tts", "device": "gpu-vulkan", "port": 8090},
@@ -216,7 +283,7 @@ class TestNonLlamaVulkanRuntimesAreNotGated:
             ),
         ],
     )
-    def test_load_sync_loads_a_non_llama_vulkan_slot(self, monkeypatch, slot_cfg) -> None:
+    def test_load_sync_loads_a_non_rocm_vulkan_slot(self, monkeypatch, slot_cfg) -> None:
         from hal0.providers import container as container_mod
 
         self._amd_box_without_kfd(monkeypatch)
@@ -240,10 +307,48 @@ class TestNonLlamaVulkanRuntimesAreNotGated:
                 {"name": "utility", "device": "gpu-vulkan", "port": 8082}, {}
             )
 
+    @pytest.mark.parametrize(
+        "slot_cfg",
+        [
+            pytest.param(
+                {"name": "imagegen", "type": "image", "device": "gpu-vulkan", "port": 8188},
+                id="comfyui-on-the-vulkan-label",
+            ),
+            pytest.param(
+                {
+                    "name": "voice",
+                    "type": "tts",
+                    "profile": "qwen3-tts",
+                    "device": "gpu-vulkan",
+                    "port": 8095,
+                },
+                id="qwen3tts-on-the-vulkan-label",
+            ),
+        ],
+    )
+    def test_load_sync_still_refuses_a_rocm_image_on_the_vulkan_label(
+        self, monkeypatch, slot_cfg
+    ) -> None:
+        """The half the naive "non-llama ⇒ safe" scoping would have broken.
+
+        ComfyUI's Strix Halo image is a PyTorch-ROCm build, and
+        ``tts_profile_for_device`` maps ANY GPU device — ``gpu-vulkan``
+        included — to the ROCm-only ``qwen3-tts`` profile. Both forward
+        ``/dev/kfd`` in their specs, so both must keep the refusal even though
+        neither is llama.cpp.
+        """
+        from hal0.providers import container as container_mod
+
+        self._amd_box_without_kfd(monkeypatch)
+        self._stub_unit_write(monkeypatch)
+
+        with pytest.raises(GpuPreflightError):
+            container_mod.ContainerProvider().load_sync(dict(slot_cfg), {})
+
     def test_a_non_llama_gpu_rocm_slot_is_still_gated(self, tmp_path) -> None:
-        """Scoping relaxes ``gpu-vulkan`` only. ``gpu-rocm`` stays gated for
-        every runtime: the device name IS the ROCm claim, and a ROCm image
-        (Qwen3-TTS) cannot initialise HIP without the compute node either."""
+        """Scoping relaxes ``gpu-vulkan`` only. ``gpu-rocm`` stays gated in
+        every lane: the device name IS the ROCm claim, whatever the runtime
+        does with it."""
         with pytest.raises(GpuPreflightError):
             require_kfd_for_gpu_slot(
                 "voice",
@@ -251,20 +356,20 @@ class TestNonLlamaVulkanRuntimesAreNotGated:
                 kfd_path=str(tmp_path / "kfd"),
                 env={},
                 amd_host=True,
-                llama_lane=False,
+                runtime_lane="no-rocm",
             )
 
     def test_the_non_llama_refusal_does_not_blame_the_vulkan_fallback(self, tmp_path) -> None:
         """#1888's silent-Vulkan-fallback story is llama.cpp's alone — quoting
-        it at a Qwen3-TTS operator sends them chasing the wrong defect."""
+        it at a ComfyUI operator sends them chasing the wrong defect."""
         with pytest.raises(GpuPreflightError) as exc:
             require_kfd_for_gpu_slot(
-                "voice",
-                device="gpu-rocm",
+                "imagegen",
+                device="gpu-vulkan",
                 kfd_path=str(tmp_path / "kfd"),
                 env={},
                 amd_host=True,
-                llama_lane=False,
+                runtime_lane="rocm",
             )
         msg = str(exc.value)
         assert "1888" not in msg

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -146,18 +146,131 @@ class TestLoadSyncGuard:
     def test_load_sync_calls_the_guard_with_the_slots_device(self, monkeypatch) -> None:
         from hal0.providers import container as container_mod
 
-        seen: dict[str, str] = {}
+        seen: dict[str, object] = {}
 
-        def _spy(slot_name: str, *, device: str, **_kw: object) -> None:
+        def _spy(slot_name: str, *, device: str, llama_lane: bool = True, **_kw: object) -> None:
             seen["slot"] = slot_name
             seen["device"] = device
+            seen["llama_lane"] = llama_lane
             raise GpuPreflightError("stop here — the rest of load_sync writes units")
 
         monkeypatch.setattr(container_mod, "require_kfd_for_gpu_slot", _spy)
         provider = container_mod.ContainerProvider()
         with pytest.raises(GpuPreflightError):
             provider.load_sync({"name": "utility", "device": "gpu-vulkan", "port": 8082}, {})
-        assert seen == {"slot": "utility", "device": "gpu-vulkan"}
+        assert seen == {"slot": "utility", "device": "gpu-vulkan", "llama_lane": True}
+
+
+class TestNonLlamaVulkanRuntimesAreNotGated:
+    """#1941 — the guard is about llama.cpp's unified ROCmFPX runner, not the
+    device string on its own.
+
+    ``device = "gpu-vulkan"`` is NOT an llama.cpp-only label: ``capabilities/
+    catalog.py`` deliberately keeps it for Kokoro TTS, whisper.cpp/Moonshine
+    STT and ComfyUI, which run genuinely-Vulkan images and never had #1888's
+    silent-fallback defect. Gating those on ``/dev/kfd`` refused working
+    STT/TTS/image slots at load on every AMD box without the compute node.
+    """
+
+    @staticmethod
+    def _amd_box_without_kfd(monkeypatch) -> None:
+        """An AMD host (amdgpu bound) that has no usable /dev/kfd — the exact
+        shape of the box #1941 was reported from."""
+        from hal0.providers import _gpu as gpu_mod
+
+        monkeypatch.setattr(gpu_mod, "host_is_amd_gpu", lambda *_a, **_k: True)
+        monkeypatch.setattr(gpu_mod, "kfd_present", lambda *_a, **_k: False)
+
+    @staticmethod
+    def _stub_unit_write(monkeypatch) -> list[str]:
+        """Stop load_sync after the guard: record the unit write, do none."""
+        from hal0.providers import container as container_mod
+
+        written: list[str] = []
+        monkeypatch.setattr(
+            container_mod.ContainerProvider,
+            "_render_quadlet_text",
+            lambda self, slot_cfg, model_info: "[Container]\n",
+        )
+        monkeypatch.setattr(
+            container_mod.ContainerProvider,
+            "_write_and_start_unit",
+            lambda self, token, unit_text: written.append(token),
+        )
+        return written
+
+    @pytest.mark.parametrize(
+        "slot_cfg",
+        [
+            pytest.param(
+                {"name": "imagegen", "type": "image", "device": "gpu-vulkan", "port": 8188},
+                id="comfyui",
+            ),
+            pytest.param(
+                {"name": "stt", "type": "transcription", "device": "gpu-vulkan", "port": 8092},
+                id="whispercpp-stt",
+            ),
+            pytest.param(
+                {"name": "voice", "type": "tts", "device": "gpu-vulkan", "port": 8090},
+                id="kokoro-tts",
+            ),
+        ],
+    )
+    def test_load_sync_loads_a_non_llama_vulkan_slot(self, monkeypatch, slot_cfg) -> None:
+        from hal0.providers import container as container_mod
+
+        self._amd_box_without_kfd(monkeypatch)
+        written = self._stub_unit_write(monkeypatch)
+
+        container_mod.ContainerProvider().load_sync(dict(slot_cfg), {})
+
+        assert written == [slot_cfg["name"]]
+
+    def test_load_sync_still_refuses_the_llama_lane(self, monkeypatch) -> None:
+        """The #1888 refusal must survive the scoping: a profile-less
+        ``gpu-vulkan`` slot resolves to the default llama-server provider and
+        still runs the poisoned ROCmFPX Vulkan lane."""
+        from hal0.providers import container as container_mod
+
+        self._amd_box_without_kfd(monkeypatch)
+        self._stub_unit_write(monkeypatch)
+
+        with pytest.raises(GpuPreflightError):
+            container_mod.ContainerProvider().load_sync(
+                {"name": "utility", "device": "gpu-vulkan", "port": 8082}, {}
+            )
+
+    def test_a_non_llama_gpu_rocm_slot_is_still_gated(self, tmp_path) -> None:
+        """Scoping relaxes ``gpu-vulkan`` only. ``gpu-rocm`` stays gated for
+        every runtime: the device name IS the ROCm claim, and a ROCm image
+        (Qwen3-TTS) cannot initialise HIP without the compute node either."""
+        with pytest.raises(GpuPreflightError):
+            require_kfd_for_gpu_slot(
+                "voice",
+                device="gpu-rocm",
+                kfd_path=str(tmp_path / "kfd"),
+                env={},
+                amd_host=True,
+                llama_lane=False,
+            )
+
+    def test_the_non_llama_refusal_does_not_blame_the_vulkan_fallback(self, tmp_path) -> None:
+        """#1888's silent-Vulkan-fallback story is llama.cpp's alone — quoting
+        it at a Qwen3-TTS operator sends them chasing the wrong defect."""
+        with pytest.raises(GpuPreflightError) as exc:
+            require_kfd_for_gpu_slot(
+                "voice",
+                device="gpu-rocm",
+                kfd_path=str(tmp_path / "kfd"),
+                env={},
+                amd_host=True,
+                llama_lane=False,
+            )
+        msg = str(exc.value)
+        assert "1888" not in msg
+        # Still actionable: what is missing and how to forward it.
+        assert "/kfd" in msg
+        assert "pct stop/start" in msg
 
 
 def _raiser(*_a: object, **_kw: object) -> None:

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -377,6 +377,93 @@ class TestNonRocmRuntimesAreNotGated:
         assert "/kfd" in msg
         assert "pct stop/start" in msg
 
+    def test_the_no_rocm_gpu_rocm_refusal_describes_a_device_mismatch(self, tmp_path) -> None:
+        """A no-rocm runtime (Kokoro/Moonshine) only reaches the raise path via
+        a hand-set ``device="gpu-rocm"``, since the gpu-vulkan branch already
+        exempts this lane. The image never resolves ROCm/HIP, so the refusal
+        must not claim it does (Codex review on PR #1952) — the actual
+        problem is the device declaration, not the runtime."""
+        with pytest.raises(GpuPreflightError) as exc:
+            require_kfd_for_gpu_slot(
+                "voice",
+                device="gpu-rocm",
+                kfd_path=str(tmp_path / "kfd"),
+                env={},
+                amd_host=True,
+                runtime_lane="no-rocm",
+            )
+        msg = str(exc.value)
+        assert "1888" not in msg
+        assert "resolves ROCm at launch" not in msg
+        assert "cannot initialise HIP without it" not in msg
+        assert "never touches ROCm/HIP" in msg
+        assert "declared 'gpu-rocm'" in msg
+        # Still actionable: what is missing and how to forward it.
+        assert "/kfd" in msg
+        assert "pct stop/start" in msg
+
+
+class TestFallbackWarningIsLaneScoped:
+    """PR #1952 review: the ``HAL0_ALLOW_VULKAN_FALLBACK`` warn path
+    hardcoded ``detail="output will be invalid — see #1888"`` for every lane,
+    including ``"rocm"`` — a ComfyUI/Qwen3-TTS operator has no Vulkan
+    fallback to speak of and gets sent to the wrong defect. The warning must
+    reuse the same lane-scoped explanation as the raise path."""
+
+    def test_the_llama_lane_warning_still_names_1888(self, tmp_path) -> None:
+        from structlog.testing import capture_logs
+
+        with capture_logs() as logs:
+            require_kfd_for_gpu_slot(
+                "agent",
+                device="gpu-rocm",
+                kfd_path=str(tmp_path / "kfd"),
+                env={ENV_ALLOW_VULKAN_FALLBACK: "1"},
+                amd_host=True,
+                runtime_lane="llama",
+            )
+        warnings = [e for e in logs if e.get("log_level") == "warning"]
+        assert len(warnings) == 1
+        assert "1888" in warnings[0]["detail"]
+
+    def test_the_rocm_lane_warning_does_not_blame_the_vulkan_fallback(self, tmp_path) -> None:
+        from structlog.testing import capture_logs
+
+        with capture_logs() as logs:
+            require_kfd_for_gpu_slot(
+                "imagegen",
+                device="gpu-vulkan",
+                kfd_path=str(tmp_path / "kfd"),
+                env={ENV_ALLOW_VULKAN_FALLBACK: "1"},
+                amd_host=True,
+                runtime_lane="rocm",
+            )
+        warnings = [e for e in logs if e.get("log_level") == "warning"]
+        assert len(warnings) == 1
+        detail = warnings[0]["detail"]
+        assert "1888" not in detail
+        assert "output will be invalid" not in detail
+        assert "resolves ROCm at launch" in detail
+
+    def test_the_no_rocm_lane_warning_describes_the_device_mismatch(self, tmp_path) -> None:
+        from structlog.testing import capture_logs
+
+        with capture_logs() as logs:
+            require_kfd_for_gpu_slot(
+                "voice",
+                device="gpu-rocm",
+                kfd_path=str(tmp_path / "kfd"),
+                env={ENV_ALLOW_VULKAN_FALLBACK: "1"},
+                amd_host=True,
+                runtime_lane="no-rocm",
+            )
+        warnings = [e for e in logs if e.get("log_level") == "warning"]
+        assert len(warnings) == 1
+        detail = warnings[0]["detail"]
+        assert "1888" not in detail
+        assert "output will be invalid" not in detail
+        assert "never touches ROCm/HIP" in detail
+
 
 def _raiser(*_a: object, **_kw: object) -> None:
     raise GpuPreflightError("no /dev/kfd")


### PR DESCRIPTION
## What changed

The `/dev/kfd` load guard now keys on **what the slot's runtime image actually
needs**, not on its `device` string.

* `Provider.gpu_runtime_needs_rocm` — a new per-provider declaration. `True`
  for `ComfyUIProvider`, `Qwen3TTSProvider` and `ContainerProvider` (the
  ROCmFPX llama runner); `False` for the CPU/NPU runtimes (Kokoro, Moonshine,
  FLM).
* `runtime_lane_for_provider()` turns `_spec_provider_for`'s result into a
  `RuntimeLane` — `"llama"` / `"rocm"` / `"no-rocm"` — which
  `require_kfd_for_gpu_slot` uses for both the gate and the refusal wording.
* `gpu-vulkan` is gated only on an AMD host **and** only when the lane needs
  ROCm. `gpu-rocm` stays gated in every lane (the device name *is* the ROCm
  claim). `cpu` / `npu` / `gpu-cuda` unchanged.
* The refusal no longer quotes #1888's llama-only silent-garbage story at a
  ComfyUI or Qwen3-TTS operator; they get "this runtime resolves ROCm at
  launch and cannot initialise HIP without it" plus the same remedy.
* The `HAL0_ALLOW_VULKAN_FALLBACK` warn path (`_gpu.py`) reuses that same
  lane-scoped `why` instead of hardcoding `#1888`'s llama-only wording for
  every lane — a ComfyUI/Qwen3-TTS operator who sets the escape hatch no
  longer gets told their non-existent Vulkan fallback will be invalid, and a
  `gpu-rocm`-declared no-rocm runtime (Kokoro/Moonshine hand-edited past the
  picker) gets a device-mismatch explanation instead of an image-needs-ROCm
  one it doesn't fit either.
* `load_sync` resolves the spec provider once and reuses it for the NPU guard.
* Comments in `capabilities/catalog.py` and `updater.relabel_stale_vulkan_slots`
  that claimed these runtimes "run genuinely-Vulkan images" are corrected —
  that mistaken model is what produced the bug.

## Why

#1923 made `/dev/kfd` a hard requirement, but the guard only ever saw the
slot's **device string**. `device = "gpu-vulkan"` is the catalog's *GPU row in
the picker* for every non-llama runtime — not a statement about the image
(`capabilities/catalog.py:417-441`, `_RUNTIME_TO_HOST_BACKENDS`). Meanwhile
`available_backends()` advertises `gpu-vulkan` whenever any GPU is detected,
and on a kfd-less AMD box it is the only GPU row offered. So the picker offered
a lane the load path then refused.

Root cause is that missing discriminator. The first commit here fixed it with
`llama_lane = _spec_provider_for(...) is None`, which the Codex review
correctly flagged as still wrong — and running that down showed the issue's own
premise was half wrong too. "Not llama.cpp" does not imply "needs no compute
node":

* ComfyUI's image is `kyuz0/amd-strix-halo-comfyui`, a **PyTorch-ROCm** build.
  `RUNNER_IMAGES["comfyui"].supported_backends == ("rocm",)`, the module
  docstring says `Backend default: rocm`, and `container_spec` forwards
  `resolve_gpu_device_paths()` — which includes `/dev/kfd`. Its refusal on a
  kfd-less box was **correct**, so #1941's ComfyUI case is respectfully
  rejected with evidence.
* Qwen3-TTS is ROCm-only and reachable on a `gpu-vulkan` slot, because
  `tts_profile_for_device` maps *any* GPU device to the `qwen3-tts` profile.
  The `llama_lane` version would have let that slot start with no compute node.

Only the provider knows which of those its image is, so it says so, once.

The class this genuinely unblocks: **Kokoro TTS and Moonshine STT on
`gpu-vulkan`** — CPU ONNX images that forward no GPU node at all.

Note `updater.relabel_stale_vulkan_slots` (#1934) is deliberately *not* the
same predicate: it skips every non-llama slot (relabeling one would break its
device passthrough regardless of backend), while the guard keys on what the
image needs at launch. Both docstrings now say so.

## How it was verified

Regression tests written first, confirmed red on `main`, green after
(`tests/providers/test_gpu_kfd_preflight.py`). The load-path cases drive the
**real** `load_sync` on a simulated AMD box with no usable `/dev/kfd`
(`host_is_amd_gpu` → True, `kfd_present` → False) rather than patching the
guard out:

* `test_load_sync_loads_a_non_rocm_vulkan_slot[moonshine-stt|kokoro-tts]` —
  now reach the unit write. Before: `GpuPreflightError` at `container.py:2363`.
* `test_load_sync_still_refuses_a_rocm_image_on_the_vulkan_label[comfyui|qwen3tts]`
  — the exact hole the review found; both keep the refusal.
* `test_load_sync_still_refuses_the_llama_lane` — #1888's protection is
  provably not over-relaxed.
* `TestRuntimeLaneForProvider::test_the_declaration_matches_the_runner_registry`
  — cross-checks every provider's flag against
  `RUNNER_IMAGES[...].supported_backends`, so the two records of the same fact
  cannot drift apart silently.

Provider resolution spot-checked directly:

```
profile    type            -> provider             lane
-          -               -> NoneType             llama
-          image           -> ComfyUIProvider      rocm
qwen3-tts  tts             -> Qwen3TTSProvider     rocm
-          tts             -> KokoroProvider       no-rocm
-          transcription   -> MoonshineProvider    no-rocm
```

```
HAL0_HOME=$(mktemp -d) uv run --extra dev pytest -q -p no:randomly
  → 10945 passed, 16 skipped, 1 xfailed in 1072.69s
HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/providers tests/updater tests/capabilities -q
  → 1042 passed
ruff check src tests            → All checks passed!
ruff format --check src tests   → 1160 files already formatted
mypy src/hal0/providers/{_gpu,container,base,comfyui,qwen3tts}.py
  → 3 errors, all pre-existing and in code this diff does not touch
    (container.py:368, container.py:2735, comfyui.py:302)
```

## Deliberately out of scope

* No `CHANGELOG.md` hunk (per #1545 — one consolidated changelog PR lands at
  the end of the wave).
* `_RUNTIME_TO_HOST_BACKENDS` still labels ComfyUI/Qwen3-TTS `gpu-vulkan`. That
  label is now documented as "the picker's GPU row" and no longer drives any
  correctness decision; renaming it is a catalog-vocabulary change with its own
  migration surface.
* No change to `available_backends()` advertising `gpu-vulkan` on a kfd-less
  AMD box.
* The `HAL0_ALLOW_VULKAN_FALLBACK` escape hatch still applies to the `"rocm"`
  lane, unchanged from before this PR.
* ComfyUI's img half of #1941 is refused correctly by this PR, but the
  picker still offers it no reachable lane on a kfd-less AMD box (only
  `gpu-vulkan`, no `cpu` row, no CPU `[profile.comfyui]` variant, so the
  guard's own "move this slot to `device='cpu'`" remedy is unreachable
  advice). That is a picker/profile gap, not a guard-scoping bug, and needs
  its own catalog change — split out to #1966 rather than folded in here or
  retired silently by this PR's `Closes #1941`.

Closes #1941
Refs #1888, #1923, #1924, #1934, #1966
