### PR TITLE
fix(gpu): re-apply the kfd group at boot, and record the untested unprivileged-LXC path

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1414,6 +1414,28 @@ else
     warn "${TARGET_UNIT_SRC} not found — hal0.target not installed; slots will not autostart after reboot"
 fi
 
+# GPU device permissions (#1953). /dev/kfd is recreated every boot, so the
+# install/update-time converge is undone by the next reboot unless the host's
+# LXC `dev` entry carries gid=. This oneshot re-derives the target gid FROM THE
+# RENDER NODE and re-applies it before hal0.target — deliberately a service
+# rather than a tmpfiles.d/udev rule, both of which would have to name a gid,
+# and a baked gid is not portable across hosts (see preflight_gpu).
+GPU_PERMS_UNIT_SRC="${REPO_ROOT}/installer/systemd/hal0-gpu-perms.service"
+GPU_PERMS_UNIT_DST="${UNIT_DIR}/hal0-gpu-perms.service"
+if [[ -f "${GPU_PERMS_UNIT_SRC}" ]]; then
+    install -m 0644 "${GPU_PERMS_UNIT_SRC}" "${GPU_PERMS_UNIT_DST}"
+    info "wrote ${GPU_PERMS_UNIT_DST}"
+    if [[ "${DEV_MODE}" -eq 0 ]]; then
+        # WantedBy=hal0.target. Enabling is safe on a non-AMD box: the unit
+        # carries ConditionPathExists=/dev/kfd and the module no-ops without
+        # amdgpu bound.
+        systemctl enable hal0-gpu-perms.service >/dev/null 2>&1 \
+            || warn "could not enable hal0-gpu-perms.service"
+    fi
+else
+    warn "${GPU_PERMS_UNIT_SRC} not found — /dev/kfd group will not be re-applied after a reboot"
+fi
+
 OPENWEBUI_UNIT_SRC="${REPO_ROOT}/packaging/systemd/hal0-openwebui.service"
 OPENWEBUI_UNIT_DST="${UNIT_DIR}/hal0-openwebui.service"
 # pin per release (#79) — single source of truth for the OpenWebUI image

--- a/installer/systemd/hal0-gpu-perms.service
+++ b/installer/systemd/hal0-gpu-perms.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=hal0 GPU device permissions (align /dev/kfd with the render node)
+Documentation=https://github.com/Hal0ai/hal0/issues/1953
+# /dev/kfd is recreated every boot — by udev on bare metal, by container start
+# from the host's `dev` entry on an LXC — so the install/update-time converge is
+# undone unless the host entry itself carries gid=. Re-apply it once per boot.
+#
+# After systemd-tmpfiles-setup-dev: /dev must be populated before there is a
+# node to chgrp. Before hal0.target: slots and the API must observe the
+# converged state, never race it.
+After=systemd-tmpfiles-setup-dev.service local-fs.target
+Before=hal0.target
+ConditionPathExists=/dev/kfd
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Root: chgrp on a device node needs it, and this is exactly the privileged
+# tidy-up the unprivileged API must never perform itself.
+ExecStart=/usr/lib/hal0/venv/bin/python -m hal0.install.gpu_perms
+# A GPU-permissions tidy-up must never be able to wedge the boot. The module
+# already returns 0 for every outcome including "refused by an unprivileged
+# LXC"; this is the belt to that braces.
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=hal0.target

--- a/src/hal0/install/gpu_perms.py
+++ b/src/hal0/install/gpu_perms.py
@@ -1,0 +1,64 @@
+"""Boot-time convergence of the ROCm compute node's group (#1953).
+
+``/dev/kfd`` is recreated on every boot — by udev on bare metal, by container
+start from the host's ``dev`` entry on an LXC — so any ownership fix applied at
+install or update time is undone by the next reboot unless the host entry
+itself carries ``gid=``. This module is the ``ExecStart`` of
+``hal0-gpu-perms.service``, which re-applies it once per boot before
+``hal0.target``.
+
+Why a service and not a ``tmpfiles.d`` / ``udev`` rule: both of those would
+have to name a gid, and a *baked* gid is precisely the bug this line of work
+exists to remove. The kernel gates on the integer, and the integer is not
+portable across hosts — on a halo143-class box ``renderD128`` is owned by a gid
+whose ``/etc/group`` name is ``clock`` while ``render`` resolves elsewhere.
+Re-running the converge lets the target gid be *re-derived from the render
+node* on each boot, so a box whose passthrough changes is still correct.
+
+Scope, deliberately small. Post-#1953 no hal0-user code path opens ``/dev/kfd``
+— the slot-load guard asks about the root runner, and the bench harness only
+resolves device PATHS to hand to podman. So this does not fix a live outage; it
+keeps the invariant true rather than leaving it resting on "nothing happens to
+need it right now", which is a fact that can change silently. A mismatched gid
+costs hal0-user probes and diagnostics their GPU visibility, not inference.
+
+Never fails the boot. Every outcome — converged, already fine, nothing to do,
+refused by an unprivileged LXC — exits 0. A GPU-permissions tidy-up must not be
+able to wedge ``hal0.target``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Converge ``/dev/kfd``'s group, log the outcome, and always succeed."""
+    from hal0.providers._gpu import converge_kfd_device_group, host_is_amd_gpu
+
+    if not host_is_amd_gpu():
+        log.info("gpu_perms.skipped", reason="amdgpu is not bound on this host")
+        return 0
+    try:
+        status, detail = converge_kfd_device_group()
+    except Exception as exc:  # pragma: no cover - defensive; converge catches its own
+        log.warning("gpu_perms.failed", error=str(exc))
+        return 0
+    if status == "changed":
+        log.warning("gpu_perms.converged", detail=detail)
+    elif status == "failed":
+        # Unprivileged LXC: the node's ownership is host-mapped and chown is
+        # EPERM. The remedy is a gid= on the host's dev entry, which the detail
+        # string spells out. Not a boot failure.
+        log.warning("gpu_perms.refused", detail=detail)
+    else:
+        log.info("gpu_perms.noop", status=status, detail=detail)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    sys.exit(main())

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -3327,6 +3327,50 @@ def _restore_service_ownership(root: Path, *, job_id: str | None = None) -> None
         log.warning("updater.cache_chown_failed", job_id=job_id, path=str(root), error=str(exc))
 
 
+def refresh_gpu_perms_unit(target: Path, *, job_id: str | None = None) -> str:
+    """Install/refresh ``hal0-gpu-perms.service`` from the activated release (#1953).
+
+    Same #1689 shape as :func:`refresh_privileged_wrappers`: ``install.sh`` was
+    about to become the only installer of this unit, so a box that only ever
+    runs ``hal0 update`` would never receive it and its ``/dev/kfd`` group would
+    silently revert on the next reboot with nothing to re-apply it.
+
+    Privileged-side ONLY — a no-op unless ``os.geteuid() == 0``, matching
+    :func:`refresh_privileged_wrappers`. The unprivileged daemon must never
+    write ``/etc/systemd/system``.
+
+    Best-effort: a release tree without the unit source is skipped, and a
+    failed ``systemctl enable`` is logged rather than raised. A missing
+    permissions tidy-up must never fail an otherwise-successful activate.
+
+    Returns one of ``"installed"``, ``"unchanged"``, ``"skipped"``, ``"failed"``.
+    """
+    if os.geteuid() != 0:
+        return "skipped"
+    src = target / "installer" / "systemd" / "hal0-gpu-perms.service"
+    if not src.is_file():
+        log.info("updater.gpu_perms_unit_absent", job_id=job_id, src=str(src))
+        return "skipped"
+    dst = Path("/etc/systemd/system/hal0-gpu-perms.service")
+    try:
+        desired = src.read_text(encoding="utf-8")
+        if dst.is_file() and dst.read_text(encoding="utf-8") == desired:
+            return "unchanged"
+        dst.write_text(desired, encoding="utf-8")
+        os.chmod(dst, 0o644)
+        subprocess.run(["systemctl", "daemon-reload"], check=False, capture_output=True)
+        subprocess.run(
+            ["systemctl", "enable", "hal0-gpu-perms.service"],
+            check=False,
+            capture_output=True,
+        )
+    except OSError as exc:
+        log.warning("updater.gpu_perms_unit_failed", job_id=job_id, error=str(exc))
+        return "failed"
+    log.info("updater.gpu_perms_unit_installed", job_id=job_id, path=str(dst))
+    return "installed"
+
+
 def refresh_privileged_wrappers(target: Path, *, job_id: str | None = None) -> dict[str, Any]:
     """Re-install the privileged sudo wrappers from the just-activated release (#1689).
 
@@ -3528,6 +3572,7 @@ def activate_release(dir_name: str, *, job_id: str | None = None) -> dict[str, A
     # activate (a wrapper that fails to refresh keeps the OLD one in place,
     # same class of degradation as before this fix, not a new failure mode).
     wrappers = refresh_privileged_wrappers(target, job_id=job_id)
+    gpu_perms_unit = refresh_gpu_perms_unit(target, job_id=job_id)
 
     log.info(
         "updater.activate_ok",
@@ -3539,6 +3584,7 @@ def activate_release(dir_name: str, *, job_id: str | None = None) -> dict[str, A
         "previous": str(prior) if prior else None,
         "target": str(target),
         "wrappers_refreshed": wrappers["refreshed"],
+        "gpu_perms_unit": gpu_perms_unit,
     }
 
 
@@ -4103,6 +4149,7 @@ __all__ = [
     "ensure_seed_profiles",
     "fetch_release_manifest",
     "profile_reset_status",
+    "refresh_gpu_perms_unit",
     "refresh_privileged_wrappers",
     "release_dir_name",
     "releases_url",

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -304,3 +304,54 @@ class TestGuardRemedyText:
         with pytest.raises(GpuPreflightError) as err:
             require_kfd_for_gpu_slot("brain", device="gpu-rocm", kfd_path=str(tmp_path / "nope"))
         assert "dev1:" in str(err.value)
+
+
+class TestConvergeAgainstRealPermissionDenial:
+    """#1953 gap 2 — exercise a GENUINE chgrp refusal, not a monkeypatched one.
+
+    The unprivileged-LXC path (where ``/dev/kfd``'s ownership is host-mapped and
+    ``chown`` returns EPERM) has NOT been validated on a real unprivileged
+    container — see the regression register entry
+    ``kfd-gid-unprivileged-lxc-unverified``. This gets as close as a unit test
+    honestly can: a real chown against a gid the running user is not a member
+    of, which the kernel refuses for the same reason.
+
+    It proves the failure is reported rather than raised, and that the message
+    carries an actionable gid. It does NOT prove the idmap semantics of a real
+    unprivileged LXC, and must not be read as if it did.
+    """
+
+    def test_a_real_eperm_is_reported_with_an_actionable_remedy(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        if os.geteuid() == 0:
+            pytest.skip("root can chown to any gid — no denial to observe")
+        kfd = tmp_path / "kfd"
+        kfd.write_text("")
+        # A gid this user is certainly not a member of.
+        foreign_gid = 61997
+        assert foreign_gid not in os.getgroups()
+        monkeypatch.setattr(
+            "hal0.providers._gpu.resolve_kfd_target_gid", lambda *a, **k: foreign_gid
+        )
+        status, detail = converge_kfd_device_group(str(kfd))
+        assert status == "failed"
+        # The operator must be able to act on this without reading the source.
+        assert f"gid={foreign_gid}" in detail
+        assert "unprivileged" in detail.lower() or "host" in detail.lower()
+
+    def test_the_node_is_left_untouched_when_the_chgrp_is_refused(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A refused converge must not half-apply (e.g. chmod without chgrp)."""
+        if os.geteuid() == 0:
+            pytest.skip("root can chown to any gid — no denial to observe")
+        kfd = tmp_path / "kfd"
+        kfd.write_text("")
+        kfd.chmod(0o600)
+        before = os.stat(kfd)
+        monkeypatch.setattr("hal0.providers._gpu.resolve_kfd_target_gid", lambda *a, **k: 61997)
+        converge_kfd_device_group(str(kfd))
+        after = os.stat(kfd)
+        assert after.st_gid == before.st_gid
+        assert after.st_mode == before.st_mode

--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -29,6 +29,41 @@ updated: 2026-08-15
 # in the filing PR. An entry with issue: null is still probed every release.
 
 regressions:
+
+  - id: kfd-gid-unprivileged-lxc-unverified
+    issue: 1953
+    from: v1.0.0-rc.7
+    severity: minor
+    tier: judgment
+    lane: gpu
+    summary: >-
+      #1953's repair path for a group-misaligned /dev/kfd has NEVER been exercised on a real
+      UNPRIVILEGED LXC. The fix assumes chgrp returns EPERM there (ownership is host-mapped)
+      and falls back to printing a host-side `dev1: /dev/kfd,gid=<gid>` remedy. Both halves of
+      that assumption are untested: that the refusal actually happens, and that the gid resolved
+      INSIDE the container is the correct value to write on the host once idmap shifting applies.
+    why_unverified: >-
+      The box the defect was found on (CT105) is PRIVILEGED, where chgrp simply succeeds. No
+      unprivileged box on the fleet has /dev/kfd passed through, and adding it is a Proxmox
+      host-level change plus a container restart — an operator decision, not an agent one.
+    covered_by_unit_tests: >-
+      A genuine (non-mocked) EPERM is exercised in
+      tests/providers/test_gpu_kfd_preflight.py::TestConvergeAgainstRealPermissionDenial by
+      chowning to a gid the test user does not belong to. That proves the failure is REPORTED
+      not raised, and that the remedy string carries an actionable gid. It does NOT prove the
+      idmap semantics of a real unprivileged LXC. Do not treat it as if it did.
+    repro: |
+      On an UNPRIVILEGED LXC with /dev/kfd forwarded:
+        stat -c '%n %U:%G %a' /dev/kfd /dev/dri/renderD128   # expect a gid divergence
+        HAL0_GPU_GATE=1 bash -c 'source installer/lib/preflight.sh; preflight_gpu; echo rc=$?'
+        # expect rc=6 (HAL0_GPU_RC_KFD_GID) and a remedy naming the render node's real gid
+        python -m hal0.install.gpu_perms   # expect exit 0, journal 'gpu_perms.refused'
+      Then apply the printed host-side remedy and confirm the gate goes green.
+    expect: >-
+      install.sh WARNS and continues (never exits non-zero); the converge reports "failed" with
+      a remedy carrying a real numeric gid; GPU slots still load, because the #1953 identity fix
+      evaluates the root slot runner rather than the hal0 user.
+    promote_ready: false
   # ── Carried from v1.0.0-rc.4 ────────────────────────────────────────────────
 
   - id: profile-flags-argv

--- a/tests/updater/test_gpu_perms_unit.py
+++ b/tests/updater/test_gpu_perms_unit.py
@@ -1,0 +1,96 @@
+"""#1953 durability — the boot-time converge and its delivery to existing boxes.
+
+Two gaps this closes:
+
+1. ``/dev/kfd`` is recreated every boot, so the install/update-time converge is
+   undone unless the host's LXC ``dev`` entry carries ``gid=``.
+2. A unit shipped only by ``install.sh`` never reaches a box that upgrades via
+   ``hal0 update`` — the #1689 shape.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import hal0.updater.updater as updater_mod
+from hal0.install import gpu_perms
+
+
+class TestGpuPermsEntryPoint:
+    def test_non_amd_host_is_a_noop(self, monkeypatch) -> None:
+        monkeypatch.setattr("hal0.providers._gpu.host_is_amd_gpu", lambda *a, **k: False)
+        called: list[int] = []
+        monkeypatch.setattr(
+            "hal0.providers._gpu.converge_kfd_device_group",
+            lambda *a, **k: called.append(1) or ("changed", ""),
+        )
+        assert gpu_perms.main() == 0
+        assert called == []
+
+    @pytest.mark.parametrize("status", ["changed", "noop", "skipped", "failed"])
+    def test_every_outcome_exits_zero(self, status, monkeypatch) -> None:
+        """A GPU-permissions tidy-up must never be able to wedge the boot."""
+        monkeypatch.setattr("hal0.providers._gpu.host_is_amd_gpu", lambda *a, **k: True)
+        monkeypatch.setattr(
+            "hal0.providers._gpu.converge_kfd_device_group",
+            lambda *a, **k: (status, "detail"),
+        )
+        assert gpu_perms.main() == 0
+
+    def test_an_unexpected_exception_still_exits_zero(self, monkeypatch) -> None:
+        monkeypatch.setattr("hal0.providers._gpu.host_is_amd_gpu", lambda *a, **k: True)
+
+        def _boom(*a, **k):
+            raise RuntimeError("nope")
+
+        monkeypatch.setattr("hal0.providers._gpu.converge_kfd_device_group", _boom)
+        assert gpu_perms.main() == 0
+
+
+class TestGpuPermsUnitRefresh:
+    def test_unprivileged_is_a_noop(self, monkeypatch, tmp_path: Path) -> None:
+        """The unprivileged daemon must never write /etc/systemd/system."""
+        monkeypatch.setattr(os, "geteuid", lambda: 1000)
+        assert updater_mod.refresh_gpu_perms_unit(tmp_path) == "skipped"
+
+    def test_a_release_without_the_unit_is_skipped_not_fatal(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        assert updater_mod.refresh_gpu_perms_unit(tmp_path) == "skipped"
+
+
+class TestUnitFileContract:
+    """The unit's ordering is load-bearing; assert it rather than trusting it."""
+
+    def _unit(self) -> str:
+        root = Path(__file__).resolve().parents[2]
+        return (root / "installer" / "systemd" / "hal0-gpu-perms.service").read_text()
+
+    def test_runs_after_dev_is_populated_and_before_hal0(self) -> None:
+        unit = self._unit()
+        # There is no node to chgrp until /dev is populated...
+        assert "systemd-tmpfiles-setup-dev.service" in unit
+        # ...and slots must observe the converged state, never race it.
+        assert "Before=hal0.target" in unit
+
+    def test_is_a_oneshot_that_cannot_wedge_the_boot(self) -> None:
+        unit = self._unit()
+        assert "Type=oneshot" in unit
+        assert "ConditionPathExists=/dev/kfd" in unit
+
+    def test_does_not_bake_a_gid(self) -> None:
+        """The whole point: the gid is re-derived from the render node at boot.
+
+        A tmpfiles.d/udev rule would have to name one, and a baked gid is not
+        portable — hence a service.
+        """
+        directives = [
+            ln for ln in self._unit().splitlines() if ln.strip() and not ln.lstrip().startswith("#")
+        ]
+        body = "\n".join(directives)
+        assert "gid=" not in body
+        assert "993" not in body


### PR DESCRIPTION
Closes the two gaps left open by #1954. **Stacked on `fix/kfd-device-perms`** — base is that branch, not `main`, because this builds on `converge_kfd_device_group()`.

## Gap 1 — boot persistence

`/dev/kfd` is recreated on every boot (udev on bare metal; container start from the host's `dev` entry on LXC), so the install/update-time converge is undone unless that entry carries `gid=`.

Adds **`hal0-gpu-perms.service`**: a oneshot ordered `After=systemd-tmpfiles-setup-dev.service` (nothing to chgrp until `/dev` is populated) and `Before=hal0.target` (slots must observe the converged state, not race it), whose `ExecStart` is `python -m hal0.install.gpu_perms` — the same converge, so the target gid is **re-derived from the render node on every boot**.

**Why a service and not tmpfiles.d/udev.** Both would have to *name* a gid, and a baked gid is exactly the portability bug this line of work exists to remove — the kernel gates on the integer, and on a halo143-class box `renderD128` is owned by a gid whose `/etc/group` name is `clock` while `render` resolves elsewhere. There's a test asserting the unit body contains no gid literal, so this can't regress into a hardcoded number.

**Delivered by both paths.** `install.sh` installs and enables it, and `refresh_gpu_perms_unit()` re-installs it on activate. A unit shipped only by the installer never reaches a box that upgrades via `hal0 update` — #1689's shape, and the same reason `refresh_privileged_wrappers` exists.

**Honest impact statement.** I checked before building this: post-#1953 **no hal0-user code path opens `/dev/kfd`**. The slot-load guard asks about the root runner, the MCP probe reads sysfs rather than the device, and the bench harness only resolves device *paths* to hand to podman. So this does not fix a live outage — it keeps the invariant true instead of leaving it resting on "nothing happens to need it right now", which is a fact that can change silently. `hal0-agent@` and `hal0-bench-worker` do run `User=hal0`, which is the population that would notice first.

Every outcome exits 0. A GPU-permissions tidy-up must never be able to wedge `hal0.target`.

## Gap 2 — the unprivileged-LXC path

**This one I cannot close from here, and I am not going to pretend otherwise.** CT105 is privileged, so `chgrp` simply succeeds there; no unprivileged box on the fleet has `/dev/kfd` passed through, and adding it is a Proxmox host-level change plus a container restart — an operator decision.

Two things instead:

1. **Regression-register entry `kfd-gid-unprivileged-lxc-unverified`** (`tier: judgment`, `lane: gpu`) carrying a runnable repro, the exact expectations, and an explicit `why_unverified`. It gets re-probed every release until someone runs it on real hardware.
2. **A genuine, non-mocked EPERM test** — `chown` to a gid the test user does not belong to, which the kernel refuses for the same reason. It proves the failure is *reported* rather than raised, that the remedy string carries an actionable numeric gid, and that a refused converge leaves the node **untouched** rather than half-applying a `chmod` without the `chgrp`.

The register entry says in as many words that the unit test does **not** prove the idmap semantics of a real unprivileged LXC and must not be read as if it did.

## Verification

```
tests/providers tests/installer tests/updater tests/slots
2602 passed, 1 skipped
ruff check + ruff format: clean on all changed files
bash -n installer/install.sh: ok
regressions.yaml: parses, 45 entries
```

New coverage: non-AMD no-op, all four converge outcomes exit 0, unexpected exceptions still exit 0, unprivileged refresh is a no-op, a release tree without the unit is skipped not fatal, the unit's ordering contract, the no-baked-gid contract, real EPERM reporting, and no half-application on refusal.

## Still open

The unit is installed and enabled but has **not been observed across an actual reboot** — CT105 is production and I'm not rebooting it to test this. Worth watching on the next planned restart, or on a test box.
