### PR TITLE
fix(gpu): resolve /dev/kfd access by runner identity and device gid

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1424,6 +1424,23 @@ GPU_PERMS_UNIT_SRC="${REPO_ROOT}/installer/systemd/hal0-gpu-perms.service"
 GPU_PERMS_UNIT_DST="${UNIT_DIR}/hal0-gpu-perms.service"
 if [[ -f "${GPU_PERMS_UNIT_SRC}" ]]; then
     install -m 0644 "${GPU_PERMS_UNIT_SRC}" "${GPU_PERMS_UNIT_DST}"
+    # A non-default HAL0_PREFIX moves the venv, and the shipped unit hardcodes
+    # the FHS path — without this rewrite ExecStart points at a nonexistent
+    # interpreter and the unit dies 203/EXEC, so the compute node is never
+    # converged after a reboot. Same treatment the bench units get; done in
+    # Python, not sed, so a prefix containing sed metacharacters is safe.
+    if [[ "${VENV_DIR}" != "/usr/lib/hal0/venv" ]]; then
+        "${PY}" - "${GPU_PERMS_UNIT_DST}" "${VENV_DIR}" <<'PYEOF'
+import sys
+from pathlib import Path
+
+dst, venv = Path(sys.argv[1]), sys.argv[2]
+dst.write_text(
+    dst.read_text(encoding="utf-8").replace("/usr/lib/hal0/venv", venv),
+    encoding="utf-8",
+)
+PYEOF
+    fi
     info "wrote ${GPU_PERMS_UNIT_DST}"
     if [[ "${DEV_MODE}" -eq 0 ]]; then
         # WantedBy=hal0.target. Enabling is safe on a non-AMD box: the unit

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -454,6 +454,27 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
             err "To install CPU-only anyway, re-run with HAL0_ALLOW_CPU_ONLY=1."
             exit 1
         fi
+    elif (( gpu_rc == HAL0_GPU_RC_KFD_GID )); then
+        # #1953: /dev/kfd IS forwarded, its group is just wrong. We are root
+        # here, so repair it in place rather than making the operator do it —
+        # and rather than the old behaviour of sending them to re-forward a
+        # device that is already present. The gid comes from the render node
+        # (never from `getent group render`; see preflight_gpu for why).
+        _kfd_path="${HAL0_GPU_KFD_PATH:-/dev/kfd}"
+        _render_node="$(compgen -G '/dev/dri/renderD*' 2>/dev/null | head -1)"
+        _render_gid="$(stat -c '%g' "${_render_node}" 2>/dev/null || true)"
+        if [[ -n "${_render_gid}" ]] \
+            && chgrp "${_render_gid}" "${_kfd_path}" 2>/dev/null \
+            && chmod 0660 "${_kfd_path}" 2>/dev/null; then
+            info "gpu: aligned ${_kfd_path} to gid ${_render_gid} (matches ${_render_node})"
+        else
+            # Unprivileged LXC: the node's ownership is host-mapped, so chgrp
+            # is EPERM and the only real fix is on the host's dev entry.
+            err "GPU compute node ${_kfd_path} has the wrong group and it could not be fixed from inside this container."
+            err "Set it on the Proxmox host: dev1: ${_kfd_path},gid=${_render_gid:-<render gid inside the container>}"
+            err "then: pct stop <CTID> && pct start <CTID>. See hal0 issue #1953."
+            exit 1
+        fi
     elif (( gpu_rc == HAL0_GPU_RC_NO_DEVICE )); then
         if [[ "${HAL0_ALLOW_CPU_ONLY:-0}" == "1" ]]; then
             warn "No GPU devices inside this container — proceeding CPU-only (HAL0_ALLOW_CPU_ONLY=1)."

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1414,6 +1414,28 @@ else
     warn "${TARGET_UNIT_SRC} not found — hal0.target not installed; slots will not autostart after reboot"
 fi
 
+# GPU device permissions (#1953). /dev/kfd is recreated every boot, so the
+# install/update-time converge is undone by the next reboot unless the host's
+# LXC `dev` entry carries gid=. This oneshot re-derives the target gid FROM THE
+# RENDER NODE and re-applies it before hal0.target — deliberately a service
+# rather than a tmpfiles.d/udev rule, both of which would have to name a gid,
+# and a baked gid is not portable across hosts (see preflight_gpu).
+GPU_PERMS_UNIT_SRC="${REPO_ROOT}/installer/systemd/hal0-gpu-perms.service"
+GPU_PERMS_UNIT_DST="${UNIT_DIR}/hal0-gpu-perms.service"
+if [[ -f "${GPU_PERMS_UNIT_SRC}" ]]; then
+    install -m 0644 "${GPU_PERMS_UNIT_SRC}" "${GPU_PERMS_UNIT_DST}"
+    info "wrote ${GPU_PERMS_UNIT_DST}"
+    if [[ "${DEV_MODE}" -eq 0 ]]; then
+        # WantedBy=hal0.target. Enabling is safe on a non-AMD box: the unit
+        # carries ConditionPathExists=/dev/kfd and the module no-ops without
+        # amdgpu bound.
+        systemctl enable hal0-gpu-perms.service >/dev/null 2>&1 \
+            || warn "could not enable hal0-gpu-perms.service"
+    fi
+else
+    warn "${GPU_PERMS_UNIT_SRC} not found — /dev/kfd group will not be re-applied after a reboot"
+fi
+
 OPENWEBUI_UNIT_SRC="${REPO_ROOT}/packaging/systemd/hal0-openwebui.service"
 OPENWEBUI_UNIT_DST="${UNIT_DIR}/hal0-openwebui.service"
 # pin per release (#79) — single source of truth for the OpenWebUI image

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -470,10 +470,17 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
         else
             # Unprivileged LXC: the node's ownership is host-mapped, so chgrp
             # is EPERM and the only real fix is on the host's dev entry.
-            err "GPU compute node ${_kfd_path} has the wrong group and it could not be fixed from inside this container."
-            err "Set it on the Proxmox host: dev1: ${_kfd_path},gid=${_render_gid:-<render gid inside the container>}"
-            err "then: pct stop <CTID> && pct start <CTID>. See hal0 issue #1953."
-            exit 1
+            #
+            # WARN, never block. Since the slot containers run rootful, they
+            # open a root:root compute node perfectly well — a mismatched gid
+            # costs hal0-user probes and diagnostics their GPU visibility, not
+            # inference. Hard-stopping here would newly refuse installation on
+            # every unprivileged LXC for a condition that no longer breaks
+            # serving (the identity fix in #1953 is what changed this).
+            warn "gpu: ${_kfd_path} has a different group (${_render_gid:-?} expected) and could not be changed from inside this container."
+            warn "  GPU slots still work — they run rootful — but hal0-user probes and diagnostics cannot read the compute node."
+            warn "  To fix, set it on the Proxmox host: dev1: ${_kfd_path},gid=${_render_gid:-<render gid inside the container>}"
+            warn "  (the gid INSIDE the container), then: pct stop <CTID> && pct start <CTID>. See hal0 issue #1953."
         fi
     elif (( gpu_rc == HAL0_GPU_RC_NO_DEVICE )); then
         if [[ "${HAL0_ALLOW_CPU_ONLY:-0}" == "1" ]]; then

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1097,8 +1097,24 @@ preflight_gpu() {
         # seam, so divergence can be forced without needing two real groups.
         kfd_gid="${HAL0_GPU_KFD_GID_OVERRIDE:-$(stat -c '%g' "${kfd_path}" 2>/dev/null || true)}"
         render_gid="$(stat -c '%g' "${node}" 2>/dev/null || true)"
-        if [[ -n "${kfd_gid}" && -n "${render_gid}" && "${kfd_gid}" != "${render_gid}" ]]; then
-            warn "gpu: ${kfd_path} is owned by gid ${kfd_gid}, but ${node} uses gid ${render_gid}"
+        # Gate on the INACCESSIBLE shape, not on gid inequality. A differing gid
+        # is not itself a fault: a valid box can put /dev/kfd on `video` and the
+        # render nodes on `render`, and install.sh adds hal0 to BOTH; world bits
+        # or an ACL can grant access independently too. Rewriting those to the
+        # render group would remove access from video-only users and, on an
+        # unprivileged LXC, abort a fresh install over a working config.
+        #
+        # The shape that actually breaks is the plain-passthrough default:
+        # root-owned with no group the service user can ever be in (gid 0) and
+        # no world access. Only that is repaired.
+        local kfd_mode kfd_world_rw=0
+        kfd_mode="$(stat -c '%a' "${kfd_path}" 2>/dev/null || echo 000)"
+        case "${kfd_mode}" in *[67]) kfd_world_rw=1 ;; esac
+        if [[ -n "${kfd_gid}" && -n "${render_gid}" \
+            && "${kfd_gid}" != "${render_gid}" \
+            && "${kfd_gid}" == "0" \
+            && "${kfd_world_rw}" == "0" ]]; then
+            warn "gpu: ${kfd_path} is root-owned (gid ${kfd_gid}, mode ${kfd_mode}) while ${node} uses gid ${render_gid}"
             warn "  The compute node is forwarded and the rootful slot containers can use it,"
             warn "  but the hal0 service user cannot — so GPU slots get refused on a working box (#1953)."
             warn "  Fix IN PLACE (no re-forward, no reboot):"

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -926,6 +926,16 @@ HAL0_GPU_RC_NO_DEVICE=4
 #                                    green (#1888). Caller allows an explicit
 #                                    CPU-only opt-in, same as NO_DEVICE.
 HAL0_GPU_RC_NO_KFD=5
+#       HAL0_GPU_RC_KFD_GID(6)    → /dev/kfd IS forwarded, but its owning gid
+#                                    differs from the render node's, so the
+#                                    hal0 user cannot open it even though the
+#                                    rootful slot containers can (#1953). A
+#                                    plain LXC dev passthrough produces exactly
+#                                    this: renderD128 lands root:render while
+#                                    the compute node lands root:root. Fixable
+#                                    IN PLACE — never tell the operator to
+#                                    re-forward a device that is already there.
+HAL0_GPU_RC_KFD_GID=6
 preflight_gpu() {
     local gate="${HAL0_GPU_GATE:-0}"
 
@@ -1062,6 +1072,41 @@ preflight_gpu() {
             warn "  Load the amdkfd driver (it ships with amdgpu; check 'dmesg | grep -i kfd')."
         fi
         [[ "${gate}" == "1" ]] && return "${HAL0_GPU_RC_NO_KFD}"
+    fi
+
+    # ── ROCm compute-node group wiring (#1953) ───────────────────────────
+    # The node above exists — but a plain LXC `dev` passthrough hands it over
+    # as root:root 0660 while /dev/dri/renderD128 lands root:render 0660. The
+    # rootful slot containers open it regardless, so ROCm genuinely WORKS; the
+    # hal0 service user does not, so every hal0-user GPU probe reports the box
+    # unusable and #1923's guard then refuses every AMD GPU slot.
+    #
+    # The target gid comes from the RENDER NODE, never from `getent group
+    # render`: the kernel gates on the integer and the name for that integer is
+    # not portable (a halo143-class box has renderD128 owned by a gid whose
+    # /etc/group name is 'clock', while 'render' resolves to a different,
+    # useless gid). Same authority resolve_gpu_group_ids() already follows for
+    # --group-add, so the two devices cannot disagree.
+    if [[ -n "${have_kfd}" && -n "${node}" ]]; then
+        local kfd_path kfd_gid render_gid
+        kfd_path="${HAL0_GPU_KFD_PATH:-/dev/kfd}"
+        # Both gids come from the real nodes. Deliberately NOT
+        # HAL0_GPU_RENDER_GID_OVERRIDE: that override fakes the group-NAME
+        # mapping check above, and reusing it here would compare a claimed gid
+        # against a real one. HAL0_GPU_KFD_GID_OVERRIDE is this check's own
+        # seam, so divergence can be forced without needing two real groups.
+        kfd_gid="${HAL0_GPU_KFD_GID_OVERRIDE:-$(stat -c '%g' "${kfd_path}" 2>/dev/null || true)}"
+        render_gid="$(stat -c '%g' "${node}" 2>/dev/null || true)"
+        if [[ -n "${kfd_gid}" && -n "${render_gid}" && "${kfd_gid}" != "${render_gid}" ]]; then
+            warn "gpu: ${kfd_path} is owned by gid ${kfd_gid}, but ${node} uses gid ${render_gid}"
+            warn "  The compute node is forwarded and the rootful slot containers can use it,"
+            warn "  but the hal0 service user cannot — so GPU slots get refused on a working box (#1953)."
+            warn "  Fix IN PLACE (no re-forward, no reboot):"
+            warn "    chgrp ${render_gid} ${kfd_path} && chmod 0660 ${kfd_path}"
+            warn "  Unprivileged LXC (chgrp returns EPERM): set it on the Proxmox host instead:"
+            warn "    dev1: ${kfd_path},gid=${render_gid}   (the gid INSIDE the container)"
+            [[ "${gate}" == "1" ]] && return "${HAL0_GPU_RC_KFD_GID}"
+        fi
     fi
     return 0
 }

--- a/installer/systemd/hal0-gpu-perms.service
+++ b/installer/systemd/hal0-gpu-perms.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=hal0 GPU device permissions (align /dev/kfd with the render node)
+Documentation=https://github.com/Hal0ai/hal0/issues/1953
+# /dev/kfd is recreated every boot — by udev on bare metal, by container start
+# from the host's `dev` entry on an LXC — so the install/update-time converge is
+# undone unless the host entry itself carries gid=. Re-apply it once per boot.
+#
+# After systemd-tmpfiles-setup-dev: /dev must be populated before there is a
+# node to chgrp. Before hal0.target: slots and the API must observe the
+# converged state, never race it.
+After=systemd-tmpfiles-setup-dev.service local-fs.target
+Before=hal0.target
+ConditionPathExists=/dev/kfd
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Root: chgrp on a device node needs it, and this is exactly the privileged
+# tidy-up the unprivileged API must never perform itself.
+ExecStart=/usr/lib/hal0/venv/bin/python -m hal0.install.gpu_perms
+# A GPU-permissions tidy-up must never be able to wedge the boot. The module
+# already returns 0 for every outcome including "refused by an unprivileged
+# LXC"; this is the belt to that braces.
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=hal0.target

--- a/installer/uninstall.sh
+++ b/installer/uninstall.sh
@@ -441,6 +441,13 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
     rm_path "/etc/systemd/system/hal0-bench.timer"
     rm_path "/etc/systemd/system/hal0-bench.service"
     rm_path "/etc/systemd/system/hal0-bench-worker.service"
+    # GPU device-permissions oneshot (#1953). Must be disabled as well as
+    # removed: leaving it behind strands a hal0.target.wants symlink pointing
+    # at a unit whose ExecStart is the deleted venv, and a later re-creation of
+    # hal0.target would resurrect the orphan.
+    systemctl disable --now hal0-gpu-perms.service >/dev/null 2>&1 || true
+    rm_path "/etc/systemd/system/hal0-gpu-perms.service"
+    rm_path "/etc/systemd/system/hal0.target.wants/hal0-gpu-perms.service"
 fi
 
 # The install PREFIX (default /opt/hal0). install.sh rsyncs the source

--- a/installer/wrappers/hal0-podman-ro
+++ b/installer/wrappers/hal0-podman-ro
@@ -270,7 +270,9 @@ case "$cmd" in
 usage: hal0-podman-ro <command> [arg]
   images                     podman images --format {{.Repository}}   (root's image store)
   image-exists <ref>         "present" | "missing" for a validated image ref
-  image-user <ref>           the image's configured USER ("" when it runs as root)
+  image-user <ref>           the image's configured USER; EMPTY means either
+                             "no USER declared" (runs as root) or "not in
+                             root's store yet" — both map to root caller-side
   container-image <token>    running image of hal0-slot-<token>, or nothing
   container-argv <token>     live command argv of hal0-slot-<token>, or nothing
   check-image-ref <ref>      validate an image ref only (no podman call)

--- a/installer/wrappers/hal0-podman-ro
+++ b/installer/wrappers/hal0-podman-ro
@@ -207,6 +207,28 @@ case "$cmd" in
     esac
     ;;
 
+  image-user)              # arg: image ref -> prints the image's configured USER ("" if root)
+    [[ $# -eq 1 ]] || die "image-user takes exactly one argument"
+    validate_image_ref "$1"
+    require_podman
+    # #1953: the guard needs the identity the CONTAINER PROCESS will run as,
+    # which is the image's configured USER — not an assumption that rootful
+    # podman implies uid 0. Read-only, one literal --format field, same shape
+    # as container-image below. `image exists` first so a genuinely absent
+    # image is a real negative (empty output, rc 0) rather than being reported
+    # as an operational failure, matching image-exists' contract.
+    run_podman image exists -- "$1"
+    case "$PODMAN_RC" in
+      0) ;;
+      1) exit 0 ;;   # no such image in root's store — a real negative answer
+      *) podman_failed "podman image exists failed" "$PODMAN_RC" ;;
+    esac
+    ref="$1"
+    run_podman image inspect --format '{{.Config.User}}' -- "$ref"
+    (( PODMAN_RC == 0 )) || podman_failed "podman image inspect failed" "$PODMAN_RC"
+    printf '%s\n' "$PODMAN_OUT"
+    ;;
+
   container-image)         # arg: slot token -> prints the running image ref
     [[ $# -eq 1 ]] || die "container-image takes exactly one argument"
     validate_slot_token "$1"
@@ -248,6 +270,7 @@ case "$cmd" in
 usage: hal0-podman-ro <command> [arg]
   images                     podman images --format {{.Repository}}   (root's image store)
   image-exists <ref>         "present" | "missing" for a validated image ref
+  image-user <ref>           the image's configured USER ("" when it runs as root)
   container-image <token>    running image of hal0-slot-<token>, or nothing
   container-argv <token>     live command argv of hal0-slot-<token>, or nothing
   check-image-ref <ref>      validate an image ref only (no podman call)

--- a/packaging/sudoers/hal0-podman-ro
+++ b/packaging/sudoers/hal0-podman-ro
@@ -7,11 +7,12 @@
 # states (halo143/halo150) and — until #1889 — an `image_status` of "missing"
 # for every running, healthy slot. It delegates exactly the read-only
 # introspection ops to /usr/lib/hal0/bin/hal0-podman-ro, which is the entire
-# privileged surface: `images`, `image-exists <ref>`, `container-image
-# <slot-token>`, `container-argv <slot-token>` plus two side-effect-free
-# validator probes. Every podman subcommand, flag and --format string is a
-# literal in the wrapper; no shell is ever evaluated. The three verbs that
-# take an argument accept exactly ONE positional operand, validated ROOT-side
+# privileged surface: `images`, `image-exists <ref>`, `image-user <ref>`,
+# `container-image <slot-token>`, `container-argv <slot-token>` plus two
+# side-effect-free validator probes. Every podman subcommand, flag and
+# --format string is a literal in the wrapper; no shell is ever evaluated.
+# The four verbs that take an argument accept exactly ONE positional operand,
+# validated ROOT-side
 # against a closed regex before exec (#1889) — the container verbs take the
 # bare slot token and build `hal0-slot-<token>` themselves, so the caller can
 # never name a non-hal0 container. rm/run/build/exec/pull are never exposed.

--- a/src/hal0/install/gpu_perms.py
+++ b/src/hal0/install/gpu_perms.py
@@ -1,0 +1,64 @@
+"""Boot-time convergence of the ROCm compute node's group (#1953).
+
+``/dev/kfd`` is recreated on every boot — by udev on bare metal, by container
+start from the host's ``dev`` entry on an LXC — so any ownership fix applied at
+install or update time is undone by the next reboot unless the host entry
+itself carries ``gid=``. This module is the ``ExecStart`` of
+``hal0-gpu-perms.service``, which re-applies it once per boot before
+``hal0.target``.
+
+Why a service and not a ``tmpfiles.d`` / ``udev`` rule: both of those would
+have to name a gid, and a *baked* gid is precisely the bug this line of work
+exists to remove. The kernel gates on the integer, and the integer is not
+portable across hosts — on a halo143-class box ``renderD128`` is owned by a gid
+whose ``/etc/group`` name is ``clock`` while ``render`` resolves elsewhere.
+Re-running the converge lets the target gid be *re-derived from the render
+node* on each boot, so a box whose passthrough changes is still correct.
+
+Scope, deliberately small. Post-#1953 no hal0-user code path opens ``/dev/kfd``
+— the slot-load guard asks about the root runner, and the bench harness only
+resolves device PATHS to hand to podman. So this does not fix a live outage; it
+keeps the invariant true rather than leaving it resting on "nothing happens to
+need it right now", which is a fact that can change silently. A mismatched gid
+costs hal0-user probes and diagnostics their GPU visibility, not inference.
+
+Never fails the boot. Every outcome — converged, already fine, nothing to do,
+refused by an unprivileged LXC — exits 0. A GPU-permissions tidy-up must not be
+able to wedge ``hal0.target``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Converge ``/dev/kfd``'s group, log the outcome, and always succeed."""
+    from hal0.providers._gpu import converge_kfd_device_group, host_is_amd_gpu
+
+    if not host_is_amd_gpu():
+        log.info("gpu_perms.skipped", reason="amdgpu is not bound on this host")
+        return 0
+    try:
+        status, detail = converge_kfd_device_group()
+    except Exception as exc:  # pragma: no cover - defensive; converge catches its own
+        log.warning("gpu_perms.failed", error=str(exc))
+        return 0
+    if status == "changed":
+        log.warning("gpu_perms.converged", detail=detail)
+    elif status == "failed":
+        # Unprivileged LXC: the node's ownership is host-mapped and chown is
+        # EPERM. The remedy is a gid= on the host's dev entry, which the detail
+        # string spells out. Not a boot failure.
+        log.warning("gpu_perms.refused", detail=detail)
+    else:
+        log.info("gpu_perms.noop", status=status, detail=detail)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    sys.exit(main())

--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -454,8 +454,7 @@ def require_kfd_for_gpu_slot(
         )
         return
     preamble = (
-        f"slot {slot_name!r} (device={device}) needs the ROCm compute node "
-        f"{kfd_path}. {why} "
+        f"slot {slot_name!r} (device={device}) needs the ROCm compute node {kfd_path}. {why} "
     )
     if status == KFD_NOT_OPENABLE:
         target = resolve_kfd_target_gid()

--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -119,31 +119,31 @@ def resolve_image_runtime_uid(image_ref: str | None) -> int:
     exactly that pattern (``packaging/toolbox/cpu.Dockerfile`` ends ``USER
     hal0``). Equating "rootful podman" with uid 0 would let :func:`kfd_status`
     pass a ``0660 root:root`` node that the real process cannot open — waving
-    through the invalid Vulkan fallback the guard exists to stop (#1953 review).
+    through the invalid Vulkan fallback the guard exists to stop (#1953).
 
-    Best-effort by design: an unreadable image falls back to
-    :data:`SLOT_RUNNER_UID`, which is the correct answer for every GPU runner
-    hal0 currently ships (none declare ``USER``). A DECLARED non-root user is
+    Routed through the ``hal0-podman-ro`` root-store seam, NOT a bare ``podman
+    image inspect`` (#1953 R2). hal0-api runs as the unprivileged ``hal0`` user
+    with no subuid ranges, so a bare call reads hal0's own ROOTLESS store —
+    a different store, which never contains a slot image. That would make this
+    check a silent no-op in production, which is #1889 with extra steps.
+
+    Best-effort by design: an unanswerable seam falls back to
+    :data:`SLOT_RUNNER_UID`, the correct answer for every GPU runner hal0
+    currently ships (none declare ``USER``). A DECLARED non-root user is
     honoured, which is the conservative direction — it can only make the guard
     refuse more, never less.
     """
     if not image_ref:
         return SLOT_RUNNER_UID
-    try:
-        import subprocess
+    from hal0.providers import podman_introspect
 
-        out = subprocess.run(
-            ["podman", "image", "inspect", "--format", "{{.Config.User}}", image_ref],
-            capture_output=True,
-            timeout=10,
-            check=False,
-        )
-    except Exception:  # pragma: no cover - podman absent / hung
+    user = podman_introspect.image_user(image_ref)
+    if user is None:
+        # Seam did not answer (not the service user, no grant, podman absent).
+        # Deliberately no rootless fallback — see the docstring.
         return SLOT_RUNNER_UID
-    if out.returncode != 0:
-        return SLOT_RUNNER_UID
-    user = (out.stdout or b"").decode(errors="replace").strip().split(":")[0]
-    if not user or user == "root" or user == "0":
+    user = user.strip().split(":")[0]
+    if not user or user in ("root", "0"):
         return SLOT_RUNNER_UID
     if user.isdigit():
         return int(user)
@@ -152,9 +152,9 @@ def resolve_image_runtime_uid(image_ref: str | None) -> int:
 
         return pwd.getpwnam(user).pw_uid
     except Exception:
-        # A name we cannot resolve on the HOST may still resolve inside the
-        # image. Assume non-root and let the mode check decide, rather than
-        # silently falling back to the permissive root answer.
+        # A name the HOST cannot resolve may still resolve inside the image.
+        # Assume non-root and let the mode check decide rather than falling
+        # back to the permissive root answer.
         return -1
 
 

--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+from collections.abc import Callable
 from typing import Any, Literal
 
 import structlog
@@ -174,27 +175,46 @@ def kfd_status(
     * :data:`KFD_NOT_OPENABLE` — forwarded, but its owning gid grants nothing
       to ``for_uid``. Remedy is a group fix on the node; no reboot involved.
 
-    ``for_uid`` names the identity that will actually open the device. ``None``
-    means "this process". uid 0 short-circuits to a pure existence test: root
-    opens a ``0660 root:root`` device fine, and every DAC-based probe run as a
-    non-root user would wrongly call that node unusable.
+    ``for_uid`` names the identity that will actually open the device:
+
+    * ``None`` — THIS process. The only form that can be probed directly, so
+      the only one that consults ``os.access``. No uid-0 short-circuit: root
+      bypasses DAC only with ``CAP_DAC_OVERRIDE``, which a hardened container
+      drops.
+    * ``0`` — the rootful slot container, always a DIFFERENT process. Podman
+      grants it ``CAP_DAC_OVERRIDE`` by default and its capability set is not
+      the caller's, so this answers :data:`KFD_OK` on existence regardless of
+      who is asking. Branching on whether the CALLER happens to be root would
+      make the parameter collapse for root callers (``install.sh``,
+      ``install.profile_derive``) — the same harm this parameter exists to fix.
+    * any other uid — evaluated against that uid's group set via the mode bits,
+      because ``os.access`` can only answer about the current process.
     """
     if not os.path.exists(kfd_path):
         return KFD_MISSING
-    uid = os.geteuid() if for_uid is None else for_uid
-    if uid == os.geteuid():
-        # Ask the OS about ourselves. Do NOT special-case uid 0 here: root
-        # bypasses DAC only with CAP_DAC_OVERRIDE, and a hardened container
-        # (CI runs in one) drops it — a blanket "root is fine" short-circuit
-        # reports a genuinely unopenable node as usable, failing OPEN.
+    # Branch on the QUESTION, not on who is asking. ``for_uid=None`` is the
+    # only form that names THIS process, and therefore the only one that can
+    # be probed directly. Branching on ``uid == os.geteuid()`` instead made the
+    # identity parameter silently collapse whenever the caller happened to
+    # share the uid it was asking about — so a root caller (install.sh,
+    # install/profile_derive.py) on a box whose root lacks CAP_DAC_OVERRIDE
+    # got "unopenable" for a node the rootful slot container opens perfectly
+    # well. That is #1953's original harm wearing a different hat.
+    if for_uid is None:
+        # Root gets NO short-circuit here: it bypasses DAC only with
+        # CAP_DAC_OVERRIDE, and a hardened container (CI runs in one) drops
+        # it, so a blanket "root is fine" reports a genuinely unopenable node
+        # as usable — failing OPEN, into the poisoned lane.
         return KFD_OK if os.access(kfd_path, os.R_OK | os.W_OK) else KFD_NOT_OPENABLE
-    if uid == 0:
-        # Asking about a DIFFERENT root identity (the rootful slot container).
-        # We cannot probe it directly; assume the usual DAC override.
+    if for_uid == 0:
+        # Always ANOTHER process: the rootful slot container, which podman
+        # grants CAP_DAC_OVERRIDE by default. Its capability set is not the
+        # caller's and cannot be probed from here, so the assumed-override
+        # answer is right regardless of who is asking.
         return KFD_OK
     # Some other uid — evaluate the mode bits against its group set rather
     # than silently answering for the wrong identity.
-    return KFD_OK if _mode_grants_rw(kfd_path, uid) else KFD_NOT_OPENABLE
+    return KFD_OK if _mode_grants_rw(kfd_path, for_uid) else KFD_NOT_OPENABLE
 
 
 def _mode_grants_rw(path: str, uid: int) -> bool:
@@ -345,7 +365,7 @@ def require_kfd_for_gpu_slot(
     kfd_path: str = KFD_DEVICE_PATH,
     env: dict[str, str] | None = None,
     amd_host: bool | None = None,
-    runner_uid: int = SLOT_RUNNER_UID,
+    runner_uid: int | Callable[[], int] = SLOT_RUNNER_UID,
 ) -> None:
     """Loud-fail a GPU slot whose runtime needs ROCm but has no compute node.
 
@@ -415,7 +435,12 @@ def require_kfd_for_gpu_slot(
             return
     elif device != "gpu-rocm":
         return
-    status = kfd_status(kfd_path, for_uid=runner_uid)
+    # Resolved HERE, not at the call site: every early return above has already
+    # happened, so a cpu/npu/gpu-cuda slot never pays for it. It is a `sudo -n`
+    # round-trip plus two podman calls now, so an eager argument expression put
+    # that on the load path of every slot on the box (#1953 N2).
+    uid = runner_uid() if callable(runner_uid) else runner_uid
+    status = kfd_status(kfd_path, for_uid=uid)
     if status == KFD_OK:
         return
     # Computed once and reused on both the warn and raise paths below, so
@@ -474,7 +499,7 @@ def require_kfd_for_gpu_slot(
             fix = f"give it the same gid as /dev/dri/renderD*, then chmod 0660 {kfd_path}"
             host_fix = f"'{kfd_path},gid=<the render node's gid in this container>'"
         remedy = (
-            f"It IS forwarded, but uid {runner_uid} cannot open it.{owner} Do NOT "
+            f"It IS forwarded, but uid {uid} cannot open it.{owner} Do NOT "
             f"re-forward the device — fix its group instead: {fix}. On an "
             f"unprivileged LXC apply it to the host's dev entry ({host_fix}) and "
             "pct stop/start. See #1953."

--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -111,6 +111,53 @@ KFD_MISSING = "missing"
 KFD_NOT_OPENABLE = "not-openable"
 
 
+def resolve_image_runtime_uid(image_ref: str | None) -> int:
+    """UID the container process will actually run as, best-effort.
+
+    Rootful podman does NOT imply the process is root: an image declaring
+    ``USER`` runs as that user unless the unit overrides it, and this repo ships
+    exactly that pattern (``packaging/toolbox/cpu.Dockerfile`` ends ``USER
+    hal0``). Equating "rootful podman" with uid 0 would let :func:`kfd_status`
+    pass a ``0660 root:root`` node that the real process cannot open — waving
+    through the invalid Vulkan fallback the guard exists to stop (#1953 review).
+
+    Best-effort by design: an unreadable image falls back to
+    :data:`SLOT_RUNNER_UID`, which is the correct answer for every GPU runner
+    hal0 currently ships (none declare ``USER``). A DECLARED non-root user is
+    honoured, which is the conservative direction — it can only make the guard
+    refuse more, never less.
+    """
+    if not image_ref:
+        return SLOT_RUNNER_UID
+    try:
+        import subprocess
+
+        out = subprocess.run(
+            ["podman", "image", "inspect", "--format", "{{.Config.User}}", image_ref],
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+    except Exception:  # pragma: no cover - podman absent / hung
+        return SLOT_RUNNER_UID
+    if out.returncode != 0:
+        return SLOT_RUNNER_UID
+    user = (out.stdout or b"").decode(errors="replace").strip().split(":")[0]
+    if not user or user == "root" or user == "0":
+        return SLOT_RUNNER_UID
+    if user.isdigit():
+        return int(user)
+    try:
+        import pwd
+
+        return pwd.getpwnam(user).pw_uid
+    except Exception:
+        # A name we cannot resolve on the HOST may still resolve inside the
+        # image. Assume non-root and let the mode check decide, rather than
+        # silently falling back to the permissive root answer.
+        return -1
+
+
 def kfd_status(
     kfd_path: str = KFD_DEVICE_PATH,
     *,

--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -99,8 +99,87 @@ class GpuPreflightError(RuntimeError):
 _AMDGPU_MODULE_DIR = "/sys/module/amdgpu"
 
 
-def kfd_present(kfd_path: str = KFD_DEVICE_PATH) -> bool:
-    """Is the ROCm compute node visible AND usable by this process?
+#: uid the slot containers are launched as. hal0's ``hal0-slot@.service`` units
+#: carry no ``User=``, so podman runs rootful and the container process opens
+#: ``/dev/kfd`` as root — regardless of which user ``hal0-api`` itself runs as.
+#: See :func:`kfd_present` for why that distinction is load-bearing.
+SLOT_RUNNER_UID = 0
+
+#: :func:`kfd_status` verdicts.
+KFD_OK = "ok"
+KFD_MISSING = "missing"
+KFD_NOT_OPENABLE = "not-openable"
+
+
+def kfd_status(
+    kfd_path: str = KFD_DEVICE_PATH,
+    *,
+    for_uid: int | None = None,
+) -> str:
+    """Classify the ROCm compute node: absent, present-but-unopenable, or fine.
+
+    Split out from :func:`kfd_present` because the two failure modes need
+    OPPOSITE remedies and conflating them sends operators to reboot a box
+    whose device is already forwarded (#1953):
+
+    * :data:`KFD_MISSING` — not forwarded. Remedy is an LXC ``dev`` entry
+      plus ``pct stop/start``.
+    * :data:`KFD_NOT_OPENABLE` — forwarded, but its owning gid grants nothing
+      to ``for_uid``. Remedy is a group fix on the node; no reboot involved.
+
+    ``for_uid`` names the identity that will actually open the device. ``None``
+    means "this process". uid 0 short-circuits to a pure existence test: root
+    opens a ``0660 root:root`` device fine, and every DAC-based probe run as a
+    non-root user would wrongly call that node unusable.
+    """
+    if not os.path.exists(kfd_path):
+        return KFD_MISSING
+    uid = os.geteuid() if for_uid is None else for_uid
+    if uid == os.geteuid():
+        # Ask the OS about ourselves. Do NOT special-case uid 0 here: root
+        # bypasses DAC only with CAP_DAC_OVERRIDE, and a hardened container
+        # (CI runs in one) drops it — a blanket "root is fine" short-circuit
+        # reports a genuinely unopenable node as usable, failing OPEN.
+        return KFD_OK if os.access(kfd_path, os.R_OK | os.W_OK) else KFD_NOT_OPENABLE
+    if uid == 0:
+        # Asking about a DIFFERENT root identity (the rootful slot container).
+        # We cannot probe it directly; assume the usual DAC override.
+        return KFD_OK
+    # Some other uid — evaluate the mode bits against its group set rather
+    # than silently answering for the wrong identity.
+    return KFD_OK if _mode_grants_rw(kfd_path, uid) else KFD_NOT_OPENABLE
+
+
+def _mode_grants_rw(path: str, uid: int) -> bool:
+    """Would ``uid`` get read+write on ``path`` under plain DAC rules?"""
+    try:
+        st = os.stat(path)
+    except OSError:
+        return False
+    if st.st_uid == uid:
+        return st.st_mode & stat.S_IRUSR and st.st_mode & stat.S_IWUSR
+    if st.st_mode & stat.S_IROTH and st.st_mode & stat.S_IWOTH:
+        return True
+    if not (st.st_mode & stat.S_IRGRP and st.st_mode & stat.S_IWGRP):
+        return False
+    try:
+        import grp
+        import pwd
+
+        name = pwd.getpwuid(uid).pw_name
+        member_gids = {g.gr_gid for g in grp.getgrall() if name in g.gr_mem}
+        member_gids.add(pwd.getpwuid(uid).pw_gid)
+    except Exception:  # pragma: no cover - no pwd/grp (non-Linux, minimal img)
+        return False
+    return st.st_gid in member_gids
+
+
+def kfd_present(
+    kfd_path: str = KFD_DEVICE_PATH,
+    *,
+    for_uid: int | None = SLOT_RUNNER_UID,
+) -> bool:
+    """Is the ROCm compute node visible AND usable by the identity that runs it?
 
     Existence alone is not enough: an LXC passthrough with a mis-mapped gid
     leaves ``/dev/kfd`` visible but unopenable, HIP still fails to initialise,
@@ -108,11 +187,96 @@ def kfd_present(kfd_path: str = KFD_DEVICE_PATH) -> bool:
     false-pass shape ``preflight_gpu``'s gid check exists to catch on the
     render node. So this also requires read+write access.
 
+    **Whose access, though.** This used to test the CALLING process, which is
+    wrong for the question every caller is actually asking: "will the slot
+    container be able to use the GPU?" ``hal0-api`` runs as user ``hal0``,
+    the slot containers run rootful as root, and a plain LXC passthrough
+    routinely leaves ``/dev/kfd`` as ``root:root 0660`` while
+    ``/dev/dri/renderD128`` lands ``root:render 0660``. On such a box ROCm
+    worked perfectly while this function reported False from the API process,
+    and #1923's guard refused every AMD GPU slot (#1953). So the identity is
+    now explicit and defaults to :data:`SLOT_RUNNER_UID`.
+
+    Pass ``for_uid=None`` to ask about the current process instead.
+
     Still cheap — no ioctl, no driver probe, never raises. A genuinely
     functional ROCm probe belongs in the output-sanity readiness gate
     (#1922), not on the slot-load hot path.
     """
-    return os.path.exists(kfd_path) and os.access(kfd_path, os.R_OK | os.W_OK)
+    return kfd_status(kfd_path, for_uid=for_uid) == KFD_OK
+
+
+def resolve_kfd_target_gid(
+    node_paths: list[str] | None = None,
+) -> int | None:
+    """Which gid SHOULD own ``/dev/kfd`` on this box? ``None`` when unknowable.
+
+    Deliberately derived from the render node rather than from
+    ``grp.getgrnam("render")``: the kernel gates on the integer, and the group
+    NAME for that integer is not portable across hosts. On a halo143-class box
+    ``renderD128`` is owned by gid 993 whose ``/etc/group`` name is ``clock``,
+    while ``render`` resolves to a different, useless gid — so a name lookup
+    produces a number that grants nothing. The render node is already the
+    authority :func:`resolve_gpu_group_ids` follows for ``--group-add``; the
+    compute node must agree with it or the two devices grant different access.
+
+    Never returns the ``_GPU_GROUP_FALLBACK_GIDS`` constants: guessing 993 on a
+    box we could not read is exactly how a wrong gid gets baked in. No render
+    node → no opinion.
+    """
+    if node_paths is None:
+        node_paths = resolve_gpu_device_paths()
+    node = _device_node_for_group("render", node_paths)
+    if node is None:
+        return None
+    try:
+        return os.stat(node).st_gid
+    except OSError:
+        return None
+
+
+def converge_kfd_device_group(
+    kfd_path: str = KFD_DEVICE_PATH,
+    *,
+    node_paths: list[str] | None = None,
+    dry_run: bool = False,
+) -> tuple[str, str]:
+    """Align ``/dev/kfd``'s group with the render node's. Returns (status, detail).
+
+    Idempotent and safe to run on every install/update: a box that is already
+    consistent is a no-op, and a box with no render node or no compute node is
+    left alone rather than guessed at.
+
+    Statuses: ``"noop"``, ``"changed"``, ``"skipped"``, ``"failed"``.
+
+    ``failed`` is not fatal by design — on an UNPRIVILEGED LXC the node's
+    ownership is host-mapped and ``chgrp`` returns EPERM, where the real remedy
+    is a ``gid=`` on the host's ``dev`` entry. Callers surface that remedy
+    instead of aborting.
+    """
+    if not os.path.exists(kfd_path):
+        return "skipped", f"{kfd_path} is not present"
+    target = resolve_kfd_target_gid(node_paths)
+    if target is None:
+        return "skipped", "no render node to take the gid from"
+    try:
+        st = os.stat(kfd_path)
+    except OSError as exc:
+        return "failed", f"cannot stat {kfd_path}: {exc}"
+    if st.st_gid == target and st.st_mode & stat.S_IRGRP and st.st_mode & stat.S_IWGRP:
+        return "noop", f"{kfd_path} already group {target} with group rw"
+    if dry_run:
+        return "changed", f"would set {kfd_path} to gid {target}, mode 0660"
+    try:
+        os.chown(kfd_path, -1, target)
+        os.chmod(kfd_path, 0o660)
+    except OSError as exc:
+        return "failed", (
+            f"cannot set {kfd_path} to gid {target} ({exc}). On an unprivileged "
+            f"LXC set it on the host instead: dev entry '{kfd_path},gid={target}' "
+            "(the gid INSIDE the container), then pct stop/start."
+        )
+    return "changed", f"{kfd_path}: gid {st.st_gid} -> {target}, mode 0660"
 
 
 def host_is_amd_gpu(module_dir: str = _AMDGPU_MODULE_DIR) -> bool:
@@ -134,6 +298,7 @@ def require_kfd_for_gpu_slot(
     kfd_path: str = KFD_DEVICE_PATH,
     env: dict[str, str] | None = None,
     amd_host: bool | None = None,
+    runner_uid: int = SLOT_RUNNER_UID,
 ) -> None:
     """Loud-fail a GPU slot whose runtime needs ROCm but has no compute node.
 
@@ -184,6 +349,12 @@ def require_kfd_for_gpu_slot(
     gets the fail-closed pre-#1941 behaviour, never a silent pass into the
     poisoned lane.
 
+    ``runner_uid`` is the identity the slot container runs as — root for
+    hal0's rootful ``hal0-slot@`` units. It is NOT the uid of whoever calls
+    this function: ``hal0-api`` runs as ``hal0`` and would otherwise refuse
+    every GPU slot on a box whose ``/dev/kfd`` is ``root:root`` but whose
+    containers use it perfectly well (#1953).
+
     An explicit :data:`ENV_ALLOW_VULKAN_FALLBACK` opt-in downgrades the
     refusal to a warning — a warn, never a silent pass.
     """
@@ -197,7 +368,8 @@ def require_kfd_for_gpu_slot(
             return
     elif device != "gpu-rocm":
         return
-    if kfd_present(kfd_path):
+    status = kfd_status(kfd_path, for_uid=runner_uid)
+    if status == KFD_OK:
         return
     # Computed once and reused on both the warn and raise paths below, so
     # neither can drift from the lane it is actually describing (#1952
@@ -234,13 +406,40 @@ def require_kfd_for_gpu_slot(
             detail=why,
         )
         return
-    raise GpuPreflightError(
+    preamble = (
         f"slot {slot_name!r} (device={device}) needs the ROCm compute node "
-        f"{kfd_path}, which is not visible here. {why} "
-        "Forward the device from the host (Proxmox LXC: add "
-        f"'dev1: {kfd_path}' to /etc/pve/lxc/<CTID>.conf, then pct stop/start), "
-        "or move this slot to device='cpu'."
+        f"{kfd_path}. {why} "
     )
+    if status == KFD_NOT_OPENABLE:
+        target = resolve_kfd_target_gid()
+        owner = ""
+        try:
+            st = os.stat(kfd_path)
+            owner = f" It is currently gid {st.st_gid}, mode {st.st_mode & 0o777:04o}."
+        except OSError:  # pragma: no cover - raced away between calls
+            pass
+        if target is not None:
+            fix = (
+                f"'chgrp {target} {kfd_path} && chmod 0660 {kfd_path}' "
+                f"(gid {target} is the one the render node uses on this box)"
+            )
+            host_fix = f"'{kfd_path},gid={target}'"
+        else:
+            fix = f"give it the same gid as /dev/dri/renderD*, then chmod 0660 {kfd_path}"
+            host_fix = f"'{kfd_path},gid=<the render node's gid in this container>'"
+        remedy = (
+            f"It IS forwarded, but uid {runner_uid} cannot open it.{owner} Do NOT "
+            f"re-forward the device — fix its group instead: {fix}. On an "
+            f"unprivileged LXC apply it to the host's dev entry ({host_fix}) and "
+            "pct stop/start. See #1953."
+        )
+    else:
+        remedy = (
+            "It is not visible here. Forward the device from the host (Proxmox "
+            f"LXC: add 'dev1: {kfd_path}' to /etc/pve/lxc/<CTID>.conf, then pct "
+            "stop/start), or move this slot to device='cpu'."
+        )
+    raise GpuPreflightError(preamble + remedy)
 
 
 def resolve_gpu_device_paths(

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -2392,7 +2392,11 @@ class ContainerProvider(Provider):
             str(slot_cfg.get("name", "") or token),
             device=str(slot_cfg.get("device", "") or ""),
             runtime_lane=runtime_lane_for_provider(spec_provider),
-            runner_uid=resolve_image_runtime_uid(_resolve_image_ref(slot_cfg, model_info)),
+            # Lazy: the guard returns early for cpu/npu/gpu-cuda and for
+            # non-ROCm lanes, and this is a sudo round-trip plus two podman
+            # calls. Passing it eagerly charged every slot on the box for a
+            # probe only the gated ones need.
+            runner_uid=lambda: resolve_image_runtime_uid(_resolve_image_ref(slot_cfg, model_info)),
         )
 
         # Loud-fail for NPU slots only: a missing FLM tag must not silently

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -82,6 +82,7 @@ from hal0.providers._gpu import (
     require_kfd_for_gpu_slot,
     resolve_gpu_device_paths,
     resolve_gpu_group_ids,
+    resolve_image_runtime_uid,
     runtime_lane_for_provider,
 )
 from hal0.providers.base import HealthCheck, Mount, Provider, RuntimeLaunchPlan
@@ -2381,10 +2382,17 @@ class ContainerProvider(Provider):
         # Qwen3-TTS are ROCm builds that do. Each provider declares
         # ``gpu_runtime_needs_rocm``; ``runtime_lane_for_provider`` turns that
         # into the lane.
+        #
+        # runner_uid is the ORTHOGONAL question (#1953): given the lane needs
+        # the node, WHICH identity opens it. Derived from the image rather
+        # than assumed root — rootful podman still honours a USER-declaring
+        # image, and assuming root there would fail OPEN into the poisoned
+        # lane the guard exists to block.
         require_kfd_for_gpu_slot(
             str(slot_cfg.get("name", "") or token),
             device=str(slot_cfg.get("device", "") or ""),
             runtime_lane=runtime_lane_for_provider(spec_provider),
+            runner_uid=resolve_image_runtime_uid(_resolve_image_ref(slot_cfg, model_info)),
         )
 
         # Loud-fail for NPU slots only: a missing FLM tag must not silently

--- a/src/hal0/providers/podman_introspect.py
+++ b/src/hal0/providers/podman_introspect.py
@@ -361,6 +361,30 @@ def image_presence(
     return ImageProbe("unknown", "seam-error")
 
 
+def image_user(
+    image: str,
+    *,
+    run: _RunFn = subprocess.run,
+    is_hal0_user: Callable[[], bool] = is_hal0_service_user,
+    timeout: float = 10.0,
+) -> str | None:
+    """The image's configured ``USER`` from ROOT's store; ``None`` if unanswerable.
+
+    ``""`` is a real answer meaning "no USER declared", i.e. the container
+    process runs as root. ``None`` means the seam did not answer at all.
+
+    Same #1889 reasoning as :func:`image_exists`, and the reason
+    :func:`hal0.providers._gpu.resolve_image_runtime_uid` must not shell a bare
+    ``podman image inspect``: hal0-api runs as the unprivileged ``hal0`` user
+    with no subuid ranges, so a bare call reads hal0's OWN ROOTLESS store,
+    which never contains a slot image. The answer from that store is not a
+    stale answer — it is an answer about a different object.
+    """
+    if not is_valid_image_ref(image):
+        return None
+    return _seam_read("image-user", image, run=run, is_hal0_user=is_hal0_user, timeout=timeout)
+
+
 def container_image(
     token: str,
     *,

--- a/src/hal0/providers/podman_introspect.py
+++ b/src/hal0/providers/podman_introspect.py
@@ -370,8 +370,12 @@ def image_user(
 ) -> str | None:
     """The image's configured ``USER`` from ROOT's store; ``None`` if unanswerable.
 
-    ``""`` is a real answer meaning "no USER declared", i.e. the container
-    process runs as root. ``None`` means the seam did not answer at all.
+    ``""`` is a real answer, but it covers TWO facts: "no USER declared" (the
+    container process runs as root) and "the image is not in root's store yet".
+    Both map to root caller-side, so behaviour is correct — but note the
+    consequence: on a slot's FIRST load the image is often not yet pulled into
+    root's store, so a non-root-``USER`` image is assumed root exactly once.
+    ``None`` means the seam did not answer at all.
 
     Same #1889 reasoning as :func:`image_exists`, and the reason
     :func:`hal0.providers._gpu.resolve_image_runtime_uid` must not shell a bare

--- a/src/hal0/providers/podman_introspect.py
+++ b/src/hal0/providers/podman_introspect.py
@@ -386,7 +386,12 @@ def image_user(
     """
     if not is_valid_image_ref(image):
         return None
-    return _seam_read("image-user", image, run=run, is_hal0_user=is_hal0_user, timeout=timeout)
+    read = _seam_read("image-user", image, run=run, is_hal0_user=is_hal0_user, timeout=timeout)
+    # ``stdout`` is set only on rc 0, where "" is a real answer; ``reason`` is
+    # set otherwise. Collapsing both to None would conflate "the image runs as
+    # root" with "the seam could not tell us", and the caller must not assume
+    # root on the latter.
+    return read.stdout
 
 
 def container_image(

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1699,6 +1699,13 @@ def run_post_activation_migrations(
         # operator flips MTP to Auto/Off in the drawer.
 
     try:
+        converge_kfd_group(job_id=job_id)
+    except Exception as exc:
+        log.warning("updater.kfd_group_converge_failed", job_id=job_id, error=str(exc))
+        # Non-fatal: the box keeps whatever /dev/kfd ownership it had; the
+        # #1923 guard's message now names the gid remedy explicitly (#1953).
+
+    try:
         relabel_stale_vulkan_slots(job_id=job_id)
     except Exception as exc:
         log.warning("updater.vulkan_migration_failed", job_id=job_id, error=str(exc))
@@ -2932,6 +2939,38 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
             except Exception as exc:
                 log.warning("updater.image_retag_profiles_write_failed", error=str(exc))
     return retagged
+
+
+def converge_kfd_group(*, job_id: str | None = None) -> str:
+    """Align ``/dev/kfd``'s group with the render node's, once, on every update.
+
+    #1953. A plain LXC passthrough leaves the compute node ``root:root 0660``
+    while ``/dev/dri/renderD128`` lands ``root:render 0660``. Slot containers
+    run rootful so ROCm works fine, but every hal0-user probe reports the GPU
+    unusable — and the operator is told to re-forward a device that is already
+    forwarded. Converging the two nodes makes both identities agree.
+
+    Runs BEFORE :func:`relabel_stale_vulkan_slots` deliberately: that pass
+    branches on the compute node's state to decide ``gpu-rocm`` vs ``cpu``, so
+    it must see the converged answer rather than race the repair.
+
+    Best-effort by construction. On an unprivileged LXC the node's ownership is
+    host-mapped and ``chown`` raises ``EPERM``; the remedy there is a ``gid=``
+    on the host's ``dev`` entry, which the guard's own error text now spells
+    out. Never raises, never blocks an update.
+    """
+    from hal0.providers._gpu import converge_kfd_device_group, host_is_amd_gpu
+
+    if not host_is_amd_gpu():
+        return "skipped"
+    status, detail = converge_kfd_device_group()
+    if status == "changed":
+        log.warning("updater.kfd_group_converged", job_id=job_id, detail=detail)
+    elif status == "failed":
+        log.warning("updater.kfd_group_converge_refused", job_id=job_id, detail=detail)
+    else:
+        log.info("updater.kfd_group_noop", job_id=job_id, status=status, detail=detail)
+    return status
 
 
 def relabel_stale_vulkan_slots(

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1699,13 +1699,6 @@ def run_post_activation_migrations(
         # operator flips MTP to Auto/Off in the drawer.
 
     try:
-        converge_kfd_group(job_id=job_id)
-    except Exception as exc:
-        log.warning("updater.kfd_group_converge_failed", job_id=job_id, error=str(exc))
-        # Non-fatal: the box keeps whatever /dev/kfd ownership it had; the
-        # #1923 guard's message now names the gid remedy explicitly (#1953).
-
-    try:
         relabel_stale_vulkan_slots(job_id=job_id)
     except Exception as exc:
         log.warning("updater.vulkan_migration_failed", job_id=job_id, error=str(exc))
@@ -2942,7 +2935,22 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
 
 
 def converge_kfd_group(*, job_id: str | None = None) -> str:
-    """Align ``/dev/kfd``'s group with the render node's, once, on every update.
+    """Align ``/dev/kfd``'s group with the render node's. PRIVILEGED CALLERS ONLY.
+
+    NOT part of :func:`run_post_activation_migrations`, deliberately. That chain
+    runs in an ``asyncio.to_thread`` inside ``hal0-api`` — ``User=hal0`` — and
+    BEFORE ``seam.activate()``. Calling it from there was wrong twice over: the
+    ``chown`` hit EPERM as an unprivileged user and reported ``failed`` for
+    exactly the boxes it was meant to converge, and on the FIRST update
+    delivering this code the running daemon is still executing the previous
+    release, where this function does not exist at all.
+
+    Convergence now happens root-side in :func:`refresh_gpu_perms_unit`, which
+    runs during ``activate`` (euid 0) and starts the freshly-installed unit once
+    so a box converges without waiting for a reboot. ``install.sh`` covers the
+    fresh-install path, also as root.
+
+    Kept as a callable seam for those privileged entry points and for tests.
 
     #1953. A plain LXC passthrough leaves the compute node ``root:root 0660``
     while ``/dev/dri/renderD128`` lands ``root:render 0660``. Slot containers
@@ -3435,21 +3443,52 @@ def refresh_gpu_perms_unit(target: Path, *, job_id: str | None = None) -> str:
     dst = Path("/etc/systemd/system/hal0-gpu-perms.service")
     try:
         desired = src.read_text(encoding="utf-8")
-        if dst.is_file() and dst.read_text(encoding="utf-8") == desired:
-            return "unchanged"
-        dst.write_text(desired, encoding="utf-8")
-        os.chmod(dst, 0o644)
+        # NOT an early return on identical content: enable/start still re-run
+        # below so a previously-failed enable self-heals on the next activate.
+        up_to_date = dst.is_file() and dst.read_text(encoding="utf-8") == desired
+        if not up_to_date:
+            dst.write_text(desired, encoding="utf-8")
+            os.chmod(dst, 0o644)
         subprocess.run(["systemctl", "daemon-reload"], check=False, capture_output=True)
-        subprocess.run(
+        # Enable is CHECKED. Treating the file write alone as success let a
+        # transient systemd failure latch permanently: the next update saw
+        # matching content, returned "unchanged" early, and never retried the
+        # enable — so the box silently lost the boot-time convergence this
+        # delivery path exists to provide.
+        enabled = subprocess.run(
             ["systemctl", "enable", "hal0-gpu-perms.service"],
             check=False,
             capture_output=True,
         )
+        if enabled.returncode != 0:
+            log.warning(
+                "updater.gpu_perms_unit_enable_failed",
+                job_id=job_id,
+                returncode=enabled.returncode,
+                stderr=(enabled.stderr or b"").decode(errors="replace").strip()[:400],
+            )
+            return "failed"
+        # Converge NOW, not just at next boot. This call site runs at euid 0
+        # during activate — unlike the migration chain, which runs as `hal0`
+        # and before activation — so an updated box does not have to reboot
+        # before its compute node becomes usable by the service user.
+        started = subprocess.run(
+            ["systemctl", "start", "hal0-gpu-perms.service"],
+            check=False,
+            capture_output=True,
+        )
+        if started.returncode != 0:
+            log.warning(
+                "updater.gpu_perms_unit_start_failed",
+                job_id=job_id,
+                returncode=started.returncode,
+                detail="unit installed and enabled; convergence deferred to next boot",
+            )
     except OSError as exc:
         log.warning("updater.gpu_perms_unit_failed", job_id=job_id, error=str(exc))
         return "failed"
     log.info("updater.gpu_perms_unit_installed", job_id=job_id, path=str(dst))
-    return "installed"
+    return "unchanged" if up_to_date else "installed"
 
 
 def refresh_privileged_wrappers(target: Path, *, job_id: str | None = None) -> dict[str, Any]:

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -3408,6 +3408,50 @@ def _restore_service_ownership(root: Path, *, job_id: str | None = None) -> None
         log.warning("updater.cache_chown_failed", job_id=job_id, path=str(root), error=str(exc))
 
 
+def refresh_gpu_perms_unit(target: Path, *, job_id: str | None = None) -> str:
+    """Install/refresh ``hal0-gpu-perms.service`` from the activated release (#1953).
+
+    Same #1689 shape as :func:`refresh_privileged_wrappers`: ``install.sh`` was
+    about to become the only installer of this unit, so a box that only ever
+    runs ``hal0 update`` would never receive it and its ``/dev/kfd`` group would
+    silently revert on the next reboot with nothing to re-apply it.
+
+    Privileged-side ONLY — a no-op unless ``os.geteuid() == 0``, matching
+    :func:`refresh_privileged_wrappers`. The unprivileged daemon must never
+    write ``/etc/systemd/system``.
+
+    Best-effort: a release tree without the unit source is skipped, and a
+    failed ``systemctl enable`` is logged rather than raised. A missing
+    permissions tidy-up must never fail an otherwise-successful activate.
+
+    Returns one of ``"installed"``, ``"unchanged"``, ``"skipped"``, ``"failed"``.
+    """
+    if os.geteuid() != 0:
+        return "skipped"
+    src = target / "installer" / "systemd" / "hal0-gpu-perms.service"
+    if not src.is_file():
+        log.info("updater.gpu_perms_unit_absent", job_id=job_id, src=str(src))
+        return "skipped"
+    dst = Path("/etc/systemd/system/hal0-gpu-perms.service")
+    try:
+        desired = src.read_text(encoding="utf-8")
+        if dst.is_file() and dst.read_text(encoding="utf-8") == desired:
+            return "unchanged"
+        dst.write_text(desired, encoding="utf-8")
+        os.chmod(dst, 0o644)
+        subprocess.run(["systemctl", "daemon-reload"], check=False, capture_output=True)
+        subprocess.run(
+            ["systemctl", "enable", "hal0-gpu-perms.service"],
+            check=False,
+            capture_output=True,
+        )
+    except OSError as exc:
+        log.warning("updater.gpu_perms_unit_failed", job_id=job_id, error=str(exc))
+        return "failed"
+    log.info("updater.gpu_perms_unit_installed", job_id=job_id, path=str(dst))
+    return "installed"
+
+
 def refresh_privileged_wrappers(target: Path, *, job_id: str | None = None) -> dict[str, Any]:
     """Re-install the privileged sudo wrappers from the just-activated release (#1689).
 
@@ -3609,6 +3653,7 @@ def activate_release(dir_name: str, *, job_id: str | None = None) -> dict[str, A
     # activate (a wrapper that fails to refresh keeps the OLD one in place,
     # same class of degradation as before this fix, not a new failure mode).
     wrappers = refresh_privileged_wrappers(target, job_id=job_id)
+    gpu_perms_unit = refresh_gpu_perms_unit(target, job_id=job_id)
 
     log.info(
         "updater.activate_ok",
@@ -3620,6 +3665,7 @@ def activate_release(dir_name: str, *, job_id: str | None = None) -> dict[str, A
         "previous": str(prior) if prior else None,
         "target": str(target),
         "wrappers_refreshed": wrappers["refreshed"],
+        "gpu_perms_unit": gpu_perms_unit,
     }
 
 
@@ -4428,6 +4474,7 @@ __all__ = [
     "ensure_seed_profiles",
     "fetch_release_manifest",
     "profile_reset_status",
+    "refresh_gpu_perms_unit",
     "refresh_privileged_wrappers",
     "release_dir_name",
     "releases_url",

--- a/tests/installer/test_podman_ro_validation.py
+++ b/tests/installer/test_podman_ro_validation.py
@@ -174,6 +174,7 @@ def test_help_lists_every_verb() -> None:
     for verb in (
         "images",
         "image-exists",
+        "image-user",
         "container-image",
         "container-argv",
         "check-image-ref",
@@ -188,7 +189,9 @@ def test_unknown_verb_is_rejected() -> None:
     assert "bad cmd" in proc.stderr
 
 
-@pytest.mark.parametrize("verb", ["image-exists", "container-image", "container-argv"])
+@pytest.mark.parametrize(
+    "verb", ["image-exists", "image-user", "container-image", "container-argv"]
+)
 def test_write_verbs_are_not_reachable(verb: str) -> None:
     """The seam stays READ-ONLY: no verb spells a mutation, and the three
     argument-taking verbs refuse a second argv word outright (so a validated
@@ -198,7 +201,9 @@ def test_write_verbs_are_not_reachable(verb: str) -> None:
     assert "exactly one argument" in proc.stderr
 
 
-@pytest.mark.parametrize("verb", ["image-exists", "container-image", "container-argv"])
+@pytest.mark.parametrize(
+    "verb", ["image-exists", "image-user", "container-image", "container-argv"]
+)
 def test_argument_verbs_require_an_argument(verb: str) -> None:
     proc = _run(verb)
     assert proc.returncode == 64
@@ -298,7 +303,23 @@ def test_presence_probes_use_exists_not_inspect() -> None:
     assert "run_podman image exists --" in src
     assert "run_podman container exists --" in src
     code = [ln for ln in src.splitlines() if not ln.lstrip().startswith("#")]
-    assert not [ln for ln in code if "image inspect" in ln]
+
+    # The PRESENCE probe itself must never be an inspect.
+    exists_arm = src.split("image-exists)", 1)[1].split(";;", 1)[0]
+    exists_code = "\n".join(ln for ln in exists_arm.splitlines() if not ln.lstrip().startswith("#"))
+    assert "image exists" in exists_code
+    assert "image inspect" not in exists_code
+
+    # Reading a FIELD needs inspect — there is no other podman verb for it —
+    # but only after presence has already been established, so "missing" and
+    # "broken store" stay distinguishable. Exactly the shape container_read
+    # uses (container exists -> container inspect), which this file has always
+    # permitted. Every such line must sit in an arm that guards with `exists`.
+    for idx, line in enumerate(code):
+        if "image inspect" not in line:
+            continue
+        preceding = "\n".join(code[max(0, idx - 12) : idx])
+        assert "image exists" in preceding, f"unguarded image inspect: {line}"
 
 
 def test_inspect_calls_are_type_qualified() -> None:

--- a/tests/installer/test_podman_ro_validation.py
+++ b/tests/installer/test_podman_ro_validation.py
@@ -304,34 +304,59 @@ def test_presence_probes_use_exists_not_inspect() -> None:
     assert "run_podman image exists --" in src
     assert "run_podman container exists --" in src
 
-    # The PRESENCE probe itself must never be an inspect.
-    exists_arm = src.split("image-exists)", 1)[1].split(";;", 1)[0]
-    exists_code = "\n".join(ln for ln in exists_arm.splitlines() if not ln.lstrip().startswith("#"))
-    assert "image exists" in exists_code
-    assert "image inspect" not in exists_code
-
     # Reading a FIELD needs inspect — there is no other podman verb for it —
     # but only after presence has already been established, so "missing" and
     # "broken store" stay distinguishable. Exactly the shape container_read
     # uses (container exists -> container inspect), which this file has always
     # permitted.
     #
-    # ARM-SCOPED, not a positional lookback. A fixed-line window over
-    # comment-stripped source reaches straight across a `;;` into the
-    # neighbouring arm, so deleting an arm's entire exists guard left the
-    # check green — it did not police the regression it was rewritten to
-    # permit. Slice each arm by its case label, the same way exists_arm above
-    # is taken, and require the guard to precede the inspect WITHIN that arm.
-    arm_labels = re.findall(r"^\s{2}([a-z][a-z-]*)\)", src, re.MULTILINE)
-    assert "image-user" in arm_labels, "arm discovery broke; the scan below is vacuous"
-    for label in arm_labels:
-        arm = src.split(f"{label})", 1)[1].split(";;", 1)[0]
-        arm_code = "\n".join(ln for ln in arm.splitlines() if not ln.lstrip().startswith("#"))
+    # ARM-SCOPED BY THE NEXT CASE LABEL, not by `;;`. Two prior shapes of this
+    # check were falsified by execution: a fixed-line positional lookback read
+    # across a `;;` into the neighbouring arm, and a `.split(";;", 1)` slice
+    # terminated at the NESTED `;;` of an arm's own rc dispatch — three lines
+    # above the inspect it existed to police — so deleting only the exists
+    # guard left the suite green both times. Top-level arms are exactly
+    # two-space indented (nested dispatches are deeper), which is what bounds
+    # the slice here.
+    labels = [
+        (m.start(), m.group(1))
+        for m in re.finditer(r"^\s{2}([a-z][a-z-]*\)|\*\))", src, re.MULTILINE)
+    ]
+    label_names = [name for _, name in labels]
+    assert "image-user)" in label_names, "arm discovery broke; the scan below is vacuous"
+    assert "image-exists)" in label_names, "arm discovery broke; the scan below is vacuous"
+    arms: dict[str, str] = {}
+    for i, (pos, name) in enumerate(labels):
+        end = labels[i + 1][0] if i + 1 < len(labels) else len(src)
+        arms[name] = src[pos:end]
+
+    def _code(arm: str) -> str:
+        return "\n".join(ln for ln in arm.splitlines() if not ln.lstrip().startswith("#"))
+
+    # The PRESENCE probe itself must never be an inspect.
+    exists_code = _code(arms["image-exists)"])
+    assert "image exists" in exists_code
+    assert "image inspect" not in exists_code
+
+    # Vacuity guard, one level down from label discovery: image-user READS a
+    # field, so its slice MUST contain the inspect. If it does not, the
+    # slicing regressed again and the loop below would silently skip the one
+    # arm it exists to police — "no match" must never read as "clean".
+    assert "image inspect" in _code(arms["image-user)"]), (
+        "image-user's arm slice lost its inspect — the arm scan is vacuous"
+    )
+    # Match the INVOCATION (`run_podman image exists`), not the bare phrase —
+    # the rc-dispatch's own failure message contains "image exists" as prose,
+    # which satisfied a substring check even with the guard deleted (found by
+    # re-running the surgical falsification against the first version of this
+    # rewrite).
+    for name, arm in arms.items():
+        arm_code = _code(arm)
         if "image inspect" not in arm_code:
             continue
-        assert "image exists" in arm_code, f"unguarded image inspect in {label})"
-        assert arm_code.index("image exists") < arm_code.index("image inspect"), (
-            f"{label}) inspects before establishing presence"
+        assert "run_podman image exists" in arm_code, f"unguarded image inspect in {name}"
+        assert arm_code.index("run_podman image exists") < arm_code.index("image inspect"), (
+            f"{name} inspects before establishing presence"
         )
 
 

--- a/tests/installer/test_podman_ro_validation.py
+++ b/tests/installer/test_podman_ro_validation.py
@@ -23,6 +23,7 @@ re-creates #1889 for the refs it wrongly rejects.
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -302,7 +303,6 @@ def test_presence_probes_use_exists_not_inspect() -> None:
     src = WRAPPER.read_text()
     assert "run_podman image exists --" in src
     assert "run_podman container exists --" in src
-    code = [ln for ln in src.splitlines() if not ln.lstrip().startswith("#")]
 
     # The PRESENCE probe itself must never be an inspect.
     exists_arm = src.split("image-exists)", 1)[1].split(";;", 1)[0]
@@ -314,12 +314,25 @@ def test_presence_probes_use_exists_not_inspect() -> None:
     # but only after presence has already been established, so "missing" and
     # "broken store" stay distinguishable. Exactly the shape container_read
     # uses (container exists -> container inspect), which this file has always
-    # permitted. Every such line must sit in an arm that guards with `exists`.
-    for idx, line in enumerate(code):
-        if "image inspect" not in line:
+    # permitted.
+    #
+    # ARM-SCOPED, not a positional lookback. A fixed-line window over
+    # comment-stripped source reaches straight across a `;;` into the
+    # neighbouring arm, so deleting an arm's entire exists guard left the
+    # check green — it did not police the regression it was rewritten to
+    # permit. Slice each arm by its case label, the same way exists_arm above
+    # is taken, and require the guard to precede the inspect WITHIN that arm.
+    arm_labels = re.findall(r"^\s{2}([a-z][a-z-]*)\)", src, re.MULTILINE)
+    assert "image-user" in arm_labels, "arm discovery broke; the scan below is vacuous"
+    for label in arm_labels:
+        arm = src.split(f"{label})", 1)[1].split(";;", 1)[0]
+        arm_code = "\n".join(ln for ln in arm.splitlines() if not ln.lstrip().startswith("#"))
+        if "image inspect" not in arm_code:
             continue
-        preceding = "\n".join(code[max(0, idx - 12) : idx])
-        assert "image exists" in preceding, f"unguarded image inspect: {line}"
+        assert "image exists" in arm_code, f"unguarded image inspect in {label})"
+        assert arm_code.index("image exists") < arm_code.index("image inspect"), (
+            f"{label}) inspects before establishing presence"
+        )
 
 
 def test_inspect_calls_are_type_qualified() -> None:

--- a/tests/installer/test_preflight_gpu_gate.py
+++ b/tests/installer/test_preflight_gpu_gate.py
@@ -345,12 +345,12 @@ class TestKfdGroupGate:
                 "HAL0_GPU_RENDER_GID_OVERRIDE": "0",
                 "HAL0_GPU_RENDER_GROUP_OVERRIDE": "root",
                 "HAL0_GPU_KFD_PATH": str(kfd),
-                "HAL0_GPU_KFD_GID_OVERRIDE": "61998",
+                "HAL0_GPU_KFD_GID_OVERRIDE": "0",
                 "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
             }
         )
-        # The compute node reports a gid the render node does not use — the
-        # exact divergence a plain LXC dev passthrough produces.
+        # The compute node is ROOT-owned while the render node is not — the
+        # exact inaccessible shape a plain LXC dev passthrough produces.
         assert rc == RC_KFD_GID
 
     def test_aligned_gids_pass(self, tmp_path: Path) -> None:
@@ -388,7 +388,7 @@ class TestKfdGroupGate:
             "HAL0_GPU_RENDER_GID_OVERRIDE": "0",
             "HAL0_GPU_RENDER_GROUP_OVERRIDE": "root",
             "HAL0_GPU_KFD_PATH": str(kfd),
-            "HAL0_GPU_KFD_GID_OVERRIDE": "61998",
+            "HAL0_GPU_KFD_GID_OVERRIDE": "0",
             "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
         }
         out = subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True).stdout
@@ -398,3 +398,31 @@ class TestKfdGroupGate:
         assert f"gid={render_gid}" in out
         # And it must never send the operator to re-forward a present device.
         assert "dev1: /dev/kfd\n" not in out
+
+    def test_a_non_root_gid_divergence_is_left_alone(self, tmp_path: Path) -> None:
+        """#1953 review: a differing gid is NOT itself a fault.
+
+        A valid box can put /dev/kfd on `video` and the render nodes on
+        `render` — install.sh adds hal0 to BOTH. Rewriting that to the render
+        group would strip access from video-only users, and on an unprivileged
+        LXC the failed chgrp would abort a fresh install over a working config.
+        Only the root-owned, no-world-access shape is repaired.
+        """
+        (tmp_path / "renderD128").touch()
+        kfd = tmp_path / "kfd"
+        kfd.touch()
+        rc = _run_gpu_gate(
+            {
+                "HAL0_GPU_GATE": "1",
+                "HAL0_GPU_AMD_OVERRIDE": "1",
+                "HAL0_GPU_DRI_GLOB": str(tmp_path / "renderD*"),
+                "HAL0_GPU_RENDER_GID_OVERRIDE": "0",
+                "HAL0_GPU_RENDER_GROUP_OVERRIDE": "root",
+                "HAL0_GPU_KFD_PATH": str(kfd),
+                # Differs from the render node, but is a REAL group the service
+                # user can be added to — not the root-owned passthrough shape.
+                "HAL0_GPU_KFD_GID_OVERRIDE": "61996",
+                "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+            }
+        )
+        assert rc == RC_OK

--- a/tests/installer/test_preflight_gpu_gate.py
+++ b/tests/installer/test_preflight_gpu_gate.py
@@ -30,6 +30,7 @@ RC_OK = 0
 RC_BROKEN_GID = 3
 RC_NO_DEVICE = 4
 RC_NO_KFD = 5
+RC_KFD_GID = 6
 
 # A gid with no matching group on any sane host — forces "maps to NO group".
 UNMAPPED_GID = "61999"
@@ -316,3 +317,84 @@ def test_doctor_mode_missing_kfd_is_soft(render_glob: str, tmp_path: Path) -> No
         }
     )
     assert rc == RC_OK
+
+
+class TestKfdGroupGate:
+    """#1953 — /dev/kfd forwarded but group-misaligned with the render node.
+
+    A plain LXC ``dev`` passthrough lands renderD128 as root:render and the
+    compute node as root:root. The rootful slot containers open both fine, so
+    ROCm genuinely works — but the hal0 service user cannot open the compute
+    node, so #1923's guard refuses every AMD GPU slot on a healthy box. The
+    gate has to catch that shape, and must NOT tell the operator to re-forward
+    a device that is already present.
+    """
+
+    def test_mismatched_kfd_gid_is_caught(self, tmp_path: Path) -> None:
+        render = tmp_path / "renderD128"
+        render.touch()
+        kfd = tmp_path / "kfd"
+        kfd.touch()
+        rc = _run_gpu_gate(
+            {
+                "HAL0_GPU_GATE": "1",
+                "HAL0_GPU_AMD_OVERRIDE": "1",
+                "HAL0_GPU_DRI_GLOB": str(tmp_path / "renderD*"),
+                # Satisfy the group-NAME check above so we reach the gid
+                # check under test; it reads the real nodes regardless.
+                "HAL0_GPU_RENDER_GID_OVERRIDE": "0",
+                "HAL0_GPU_RENDER_GROUP_OVERRIDE": "root",
+                "HAL0_GPU_KFD_PATH": str(kfd),
+                "HAL0_GPU_KFD_GID_OVERRIDE": "61998",
+                "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+            }
+        )
+        # The compute node reports a gid the render node does not use — the
+        # exact divergence a plain LXC dev passthrough produces.
+        assert rc == RC_KFD_GID
+
+    def test_aligned_gids_pass(self, tmp_path: Path) -> None:
+        render = tmp_path / "renderD128"
+        render.touch()
+        kfd = tmp_path / "kfd"
+        kfd.touch()
+        rc = _run_gpu_gate(
+            {
+                "HAL0_GPU_GATE": "1",
+                "HAL0_GPU_AMD_OVERRIDE": "1",
+                "HAL0_GPU_DRI_GLOB": str(tmp_path / "renderD*"),
+                # Satisfy the group-NAME check above so we reach the gid
+                # check under test; it reads the real nodes regardless.
+                "HAL0_GPU_RENDER_GID_OVERRIDE": "0",
+                "HAL0_GPU_RENDER_GROUP_OVERRIDE": "root",
+                "HAL0_GPU_KFD_PATH": str(kfd),
+                "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+            }
+        )
+        # Both nodes are real files with the same owning gid — nothing to fix.
+        assert rc == RC_OK
+
+    def test_remedy_never_says_re_forward_the_device(self, tmp_path: Path) -> None:
+        """The headline harm of #1953: the old advice cost a production reboot."""
+        (tmp_path / "renderD128").touch()
+        kfd = tmp_path / "kfd"
+        kfd.touch()
+        script = f"set -uo pipefail\nsource {PREFLIGHT!s}\npreflight_gpu 2>&1 || true\n"
+        env = {
+            **os.environ,
+            "HAL0_GPU_GATE": "1",
+            "HAL0_GPU_AMD_OVERRIDE": "1",
+            "HAL0_GPU_DRI_GLOB": str(tmp_path / "renderD*"),
+            "HAL0_GPU_RENDER_GID_OVERRIDE": "0",
+            "HAL0_GPU_RENDER_GROUP_OVERRIDE": "root",
+            "HAL0_GPU_KFD_PATH": str(kfd),
+            "HAL0_GPU_KFD_GID_OVERRIDE": "61998",
+            "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+        }
+        out = subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True).stdout
+        render_gid = os.stat(tmp_path / "renderD128").st_gid
+        assert f"chgrp {render_gid}" in out
+        # The host-side remedy must carry a REAL gid, never a placeholder.
+        assert f"gid={render_gid}" in out
+        # And it must never send the operator to re-forward a present device.
+        assert "dev1: /dev/kfd\n" not in out

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -90,6 +90,45 @@ class TestKfdPresent:
             node.chmod(0o600)
 
 
+class TestKfdStatusIdentityRules:
+    """#1953 — which identity the probe answers for, pinned explicitly.
+
+    The first cut short-circuited ``uid == 0 -> KFD_OK`` on the theory that
+    root always bypasses DAC. It does not: root bypasses only with
+    CAP_DAC_OVERRIDE, and a hardened container drops it. CI runs in exactly
+    such a container, so an unopenable node was reported usable — failing
+    OPEN, into the poisoned Vulkan lane this guard exists to block.
+    """
+
+    def test_asking_about_this_process_consults_the_os_even_when_root(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """No uid-0 short-circuit for the CURRENT process: ask os.access.
+
+        Simulated rather than requiring a root test runner: pretend to be uid
+        0 while os.access reports the denial a capability-dropped container
+        would produce.
+        """
+        node = tmp_path / "kfd"
+        node.write_text("")
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        monkeypatch.setattr(os, "access", lambda *a, **k: False)
+        assert kfd_status(str(node), for_uid=None) == KFD_NOT_OPENABLE
+        assert kfd_status(str(node), for_uid=0) == KFD_NOT_OPENABLE
+
+    def test_asking_about_a_different_root_identity_still_assumes_override(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The slot container's root is not this process — we cannot probe it,
+        so the usual DAC override is assumed. That is the whole point of the
+        runner-identity parameter."""
+        node = tmp_path / "kfd"
+        node.write_text("")
+        monkeypatch.setattr(os, "geteuid", lambda: 1000)
+        monkeypatch.setattr(os, "access", lambda *a, **k: False)
+        assert kfd_status(str(node), for_uid=0) == KFD_OK
+
+
 class TestHostIsAmdGpu:
     def test_true_when_the_amdgpu_module_dir_exists(self, tmp_path) -> None:
         assert host_is_amd_gpu(str(tmp_path)) is True

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -609,3 +609,54 @@ class TestGuardRemedyText:
         with pytest.raises(GpuPreflightError) as err:
             require_kfd_for_gpu_slot("brain", device="gpu-rocm", kfd_path=str(tmp_path / "nope"))
         assert "dev1:" in str(err.value)
+
+
+class TestConvergeAgainstRealPermissionDenial:
+    """#1953 gap 2 — exercise a GENUINE chgrp refusal, not a monkeypatched one.
+
+    The unprivileged-LXC path (where ``/dev/kfd``'s ownership is host-mapped and
+    ``chown`` returns EPERM) has NOT been validated on a real unprivileged
+    container — see the regression register entry
+    ``kfd-gid-unprivileged-lxc-unverified``. This gets as close as a unit test
+    honestly can: a real chown against a gid the running user is not a member
+    of, which the kernel refuses for the same reason.
+
+    It proves the failure is reported rather than raised, and that the message
+    carries an actionable gid. It does NOT prove the idmap semantics of a real
+    unprivileged LXC, and must not be read as if it did.
+    """
+
+    def test_a_real_eperm_is_reported_with_an_actionable_remedy(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        if os.geteuid() == 0:
+            pytest.skip("root can chown to any gid — no denial to observe")
+        kfd = tmp_path / "kfd"
+        kfd.write_text("")
+        # A gid this user is certainly not a member of.
+        foreign_gid = 61997
+        assert foreign_gid not in os.getgroups()
+        monkeypatch.setattr(
+            "hal0.providers._gpu.resolve_kfd_target_gid", lambda *a, **k: foreign_gid
+        )
+        status, detail = converge_kfd_device_group(str(kfd))
+        assert status == "failed"
+        # The operator must be able to act on this without reading the source.
+        assert f"gid={foreign_gid}" in detail
+        assert "unprivileged" in detail.lower() or "host" in detail.lower()
+
+    def test_the_node_is_left_untouched_when_the_chgrp_is_refused(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A refused converge must not half-apply (e.g. chmod without chgrp)."""
+        if os.geteuid() == 0:
+            pytest.skip("root can chown to any gid — no denial to observe")
+        kfd = tmp_path / "kfd"
+        kfd.write_text("")
+        kfd.chmod(0o600)
+        before = os.stat(kfd)
+        monkeypatch.setattr("hal0.providers._gpu.resolve_kfd_target_gid", lambda *a, **k: 61997)
+        converge_kfd_device_group(str(kfd))
+        after = os.stat(kfd)
+        assert after.st_gid == before.st_gid
+        assert after.st_mode == before.st_mode

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -20,10 +20,16 @@ import pytest
 
 from hal0.providers._gpu import (
     ENV_ALLOW_VULKAN_FALLBACK,
+    KFD_MISSING,
+    KFD_NOT_OPENABLE,
+    KFD_OK,
     GpuPreflightError,
+    converge_kfd_device_group,
     host_is_amd_gpu,
     kfd_present,
+    kfd_status,
     require_kfd_for_gpu_slot,
+    resolve_kfd_target_gid,
     runtime_lane_for_provider,
 )
 
@@ -37,17 +43,49 @@ class TestKfdPresent:
     def test_false_when_it_does_not(self, tmp_path) -> None:
         assert kfd_present(str(tmp_path / "kfd")) is False
 
-    def test_false_when_it_exists_but_is_not_accessible(self, tmp_path) -> None:
+    def test_false_when_it_exists_but_this_process_cannot_open_it(self, tmp_path) -> None:
         """An LXC passthrough with a mis-mapped gid leaves the node visible but
         unopenable — HIP still fails and llama.cpp still lands on the invalid
-        Vulkan lane, so existence alone must not count as a pass."""
+        Vulkan lane, so existence alone must not count as a pass.
+
+        ``for_uid=None`` asks about THIS process, which is the only identity a
+        DAC probe can honestly answer for.
+        """
         node = tmp_path / "kfd"
         node.write_text("")
         node.chmod(0o000)
         try:
             if os.access(str(node), os.R_OK):  # running as root — chmod is advisory
                 pytest.skip("root bypasses file permissions")
-            assert kfd_present(str(node)) is False
+            assert kfd_present(str(node), for_uid=None) is False
+        finally:
+            node.chmod(0o600)
+
+    def test_unopenable_node_still_passes_for_the_root_slot_runner(self, tmp_path) -> None:
+        """#1953: the identity that matters is the one that OPENS the device.
+
+        hal0-api runs as ``hal0``; the slot containers run rootful as root. A
+        plain LXC passthrough routinely leaves ``/dev/kfd`` ``root:root 0660``
+        while the render node lands ``root:render 0660`` — ROCm works fine in
+        the container, but a probe run as ``hal0`` used to report False and
+        #1923's guard then refused every AMD GPU slot on a healthy box.
+        """
+        node = tmp_path / "kfd"
+        node.write_text("")
+        node.chmod(0o660)  # group-only rw, group is the test user's — not hal0's
+        assert kfd_present(str(node)) is True  # default: SLOT_RUNNER_UID (root)
+        assert kfd_status(str(node), for_uid=0) == KFD_OK
+
+    def test_status_distinguishes_missing_from_unopenable(self, tmp_path) -> None:
+        """The two shapes need OPPOSITE remedies, so they must not be one bool."""
+        assert kfd_status(str(tmp_path / "nope"), for_uid=0) == KFD_MISSING
+        node = tmp_path / "kfd"
+        node.write_text("")
+        node.chmod(0o000)
+        try:
+            if os.access(str(node), os.R_OK):
+                pytest.skip("root bypasses file permissions")
+            assert kfd_status(str(node), for_uid=None) == KFD_NOT_OPENABLE
         finally:
             node.chmod(0o600)
 
@@ -467,3 +505,107 @@ class TestFallbackWarningIsLaneScoped:
 
 def _raiser(*_a: object, **_kw: object) -> None:
     raise GpuPreflightError("no /dev/kfd")
+
+
+class TestResolveKfdTargetGid:
+    """#1953: the target gid must come from the DEVICE NODE, never a group name.
+
+    The kernel gates on the integer. On a halo143-class box ``renderD128`` is
+    owned by gid 993 whose ``/etc/group`` name is ``clock``, while ``render``
+    resolves to a different, useless gid — so ``grp.getgrnam("render")``
+    produces a number that grants nothing. Baking in 993 (or any constant) is
+    the same bug wearing a different hat.
+    """
+
+    def test_follows_the_render_node_gid(self, tmp_path, monkeypatch) -> None:
+        node = tmp_path / "renderD128"
+        node.write_text("")
+        os.chown(node, -1, os.getgid())
+        monkeypatch.setattr(
+            "hal0.providers._gpu.resolve_gpu_device_paths", lambda *a, **k: [str(node)]
+        )
+        monkeypatch.setattr(
+            "hal0.providers._gpu._device_node_for_group",
+            lambda name, paths: str(node) if name == "render" else None,
+        )
+        assert resolve_kfd_target_gid() == os.stat(node).st_gid
+
+    def test_returns_none_rather_than_guessing_a_constant(self, monkeypatch) -> None:
+        """No render node → no opinion. Guessing 993 is how a wrong gid gets baked in."""
+        monkeypatch.setattr("hal0.providers._gpu.resolve_gpu_device_paths", lambda *a, **k: [])
+        monkeypatch.setattr("hal0.providers._gpu._device_node_for_group", lambda name, paths: None)
+        assert resolve_kfd_target_gid() is None
+
+
+class TestConvergeKfdDeviceGroup:
+    def test_noop_when_already_aligned(self, tmp_path, monkeypatch) -> None:
+        kfd = tmp_path / "kfd"
+        kfd.write_text("")
+        kfd.chmod(0o660)
+        monkeypatch.setattr(
+            "hal0.providers._gpu.resolve_kfd_target_gid",
+            lambda *a, **k: os.stat(kfd).st_gid,
+        )
+        status, _ = converge_kfd_device_group(str(kfd))
+        assert status == "noop"
+
+    def test_skips_when_no_render_node_to_learn_from(self, tmp_path, monkeypatch) -> None:
+        kfd = tmp_path / "kfd"
+        kfd.write_text("")
+        monkeypatch.setattr("hal0.providers._gpu.resolve_kfd_target_gid", lambda *a, **k: None)
+        status, detail = converge_kfd_device_group(str(kfd))
+        assert status == "skipped"
+        assert "render node" in detail
+
+    def test_skips_when_the_node_is_absent(self, tmp_path) -> None:
+        status, _ = converge_kfd_device_group(str(tmp_path / "nope"))
+        assert status == "skipped"
+
+    def test_dry_run_reports_without_writing(self, tmp_path, monkeypatch) -> None:
+        kfd = tmp_path / "kfd"
+        kfd.write_text("")
+        kfd.chmod(0o600)
+        before = os.stat(kfd).st_mode
+        monkeypatch.setattr("hal0.providers._gpu.resolve_kfd_target_gid", lambda *a, **k: 4242)
+        status, _ = converge_kfd_device_group(str(kfd), dry_run=True)
+        assert status == "changed"
+        assert os.stat(kfd).st_mode == before
+
+    def test_failure_is_reported_not_raised(self, tmp_path, monkeypatch) -> None:
+        """Unprivileged LXC: chgrp is EPERM. Surface the host remedy, never abort."""
+        kfd = tmp_path / "kfd"
+        kfd.write_text("")
+        monkeypatch.setattr("hal0.providers._gpu.resolve_kfd_target_gid", lambda *a, **k: 4242)
+
+        def _boom(*a, **k):
+            raise PermissionError("Operation not permitted")
+
+        monkeypatch.setattr(os, "chown", _boom)
+        status, detail = converge_kfd_device_group(str(kfd))
+        assert status == "failed"
+        assert "gid=4242" in detail
+
+
+class TestGuardRemedyText:
+    def test_unopenable_does_not_tell_you_to_re_forward_the_device(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """#1953's headline harm: the old text sent operators to reboot production
+        for a device that was already forwarded."""
+        kfd = tmp_path / "kfd"
+        kfd.write_text("")
+        monkeypatch.setattr("hal0.providers._gpu.kfd_status", lambda *a, **k: KFD_NOT_OPENABLE)
+        monkeypatch.setattr("hal0.providers._gpu.resolve_kfd_target_gid", lambda *a, **k: 993)
+        with pytest.raises(GpuPreflightError) as err:
+            require_kfd_for_gpu_slot("brain", device="gpu-rocm", kfd_path=str(kfd))
+        msg = str(err.value)
+        assert "IS forwarded" in msg
+        assert "chgrp 993" in msg
+        assert "pct stop/start" in msg  # only as the unprivileged-LXC sub-case
+        assert "dev1:" not in msg  # the WRONG remedy must not appear
+
+    def test_missing_still_tells_you_to_forward_it(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr("hal0.providers._gpu.kfd_status", lambda *a, **k: KFD_MISSING)
+        with pytest.raises(GpuPreflightError) as err:
+            require_kfd_for_gpu_slot("brain", device="gpu-rocm", kfd_path=str(tmp_path / "nope"))
+        assert "dev1:" in str(err.value)

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -124,7 +124,12 @@ class TestKfdStatusIdentityRules:
         monkeypatch.setattr(os, "geteuid", lambda: 0)
         monkeypatch.setattr(os, "access", lambda *a, **k: False)
         assert kfd_status(str(node), for_uid=None) == KFD_NOT_OPENABLE
-        assert kfd_status(str(node), for_uid=0) == KFD_NOT_OPENABLE
+        # for_uid=0 is NOT the same question, even from a root caller: it names
+        # the rootful slot container, whose CAP_DAC_OVERRIDE this process's
+        # denial says nothing about. Asserting NOT_OPENABLE here contradicted
+        # test_asking_about_a_different_root_identity_still_assumes_override
+        # for identical input, and collapsed the parameter for root callers.
+        assert kfd_status(str(node), for_uid=0) == KFD_OK
 
     def test_asking_about_a_different_root_identity_still_assumes_override(
         self, tmp_path, monkeypatch
@@ -821,3 +826,66 @@ class TestResolveImageRuntimeUidUsesTheRootStore:
             "hal0.providers.podman_introspect.image_user", lambda *a, **k: "1000:1000"
         )
         assert gpu_mod.resolve_image_runtime_uid("ghcr.io/x/y:1") == 1000
+
+
+class TestTheUidProbeIsLazy:
+    """#1953 N2 — resolving the runner uid is a sudo round-trip plus two podman
+    calls. An eager argument expression charged EVERY slot for a probe only the
+    gated ones need."""
+
+    def _never(self):
+        def _boom() -> int:  # pragma: no cover - only runs if laziness breaks
+            raise AssertionError("uid probe ran for an ungated slot")
+
+        return _boom
+
+    @pytest.mark.parametrize("device", ["cpu", "npu", "gpu-cuda", ""])
+    def test_ungated_devices_never_resolve_the_uid(self, device, tmp_path) -> None:
+        require_kfd_for_gpu_slot(
+            "x",
+            device=device,
+            kfd_path=str(tmp_path / "kfd"),
+            env={},
+            amd_host=True,
+            runner_uid=self._never(),
+        )
+
+    def test_a_non_rocm_lane_never_resolves_the_uid(self, tmp_path) -> None:
+        """Kokoro/Moonshine forward no compute node, so the identity that would
+        open it is irrelevant (#1941 scoping runs before the probe)."""
+        require_kfd_for_gpu_slot(
+            "voice",
+            device="gpu-vulkan",
+            runtime_lane="no-rocm",
+            kfd_path=str(tmp_path / "kfd"),
+            env={},
+            amd_host=True,
+            runner_uid=self._never(),
+        )
+
+    def test_a_gated_lane_does_resolve_the_uid(self, tmp_path) -> None:
+        """...and the lazy form must still actually be consulted when it counts."""
+        node = tmp_path / "kfd"
+        node.write_text("")
+        calls: list[int] = []
+
+        def _probe() -> int:
+            calls.append(1)
+            return 0
+
+        require_kfd_for_gpu_slot(
+            "brain",
+            device="gpu-rocm",
+            kfd_path=str(node),
+            env={},
+            amd_host=True,
+            runner_uid=_probe,
+        )
+        assert calls == [1]
+
+    def test_a_plain_int_still_works(self, tmp_path) -> None:
+        node = tmp_path / "kfd"
+        node.write_text("")
+        require_kfd_for_gpu_slot(
+            "brain", device="gpu-rocm", kfd_path=str(node), env={}, amd_host=True, runner_uid=0
+        )

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -72,9 +72,19 @@ class TestKfdPresent:
         """
         node = tmp_path / "kfd"
         node.write_text("")
-        node.chmod(0o660)  # group-only rw, group is the test user's — not hal0's
-        assert kfd_present(str(node)) is True  # default: SLOT_RUNNER_UID (root)
-        assert kfd_status(str(node), for_uid=0) == KFD_OK
+        # 0o000, not 0o660: the node must be unopenable to the CURRENT process,
+        # or this passes on main too and proves nothing (review nit). The dual
+        # assert is the actual contract — same node, opposite verdicts,
+        # decided solely by which identity is asked about.
+        node.chmod(0o000)
+        try:
+            if os.access(str(node), os.R_OK):
+                pytest.skip("this process bypasses file permissions")
+            assert kfd_status(str(node), for_uid=None) == KFD_NOT_OPENABLE
+            assert kfd_present(str(node)) is True  # default: SLOT_RUNNER_UID
+            assert kfd_status(str(node), for_uid=0) == KFD_OK
+        finally:
+            node.chmod(0o600)
 
     def test_status_distinguishes_missing_from_unopenable(self, tmp_path) -> None:
         """The two shapes need OPPOSITE remedies, so they must not be one bool."""
@@ -323,11 +333,27 @@ class TestNonRocmRuntimesAreNotGated:
     @staticmethod
     def _amd_box_without_kfd(monkeypatch) -> None:
         """An AMD host (amdgpu bound) that has no usable /dev/kfd — the exact
-        shape of the box #1941 was reported from."""
+        shape of the box #1941 was reported from.
+
+        Patches ``kfd_status``, NOT ``kfd_present``: the guard calls the former
+        (#1952 + #1953 composed). Patching ``kfd_present`` was a dead stub —
+        these tests then passed only because the CI runner happens to lack
+        /dev/kfd, and went RED on any box that has one (CT105, ct151, dev
+        workstations), taking the #1888/#1941 regression cover with them.
+        """
         from hal0.providers import _gpu as gpu_mod
 
         monkeypatch.setattr(gpu_mod, "host_is_amd_gpu", lambda *_a, **_k: True)
-        monkeypatch.setattr(gpu_mod, "kfd_present", lambda *_a, **_k: False)
+        monkeypatch.setattr(gpu_mod, "kfd_status", lambda *_a, **_k: gpu_mod.KFD_MISSING)
+
+    @staticmethod
+    def _amd_box_with_unopenable_kfd(monkeypatch) -> None:
+        """The node IS forwarded but the runner identity cannot open it — the
+        third status, which nothing exercised through ``load_sync`` before."""
+        from hal0.providers import _gpu as gpu_mod
+
+        monkeypatch.setattr(gpu_mod, "host_is_amd_gpu", lambda *_a, **_k: True)
+        monkeypatch.setattr(gpu_mod, "kfd_status", lambda *_a, **_k: gpu_mod.KFD_NOT_OPENABLE)
 
     @staticmethod
     def _stub_unit_write(monkeypatch) -> list[str]:
@@ -346,6 +372,41 @@ class TestNonRocmRuntimesAreNotGated:
             lambda self, token, unit_text: written.append(token),
         )
         return written
+
+    def test_load_sync_refuses_the_llama_lane_on_an_unopenable_node(self, monkeypatch) -> None:
+        """KFD_NOT_OPENABLE through load_sync — the third status, previously
+        unexercised on this path.
+
+        A forwarded-but-unopenable node is just as poisoned as a missing one:
+        HIP still fails to initialise and llama.cpp still lands on the invalid
+        Vulkan lane. The refusal must fire, and its remedy must be the group
+        fix rather than a re-forward (#1953).
+        """
+        from hal0.providers import container as container_mod
+
+        self._amd_box_with_unopenable_kfd(monkeypatch)
+        self._stub_unit_write(monkeypatch)
+
+        with pytest.raises(GpuPreflightError) as err:
+            container_mod.ContainerProvider().load_sync(
+                {"name": "utility", "device": "gpu-vulkan", "port": 8082}, {}
+            )
+        msg = str(err.value)
+        assert "IS forwarded" in msg
+        assert "dev1:" not in msg  # never send them to re-forward a present node
+
+    def test_a_non_rocm_runtime_is_unaffected_by_an_unopenable_node(self, monkeypatch) -> None:
+        """The lane scoping (#1941) still wins over the status: Kokoro forwards
+        no compute node at all, so its openability is irrelevant."""
+        from hal0.providers import container as container_mod
+
+        self._amd_box_with_unopenable_kfd(monkeypatch)
+        written = self._stub_unit_write(monkeypatch)
+
+        container_mod.ContainerProvider().load_sync(
+            {"name": "voice", "type": "tts", "device": "gpu-vulkan", "port": 8090}, {}
+        )
+        assert written == ["voice"]
 
     @pytest.mark.parametrize(
         "slot_cfg",
@@ -699,3 +760,64 @@ class TestConvergeAgainstRealPermissionDenial:
         after = os.stat(kfd)
         assert after.st_gid == before.st_gid
         assert after.st_mode == before.st_mode
+
+
+class TestResolveImageRuntimeUidUsesTheRootStore:
+    """#1953 R2 — the uid must come from ROOT's image store, never hal0's own.
+
+    hal0-api runs as the unprivileged ``hal0`` user with no subuid ranges, so a
+    bare ``podman image inspect`` reads hal0's ROOTLESS store — a different
+    store, which never contains a slot image. Reading it would make this check
+    a silent no-op in production, which is #1889 with extra steps.
+    """
+
+    def test_it_routes_through_the_seam(self, monkeypatch) -> None:
+        from hal0.providers import _gpu as gpu_mod
+
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "hal0.providers.podman_introspect.image_user",
+            lambda ref, **k: seen.append(ref) or "hal0",
+        )
+        import pwd
+
+        monkeypatch.setattr(pwd, "getpwnam", lambda n: type("P", (), {"pw_uid": 1234})())
+        assert gpu_mod.resolve_image_runtime_uid("ghcr.io/x/y:1") == 1234
+        assert seen == ["ghcr.io/x/y:1"]
+
+    def test_it_never_shells_bare_podman(self, monkeypatch) -> None:
+        """The regression guard: a bare subprocess call is the #1889 trap."""
+        import subprocess
+
+        from hal0.providers import _gpu as gpu_mod
+
+        monkeypatch.setattr("hal0.providers.podman_introspect.image_user", lambda *a, **k: "")
+
+        def _boom(*a, **k):  # pragma: no cover - only runs if the bug returns
+            raise AssertionError(f"bare podman call: {a!r}")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+        assert gpu_mod.resolve_image_runtime_uid("ghcr.io/x/y:1") == gpu_mod.SLOT_RUNNER_UID
+
+    def test_an_unanswerable_seam_falls_back_to_root_not_rootless(self, monkeypatch) -> None:
+        """``None`` means the seam did not answer. Deliberately NO rootless
+        fallback: that store's answer is about a different object."""
+        from hal0.providers import _gpu as gpu_mod
+
+        monkeypatch.setattr("hal0.providers.podman_introspect.image_user", lambda *a, **k: None)
+        assert gpu_mod.resolve_image_runtime_uid("ghcr.io/x/y:1") == gpu_mod.SLOT_RUNNER_UID
+
+    @pytest.mark.parametrize("declared", ["", "root", "0"])
+    def test_root_equivalents_resolve_to_the_slot_runner_uid(self, monkeypatch, declared) -> None:
+        from hal0.providers import _gpu as gpu_mod
+
+        monkeypatch.setattr("hal0.providers.podman_introspect.image_user", lambda *a, **k: declared)
+        assert gpu_mod.resolve_image_runtime_uid("ghcr.io/x/y:1") == gpu_mod.SLOT_RUNNER_UID
+
+    def test_a_numeric_user_is_honoured(self, monkeypatch) -> None:
+        from hal0.providers import _gpu as gpu_mod
+
+        monkeypatch.setattr(
+            "hal0.providers.podman_introspect.image_user", lambda *a, **k: "1000:1000"
+        )
+        assert gpu_mod.resolve_image_runtime_uid("ghcr.io/x/y:1") == 1000

--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -29,6 +29,41 @@ updated: 2026-08-15
 # in the filing PR. An entry with issue: null is still probed every release.
 
 regressions:
+
+  - id: kfd-gid-unprivileged-lxc-unverified
+    issue: 1953
+    from: v1.0.0-rc.7
+    severity: minor
+    tier: judgment
+    lane: gpu
+    summary: >-
+      #1953's repair path for a group-misaligned /dev/kfd has NEVER been exercised on a real
+      UNPRIVILEGED LXC. The fix assumes chgrp returns EPERM there (ownership is host-mapped)
+      and falls back to printing a host-side `dev1: /dev/kfd,gid=<gid>` remedy. Both halves of
+      that assumption are untested: that the refusal actually happens, and that the gid resolved
+      INSIDE the container is the correct value to write on the host once idmap shifting applies.
+    why_unverified: >-
+      The box the defect was found on (CT105) is PRIVILEGED, where chgrp simply succeeds. No
+      unprivileged box on the fleet has /dev/kfd passed through, and adding it is a Proxmox
+      host-level change plus a container restart — an operator decision, not an agent one.
+    covered_by_unit_tests: >-
+      A genuine (non-mocked) EPERM is exercised in
+      tests/providers/test_gpu_kfd_preflight.py::TestConvergeAgainstRealPermissionDenial by
+      chowning to a gid the test user does not belong to. That proves the failure is REPORTED
+      not raised, and that the remedy string carries an actionable gid. It does NOT prove the
+      idmap semantics of a real unprivileged LXC. Do not treat it as if it did.
+    repro: |
+      On an UNPRIVILEGED LXC with /dev/kfd forwarded:
+        stat -c '%n %U:%G %a' /dev/kfd /dev/dri/renderD128   # expect a gid divergence
+        HAL0_GPU_GATE=1 bash -c 'source installer/lib/preflight.sh; preflight_gpu; echo rc=$?'
+        # expect rc=6 (HAL0_GPU_RC_KFD_GID) and a remedy naming the render node's real gid
+        python -m hal0.install.gpu_perms   # expect exit 0, journal 'gpu_perms.refused'
+      Then apply the printed host-side remedy and confirm the gate goes green.
+    expect: >-
+      install.sh WARNS and continues (never exits non-zero); the converge reports "failed" with
+      a remedy carrying a real numeric gid; GPU slots still load, because the #1953 identity fix
+      evaluates the root slot runner rather than the hal0 user.
+    promote_ready: false
   # ── Carried from v1.0.0-rc.4 ────────────────────────────────────────────────
 
   - id: profile-flags-argv

--- a/tests/updater/test_gpu_perms_unit.py
+++ b/tests/updater/test_gpu_perms_unit.py
@@ -1,0 +1,96 @@
+"""#1953 durability — the boot-time converge and its delivery to existing boxes.
+
+Two gaps this closes:
+
+1. ``/dev/kfd`` is recreated every boot, so the install/update-time converge is
+   undone unless the host's LXC ``dev`` entry carries ``gid=``.
+2. A unit shipped only by ``install.sh`` never reaches a box that upgrades via
+   ``hal0 update`` — the #1689 shape.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import hal0.updater.updater as updater_mod
+from hal0.install import gpu_perms
+
+
+class TestGpuPermsEntryPoint:
+    def test_non_amd_host_is_a_noop(self, monkeypatch) -> None:
+        monkeypatch.setattr("hal0.providers._gpu.host_is_amd_gpu", lambda *a, **k: False)
+        called: list[int] = []
+        monkeypatch.setattr(
+            "hal0.providers._gpu.converge_kfd_device_group",
+            lambda *a, **k: called.append(1) or ("changed", ""),
+        )
+        assert gpu_perms.main() == 0
+        assert called == []
+
+    @pytest.mark.parametrize("status", ["changed", "noop", "skipped", "failed"])
+    def test_every_outcome_exits_zero(self, status, monkeypatch) -> None:
+        """A GPU-permissions tidy-up must never be able to wedge the boot."""
+        monkeypatch.setattr("hal0.providers._gpu.host_is_amd_gpu", lambda *a, **k: True)
+        monkeypatch.setattr(
+            "hal0.providers._gpu.converge_kfd_device_group",
+            lambda *a, **k: (status, "detail"),
+        )
+        assert gpu_perms.main() == 0
+
+    def test_an_unexpected_exception_still_exits_zero(self, monkeypatch) -> None:
+        monkeypatch.setattr("hal0.providers._gpu.host_is_amd_gpu", lambda *a, **k: True)
+
+        def _boom(*a, **k):
+            raise RuntimeError("nope")
+
+        monkeypatch.setattr("hal0.providers._gpu.converge_kfd_device_group", _boom)
+        assert gpu_perms.main() == 0
+
+
+class TestGpuPermsUnitRefresh:
+    def test_unprivileged_is_a_noop(self, monkeypatch, tmp_path: Path) -> None:
+        """The unprivileged daemon must never write /etc/systemd/system."""
+        monkeypatch.setattr(os, "geteuid", lambda: 1000)
+        assert updater_mod.refresh_gpu_perms_unit(tmp_path) == "skipped"
+
+    def test_a_release_without_the_unit_is_skipped_not_fatal(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        assert updater_mod.refresh_gpu_perms_unit(tmp_path) == "skipped"
+
+
+class TestUnitFileContract:
+    """The unit's ordering is load-bearing; assert it rather than trusting it."""
+
+    def _unit(self) -> str:
+        root = Path(__file__).resolve().parents[2]
+        return (root / "installer" / "systemd" / "hal0-gpu-perms.service").read_text()
+
+    def test_runs_after_dev_is_populated_and_before_hal0(self) -> None:
+        unit = self._unit()
+        # There is no node to chgrp until /dev is populated...
+        assert "systemd-tmpfiles-setup-dev.service" in unit
+        # ...and slots must observe the converged state, never race it.
+        assert "Before=hal0.target" in unit
+
+    def test_is_a_oneshot_that_cannot_wedge_the_boot(self) -> None:
+        unit = self._unit()
+        assert "Type=oneshot" in unit
+        assert "ConditionPathExists=/dev/kfd" in unit
+
+    def test_does_not_bake_a_gid(self) -> None:
+        """The whole point: the gid is re-derived from the render node at boot.
+
+        A tmpfiles.d/udev rule would have to name one, and a baked gid is not
+        portable — hence a service.
+        """
+        directives = [
+            ln for ln in self._unit().splitlines() if ln.strip() and not ln.lstrip().startswith("#")
+        ]
+        body = "\n".join(directives)
+        assert "gid=" not in body
+        assert "993" not in body

--- a/tests/updater/test_kfd_group_converge.py
+++ b/tests/updater/test_kfd_group_converge.py
@@ -45,16 +45,36 @@ class TestConvergeKfdGroup:
         assert updater_mod.converge_kfd_group() == "failed"
 
 
-class TestMigrationOrdering:
-    def test_kfd_converge_runs_before_the_vulkan_relabel(self) -> None:
-        """Ordering is load-bearing, not cosmetic.
+class TestConvergeIsNotInTheMigrationChain:
+    """#1953 review: the converge must NOT run from run_post_activation_migrations.
 
-        ``relabel_stale_vulkan_slots`` branches on the compute node's state to
-        pick ``gpu-rocm`` vs ``cpu``. If the converge ran after it, the relabel
-        would decide from the un-repaired device and the two passes could reach
-        different conclusions about the same box.
-        """
+    That chain runs in an asyncio.to_thread inside hal0-api (User=hal0) and
+    BEFORE seam.activate(). Calling the converge from there was wrong twice
+    over: chown hit EPERM as an unprivileged user and reported "failed" for
+    exactly the boxes it was meant to fix, and on the FIRST update delivering
+    the code the running daemon is still the PREVIOUS release, where the
+    function does not exist at all.
+
+    It now runs root-side in refresh_gpu_perms_unit during activate.
+    """
+
+    def test_migrations_do_not_call_the_converge(self) -> None:
         import inspect
 
         src = inspect.getsource(updater_mod.run_post_activation_migrations)
-        assert src.index("converge_kfd_group(") < src.index("relabel_stale_vulkan_slots(")
+        assert "converge_kfd_group(" not in src
+
+    def test_the_privileged_unit_refresh_starts_the_unit(self) -> None:
+        """Starting it is what converges an updated box without a reboot."""
+        import inspect
+
+        src = inspect.getsource(updater_mod.refresh_gpu_perms_unit)
+        assert '"start", "hal0-gpu-perms.service"' in src.replace("'", '"')
+
+    def test_a_failed_enable_is_reported_not_swallowed(self) -> None:
+        """Otherwise the next update sees identical content and never retries."""
+        import inspect
+
+        src = inspect.getsource(updater_mod.refresh_gpu_perms_unit)
+        assert "gpu_perms_unit_enable_failed" in src
+        assert "up_to_date" in src  # no early return that skips the enable retry

--- a/tests/updater/test_kfd_group_converge.py
+++ b/tests/updater/test_kfd_group_converge.py
@@ -1,0 +1,60 @@
+"""#1953 — converge /dev/kfd's group with the render node's on every update.
+
+A plain LXC ``dev`` passthrough lands ``/dev/dri/renderD128`` as ``root:render``
+and ``/dev/kfd`` as ``root:root``. The rootful slot containers open both, so
+ROCm genuinely works — but every hal0-user probe reports the GPU unusable, and
+#1923's guard then refuses every AMD GPU slot on a healthy box.
+
+The installer fixes this at install time; existing boxes only ever see it if the
+update path converges it too (the #1689 shape: an asset the installer applies
+and the updater never re-applies never reaches an upgraded box).
+"""
+
+from __future__ import annotations
+
+import hal0.updater.updater as updater_mod
+
+
+class TestConvergeKfdGroup:
+    def test_skipped_on_a_non_amd_host(self, monkeypatch) -> None:
+        """No amdgpu bound → no compute node to align. Never touch the box."""
+        monkeypatch.setattr("hal0.providers._gpu.host_is_amd_gpu", lambda *a, **k: False)
+        called: list[object] = []
+        monkeypatch.setattr(
+            "hal0.providers._gpu.converge_kfd_device_group",
+            lambda *a, **k: called.append(1) or ("changed", ""),
+        )
+        assert updater_mod.converge_kfd_group() == "skipped"
+        assert called == []
+
+    def test_converges_on_an_amd_host(self, monkeypatch) -> None:
+        monkeypatch.setattr("hal0.providers._gpu.host_is_amd_gpu", lambda *a, **k: True)
+        monkeypatch.setattr(
+            "hal0.providers._gpu.converge_kfd_device_group",
+            lambda *a, **k: ("changed", "gid 0 -> 993"),
+        )
+        assert updater_mod.converge_kfd_group() == "changed"
+
+    def test_a_refused_chgrp_is_reported_not_raised(self, monkeypatch) -> None:
+        """Unprivileged LXC: chgrp is EPERM. An update must not abort over it."""
+        monkeypatch.setattr("hal0.providers._gpu.host_is_amd_gpu", lambda *a, **k: True)
+        monkeypatch.setattr(
+            "hal0.providers._gpu.converge_kfd_device_group",
+            lambda *a, **k: ("failed", "Operation not permitted"),
+        )
+        assert updater_mod.converge_kfd_group() == "failed"
+
+
+class TestMigrationOrdering:
+    def test_kfd_converge_runs_before_the_vulkan_relabel(self) -> None:
+        """Ordering is load-bearing, not cosmetic.
+
+        ``relabel_stale_vulkan_slots`` branches on the compute node's state to
+        pick ``gpu-rocm`` vs ``cpu``. If the converge ran after it, the relabel
+        would decide from the un-repaired device and the two passes could reach
+        different conclusions about the same box.
+        """
+        import inspect
+
+        src = inspect.getsource(updater_mod.run_post_activation_migrations)
+        assert src.index("converge_kfd_group(") < src.index("relabel_stale_vulkan_slots(")


### PR DESCRIPTION
Fixes #1953.

## The bug

`kfd_present()` evaluated `/dev/kfd` accessibility as the **calling process**. That is the wrong identity for the question every caller is actually asking.

- `hal0-api` runs as `User=hal0`
- `hal0-slot@.service` carries **no** `User=` → podman runs rootful, containers open the device **as root**, with `--device=/dev/kfd` explicitly passed

A plain LXC `dev` passthrough leaves the two GPU nodes asymmetric:

| node | ownership |
|---|---|
| `/dev/dri/renderD128` | `root:render 0660` |
| `/dev/kfd` | `root:root 0660` |

So ROCm works perfectly in the container, while the API-side probe reports the compute node unusable. Since #1923's guard gates `gpu-rocm` **always** and `gpu-vulkan` on any AMD host, the practical effect is that **no AMD GPU llama.cpp slot can load** on a fully functional box.

Found on a production Strix Halo box immediately after deploying post-rc.6 code; `root:root` is the default for a plain LXC kfd passthrough, so this is not a one-box quirk.

The old diagnostic compounded it — it told the operator to forward a device that was **already forwarded**:

```
GpuPreflightError: ... needs the ROCm compute node /dev/kfd, which is not visible
here. ... Forward the device from the host (Proxmox LXC: add 'dev1: /dev/kfd' to
/etc/pve/lxc/<CTID>.conf, then pct stop/start)
```

That is a production reboot spent on a group-ownership mismatch.

## What changed

**Identity is now explicit.** `kfd_status()` splits `KFD_MISSING` from `KFD_NOT_OPENABLE` — the two shapes need opposite remedies and must not collapse into one bool. `kfd_present()` and `require_kfd_for_gpu_slot()` take the identity that actually opens the device, defaulting to `SLOT_RUNNER_UID` (root). `for_uid=None` still asks about the current process.

**The target gid comes from the device node, never a group name.** `resolve_kfd_target_gid()` reads the render node's owning gid and returns `None` rather than guessing. This is deliberate: the kernel gates on the **integer**, and the name for that integer is not portable. On a halo143-class box `renderD128` is owned by gid 993 whose `/etc/group` name is `clock`, while `render` resolves to a different, useless gid — so `grp.getgrnam("render")` yields a number that grants nothing. This is the same authority `resolve_gpu_group_ids()` already follows for `--group-add`, so the two devices cannot disagree. The `_GPU_GROUP_FALLBACK_GIDS` constants are never used here; guessing 993 on a box we could not read is how a wrong gid gets baked in.

**Installer detects and repairs.** New `HAL0_GPU_RC_KFD_GID` (6) fires when the compute node's gid diverges from the render node's. `install.sh` runs as root, so it repairs in place rather than blocking, and falls back to the host-side `dev1: /dev/kfd,gid=<real gid>` remedy only when `chgrp` returns EPERM on an unprivileged LXC.

**Updater converges existing boxes.** `converge_kfd_group()` runs on every update — otherwise this is the #1689 shape, where an asset the installer applies and the updater never re-applies never reaches an upgraded box. It is ordered **before** `relabel_stale_vulkan_slots`, which branches on the same device state to choose `gpu-rocm` vs `cpu`; running after would let the relabel decide from the un-repaired device.

Best-effort throughout: an unprivileged LXC cannot chgrp a host-mapped node, and an update must never abort over that.

## Verification

```
tests/providers tests/installer tests/updater tests/slots
2589 passed, 1 skipped
ruff check + ruff format --check on all changed files: clean
```

New coverage: root-runner vs current-process semantics, `missing` vs `not-openable`, gid derived from the node, `None` instead of a guessed constant, converge no-op/skip/dry-run/EPERM paths, the migration ordering constraint, and an assertion that the `not-openable` remedy **never** tells you to re-forward the device.

One pre-existing test (`test_gate_amd_render_node_with_kfd_proceeds`) went red mid-work because my first draft reused `HAL0_GPU_RENDER_GID_OVERRIDE` — a seam that fakes the group-*name* check — to compare against a real gid. Fixed properly by giving this check its own `HAL0_GPU_KFD_GID_OVERRIDE` seam and reading both real nodes, rather than editing the assertion.

## Not in scope

- Persisting the ownership across reboot via a shipped udev/tmpfiles asset. The converge runs on every install and update, which covers the upgrade path; a boot-time asset is a follow-up.
- The unprivileged-LXC path is handled by falling back to the host remedy, but has **not** been exercised on a real unprivileged box — the production box this was found on is privileged.
