### PR TITLE
feat(runner): repin both AMD GPU lanes to hal0-combined:0822

### DIFF
--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1010,7 +1010,7 @@ MTP_FLAG_BUNDLE = build_mtp_flag_bundle("rocm")
 #: (debug builds, A/B tests, etc.).  See #__hal0_image_control__ for the
 #: phasing: 0.9.5 wires slot.image + DEFAULT_ROCMFPX_IMAGE; 0.9.6 will
 #: drop ``image`` from SEED_PROFILES entirely.
-DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-rocmfpx:ade07ba"
+DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-combined:0822"
 
 #: Historical DEFAULT_ROCMFPX_IMAGE values (and their pre-consolidation
 #: equivalents). A slot-level ``image`` pin equal to one of these is a STALE
@@ -1040,6 +1040,10 @@ DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-rocmfpx:ade07ba"
 #: control-token pieces are stripped before the parser sees them).
 STALE_ROCMFPX_IMAGE_REFS = frozenset(
     {
+        # Former default (rc.6). Its Vulkan backend emits invalid tokens for
+        # every model (#1888) — a slot still pinned here is debris from an
+        # older release, not an opt-out, and must be retagged.
+        "ghcr.io/hal0ai/hal0-rocmfpx:ade07ba",
         "ghcr.io/hal0ai/hal0-rocmfpx:c077206",
         "ghcr.io/hal0ai/hal0-rocmfpx:vulkan-minicpm5",
         "localhost/hal0-rocmfpx:vulkan-minicpm5",

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -2873,16 +2873,21 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
         # retired runner forever — behind the release that replaces it.
         # Matching against the stale set is what keeps this safe: a genuine
         # operator pin is never an exact former default.
+        # PRECEDENCE MATCHES THE RESOLVER (#1959 review nit): ``image_pin``
+        # binds first, because ``_resolve_image_ref`` reads it first and no
+        # longer reads the bare key at all. Binding ``image`` first here made
+        # the sweep retag (or skip on) a value the runtime never serves while
+        # the pin that IS served stayed stale.
         holder: dict | None = None
-        key = "image"
-        if isinstance(raw.get("image"), str):
+        key = "image_pin"
+        if isinstance(raw.get("image_pin"), str):
             holder = raw
-        elif isinstance(raw.get("slot"), dict) and isinstance(raw["slot"].get("image"), str):
-            holder = raw["slot"]
-        elif isinstance(raw.get("image_pin"), str):
-            holder, key = raw, "image_pin"
         elif isinstance(raw.get("slot"), dict) and isinstance(raw["slot"].get("image_pin"), str):
-            holder, key = raw["slot"], "image_pin"
+            holder = raw["slot"]
+        elif isinstance(raw.get("image"), str):
+            holder, key = raw, "image"
+        elif isinstance(raw.get("slot"), dict) and isinstance(raw["slot"].get("image"), str):
+            holder, key = raw["slot"], "image"
         if holder is None or holder[key] not in STALE_RUNNER_IMAGE_REFS:
             continue
         old_ref = holder[key]

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -2861,21 +2861,38 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
         # An image REF is a top-level or [slot]-nested STRING. The ``[image]``
         # TOML table (image-gen settings, #599) shares the key and must be
         # ignored — same trap as providers.container._resolve_image_ref.
+        #
+        # BOTH key shapes, deliberately (#1948 B1). The bare ``image`` string is
+        # only half the population: ``_resolve_image_ref`` now resolves the
+        # TYPED ``image_pin`` field, and ``hal0 slot migrate-hw --apply`` folds
+        # ``image`` into it — recording the then-current default as a
+        # "deliberate pin" (it was not in STALE_RUNNER_IMAGE_REFS at the time)
+        # and dropping the older key. A folded box therefore carries
+        # ``image_pin = <old default>``, honoured verbatim and INVISIBLE to a
+        # sweep that reads only the bare key, so it would keep serving a
+        # retired runner forever — behind the release that replaces it.
+        # Matching against the stale set is what keeps this safe: a genuine
+        # operator pin is never an exact former default.
         holder: dict | None = None
+        key = "image"
         if isinstance(raw.get("image"), str):
             holder = raw
         elif isinstance(raw.get("slot"), dict) and isinstance(raw["slot"].get("image"), str):
             holder = raw["slot"]
-        if holder is None or holder["image"] not in STALE_RUNNER_IMAGE_REFS:
+        elif isinstance(raw.get("image_pin"), str):
+            holder, key = raw, "image_pin"
+        elif isinstance(raw.get("slot"), dict) and isinstance(raw["slot"].get("image_pin"), str):
+            holder, key = raw["slot"], "image_pin"
+        if holder is None or holder[key] not in STALE_RUNNER_IMAGE_REFS:
             continue
-        old_ref = holder["image"]
+        old_ref = holder[key]
         # HW-gated target: rocmfpx on a Strix GPU lane, the lean toolbox
         # elsewhere. When the host/lane default already equals the pin (e.g. a
         # non-Strix box on the vulkan toolbox), it's a no-op — leave it be.
         new_ref = resolve_default_image(_backend_of(raw), _device_class_of(raw))
         if new_ref == old_ref:
             continue
-        holder["image"] = new_ref
+        holder[key] = new_ref
         try:
             write_toml_atomic(toml_path, raw)
         except Exception as exc:
@@ -2886,6 +2903,7 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
             "updater.slot_image_retagged",
             job_id=job_id,
             slot=slot_name,
+            field=key,
             old=old_ref,
             new=new_ref,
             note=(

--- a/tests/updater/test_image_pin_retag.py
+++ b/tests/updater/test_image_pin_retag.py
@@ -1,0 +1,71 @@
+"""#1948 B1 — a folded box pins the runner in `image_pin`, not `image`.
+
+`hal0 slot migrate-hw --apply` folds a bare `image` string into the typed
+`image_pin` field, recording the then-current default as a "deliberate pin"
+because it was not yet in STALE_RUNNER_IMAGE_REFS. A sweep that reads only the
+bare key is blind to that, so the slot would keep serving a retired runner
+forever — behind the release that replaces it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.config.schema import DEFAULT_ROCMFPX_IMAGE
+from hal0.updater.updater import retag_stale_slot_images
+
+RETIRED = "ghcr.io/hal0ai/hal0-rocmfpx:ade07ba"
+
+
+@pytest.fixture
+def slots_dir(tmp_path, monkeypatch):
+    d = tmp_path / "slots"
+    d.mkdir()
+    monkeypatch.setattr("hal0.config.paths.slots_config_dir", lambda: d)
+    return d
+
+
+def test_a_stale_image_pin_is_retagged(slots_dir) -> None:
+    (slots_dir / "brain.toml").write_text(
+        f'device = "gpu-rocm"\nimage_pin = "{RETIRED}"\n', encoding="utf-8"
+    )
+    assert retag_stale_slot_images() == 1
+    body = (slots_dir / "brain.toml").read_text(encoding="utf-8")
+    assert RETIRED not in body
+    assert DEFAULT_ROCMFPX_IMAGE in body
+
+
+def test_a_nested_stale_image_pin_is_retagged(slots_dir) -> None:
+    (slots_dir / "agent.toml").write_text(
+        f'[slot]\ndevice = "gpu-rocm"\nimage_pin = "{RETIRED}"\n', encoding="utf-8"
+    )
+    assert retag_stale_slot_images() == 1
+    assert RETIRED not in (slots_dir / "agent.toml").read_text(encoding="utf-8")
+
+
+def test_the_bare_image_key_still_works(slots_dir) -> None:
+    """The original shape must not regress while adding the typed one."""
+    (slots_dir / "code.toml").write_text(
+        f'device = "gpu-rocm"\nimage = "{RETIRED}"\n', encoding="utf-8"
+    )
+    assert retag_stale_slot_images() == 1
+    assert RETIRED not in (slots_dir / "code.toml").read_text(encoding="utf-8")
+
+
+def test_a_deliberate_image_pin_is_never_touched(slots_dir) -> None:
+    """The stale-set match is the whole safety property: an operator's own pin
+    is never an exact former default, so a debug build must survive."""
+    (slots_dir / "brain.toml").write_text(
+        'device = "gpu-rocm"\nimage_pin = "ghcr.io/example/my-debug-build:v9"\n',
+        encoding="utf-8",
+    )
+    assert retag_stale_slot_images() == 0
+    assert "my-debug-build:v9" in (slots_dir / "brain.toml").read_text(encoding="utf-8")
+
+
+def test_it_is_idempotent(slots_dir) -> None:
+    (slots_dir / "brain.toml").write_text(
+        f'device = "gpu-rocm"\nimage_pin = "{RETIRED}"\n', encoding="utf-8"
+    )
+    assert retag_stale_slot_images() == 1
+    assert retag_stale_slot_images() == 0

--- a/tests/updater/test_image_pin_retag.py
+++ b/tests/updater/test_image_pin_retag.py
@@ -69,3 +69,34 @@ def test_it_is_idempotent(slots_dir) -> None:
     )
     assert retag_stale_slot_images() == 1
     assert retag_stale_slot_images() == 0
+
+
+def test_both_keys_present_the_pin_wins_like_the_resolver(slots_dir) -> None:
+    """With BOTH key shapes on one slot, the sweep must judge the key the
+    runtime serves. ``_resolve_image_ref`` reads ``image_pin`` first and no
+    longer reads the bare key at all — so a stale pin behind a current-looking
+    bare ``image`` was invisible to a bare-key-first sweep, and the slot kept
+    serving the retired runner behind the release replacing it (#1959 review
+    nit; the inverse ordering also logged retags of a value nothing reads)."""
+    (slots_dir / "agent.toml").write_text(
+        f'device = "gpu-rocm"\nimage = "{DEFAULT_ROCMFPX_IMAGE}"\nimage_pin = "{RETIRED}"\n',
+        encoding="utf-8",
+    )
+    assert retag_stale_slot_images() == 1
+    after = (slots_dir / "agent.toml").read_text(encoding="utf-8")
+    assert RETIRED not in after
+    assert f'image_pin = "{DEFAULT_ROCMFPX_IMAGE}"' in after
+
+
+def test_both_keys_with_a_deliberate_pin_is_untouched(slots_dir) -> None:
+    """The mirror case: a deliberate (non-stale) pin with stale bare-key
+    debris behind it. The runtime serves the pin, which is fine — retagging
+    the inert bare key would log a retag that changes nothing served."""
+    (slots_dir / "code.toml").write_text(
+        f'device = "gpu-rocm"\nimage = "{RETIRED}"\n'
+        'image_pin = "ghcr.io/example/my-debug-build:v9"\n',
+        encoding="utf-8",
+    )
+    before = (slots_dir / "code.toml").read_text(encoding="utf-8")
+    assert retag_stale_slot_images() == 0
+    assert (slots_dir / "code.toml").read_text(encoding="utf-8") == before


### PR DESCRIPTION
Repins **both AMD GPU lanes** to `ghcr.io/hal0ai/hal0-combined:0822`. `rocmfpx` and `vulkanfpx` both resolve `DEFAULT_ROCMFPX_IMAGE`, so one constant moves them together.

**Pure repin.** The default brain does **not** change — `hal0-brain-sft` stays.

Refs #1948, #1888. Operator-merged (ledger row 10). No automerge.

## Why the image changes

`ade07ba`'s Vulkan backend emits invalid tokens for every model (#1888). Bisected on real hardware to **`ciru-ai/ROCmFPX`'s port of ROCmFPX onto newer upstream** — not hal0's build, the driver, gfx1151, or llama.cpp mainline. Four competing hypotheses were each killed by their own test; full evidence on #1948.

`:0822` is built from charlie's tree (whose Vulkan backend is demonstrably correct) plus two ports:

1. the missing `minicpm5` **pre-tokenizer mapping** — the enum and tokenizer behaviour already existed there, only the name→enum lookup was absent, so every minicpm5-pretokenised GGUF failed to load;
2. the MiniCPM5 **XML tool-call parser**, written in that tree's own idiom rather than transplanted.

That makes `:0822` a genuine **superset** of `ade07ba` — correct Vulkan *and* working native tool calls — rather than the tradeoff an earlier revision of this branch was built around.

| | `ade07ba` (current pin) | `:0822` |
|---|---|---|
| Vulkan output correct | ❌ | ✅ |
| MiniCPM5 native tool calls | ✅ | ✅ |

## Validation

Full §3-C matrix on #1948, including the rows that were previously missing. The decisive one is **ct151** — no `/dev/kfd`, so Vulkan is the *only* lane, and the exact configuration that produced #1888:

| Probe (ct151, kfd ABSENT) | Result |
|---|---|
| Shipped FPX brain model, Vulkan0 | ✅ `' Paris, a city that has been the center of French culture…'` |
| Native tool calls, Vulkan0 | ✅ `finish_reason: tool_calls`, `{"city":"Paris"}` |
| ≥256-token generation | ✅ terminates `stop_type=eos`, no `)`-wedge |

ct150 green across both lanes on non-FPX and FPX models, plus #1936's zero-device diagnostic.

## B1 — the retag reaches folded boxes

`ade07ba` is retired into `STALE_ROCMFPX_IMAGE_REFS`, **and** `retag_stale_slot_images` is extended to the typed `image_pin` field.

The bare `image` key is only half the population. `_resolve_image_ref` resolves `image_pin`, and `hal0 slot migrate-hw --apply` folds `image` into it — recording the then-current default as a *deliberate pin* (it was not in the stale set at the time) and dropping the older key. A folded box carries `image_pin = ade07ba`, honoured verbatim and invisible to a bare-key sweep. Without this it would keep serving the broken runner **forever**, behind the release that replaces it.

Matching against the stale set is what keeps it safe: a genuine operator pin is never an exact former default. Pinned by `test_a_deliberate_image_pin_is_never_touched`. The sweep binds `image_pin` before the bare `image` key — the same precedence `_resolve_image_ref` uses — so a slot carrying both shapes is judged on the key the runtime serves (review nit, commit `6c6a84d7`, both-keys tests in each direction).

## Sequencing — this PR alone does NOT deliver ct151

**Land order is #1973 → this PR, and it is mandatory** (proven by execution in the stack review): `run_post_activation_migrations` runs the vulkan relabel BEFORE the retag, so on a kfd-less box the relabel flips `gpu-vulkan` slots to `cpu` first and the retag then resolves the CPU toolbox — the pin never reaches them. With #1973's lane re-enable (and its shared look-through predicate) landed first, the lane survives the relabel and the retag delivers `:0822`. The ct151 validation rows above describe the *chain's* end state, not this diff's standalone effect.

## Scope note — the LFM2.5 brain swap was dropped

Earlier revisions of this branch also switched the default brain to LFM2.5. **That is gone.**

It was chosen by elimination under my own incorrect sizing of the parser port (I inferred difficulty from a ~1000-line `chat.cpp` length delta; charlie in fact already carried the whole PEG subsystem and a sibling XML parser). With the parser restored the swap is unforced, so it belongs to the operator as a separate product decision rather than riding in as a consequence of a pin.

Dropping it removes two review blockers at the root rather than mitigating them:

- **B3** — existing boxes silently losing tool calls on upgrade: impossible now, the new runner parses the old brain.
- **B4** — `<think>` leaking into `content` on every fresh install: impossible now, the brain profile is untouched.
- **B5** — the vacuous provenance tests were collateral from my retargeting. The reviewer's independent mutation check kills **4 tests, one per provenance predicate** (versus 1 on the swap branch) — the right shape; an earlier revision of this body claimed 13, which did not reproduce.

## Verification

```
tests/updater tests/install tests/config tests/registry tests/runners tests/providers tests/slots
3366 passed, 9 skipped
ruff check src/ tests/   clean
make check-sunset        192 <= baseline 192
```

Diff is three files: `schema.py` (pin + stale set), `updater.py` (B1), and the new `test_image_pin_retag.py`.

## Open, tracked elsewhere

- **Perf row — DONE** (#1948 comment 5365532926, clean window): `:0822` shows no ROCm regression (+5.2% pp / −1.1% tg vs ade07ba) and its Vulkan lane now beats ROCm (+14% pp / +20% tg) on the reference box.
- **#1970** — tracked as PR #1972 (build recipe; digest-pin + provenance-note revisions outstanding).


