### PR TITLE
docs(release-validation): kit v5 — pre-rc.7 brief hardening

### DIFF
--- a/.claude/workflows/rc-validate.js
+++ b/.claude/workflows/rc-validate.js
@@ -227,7 +227,7 @@ own CONTEXT file.
    Write it for an agent that knows nothing about this fleet. Every later agent depends on it.
 
 Return the schema. Set ready=false only for something that genuinely invalidates the run.
-`, { label: `preflight:${boxId}`, phase: 'Preflight', schema: PREFLIGHT })))
+`, { label: `preflight:${boxId}`, phase: 'Preflight', schema: PREFLIGHT, model: 'sonnet' })))
 
 const ok = preflights.filter(Boolean)
 const blocked = ok.filter((p) => !p.ready)
@@ -267,7 +267,7 @@ YOUR LANE: ${key} (${kind}) on box ${box}
 YOUR BRIEF: ${briefPath(kind, key)} — read it now and work through it.
 ${extra || ''}
 Write your raw notes to ${RUN}/lanes/${box}-${key}.md as you go, then return the schema.
-Set box="${box}" and lane="${key}".`, Object.assign({ label: `${kind}:${key}`, phase: 'Sweep', schema: LANE_RESULT }, opts || {}))
+Set box="${box}" and lane="${key}".`, Object.assign({ label: `${kind}:${key}`, phase: 'Sweep', schema: LANE_RESULT, model: 'sonnet' }, opts || {}))
 }
 
 // serialised chain: each stage is handed the previous stage's box_state_on_exit verbatim
@@ -302,7 +302,7 @@ if (updateBox) {
 // intent judgement stays on the workhorse tier.
 const REG_BATCHES = [
   { tier: 'mechanical', model: 'fable', desc: 'entries with tier: mechanical' },
-  { tier: 'judgment', desc: 'entries with tier: judgment' },  // no model override: inherit session tier
+  { tier: 'judgment', model: 'sonnet', desc: 'entries with tier: judgment' },  // kit.toml regression_judgment tier
 ]
 if (freshBox && wanted('regressions')) {
   for (const b of REG_BATCHES) {
@@ -393,7 +393,7 @@ Rules:
   - If an entry's repro no longer matches the current CLI or API surface, say so.
 
 Return one result object per entry you ran.`,
-    { label: 'regressions:serialized', phase: 'Sweep', schema: REGRESSION_RESULT })
+    { label: 'regressions:serialized', phase: 'Sweep', schema: REGRESSION_RESULT, model: 'sonnet' })
   serializedRegressionResults = (serialResult && serialResult.results) || []
 }
 const laneResults = swept.filter(Boolean).flatMap((r) => (Array.isArray(r) ? r : (r.results ? [] : [r])))
@@ -479,8 +479,9 @@ relitigates it.
 
 Also judge \`other_hardware_applicability\`: would a GPU box, a privileged container, or an
 upgraded (rather than freshly installed) box hit this? No box in the fleet is BOTH a fresh
-install AND has /dev/kfd visible (the fresh boxes lack /dev/kfd and run the Vulkan lane only;
-the boxes with /dev/kfd — update and prod — are not fresh installs), so a read-only cross-check
+install AND has /dev/kfd visible (the fresh boxes lack /dev/kfd, so post-#1923 their LLM slots
+run the CPU lane — the Vulkan LLM lane is retired; the boxes with /dev/kfd — update and prod —
+are not fresh installs), so a read-only cross-check
 against the production box is the best available evidence — use it when the finding touches
 backend selection, profile flags, hardware probing, or native tool calling.
 
@@ -594,7 +595,7 @@ written. Moving work out of this kit and into CI is a success, not a loss.
 
 Return a summary of every file you changed and what you changed in it, plus the promotion list.
 Do not commit — the operator reviews the diff.`,
-  { label: 'curate', phase: 'Curate' })
+  { label: 'curate', phase: 'Curate', model: 'sonnet' })
 
 return {
   version: VERSION,

--- a/.claude/workflows/rc-validate.js
+++ b/.claude/workflows/rc-validate.js
@@ -479,9 +479,11 @@ relitigates it.
 
 Also judge \`other_hardware_applicability\`: would a GPU box, a privileged container, or an
 upgraded (rather than freshly installed) box hit this? No box in the fleet is BOTH a fresh
-install AND has /dev/kfd visible (the fresh boxes lack /dev/kfd, so post-#1923 their LLM slots
-run the CPU lane — the Vulkan LLM lane is retired; the boxes with /dev/kfd — update and prod —
-are not fresh installs), so a read-only cross-check
+install AND has /dev/kfd visible (the fresh boxes lack /dev/kfd, so post-#1923 their
+gpu-rocm LLM slots REFUSE to start — the Vulkan LLM lane is retired and there is no CPU
+fallback for a gpu-device slot; LLM coverage on those boxes means slots explicitly set to
+device=cpu. The boxes with /dev/kfd — update and prod — are not fresh installs), so a
+read-only cross-check
 against the production box is the best available evidence — use it when the finding touches
 backend selection, profile flags, hardware probing, or native tool calling.
 

--- a/tests/release-validation/README.md
+++ b/tests/release-validation/README.md
@@ -66,7 +66,7 @@ lessons*), and monitors each PR to a conclusion.
 | 1 | Read-only sweep | 1 per read-only lane | sonnet | no (pipelines into triage) |
 | 2 | Stateful lane | 1 per stateful lane, **serialised** | sonnet, effort high | serialised by construction |
 | 2b | Update lane | 1–2 on the update box | sonnet, effort high | runs concurrently with 2 (different box) |
-| 3 | Regression probes | 1 per `regressions.yaml` batch | fable (mechanical) / sonnet (judgment) | no |
+| 3 | Regression probes | 1 per `regressions.yaml` batch | fable (mechanical) / sonnet (judgment) | no — except the `serialize: true` subset, which runs sequentially after the whole sweep (its repros mutate box-wide state) |
 | 4 | Triage + dedup | 1 | opus | yes — needs every finding at once |
 | 5 | Adversarial verify | 1 skeptic per candidate | opus, effort high | no |
 | 6 | Synthesis + report | 1 | opus | yes |
@@ -79,6 +79,11 @@ brief that should have contained it. Its output is a diff for the operator to re
 silent commit.
 
 A full two-box run is roughly 25–30 agents. Restrict `lanes` for smaller passes.
+
+Tier labels are enforced in the workflow script via explicit `model:` pins (kit v5 — before
+that, only mechanical/triage/verify/report were pinned and every other phase silently inherited
+the invoking session's tier). The one deliberate exception: File issues (phase 7) still
+inherits the session tier.
 
 ## Process lessons (carried forward, do not relearn)
 
@@ -124,6 +129,24 @@ known-issues, or regressions, and add a line to the changelog below. A report re
 `kit_version` it ran under, so an old report can always be read against the rules it ran with.
 
 ### Kit changelog
+
+* **5** (2026-08-20) — pre-rc.7 brief hardening from the GA-plan handoff, applied before the
+  kit's first v-4-era full run. Four new checks close verification gaps for fixes that would
+  otherwise ship CI-verified only: `post-upgrade.md` 2b (the #1934 gpu-vulkan→gpu-rocm slot
+  relabel on the update box, device-key-only, non-llama untouched, journal breadcrumbs,
+  idempotency), `upgrade.md` 2b (the #1883 channel-URL + `.json.bundle` proxy path, which the
+  update box's pinned GitHub-asset `HAL0_RELEASES_URL` otherwise bypasses entirely),
+  `slots.md` 8b (#1922's output-sanity readiness gate must be verified as a product gate, not
+  merely worked around by the coherence canary), and `hermes-e2e.md` 9 (doctor-perms
+  convergence re-probed after all mutation, plus a manual owner/group `stat` — #1942 proved
+  green-after-mutation on the mode axis only). `upgrade.md` check 4 inverted to expect the
+  #1935-restored audit trail (populated `job_id`, prepare/verify breadcrumbs) instead of
+  documenting their absence as designed. Model tiers are now enforced: every phase's `agent()`
+  call carries an explicit `model:` pin matching `[defaults]` (previously preflight, all lanes,
+  judgment regressions, and curation silently inherited the invoking session's tier). The
+  verify prompt's fleet note no longer claims kfd-less fresh boxes "run the Vulkan lane"
+  (stale since #1923). ct151 gains gotcha 5: post-rollback services need
+  `systemctl start hal0.target`.
 
 * **4** (2026-08-15) — curation after the `v1.0.0-rc.6` run. Landed as mode=report, so the 17
   new entries first carried `issue: null`; the filing PR then filed all of them (plus one more

--- a/tests/release-validation/README.md
+++ b/tests/release-validation/README.md
@@ -70,7 +70,7 @@ lessons*), and monitors each PR to a conclusion.
 | 4 | Triage + dedup | 1 | opus | yes — needs every finding at once |
 | 5 | Adversarial verify | 1 skeptic per candidate | opus, effort high | no |
 | 6 | Synthesis + report | 1 | opus | yes |
-| 7 | File issues (`mode: file`) | 1 | sonnet | — |
+| 7 | File issues (`mode: file`) | 1 | inherits session tier | — |
 | 8 | Kit curation | 1 | sonnet | — |
 
 Phase 8 is what makes the kit compound: it writes back the new known-issues, promotes every
@@ -145,8 +145,21 @@ known-issues, or regressions, and add a line to the changelog below. A report re
   call carries an explicit `model:` pin matching `[defaults]` (previously preflight, all lanes,
   judgment regressions, and curation silently inherited the invoking session's tier). The
   verify prompt's fleet note no longer claims kfd-less fresh boxes "run the Vulkan lane"
-  (stale since #1923). ct151 gains gotcha 5: post-rollback services need
-  `systemctl start hal0.target`.
+  (stale since #1923) — and neither do `boxes.toml`'s ct151/fleet-coverage notes: post-#1923,
+  gpu-rocm LLM slots REFUSE to start on kfd-less boxes (no CPU fallback); LLM coverage there
+  means device=cpu slots. ct151 gains gotcha 5: post-rollback services need
+  `systemctl start hal0.target`. Adversarial review of this version's PR (#1956) then
+  corrected four of its own checks before first use: the post-mutation stat targets
+  `/var/lib/hal0/STATE.md` (not a `hermes/` subdir); the upgrade "before" snapshot now
+  explicitly captures each slot TOML's `device` value so the migration diff is executable;
+  the #1934 check is gated on **#1960** (filed from that review: the updater runs
+  post-activation migrations pre-swap in the OUTGOING tree, so a release's new migrations
+  never fire on the upgrade that ships them); and the channel-URL check drives the
+  cosign-verified fetch the only way it can be reached — `HAL0_RELEASES_URL` in
+  `/etc/hal0/api.env` plus `PUT /api/updates/channel` — instead of a shell env var and
+  `update --check`, which never verify. `tests/release/test_rc_validate_kit_contract.py`
+  now pins `kit.toml [defaults]` against the script's model pins so the tier contract cannot
+  silently rot.
 
 * **4** (2026-08-15) — curation after the `v1.0.0-rc.6` run. Landed as mode=report, so the 17
   new entries first carried `issue: null`; the filing PR then filed all of them (plus one more

--- a/tests/release-validation/boxes.toml
+++ b/tests/release-validation/boxes.toml
@@ -49,6 +49,9 @@ GOTCHAS, in order:
      model roots, so a staged gguf is invisible until `hal0 model add`.
   4. (stale, retired) "/dev/dri absent in sysfs" predates the dev0/dev3 passthrough. After any
      `pct rollback 151`, confirm dev0/dev3 keep gid=991 or the installer's GPU preflight aborts.
+  5. After a rollback to the `rc6-installed` snapshot, services do not come back on their own —
+     `systemctl start hal0.target` (the hermes unit is `hermes-gateway.service`). Preflight
+     reads "API unreachable" when this was skipped; this is the fix to name in the blocker.
 """
 
 [boxes.ct152-cpu-fresh]

--- a/tests/release-validation/boxes.toml
+++ b/tests/release-validation/boxes.toml
@@ -179,5 +179,7 @@ work?".
 # how the rc.6 Vulkan garbage-output defect survived undetected. Also: only prod (ct105) has
 # host rocm-smi, so compute_capable=true exists on exactly one box — capability-flag findings
 # need that cross-check. LLM slots run the ROCm lane where /dev/kfd is visible and REFUSE
-# elsewhere (no Vulkan fallback since #1923); record what a box's slots actually execute
-# (podman exec <slot ctr> ls /dev/kfd) in every preflight.
+# elsewhere (no Vulkan fallback since #1923) — by DEFAULT: ENV_ALLOW_VULKAN_FALLBACK
+# downgrades the refusal to a warning, and since that env re-opens the exact #1888 failure
+# mode, its presence on any box is itself a finding. Record what a box's slots actually
+# execute (podman exec <slot ctr> ls /dev/kfd) in every preflight.

--- a/tests/release-validation/boxes.toml
+++ b/tests/release-validation/boxes.toml
@@ -33,11 +33,12 @@ This is the BEST fresh box in the fleet — the only one with snapshots. Two res
 (`rc5-installed` no longer exists.) Prefer this box over ct152, which has no snapshot and
 carries residue.
 
-GPU PASSTHROUGH since the rc.5 era (boxes' oldest gotchas predate it): the box exercises the
-vulkan/container path (ghcr.io/hal0ai/hal0-rocmfpx runner in root's podman store). It has NO
-/dev/kfd, so llama.cpp runs the VULKAN lane here — which is precisely what caught the rc.6
-garbage-output defect. Run the coherence canary (_shared.md) before trusting any generated text.
-Do not frame findings as "CPU-only box".
+GPU PASSTHROUGH since the rc.5 era (boxes' oldest gotchas predate it): the box has the
+rocmfpx runner in root's podman store but NO /dev/kfd — and post-#1923 the Vulkan LLM lane is
+RETIRED: gpu-rocm llama.cpp slots refuse to start here (loud preflight), they do not fall
+back. LLM work on this box runs on slots explicitly set to device=cpu; non-llama GPU
+runtimes (TTS/whisper/ComfyUI) may still use Vulkan. Run the coherence canary (_shared.md)
+before trusting any generated text. Do not frame findings as "CPU-only box".
 
 GOTCHAS, in order:
   1. The pristine snapshot has broken DNS — /etc/resolv.conf points at an unreachable
@@ -165,17 +166,18 @@ Use it to answer "is this CPU-only or hardware-independent?", never "does a fres
 work?".
 """
 
-# Fleet coverage note (updated 2026-08-15): ct151 now has iGPU+NPU passthrough and exercises
-# the vulkan/container path on fresh installs, so "no GPU fresh box" is closed for the Vulkan
-# lane specifically. ct152-cpu-fresh (gpu=false, no /dev/dri) still exists and is CPU-only —
+# Fleet coverage note (updated 2026-08-20 for the post-#1923 posture): ct151 has iGPU+NPU
+# passthrough but NO /dev/kfd, and the Vulkan LLM lane is RETIRED — on fresh installs its
+# gpu-rocm llama.cpp slots refuse to start (loud preflight), so ct151's LLM coverage is
+# device=cpu slots; its GPU passthrough still exercises non-llama Vulkan runtimes and the
+# refusal path itself. ct152-cpu-fresh (gpu=false, no /dev/dri) still exists and is CPU-only —
 # do not claim "no CPU-only box remains"; it has no snapshot and carries residue, so treat it
 # as read-only-usable only (stateful lanes must not run there without a fresh install first).
-# The actual remaining gap is a GPU fresh-install box WITH /dev/kfd: ct151 has no /dev/kfd, so
-# it only ever exercises the Vulkan lane, and ct150/ct105 both have /dev/kfd but are not fresh
-# installs (update/prod) — no box in the fleet is both freshly installed and representative of
-# a bare-metal AMD host with amdkfd loaded, which is precisely how the rc.6 Vulkan garbage-output
-# defect survived undetected. Also: only prod (ct105) has host rocm-smi, so compute_capable=true
-# exists on exactly one box — capability-flag findings need that cross-check. Every box class
-# runs the ROCm lane when /dev/kfd is visible and the Vulkan lane otherwise; after rc.6's Vulkan
-# garbage-output finding, record which lane a box actually executes
+# The actual remaining gap is a GPU fresh-install box WITH /dev/kfd: ct150/ct105 both have
+# /dev/kfd but are not fresh installs (update/prod) — no box in the fleet is both freshly
+# installed and representative of a bare-metal AMD host with amdkfd loaded, which is precisely
+# how the rc.6 Vulkan garbage-output defect survived undetected. Also: only prod (ct105) has
+# host rocm-smi, so compute_capable=true exists on exactly one box — capability-flag findings
+# need that cross-check. LLM slots run the ROCm lane where /dev/kfd is visible and REFUSE
+# elsewhere (no Vulkan fallback since #1923); record what a box's slots actually execute
 # (podman exec <slot ctr> ls /dev/kfd) in every preflight.

--- a/tests/release-validation/kit.toml
+++ b/tests/release-validation/kit.toml
@@ -4,7 +4,7 @@
 # scripts cannot read the filesystem, so when you add a lane here you must also add it to the
 # LANES table in the script. The brief itself is only ever read by the agent that runs it.
 
-kit_version = 4
+kit_version = 5
 
 [defaults]
 # Model tier per phase. Rationale in README "Phases".

--- a/tests/release-validation/lanes/stateful/hermes-e2e.md
+++ b/tests/release-validation/lanes/stateful/hermes-e2e.md
@@ -76,13 +76,15 @@ live chat: it is install-time ground truth, and it distinguishes "broken out of 
 9. **Doctor-perms convergence, post-mutation (#1942/#1896).** You are the last stage of the
    serialized chain — by now the box has seen slot loads, a model pull, and at least one
    STATE.md render. Re-run `hal0 doctor perms >/dev/null 2>&1; echo rc=$?` — must be `0`, same
-   as the readonly lane saw on the fresh box. Then check the axis doctor's own exit code does
-   NOT cover: `stat -c '%U:%G %a' /var/lib/hal0/secrets /var/lib/hal0/secrets/agents
-   /var/lib/hal0/hermes/STATE.md /var/lib/hal0/model-pull-jobs` and confirm owner/group match
-   the perms table (root:root for secrets/, hal0:hal0 for daemon-written paths). The #1942
-   review proved green-after-mutation on the MODE axis only — ownership drift with correct
-   modes would still read green in the tool's self-report, which is why this manual stat is
-   the check.
+   as the readonly lane saw on the fresh box. Then verify the same facts WITHOUT the tool:
+   `stat -c '%U:%G %a' /var/lib/hal0/secrets /var/lib/hal0/secrets/agents
+   /var/lib/hal0/STATE.md /var/lib/hal0/model-pull-jobs` and confirm owner/group/mode match
+   the perms table (root:root for secrets/, hal0:hal0 for daemon-written paths). doctor perms
+   does audit all three axes (`PermDiff`), but its exit code is a self-report from the same
+   table the installer wrote — the point of the manual stat is independent evidence that the
+   table itself matches what a mutated box actually holds, and it is what proves
+   green-after-mutation on a REAL box rather than the unit-test fixture (#1942's tests cover
+   the mode axis; the live ownership axis is checked nowhere else).
 
 ## Leave behind
 

--- a/tests/release-validation/lanes/stateful/hermes-e2e.md
+++ b/tests/release-validation/lanes/stateful/hermes-e2e.md
@@ -73,6 +73,16 @@ live chat: it is install-time ground truth, and it distinguishes "broken out of 
    `[Errno 13] Permission denied: '/root/.git'` — the wrapper's cwd-safety guard exists for
    exactly this and its absence on a fresh install is the finding
    (`known-issues: hermes-cwd-eacces-crash`; the raw venv binary failing is by-design).
+9. **Doctor-perms convergence, post-mutation (#1942/#1896).** You are the last stage of the
+   serialized chain — by now the box has seen slot loads, a model pull, and at least one
+   STATE.md render. Re-run `hal0 doctor perms >/dev/null 2>&1; echo rc=$?` — must be `0`, same
+   as the readonly lane saw on the fresh box. Then check the axis doctor's own exit code does
+   NOT cover: `stat -c '%U:%G %a' /var/lib/hal0/secrets /var/lib/hal0/secrets/agents
+   /var/lib/hal0/hermes/STATE.md /var/lib/hal0/model-pull-jobs` and confirm owner/group match
+   the perms table (root:root for secrets/, hal0:hal0 for daemon-written paths). The #1942
+   review proved green-after-mutation on the MODE axis only — ownership drift with correct
+   modes would still read green in the tool's self-report, which is why this manual stat is
+   the check.
 
 ## Leave behind
 

--- a/tests/release-validation/lanes/stateful/slots.md
+++ b/tests/release-validation/lanes/stateful/slots.md
@@ -66,7 +66,10 @@ at the ends.
      with a message naming the probe and the expected token — never `ready`, never a silent
      degrade, never an infinite retry. If no bad case can be forced on this box, say so
      explicitly and record it as a coverage gap rather than a pass — a healthy slot's canary
-     passing does NOT verify the gate.
+     passing does NOT verify the gate. If the grep finds NO gate in the installed tree,
+     first check whether #1922 shipped in the release under test: if it did not, record
+     against the open #1922 rather than filing a duplicate; if it did, the missing call site
+     is its own finding.
 9. **Reject a bad model file.** Feed `hal0 model add` a file with a `.gguf` name and no GGUF
    magic (`head -c 2000000 /dev/urandom`). The registration-with-warning outcome is now
    by-design (`known-issues: model-add-detection-surfacing`) — what you assert is the warning

--- a/tests/release-validation/lanes/stateful/slots.md
+++ b/tests/release-validation/lanes/stateful/slots.md
@@ -56,6 +56,17 @@ at the ends.
    ~180 s is by-design (`known-issues.yaml: crash-loop-warming-180s-window`) — the finding is a
    state that never converges, an empty message on `error`, or a death nothing surfaces in
    `hal0 status` / `hal0 doctor`. Then swap it to a good model and clean it up.
+   * **8b. Output-sanity gate fires (#1922).** The gate that answers rc.6's #1888 class
+     (garbage output behind green health). First confirm it exists and is wired into the ready
+     path: grep the installed tree for the readiness probe call site (slots/manager.py or
+     wherever it landed) and confirm it runs before a slot is marked `ready`, with the
+     temp-0 "The capital of France is" → "Paris" shape. Then, if a synthetic bad case can be
+     constructed on this box (a degenerate/non-instruct model file, or any still-existing
+     explicit override onto a broken backend), load it and confirm the slot lands in `error`
+     with a message naming the probe and the expected token — never `ready`, never a silent
+     degrade, never an infinite retry. If no bad case can be forced on this box, say so
+     explicitly and record it as a coverage gap rather than a pass — a healthy slot's canary
+     passing does NOT verify the gate.
 9. **Reject a bad model file.** Feed `hal0 model add` a file with a `.gguf` name and no GGUF
    magic (`head -c 2000000 /dev/urandom`). The registration-with-warning outcome is now
    by-design (`known-issues: model-add-detection-surfacing`) — what you assert is the warning

--- a/tests/release-validation/lanes/update/post-upgrade.md
+++ b/tests/release-validation/lanes/update/post-upgrade.md
@@ -29,6 +29,15 @@ did not ask for?**
    operator created historically carry no `profile` key and 501 their own endpoint (#1830), and
    slot TOMLs carrying larger ceilings written by earlier releases widen the advertised-vs-served
    context gap (#1835).
+   * **2b. Vulkan-slot relabel migration (#1934).** The upgrade stage's "before" snapshot
+     recorded every slot TOML's `device` value — diff against it. For every llama.cpp-backed
+     slot that was `gpu-vulkan`: on this box (`/dev/kfd` present) it must now read `gpu-rocm`;
+     confirm only the `device` key changed (flat or nested `[slot]` shape) and every other key
+     is byte-identical modulo TOML re-serialization. Confirm any non-llama GPU slot (Kokoro
+     TTS / whisper.cpp / ComfyUI, if present) is untouched — still `gpu-vulkan`. Grep the
+     upgrade journal for `updater.slot_vulkan_relabeled_rocm` (or `_cpu_fallback` on a
+     kfd-absent box) and confirm `job_id` is populated, not `None` (ties to #1935). Re-run the
+     activation step and confirm no new relabel log lines appear — idempotency.
 3. **Functional smoke on the upgraded box.** A short version of the fresh-box lanes: chat
    completion, embeddings, a memory retain and recall, a brain steward question, the dashboard
    loading with real data. Anything broken here that works on the freshly installed box is an

--- a/tests/release-validation/lanes/update/post-upgrade.md
+++ b/tests/release-validation/lanes/update/post-upgrade.md
@@ -29,15 +29,20 @@ did not ask for?**
    operator created historically carry no `profile` key and 501 their own endpoint (#1830), and
    slot TOMLs carrying larger ceilings written by earlier releases widen the advertised-vs-served
    context gap (#1835).
-   * **2b. Vulkan-slot relabel migration (#1934).** The upgrade stage's "before" snapshot
-     recorded every slot TOML's `device` value — diff against it. For every llama.cpp-backed
-     slot that was `gpu-vulkan`: on this box (`/dev/kfd` present) it must now read `gpu-rocm`;
-     confirm only the `device` key changed (flat or nested `[slot]` shape) and every other key
-     is byte-identical modulo TOML re-serialization. Confirm any non-llama GPU slot (Kokoro
-     TTS / whisper.cpp / ComfyUI, if present) is untouched — still `gpu-vulkan`. Grep the
-     upgrade journal for `updater.slot_vulkan_relabeled_rocm` (or `_cpu_fallback` on a
-     kfd-absent box) and confirm `job_id` is populated, not `None` (ties to #1935). Re-run the
-     activation step and confirm no new relabel log lines appear — idempotency.
+   * **2b. Vulkan-slot relabel migration (#1934), gated on #1960.** The upgrade stage's
+     "before" snapshot recorded every slot TOML's `device` value — diff against it. The
+     DESIRED end state: every llama.cpp-backed slot that was `gpu-vulkan` now reads `gpu-rocm`
+     on this box (`/dev/kfd` present); only the `device` key changed (flat or nested `[slot]`
+     shape), every other key byte-identical modulo TOML re-serialization; any non-llama GPU
+     slot (Kokoro TTS / whisper.cpp / ComfyUI, if present) untouched — still `gpu-vulkan`;
+     relabel journal breadcrumbs (`updater.slot_vulkan_relabeled_rocm`, or `_cpu_fallback` on
+     a kfd-absent box) present with `job_id` populated (#1935); re-running the activation step
+     adds no new relabel lines (idempotency). **Known gate:** as of kit v5, #1960 means the
+     updater runs migrations pre-swap in the OUTGOING tree, so on an rc.6→rc.7 update the
+     relabel will NOT fire unless #1960's fix landed in the release under test. If TOMLs are
+     unchanged and no relabel breadcrumbs exist, first check whether #1960 is fixed in this
+     release: if not, record the result against #1960 (do not file a duplicate); if it is,
+     the unfired migration is a fresh regression of its own.
 3. **Functional smoke on the upgraded box.** A short version of the fresh-box lanes: chat
    completion, embeddings, a memory retain and recall, a brain steward question, the dashboard
    loading with real data. Anything broken here that works on the freshly installed box is an

--- a/tests/release-validation/lanes/update/upgrade.md
+++ b/tests/release-validation/lanes/update/upgrade.md
@@ -29,6 +29,16 @@ the fact otherwise:
    ordering? A wrong ranking silently withholds the update. `hal0 update --target <ver>`
    bypasses the gate and is the documented recovery — confirm it still works, and note that
    needing it *is* the finding.
+   * **2b. Channel-URL path (#1883).** Before the main upgrade run, separately verify the
+     documented channel-URL path end-to-end — do not rely on this box's pinned GitHub-asset
+     `HAL0_RELEASES_URL` for it (the pin bypasses exactly the path #1883 fixed).
+     `curl -sS -o /dev/null -w '%{http_code}\n'` against
+     `https://releases.hal0.dev/<channel>.json` AND the sibling
+     `https://releases.hal0.dev/<channel>.json.bundle` — both must be 200, and the bundle must
+     byte-match the GitHub release asset. Then drive one `hal0 update --check` (or `--target`)
+     with `HAL0_RELEASES_URL` pointed at the channel URL and confirm cosign verification
+     succeeds against the proxied bundle. Record the box's live `HAL0_RELEASES_URL` in your
+     report so the pinned-vs-channel distinction doesn't get lost.
 3. **The upgrade itself.** Run it. Capture the full output. Watch for: staged-tree permission
    gates (a box with `UMASK 002` produces a 0775 staged tree that the activate security gate
    refuses — the gate's own hint is the remediation), signature/digest verification, service
@@ -39,10 +49,11 @@ the fact otherwise:
    SUCCESS path (`restart_error`, `error`, `*_skipped`) and cross-check each against the journal
    outcome before reading any as a failure — `restarted: null` + `restart_error: "systemctl
    exited -15"` on a successful upgrade is the designed ambiguous-self-restart representation
-   (`known-issues: update-restart-error-breadcrumb-on-success`). While in the journal, note that
-   parent-side `updater.*` lines log `job_id=None` and a successful prepare leaves NO
-   verification breadcrumbs (regression `update-audit-trail-gaps`) — correlate by request_id and
-   timestamps instead, and confirm the verification evidence that DOES persist:
+   (`known-issues: update-restart-error-breadcrumb-on-success`). While in the journal, verify
+   the audit trail #1935 restored: parent-side `updater.*` lines must carry a populated
+   `job_id` (not `None`) and a successful prepare must leave prepare/verify breadcrumbs —
+   their absence is regression `update-audit-trail-gaps` re-opening, not designed behavior.
+   Also confirm the verification evidence that persists on disk:
    `/var/lib/hal0/cache/<ver>/manifest.json` must exist, post-date the sha256/cosign checks, and
    record the digest and signer identity.
 5. **Migrations.** Which migrations ran? Do they log what they changed? Re-run the upgrade (or

--- a/tests/release-validation/lanes/update/upgrade.md
+++ b/tests/release-validation/lanes/update/upgrade.md
@@ -14,7 +14,9 @@ Capture a complete "before" snapshot and write it into your report — you canno
 the fact otherwise:
 
 * `hal0 --version`, the release channel, and `HAL0_RELEASES_URL`
-* every slot: name, assigned model, state, port, profile
+* every slot: name, assigned model, state, port, profile — AND each slot TOML's `device`
+  value, read from the TOMLs under `/var/lib/hal0/slots/` directly (`hal0 slot list` has no
+  device column; the post-upgrade migration check diffs against exactly this)
 * `hal0 config` dump, capability bindings, model registry listing
 * memory bank inventory and counts
 * which units are enabled and running
@@ -31,14 +33,22 @@ the fact otherwise:
    needing it *is* the finding.
    * **2b. Channel-URL path (#1883).** Before the main upgrade run, separately verify the
      documented channel-URL path end-to-end — do not rely on this box's pinned GitHub-asset
-     `HAL0_RELEASES_URL` for it (the pin bypasses exactly the path #1883 fixed).
-     `curl -sS -o /dev/null -w '%{http_code}\n'` against
-     `https://releases.hal0.dev/<channel>.json` AND the sibling
-     `https://releases.hal0.dev/<channel>.json.bundle` — both must be 200, and the bundle must
-     byte-match the GitHub release asset. Then drive one `hal0 update --check` (or `--target`)
-     with `HAL0_RELEASES_URL` pointed at the channel URL and confirm cosign verification
-     succeeds against the proxied bundle. Record the box's live `HAL0_RELEASES_URL` in your
-     report so the pinned-vs-channel distinction doesn't get lost.
+     `HAL0_RELEASES_URL` for it (the pin bypasses exactly the path #1883 fixed). Two halves,
+     and the mechanics matter:
+     - Proxy correctness: `curl -sS -o /dev/null -w '%{http_code}\n'` against
+       `https://releases.hal0.dev/<channel>.json` AND the sibling
+       `https://releases.hal0.dev/<channel>.json.bundle` — both 200, and the bundle
+       byte-matches the GitHub release asset.
+     - Verified-fetch path: `HAL0_RELEASES_URL` is read by the DAEMON from
+       `/etc/hal0/api.env` — exporting it in your shell does nothing, and `hal0 update
+       --check` uses the unverified manifest fetch, so neither exercises cosign. Instead:
+       copy `/etc/hal0/api.env` aside, point `HAL0_RELEASES_URL` at the channel URL in it,
+       restart `hal0-api`, then `PUT /api/updates/channel` (re-setting the current channel is
+       enough — that route is the one path into the cosign-verified manifest fetch outside a
+       full prepare). Confirm from the journal that verification ran and succeeded against
+       the proxied bundle. Restore api.env byte-for-byte and restart again; say so in the
+       report, and record both the pinned and channel URL values so the distinction doesn't
+       get lost.
 3. **The upgrade itself.** Run it. Capture the full output. Watch for: staged-tree permission
    gates (a box with `UMASK 002` produces a 0775 staged tree that the activate security gate
    refuses — the gate's own hint is the remediation), signature/digest verification, service

--- a/tests/release-validation/lanes/update/upgrade.md
+++ b/tests/release-validation/lanes/update/upgrade.md
@@ -15,8 +15,9 @@ the fact otherwise:
 
 * `hal0 --version`, the release channel, and `HAL0_RELEASES_URL`
 * every slot: name, assigned model, state, port, profile — AND each slot TOML's `device`
-  value, read from the TOMLs under `/var/lib/hal0/slots/` directly (`hal0 slot list` has no
-  device column; the post-upgrade migration check diffs against exactly this)
+  value, read from the config TOMLs under `/etc/hal0/slots/` directly (`hal0 slot list` has
+  no device column, and `/var/lib/hal0/slots/` is per-slot STATE, not config; the
+  post-upgrade migration check diffs against exactly this)
 * `hal0 config` dump, capability bindings, model registry listing
 * memory bank inventory and counts
 * which units are enabled and running
@@ -38,7 +39,9 @@ the fact otherwise:
      - Proxy correctness: `curl -sS -o /dev/null -w '%{http_code}\n'` against
        `https://releases.hal0.dev/<channel>.json` AND the sibling
        `https://releases.hal0.dev/<channel>.json.bundle` — both 200, and the bundle
-       byte-matches the GitHub release asset.
+       byte-matches the GitHub release asset. (Note the daemon's effective URL is not
+       byte-identical to your curl target for non-stable channels on an http override —
+       `releases_url()` appends `?channel=<ch>` — so compare content, not URLs.)
      - Verified-fetch path: `HAL0_RELEASES_URL` is read by the DAEMON from
        `/etc/hal0/api.env` — exporting it in your shell does nothing, and `hal0 update
        --check` uses the unverified manifest fetch, so neither exercises cosign. Instead:
@@ -70,7 +73,10 @@ the fact otherwise:
    the activation step) and confirm migrations are idempotent.
 6. **Rollback.** `hal0 update --rollback`. Does it return the box to the previous version with
    its state intact? Then roll forward again. If rollback is not exercised here it is not
-   exercised anywhere.
+   exercised anywhere. (`updater.*` journal lines from the ROLLBACK path legitimately carry
+   `job_id=None` — the rollback route constructs its Updater without a job — so do not
+   re-open `update-audit-trail-gaps` from rollback-window lines; check 4's job_id assertion
+   applies to the upgrade itself.)
 
 ## Leave behind
 

--- a/tests/release/test_rc_validate_kit_contract.py
+++ b/tests/release/test_rc_validate_kit_contract.py
@@ -81,3 +81,21 @@ def test_synthesis_phase_pins_match_kit_defaults() -> None:
     verify = re.search(r"label: `verify:\$\{c\.key\}`[^}]*model: '([a-z]+)'", script)
     assert verify is not None, "verify agent() call has no model pin"
     assert verify.group(1) == defaults["verify"]
+
+
+def test_every_labelled_agent_call_is_model_pinned_or_whitelisted() -> None:
+    """Completeness: a NEWLY added agent() call without a model pin should fail
+    here, not silently inherit the invoking session's tier. The regression
+    batches build their opts dynamically and are asserted separately above;
+    file-issues is the one documented inherit-the-session-tier exception."""
+    inherit_ok = {"file-issues"}
+    dynamic = {"regressions:"}  # label built via `regressions:${b.tier}...`, opts via Object.assign
+    opts_literals = re.findall(r"\{ label: (?:[^{}]|\$\{[^}]*\})*\}", _script())
+    assert len(opts_literals) >= 8, "opts-literal extraction broke — update this test"
+    for literal in opts_literals:
+        label = re.search(r"label: [`']([^`']+)[`']", literal)
+        assert label is not None, f"unparseable opts literal: {literal}"
+        name = label.group(1)
+        if any(name.startswith(d) for d in dynamic) or name.split(":")[0] in inherit_ok:
+            continue
+        assert "model:" in literal, f"agent() call '{name}' has no model pin and no whitelist entry"

--- a/tests/release/test_rc_validate_kit_contract.py
+++ b/tests/release/test_rc_validate_kit_contract.py
@@ -1,0 +1,83 @@
+"""Static contract between the validation kit registry and its workflow script.
+
+``tests/release-validation/kit.toml`` declares the model tier per phase; the
+tiers only hold if ``.claude/workflows/rc-validate.js`` actually pins them on
+its ``agent()`` calls — an unpinned call silently inherits the invoking
+session's tier (kit v5's motivating defect). These tests keep the two files
+from diverging without either PR noticing.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+KIT = Path("tests/release-validation/kit.toml")
+SCRIPT = Path(".claude/workflows/rc-validate.js")
+
+
+def _defaults() -> dict[str, str]:
+    return tomllib.loads(KIT.read_text())["defaults"]
+
+
+def _script() -> str:
+    return SCRIPT.read_text()
+
+
+def test_kit_declares_a_tier_for_every_phase_the_script_pins() -> None:
+    defaults = _defaults()
+    for key in (
+        "preflight",
+        "readonly",
+        "stateful",
+        "update",
+        "regression_mechanical",
+        "regression_judgment",
+        "triage",
+        "verify",
+        "synthesis",
+        "curation",
+    ):
+        assert key in defaults, f"kit.toml [defaults] lost its {key} tier"
+
+
+def test_preflight_pin_matches_kit_defaults() -> None:
+    script = _script()
+    match = re.search(r"schema: PREFLIGHT, model: '([a-z]+)'", script)
+    assert match is not None, "preflight agent() call has no model pin"
+    assert match.group(1) == _defaults()["preflight"]
+
+
+def test_lane_agent_pin_matches_kit_defaults() -> None:
+    """laneAgent serves readonly, stateful, and update lanes; kit.toml
+    declares the same tier for all three, so one base pin covers them."""
+    defaults = _defaults()
+    assert defaults["readonly"] == defaults["stateful"] == defaults["update"]
+    match = re.search(r"schema: LANE_RESULT, model: '([a-z]+)'", _script())
+    assert match is not None, "laneAgent base opts have no model pin"
+    assert match.group(1) == defaults["readonly"]
+
+
+def test_regression_batch_pins_match_kit_defaults() -> None:
+    defaults = _defaults()
+    script = _script()
+    mech = re.search(r"tier: 'mechanical', model: '([a-z]+)'", script)
+    judg = re.search(r"tier: 'judgment', model: '([a-z]+)'", script)
+    assert mech is not None, "mechanical regression batch has no model pin"
+    assert judg is not None, "judgment regression batch has no model pin"
+    assert mech.group(1) == defaults["regression_mechanical"]
+    assert judg.group(1) == defaults["regression_judgment"]
+    serialized = re.search(r"label: 'regressions:serialized'[^}]*model: '([a-z]+)'", script)
+    assert serialized is not None, "serialized regression agent has no model pin"
+    assert serialized.group(1) == defaults["regression_judgment"]
+
+
+def test_synthesis_phase_pins_match_kit_defaults() -> None:
+    defaults = _defaults()
+    script = _script()
+    for label, key in (("triage", "triage"), ("report", "synthesis"), ("curate", "curation")):
+        match = re.search(rf"label: '{label}'[^}}]*model: '([a-z]+)'", script)
+        assert match is not None, f"{label} agent() call has no model pin"
+        assert match.group(1) == defaults[key]
+    verify = re.search(r"label: `verify:\$\{c\.key\}`[^}]*model: '([a-z]+)'", script)
+    assert verify is not None, "verify agent() call has no model pin"
+    assert verify.group(1) == defaults["verify"]


### PR DESCRIPTION
Pre-Phase-3 hardening of the validation kit, from the read-only sanity sweep the GA session ran against kit v4 before its first full exercise on rc.7.

## What changed

**Four new checks** closing gaps where recent fixes would otherwise reach rc.7 CI-verified only:

| Brief | Check | Verifies |
|---|---|---|
| `lanes/update/post-upgrade.md` 2b | #1934 gpu-vulkan relabel migration | relabel fired on real stale TOMLs, device-key-only, non-llama untouched, breadcrumbs, idempotency |
| `lanes/update/upgrade.md` 2b | #1883 channel-URL path | `releases.hal0.dev/<channel>.json` + `.json.bundle` both 200, bundle byte-matches, cosign verifies via proxy — the box's pinned GitHub-asset `HAL0_RELEASES_URL` bypasses this path entirely, so without the check rc.7 would never exercise #1883 |
| `lanes/stateful/slots.md` 8b | #1922 output-sanity gate | the gate itself fires (slot lands in `error`, never `ready`), as a product gate distinct from the agents' own coherence canary |
| `lanes/stateful/hermes-e2e.md` 9 | #1942 doctor-perms convergence | rc=0 re-probed after slot load + pull + STATE.md render, plus manual owner/group `stat` — the review proved green-after-mutation on the mode axis only |

**Corrections:**
- `upgrade.md` check 4: now expects the #1935-restored audit trail (populated `job_id`, prepare/verify breadcrumbs); the old text documented their absence as designed behavior.
- `rc-validate.js`: explicit `model:` pins on every phase to match `kit.toml [defaults]` — previously preflight, all lane agents, judgment regressions, and curation silently inherited the invoking session's tier (an opus/fable session would run the whole 25-30-agent sweep at that tier). File-issues deliberately still inherits; README documents this.
- `rc-validate.js` verify prompt: dropped the stale "fresh boxes run the Vulkan lane only" fleet note (stale since #1923).
- `boxes.toml` ct151 gotcha 5: post-rollback `systemctl start hal0.target`, so preflight blockers can name the fix instead of just "API unreachable".
- `kit_version` 4 → 5 per the versioning policy; README changelog entry added.

## Verification

`uv run --extra dev pytest tests/release -q` → 106 passed (includes `test_workflow_contract.py`, which mirrors the kit registry against the workflow script). `node --check` clean on the workflow script.

Out of scope, deliberately: the `lane: preflight` stray value in `regressions.yaml` (harmless, single entry — noted for the next curation pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)