### PR TITLE
chore: refresh public-facing meta docs and drop operator-local paths

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/mint/.local/bin/graphify hook-guard search"
+            "command": "graphify hook-guard search"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/mint/.local/bin/graphify hook-guard read"
+            "command": "graphify hook-guard read"
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/mint/.local/bin/graphify hook-check"
+            "command": "graphify hook-check"
           }
         ]
       }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to hal0
 
-hal0 is licensed [Apache 2.0](./LICENSE). hal0 is at **v0.8.2b3** — the
-container-runtime line (one podman container per slot). The contribution model is still
-being decided.
+hal0 is licensed [Apache 2.0](./LICENSE). hal0 is at **v1.0.0-rc.6**, closing
+in on the 1.0 stable release. The runtime model is one podman container per
+slot. The contribution model is still being decided.
 <!-- TODO(human): flip the next line to open the external-PR merge window
      when ready (audit Q6.3 / #630). Timing is the maintainer's call. -->
 External PRs aren't being merged yet; please open issues for discussion.

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ curl -fsSL https://hal0.dev/install.sh | sudo bash
 > brain steward model, and starts the API. When it finishes, open the
 > dashboard and assign models to slots.
 
-> **Status: release candidate — `v1.0.0-rc.5`.** v1.0.0 stable is the target
-> of the current cut. rc.5 is the validation candidate: it closes every
-> defect the rc.4 fresh-install sweep found on real hardware. See
-> [`CHANGELOG.md`](./CHANGELOG.md).
+> **Status: release candidate — `v1.0.0-rc.6`.** v1.0.0 stable is the target
+> of the current cut. Every release candidate is validated on a real-hardware
+> fleet before the next cut; see [`CHANGELOG.md`](./CHANGELOG.md) for what
+> each candidate closed.
 
 ## Screenshots
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ back-patched.
 | Version        | Supported          |
 | -------------- | ------------------ |
 | `main` (latest)| :white_check_mark: |
-| tagged alphas  | latest only        |
+| tagged release candidates | latest only |
 
 ## Bundled agent trust boundary
 

--- a/scripts/push-dev.sh
+++ b/scripts/push-dev.sh
@@ -11,7 +11,7 @@
 # no service restart at all (--ui-only).
 #
 # Usage (from anywhere inside the checkout):
-#   HAL0_DEV_HOST=root@10.0.1.142 bash scripts/push-dev.sh [options]
+#   HAL0_DEV_HOST=root@<dev-box> bash scripts/push-dev.sh [options]
 #
 # Options:
 #   --host <ssh-host>   SSH target (or HAL0_DEV_HOST). Required.


### PR DESCRIPTION
Tip-only fixes from the GA-plan Phase 4 pre-public sweep. Context the sweep surfaced: the repo has been public since May (68 stars, 7 forks), so stale meta docs are live-facing today, not hypothetically.

- **README**: status said `v1.0.0-rc.5` — two candidates stale on the public front page. Now `rc.6` with wording that only needs the version number bumped per cut. (The release recipe's set-version step does not touch README — worth adding to the cut checklist.)
- **CONTRIBUTING**: led with `v0.8.2b3`. The "External PRs aren't being merged yet" policy line and its `TODO(human)` marker are untouched — that decision is the maintainer's (GA ledger row 5).
- **SECURITY**: "tagged alphas" → "tagged release candidates". The "pre-1.0" line stays until GA.
- **`.claude/settings.json` / `.codex/hooks.json`**: `/home/mint/.local/bin/graphify` → bare `graphify` (PATH), removing the home-directory leak.
- **`scripts/push-dev.sh`**: real internal IP in the usage comment → placeholder.

Deliberately out of scope (operator decisions, tracked separately): internal IPs in `tests/release-validation/boxes.toml` (the validation kit needs them), `CLAUDE.md`'s Hindsight URL (operational for agents), `docs/adr/0002`'s box references (accepted ADR), and the 24 public issues/PRs carrying internal IPs.

Verified: rendered files reviewed; no behavioral code touched; hooks tested by name resolution (`graphify` is on PATH on the dev machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)