### PR TITLE
fix(updater): run post-activation migrations after the symlink swap

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1325,12 +1325,33 @@ async def _boot_dispatcher(app: FastAPI, ctx: BootState) -> None:
 async def _boot_slot_reconcile(app: FastAPI, ctx: BootState) -> None:
     """Phase — one-shot slot reconciliation passes + idle-monitor start.
 
-    ORDERING: ``migrate_slot_dir`` (#1369) → ``reconcile_unconfigured_slots``
-    → ``reconcile_npu_trio_slots`` → ``fold_identity`` (folds identity for the
-    trio shadows just reconciled) → ``start_idle_monitor``. Otherwise preserved
-    exactly from the monolithic boot.
+    ORDERING: ``check_outstanding_migrations`` (#1960, safety net) →
+    ``migrate_slot_dir`` (#1369) → ``reconcile_unconfigured_slots`` →
+    ``reconcile_npu_trio_slots`` → ``fold_identity`` (folds identity for the
+    trio shadows just reconciled) → ``start_idle_monitor``. Everything from
+    ``migrate_slot_dir`` on is otherwise preserved exactly from the
+    monolithic boot.
     """
-    # #1369 one-shot sweep, FIRST: every pass below reads ``model.default`` to
+    # #1960 safety net, FIRST: heal a box whose post-activation data
+    # migrations (schema, slot-TOML relabels, registry cleanup) never ran —
+    # either because it upgraded before this fix existed, or because
+    # Updater.commit()'s post-swap migration subprocess itself failed (see
+    # that function's docstring). Every pass check_outstanding_migrations
+    # runs is a documented idempotent "stale? fix it : no-op" sweep, so a
+    # converged box pays for one hal0.toml read plus five near-instant
+    # no-ops. Runs before every pass below because those passes read slot
+    # TOMLs / registry rows this can rewrite. Never raises — see its own
+    # docstring — so no try/except is needed here, but exceptions are boxed
+    # anyway (defensive-in-depth, matching every neighbouring pass in this
+    # phase) in case the import itself fails.
+    try:
+        from hal0.updater.updater import check_outstanding_migrations
+
+        check_outstanding_migrations()
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("slot.outstanding_migrations_check_failed", error=str(exc))
+
+    # #1369 one-shot sweep, next: every pass below reads ``model.default`` to
     # decide what is configured, so a slot the operator had switched off with
     # ``enabled = false`` (whose model is therefore still bound on disk) would
     # be reconciled as live for one boot. Idempotent — after the first sweep

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -460,6 +460,17 @@ async def _run_commit_job(
         job["error"] = str(exc)
         job["error_code"] = type(exc).__name__
     else:
+        # Convergence must land on the job BEFORE the terminal-state persist
+        # below, not after the restart the way it read before (#1960 B3):
+        # the restart a few lines down is the exact #1540 mechanism — it
+        # shells out from inside hal0-api's own cgroup and can SIGTERM this
+        # very process while it's in flight — so anything set only
+        # afterwards may never reach disk. A red (unconverged) post-swap
+        # migration failure has to survive that race, or a CLI that
+        # re-attaches after the restart reads `convergence: None` and
+        # _print_convergence reports a clean success for a run that wasn't.
+        job["convergence"] = (result or {}).get("convergence")
+
         # Terminal state first, then the restart - see the long note in
         # _run_apply_job. commit() is the path #1540 was reported against:
         # the restart kills this process, so "applied" has to already be on
@@ -473,7 +484,6 @@ async def _run_commit_job(
         restarted, restart_error = await asyncio.to_thread(_try_restart_hal0_api)
         job["restarted"] = restarted
         job["restart_error"] = restart_error
-        job["convergence"] = (result or {}).get("convergence")
     finally:
         job["updated_at"] = time.time()
         _persist_job(job)

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -351,6 +351,18 @@ def _maybe_converge_profiles(status: dict | None, *, yes: bool) -> bool:
     return True
 
 
+#: Human labels for the non-fatal per-pass failure events
+#: run_post_activation_migrations can log (#1960 B2) — keys must match
+#: hal0.updater.updater._NON_FATAL_MIGRATION_FAILURE_EVENTS exactly.
+_MIGRATION_PASS_LABELS: dict[str, str] = {
+    "updater.seed_profiles_prune_failed": "seed-profile cleanup",
+    "updater.mtp_migration_failed": "mtp override cleanup",
+    "updater.vulkan_migration_failed": "gpu-vulkan slot relabel",
+    "updater.image_retag_failed": "runner image retag",
+    "updater.extra_args_sanitize_failed": "managed extra_args sanitisation",
+}
+
+
 def _print_convergence(convergence: dict | None) -> bool:
     """Report how far the updated box is from the v1.0 on-disk shape.
 
@@ -394,6 +406,15 @@ def _print_convergence(convergence: dict | None) -> bool:
         src, dst = post_migrations.get("from"), post_migrations.get("to")
         if src is not None and dst is not None and src != dst:
             console.print(f"[green]✓[/green] on-disk schema migrated v{src} → v{dst}")
+        # A pass that swallowed its own exception into a warning is still
+        # non-fatal by design (see run_post_activation_migrations) — this
+        # does not flip `ok`/`converged` — but it must not be invisible
+        # outside journalctl either (#1960 B2).
+        for event in post_migrations.get("pass_warnings") or []:
+            label = _MIGRATION_PASS_LABELS.get(event, event)
+            console.print(
+                f"[yellow]![/yellow] {label} logged a warning — see journalctl for hal0-api"
+            )
     elif post_migrations:
         console.print(
             Panel(

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -384,6 +384,30 @@ def _print_convergence(convergence: dict | None) -> bool:
     elif outcome == "error":
         console.print(f"[yellow]![/yellow] profile catalog reset failed: {reset.get('error')}")
 
+    # #1960: post-activation migrations (schema + slot/registry cleanup
+    # sweeps) now run in a subprocess AFTER the symlink swap, so a failure
+    # there does NOT abort the update — the release is already active. It
+    # still has to be reported, loudly, or "hal0 update" would silently hand
+    # back a box whose on-disk data still reflects the previous release.
+    post_migrations = convergence.get("post_activation_migrations") or {}
+    if post_migrations.get("ok"):
+        src, dst = post_migrations.get("from"), post_migrations.get("to")
+        if src is not None and dst is not None and src != dst:
+            console.print(f"[green]✓[/green] on-disk schema migrated v{src} → v{dst}")
+    elif post_migrations:
+        console.print(
+            Panel(
+                "[bold red]Post-update data migrations did not apply.[/bold red]\n"
+                f"{post_migrations.get('error') or 'unknown error'}\n\n"
+                "The new code is installed and running, but on-disk data (slot TOMLs,\n"
+                "hal0.toml schema, registry rows) may still reflect the PREVIOUS release's\n"
+                "shape. hal0-api retries this automatically at its next start — restart the\n"
+                "service now to retry immediately, or wait for the next scheduled restart.",
+                title="Migration incomplete",
+                border_style="red",
+            )
+        )
+
     ownership = convergence.get("ownership_migrations") or {}
     pending = list(ownership.get("pending") or [])
     if not pending:

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1620,6 +1620,7 @@ def run_post_activation_migrations(
     *,
     job_id: str | None = None,
     ceiling: int | None = None,
+    skip_image_retag: bool = False,
 ) -> tuple[int, int]:
     """Run every post-activation migration pass hal0 ships, in order.
 
@@ -1661,6 +1662,23 @@ def run_post_activation_migrations(
     profile-catalog reset gate). ``None`` (the default, and what
     install.sh's caller always passes) applies no cap.
 
+    ``skip_image_retag`` (#1960 N2) omits ``retag_stale_slot_images``.
+    Every OTHER pass here is either purely additive (seed profiles, mtp
+    clearing) or corrects a state that actively breaks something (a
+    gpu-vulkan slot that refuses to load, an unsanitised managed flag) —
+    running them outside an update is harmless or actively good.
+    ``retag_stale_slot_images`` is different: it rewrites a slot's image
+    pin whenever that pin exactly matches a KNOWN FORMER default, which is
+    a good bet during an actual release (a new default just shipped) but
+    is not correlated with "a release just shipped" at all when called on
+    every daemon boot — an operator who deliberately re-pinned a slot to
+    an older image that happens to be a listed former default would have
+    that choice silently reverted on every crash-restart or reboot, not
+    just when they run an update. :func:`check_outstanding_migrations`
+    passes ``True`` here for exactly that reason; :meth:`Updater.commit`'s
+    post-swap subprocess (an actual update) always passes the default
+    ``False``, so the pass still gets its shot every time a release ships.
+
     Returns the ``(source, target)`` schema-version tuple for breadcrumb
     logging, the same shape ``commit()`` already returned.
     """
@@ -1687,11 +1705,12 @@ def run_post_activation_migrations(
         # Non-fatal: an affected slot keeps refusing to load (the #1923
         # preflight guard) until the operator manually relabels its device.
 
-    try:
-        retag_stale_slot_images(job_id=job_id)
-    except Exception as exc:
-        log.warning("updater.image_retag_failed", job_id=job_id, error=str(exc))
-        # Non-fatal: a stale pin just keeps the previous runner image.
+    if not skip_image_retag:
+        try:
+            retag_stale_slot_images(job_id=job_id)
+        except Exception as exc:
+            log.warning("updater.image_retag_failed", job_id=job_id, error=str(exc))
+            # Non-fatal: a stale pin just keeps the previous runner image.
 
     try:
         sanitize_model_extra_args(job_id=job_id)
@@ -1713,11 +1732,26 @@ def check_outstanding_migrations(*, job_id: str | None = None) -> tuple[int, int
     :func:`_run_post_activation_migrations_after_swap` can itself fail (disk
     full, a bug in one specific pass), and ``commit()`` deliberately does not
     retry it inline — see that function's caller for why. Calling this once
-    at every ``hal0-api`` boot heals both: every one of the six passes
-    ``run_post_activation_migrations`` runs is documented as an idempotent
-    "stale? fix it : no-op" sweep (see each pass's own docstring), so a
-    converged box pays for one ``hal0.toml`` read plus five near-instant
-    no-ops.
+    at every ``hal0-api`` boot heals both: every pass
+    ``run_post_activation_migrations`` runs here is documented as an
+    idempotent "stale? fix it : no-op" sweep (see each pass's own
+    docstring), so a converged box pays for one ``hal0.toml`` read plus a
+    handful of near-instant no-ops.
+
+    ``skip_image_retag=True`` (#1960 N2): unlike every other pass here,
+    ``retag_stale_slot_images``'s heuristic ("this pin exactly matches a
+    known FORMER default") is only actually correlated with staleness right
+    after a release ships a new default — see
+    :func:`run_post_activation_migrations`'s own docstring for the full
+    reasoning. Running it on every boot (crash-restarts and reboots
+    included, not just updates) would silently revert an operator's
+    deliberate re-pin to an old image on every bounce — the same class of
+    bug as #1867 (an automated convergence pass overwriting deliberate
+    operator state), just with a much higher firing frequency. The pass
+    still gets its shot on every actual update, via
+    :meth:`Updater.commit`'s post-swap subprocess, which does not skip it —
+    a box that misses it there only waits until its next real update to
+    converge, same as before this function existed.
 
     Mirrors :meth:`Updater.commit`'s own ``ceiling`` derivation, using
     :func:`profile_reset_status` — a pure read — so a box whose one-shot
@@ -1736,7 +1770,7 @@ def check_outstanding_migrations(*, job_id: str | None = None) -> tuple[int, int
     try:
         reset_outstanding = bool(profile_reset_status().get("due"))
         ceiling = PROFILE_CATALOG_SCHEMA_VERSION - 1 if reset_outstanding else None
-        return run_post_activation_migrations(job_id=job_id, ceiling=ceiling)
+        return run_post_activation_migrations(job_id=job_id, ceiling=ceiling, skip_image_retag=True)
     except Exception as exc:
         log.warning("updater.boot_migration_check_failed", job_id=job_id, error=str(exc))
         return None
@@ -3617,12 +3651,34 @@ async def _rerender_units_after_swap(job_id: str | None) -> None:
         )
 
 
+#: Sentinel key on the single JSON stdout line the migration subprocess
+#: emits. Mirrors :data:`hal0.updater.privileged._RESULT_KEY`'s exact
+#: contract: structured logs go to STDERR (see the script built below) so
+#: stdout carries nothing but this envelope, scanned from the end.
+_MIGRATION_RESULT_KEY = "hal0_migration_result"
+
+#: The five non-fatal per-pass failure events ``run_post_activation_migrations``
+#: can log without raising (#1960 B2). A pass that swallows its own
+#: exception still exits the subprocess with rc=0 — by design, see that
+#: function's docstring — so it would otherwise be invisible outside
+#: journalctl. ``_run_post_activation_migrations_after_swap`` scans the
+#: relayed child log for these exact event names so a swallowed failure
+#: still surfaces in commit()'s convergence report.
+_NON_FATAL_MIGRATION_FAILURE_EVENTS: tuple[str, ...] = (
+    "updater.seed_profiles_prune_failed",
+    "updater.mtp_migration_failed",
+    "updater.vulkan_migration_failed",
+    "updater.image_retag_failed",
+    "updater.extra_args_sanitize_failed",
+)
+
+
 async def _run_post_activation_migrations_after_swap(
     min_data_version: int,
     *,
     job_id: str | None,
-    ceiling: int | None,
-) -> tuple[int, int]:
+    reset_outstanding: bool,
+) -> dict[str, Any]:
     """Run :func:`run_post_activation_migrations` in a subprocess of the
     just-repipped venv, AFTER the ``current`` symlink swap (#1960).
 
@@ -3635,49 +3691,130 @@ async def _run_post_activation_migrations_after_swap(
     old call site (this function's replacement) ran BEFORE the swap. A
     subprocess of the just-repipped venv imports the NEW module instead.
 
-    Unlike ``_rerender_units_after_swap``, a failure here is not swallowed to
-    a bare warning inside this function — see :meth:`Updater.commit` for how
-    the caller decides how loud to be. This helper's job is narrow: run the
-    six passes in the right interpreter and report what happened. Raises
-    :class:`UpdateError` on any subprocess failure — a non-zero exit, or a
-    clean exit with no parsable result (both are surfaced identically).
+    ``reset_outstanding`` — a bool, not a pre-computed ``ceiling`` int
+    (#1960 N1): the ceiling is ``PROFILE_CATALOG_SCHEMA_VERSION - 1``, and
+    that constant has to be read from the INCOMING tree's code, not this
+    (still outgoing) process's. Passing an int computed here would bake the
+    OUTGOING tree's watermark into a call that runs the INCOMING tree's
+    migrations — inert today (the constant hasn't moved since it was
+    introduced), a version-skew bug the moment it does. The child script
+    re-derives the ceiling from its own import, exactly like
+    :func:`check_outstanding_migrations` already does for the same reason.
 
-    Args are passed as a single JSON argv element rather than interpolated
-    into the ``-c`` script text, so ``job_id`` can never be mis-parsed as
-    code.
+    The child's structured log is pinned to stderr (mirrors
+    :func:`hal0.updater.privileged._pin_logs_to_stderr` exactly) so stdout
+    carries only the JSON result envelope; the parent relays that stderr
+    into its own journal via :func:`hal0.updater.privileged._relay_child_log`
+    (#1960 B2) — without this, every breadcrumb the six passes emit
+    (``updater.slot_vulkan_relabeled_rocm``, ``migrations_applied``, …) dies
+    in ``capture_output`` and #1935's journal-breadcrumb contract silently
+    regresses for this one call site (the release-validation kit's
+    post-upgrade check greps the journal for exactly these lines). The
+    relayed text is also scanned for :data:`_NON_FATAL_MIGRATION_FAILURE_EVENTS`
+    so a pass that swallowed its own exception into a warning (rc=0, by
+    design) still surfaces in the returned ``pass_warnings`` list.
+
+    Unlike ``_rerender_units_after_swap``, this raises :class:`UpdateError`
+    on any hard failure — subprocess launch failure (``OSError``), a
+    timeout, a non-zero exit, or a clean exit with no parsable result are
+    ALL converted to the same typed error, so :meth:`Updater.commit`'s
+    non-fatal-but-loud containment holds for every failure shape the
+    subprocess can produce, not just a non-zero return code.
+
+    Returns ``{"from": int, "to": int, "pass_warnings": list[str]}``.
     """
     payload = json.dumps(
-        {"min_data_version": min_data_version, "job_id": job_id, "ceiling": ceiling}
+        {
+            "min_data_version": min_data_version,
+            "job_id": job_id,
+            "reset_outstanding": reset_outstanding,
+        }
+    )
+    envelope_line = (
+        "sys.stdout.write(json.dumps({"
+        + repr(_MIGRATION_RESULT_KEY)
+        + ": {'from': result[0], 'to': result[1]}}) + chr(10))\n"
     )
     script = (
         "import json, sys\n"
-        "from hal0.updater.updater import run_post_activation_migrations\n"
-        "args = json.loads(sys.argv[1])\n"
-        "result = run_post_activation_migrations(\n"
-        "    args['min_data_version'], job_id=args['job_id'], ceiling=args['ceiling']\n"
+        "import structlog\n"
+        # Mirrors hal0.updater.privileged._pin_logs_to_stderr exactly: send
+        # structured logs to stderr so stdout carries only the result line.
+        "structlog.configure(logger_factory=structlog.PrintLoggerFactory(file=sys.stderr))\n"
+        "from hal0.updater.updater import (\n"
+        "    PROFILE_CATALOG_SCHEMA_VERSION,\n"
+        "    run_post_activation_migrations,\n"
         ")\n"
-        "print('HAL0_MIGRATION_RESULT=' + json.dumps({'from': result[0], 'to': result[1]}))\n"
+        "args = json.loads(sys.argv[1])\n"
+        "ceiling = (PROFILE_CATALOG_SCHEMA_VERSION - 1) if args['reset_outstanding'] else None\n"
+        "try:\n"
+        "    result = run_post_activation_migrations(\n"
+        "        args['min_data_version'], job_id=args['job_id'], ceiling=ceiling\n"
+        "    )\n"
+        "except Exception as exc:\n"
+        "    print('hal0-migrate: ' + str(exc), file=sys.stderr)\n"
+        "    raise SystemExit(1)\n" + envelope_line
     )
-    proc = await asyncio.to_thread(
-        subprocess.run,
-        [sys.executable, "-c", script, payload],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
+    try:
+        proc = await asyncio.to_thread(
+            subprocess.run,
+            [sys.executable, "-c", script, payload],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # Same containment class as _rerender_units_after_swap and the
+        # privileged seam's own _invoke — subprocess.run itself can raise
+        # rather than return a CompletedProcess, and the old code only
+        # handled the "returns a non-zero CompletedProcess" shape (#1960 B1).
+        raise UpdateError(
+            "post-activation migrations timed out after 300s in the newly activated tree",
+            details={"job_id": job_id, "timeout": 300},
+        ) from exc
+    except OSError as exc:
+        raise UpdateError(
+            f"post-activation migrations subprocess could not be launched: {exc}",
+            details={"job_id": job_id},
+        ) from exc
+
+    stderr = proc.stderr or ""
     if proc.returncode == 0:
-        for line in (proc.stdout or "").splitlines():
-            if line.startswith("HAL0_MIGRATION_RESULT="):
-                data = json.loads(line[len("HAL0_MIGRATION_RESULT=") :])
-                return (int(data["from"]), int(data["to"]))
+        from hal0.updater.privileged import _relay_child_log
+
+        # Relay only on success, mirroring UpdateSeam._invoke exactly: a
+        # failure's stderr goes into the raised error's `details` below
+        # instead (a diagnostic breadcrumb, not the audit trail this
+        # replay closes).
+        _relay_child_log(stderr, verb="post_swap_migrations", job_id=job_id)
+        pass_warnings = [event for event in _NON_FATAL_MIGRATION_FAILURE_EVENTS if event in stderr]
+        # Scan stdout from the END, exactly like privileged._parse_result —
+        # an unexpected banner on stdout cannot displace the answer.
+        for line in reversed((proc.stdout or "").splitlines()):
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                envelope = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(envelope, dict) or _MIGRATION_RESULT_KEY not in envelope:
+                continue
+            result = envelope[_MIGRATION_RESULT_KEY]
+            if isinstance(result, dict) and "from" in result and "to" in result:
+                return {
+                    "from": int(result["from"]),
+                    "to": int(result["to"]),
+                    "pass_warnings": pass_warnings,
+                }
         raise UpdateError(
             "post-activation migrations subprocess exited 0 but produced no result marker",
             details={"job_id": job_id, "stdout": (proc.stdout or "")[-2000:]},
         )
-    stderr = proc.stderr or ""
     # Last non-empty line is almost always the exception's own message (a
-    # traceback's final line) — surfaced in the message itself (not just
-    # `details`) so it reaches the operator-facing convergence report in
+    # traceback's final line, or the "hal0-migrate: ..." line the child
+    # prints itself) — surfaced in the message itself (not just `details`)
+    # so it reaches the operator-facing convergence report in
     # cli/update_commands.py, not only the journal.
     reason = next((line.strip() for line in reversed(stderr.splitlines()) if line.strip()), "")
     raise UpdateError(
@@ -3903,14 +4040,16 @@ class Updater:
         # see _run_post_activation_migrations_after_swap for why an in-process
         # call here (the pre-fix behaviour) executed the OUTGOING version's
         # migrations, never the incoming release's. What has to stay here,
-        # unchanged, is the ceiling derivation: it caps the target below the
-        # profile-catalog watermark ONLY while that reset is genuinely
-        # outstanding — an already converged box (or a future v3 migration)
+        # unchanged, is the `reset_outstanding` derivation: it decides whether
+        # the migration target must be capped below the profile-catalog
+        # watermark — an already converged box (or a future v3 migration)
         # must not be held back — and it needs `profile_reset` (just computed
         # above), so it is cheapest to compute right where the old call used
-        # to be, even though the call itself now happens later.
+        # to be. The INT ceiling itself is no longer derived here (#1960 N1) —
+        # only the bool crosses into the subprocess; see that function's
+        # docstring for why turning it into an int on this side would be a
+        # version-skew bug waiting to happen.
         reset_outstanding = bool(profile_reset.get("due")) and not profile_reset.get("stamped")
-        ceiling = PROFILE_CATALOG_SCHEMA_VERSION - 1 if reset_outstanding else None
 
         # spec-hw-slot-ownership §6 / spec-flags-ownership §5 one-shot folds are
         # still NOT auto-run here — see detect_pending_ownership_migrations()
@@ -3967,13 +4106,16 @@ class Updater:
         # which is shared with rollback() and therefore still guards on it —
         # no editable-install branch is needed here.
         migrations_error: str | None = None
+        pass_warnings: list[str] = []
         try:
-            migration_info = await _run_post_activation_migrations_after_swap(
+            migration_result = await _run_post_activation_migrations_after_swap(
                 manifest.min_data_version,
                 job_id=self.job_id,
-                ceiling=ceiling,
+                reset_outstanding=reset_outstanding,
             )
-        except UpdateError as exc:
+            migration_info = (migration_result["from"], migration_result["to"])
+            pass_warnings = list(migration_result.get("pass_warnings") or [])
+        except Exception as exc:
             # LOUD, not silent (#1960's failure-mode decision): the tree is
             # already active by this point — the symlink swap and venv re-pip
             # above already succeeded — so raising here and reporting the
@@ -3988,6 +4130,18 @@ class Updater:
             # _print_convergence). hal0-api's boot-time
             # check_outstanding_migrations retries this automatically at the
             # next restart, so the failure is self-healing, not permanent.
+            #
+            # Bare `except Exception`, not `except UpdateError` (#1960 B1):
+            # the helper converts every failure shape it knows about to
+            # UpdateError, but subprocess.run can raise things outside that
+            # (a bug in the helper's own conversion, a future refactor that
+            # misses a case) — the same containment class
+            # _rerender_units_after_swap uses for its own subprocess call.
+            # This is the one place in commit() a bare except is correct: by
+            # this point the release is already active, so NOTHING may
+            # escape and abort the function — every later step (unit
+            # re-render, the previous-version breadcrumb, the response
+            # itself) still has to run.
             migrations_error = str(exc)
             fallback_version = _raw_schema_version(_raw_hal0_toml())
             migration_info = (fallback_version, fallback_version)
@@ -4016,6 +4170,15 @@ class Updater:
         # A commit that swapped the tree but left the box on the pre-v1.0 slot /
         # model shape is not "done" — surface exactly what is outstanding so the
         # CLI can refuse to call it a clean success.
+        #
+        # `pass_warnings` (#1960 B2) does NOT factor into `ok`/`converged`:
+        # those five passes are independently best-effort BY DESIGN (see
+        # run_post_activation_migrations's own docstring — an affected slot
+        # or model just keeps its previous state until the operator acts),
+        # exactly as true before this PR as after it. What changed is only
+        # that a swallowed pass failure used to be invisible outside
+        # journalctl; it is now visible here too, without reclassifying a
+        # long-standing non-fatal outcome as a hard one.
         convergence = {
             "profile_reset": profile_reset,
             "slot_enabled_swept": enabled_swept,
@@ -4025,6 +4188,7 @@ class Updater:
                 "from": migration_info[0],
                 "to": migration_info[1],
                 "error": migrations_error,
+                "pass_warnings": pass_warnings,
             },
             "converged": (
                 not pending_ownership.get("pending")
@@ -4040,6 +4204,7 @@ class Updater:
             slot_enabled_swept=len(enabled_swept),
             ownership_pending=pending_ownership.get("pending"),
             post_activation_migrations_ok=migrations_error is None,
+            post_activation_migrations_pass_warnings=pass_warnings,
         )
 
         return {

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1703,6 +1703,45 @@ def run_post_activation_migrations(
     return migration_info
 
 
+def check_outstanding_migrations(*, job_id: str | None = None) -> tuple[int, int] | None:
+    """Boot-time safety net for #1960: heal a box that missed its migrations.
+
+    Two boxes need this, not one: (a) any box that upgraded through the
+    pre-#1960 in-process/pre-swap call never got the incoming release's
+    migrations at all, permanently — there is no later ``commit()`` call
+    that will ever re-run them; (b) even post-fix,
+    :func:`_run_post_activation_migrations_after_swap` can itself fail (disk
+    full, a bug in one specific pass), and ``commit()`` deliberately does not
+    retry it inline — see that function's caller for why. Calling this once
+    at every ``hal0-api`` boot heals both: every one of the six passes
+    ``run_post_activation_migrations`` runs is documented as an idempotent
+    "stale? fix it : no-op" sweep (see each pass's own docstring), so a
+    converged box pays for one ``hal0.toml`` read plus five near-instant
+    no-ops.
+
+    Mirrors :meth:`Updater.commit`'s own ``ceiling`` derivation, using
+    :func:`profile_reset_status` — a pure read — so a box whose one-shot
+    profile-catalog reset is still outstanding does not have this safety net
+    race ``meta.schema_version`` past that gate. No ``reset_profile_catalog``
+    call happens here, only the read: this function never deletes
+    ``profiles.toml``.
+
+    Never raises — a startup safety net that could itself fail startup would
+    be worse than the staleness it exists to fix. Returns the ``(source,
+    target)`` schema tuple on success, ``None`` on any failure (already
+    logged as a warning; this is a background sweep, not a user-initiated
+    update, so it does not warrant the ERROR level
+    :meth:`Updater.commit` uses for the same failure).
+    """
+    try:
+        reset_outstanding = bool(profile_reset_status().get("due"))
+        ceiling = PROFILE_CATALOG_SCHEMA_VERSION - 1 if reset_outstanding else None
+        return run_post_activation_migrations(job_id=job_id, ceiling=ceiling)
+    except Exception as exc:
+        log.warning("updater.boot_migration_check_failed", job_id=job_id, error=str(exc))
+        return None
+
+
 # ── Filesystem layout (paths-aware) ────────────────────────────────────────────
 
 
@@ -3578,6 +3617,80 @@ async def _rerender_units_after_swap(job_id: str | None) -> None:
         )
 
 
+async def _run_post_activation_migrations_after_swap(
+    min_data_version: int,
+    *,
+    job_id: str | None,
+    ceiling: int | None,
+) -> tuple[int, int]:
+    """Run :func:`run_post_activation_migrations` in a subprocess of the
+    just-repipped venv, AFTER the ``current`` symlink swap (#1960).
+
+    Mirrors :func:`_rerender_units_after_swap`'s exact reasoning: this
+    process is still running the PRE-swap code — Python does not hot-swap
+    already-imported modules — so calling ``run_post_activation_migrations``
+    in-process at this point would run the OUTGOING version's migration set,
+    never the incoming release's. That was the bug: a migration shipped in
+    release N+1 never ran on the N → N+1 upgrade that shipped it, because the
+    old call site (this function's replacement) ran BEFORE the swap. A
+    subprocess of the just-repipped venv imports the NEW module instead.
+
+    Unlike ``_rerender_units_after_swap``, a failure here is not swallowed to
+    a bare warning inside this function — see :meth:`Updater.commit` for how
+    the caller decides how loud to be. This helper's job is narrow: run the
+    six passes in the right interpreter and report what happened. Raises
+    :class:`UpdateError` on any subprocess failure — a non-zero exit, or a
+    clean exit with no parsable result (both are surfaced identically).
+
+    Args are passed as a single JSON argv element rather than interpolated
+    into the ``-c`` script text, so ``job_id`` can never be mis-parsed as
+    code.
+    """
+    payload = json.dumps(
+        {"min_data_version": min_data_version, "job_id": job_id, "ceiling": ceiling}
+    )
+    script = (
+        "import json, sys\n"
+        "from hal0.updater.updater import run_post_activation_migrations\n"
+        "args = json.loads(sys.argv[1])\n"
+        "result = run_post_activation_migrations(\n"
+        "    args['min_data_version'], job_id=args['job_id'], ceiling=args['ceiling']\n"
+        ")\n"
+        "print('HAL0_MIGRATION_RESULT=' + json.dumps({'from': result[0], 'to': result[1]}))\n"
+    )
+    proc = await asyncio.to_thread(
+        subprocess.run,
+        [sys.executable, "-c", script, payload],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    if proc.returncode == 0:
+        for line in (proc.stdout or "").splitlines():
+            if line.startswith("HAL0_MIGRATION_RESULT="):
+                data = json.loads(line[len("HAL0_MIGRATION_RESULT=") :])
+                return (int(data["from"]), int(data["to"]))
+        raise UpdateError(
+            "post-activation migrations subprocess exited 0 but produced no result marker",
+            details={"job_id": job_id, "stdout": (proc.stdout or "")[-2000:]},
+        )
+    stderr = proc.stderr or ""
+    # Last non-empty line is almost always the exception's own message (a
+    # traceback's final line) — surfaced in the message itself (not just
+    # `details`) so it reaches the operator-facing convergence report in
+    # cli/update_commands.py, not only the journal.
+    reason = next((line.strip() for line in reversed(stderr.splitlines()) if line.strip()), "")
+    raise UpdateError(
+        f"post-activation migrations failed in the newly activated tree (rc={proc.returncode})"
+        + (f": {reason}" if reason else ""),
+        details={
+            "job_id": job_id,
+            "returncode": proc.returncode,
+            "stderr": stderr[-2000:],
+        },
+    )
+
+
 # ── Updater class ──────────────────────────────────────────────────────────────
 
 
@@ -3786,29 +3899,18 @@ class Updater:
             # file in place (the overlay still serves the built-in seeds), and
             # the un-stamped gate re-offers it next update.
 
-        # Step 7: config migrations. Cap the target below the profile-catalog
-        # watermark ONLY while that reset is genuinely outstanding — an already
-        # converged box (or a future v3 migration) must not be held back.
-        migration_info: tuple[int, int]
+        # Step 7's CALL is moved below, to run AFTER seam.activate() (#1960) —
+        # see _run_post_activation_migrations_after_swap for why an in-process
+        # call here (the pre-fix behaviour) executed the OUTGOING version's
+        # migrations, never the incoming release's. What has to stay here,
+        # unchanged, is the ceiling derivation: it caps the target below the
+        # profile-catalog watermark ONLY while that reset is genuinely
+        # outstanding — an already converged box (or a future v3 migration)
+        # must not be held back — and it needs `profile_reset` (just computed
+        # above), so it is cheapest to compute right where the old call used
+        # to be, even though the call itself now happens later.
         reset_outstanding = bool(profile_reset.get("due")) and not profile_reset.get("stamped")
         ceiling = PROFILE_CATALOG_SCHEMA_VERSION - 1 if reset_outstanding else None
-        try:
-            migration_info = await asyncio.to_thread(
-                run_post_activation_migrations,
-                manifest.min_data_version,
-                job_id=self.job_id,
-                ceiling=ceiling,
-            )
-        except Hal0Error as exc:
-            # Don't leave the new tree orphaned on a migration failure —
-            # nuke the half-installed dir so a retry starts fresh. Routed
-            # through the seam: /usr/lib/hal0 is root-only (#1464).
-            with contextlib.suppress(Exception):
-                seam.discard(release_dir_name(target_version))
-            raise UpdateError(
-                f"config migration failed during update: {exc.message}",
-                details={**exc.details, "version": target_version},
-            ) from exc
 
         # spec-hw-slot-ownership §6 / spec-flags-ownership §5 one-shot folds are
         # still NOT auto-run here — see detect_pending_ownership_migrations()
@@ -3855,6 +3957,47 @@ class Updater:
         prior_str = activated.get("previous")
         prior = Path(prior_str) if prior_str else None
 
+        # Step 7 (moved here, #1960): post-activation migrations now run in a
+        # subprocess of the just-repipped venv, AFTER the swap above — see
+        # _run_post_activation_migrations_after_swap. Must run BEFORE the
+        # unit re-render below so slot units render from already-migrated
+        # config (e.g. a relabelled device, sanitised extra_args). commit()
+        # already hard-refuses editable installs at its own top
+        # (_raise_if_editable_install), so — unlike _rerender_units_after_swap,
+        # which is shared with rollback() and therefore still guards on it —
+        # no editable-install branch is needed here.
+        migrations_error: str | None = None
+        try:
+            migration_info = await _run_post_activation_migrations_after_swap(
+                manifest.min_data_version,
+                job_id=self.job_id,
+                ceiling=ceiling,
+            )
+        except UpdateError as exc:
+            # LOUD, not silent (#1960's failure-mode decision): the tree is
+            # already active by this point — the symlink swap and venv re-pip
+            # above already succeeded — so raising here and reporting the
+            # whole commit() as "failed" would be misleading; the release IS
+            # running. What actually failed is narrower: on-disk data (slot
+            # TOMLs, hal0.toml schema, registry rows) may still reflect the
+            # OUTGOING release's shape — real, user-visible state divergence,
+            # so this logs at ERROR (louder than _rerender_units_after_swap's
+            # own WARNING for its lower-stakes non-fatal failure) and is
+            # threaded into `convergence` below so `hal0 update` refuses to
+            # call the run a clean success (see cli/update_commands.py's
+            # _print_convergence). hal0-api's boot-time
+            # check_outstanding_migrations retries this automatically at the
+            # next restart, so the failure is self-healing, not permanent.
+            migrations_error = str(exc)
+            fallback_version = _raw_schema_version(_raw_hal0_toml())
+            migration_info = (fallback_version, fallback_version)
+            log.error(
+                "updater.post_swap_migration_failed",
+                job_id=self.job_id,
+                version=target_version,
+                error=migrations_error,
+            )
+
         # Step 8c: re-render existing slot units through the NEW code. Must
         # run AFTER the 8b venv reinstall (see _rerender_units_after_swap).
         if not _is_editable_install():
@@ -3877,9 +4020,16 @@ class Updater:
             "profile_reset": profile_reset,
             "slot_enabled_swept": enabled_swept,
             "ownership_migrations": pending_ownership,
+            "post_activation_migrations": {
+                "ok": migrations_error is None,
+                "from": migration_info[0],
+                "to": migration_info[1],
+                "error": migrations_error,
+            },
             "converged": (
                 not pending_ownership.get("pending")
                 and profile_reset.get("outcome") in {"reset", "already_reset", "no_config"}
+                and migrations_error is None
             ),
         }
         log.info(
@@ -3889,6 +4039,7 @@ class Updater:
             profile_reset=profile_reset.get("outcome"),
             slot_enabled_swept=len(enabled_swept),
             ownership_pending=pending_ownership.get("pending"),
+            post_activation_migrations_ok=migrations_error is None,
         )
 
         return {
@@ -4058,6 +4209,7 @@ __all__ = [
     "activate_release",
     "assert_release_dir_name",
     "assert_trusted_release_dir",
+    "check_outstanding_migrations",
     "convergence_report",
     "detect_pending_ownership_migrations",
     "discard_release",

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -1187,3 +1187,81 @@ def test_apply_reaches_applied_on_disk_even_if_the_restart_never_returns(
         time.sleep(0.05)
 
     assert on_disk.get("state") == "applied", on_disk
+
+
+def test_commit_convergence_is_durable_before_the_restart_that_can_kill_us(
+    isolated_client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1960 B3: convergence must be on disk BEFORE the restart subprocess
+    runs, not after — that call is systemd bouncing hal0-api's own unit
+    from inside its own cgroup, so it can SIGTERM this very process while
+    it's still in flight (#1540's exact mechanism, same file's own
+    ``_try_restart_hal0_api`` docstring). The old code set
+    ``job["convergence"]`` AFTER ``_try_restart_hal0_api()`` returned, so a
+    same-cgroup SIGTERM landing during the restart could strand a completed
+    commit with no convergence key on disk at all — and
+    ``_print_convergence(None)`` reports a clean success for what may have
+    been a red (unconverged) post-swap migration failure.
+
+    Mirrors ``test_apply_persists_applied_before_attempting_the_restart``'s
+    exact technique: read what has actually been persisted to disk AT THE
+    MOMENT the restart's subprocess is invoked, not after the fact.
+    """
+    from hal0.api.routes import updater as u_mod
+
+    convergence_payload = {
+        "converged": False,
+        "post_activation_migrations": {
+            "ok": False,
+            "from": 1,
+            "to": 1,
+            "error": "boom",
+            "pass_warnings": [],
+        },
+    }
+
+    async def fake_commit(self: object, version: str, reset_profiles: bool | None = None) -> dict:
+        return {
+            "version": "0.0.9",
+            "installed_at": time.time(),
+            "convergence": convergence_payload,
+        }
+
+    monkeypatch.setattr(u_mod.Updater, "commit", fake_commit)
+
+    convergence_at_restart_time: list[Any] = []
+
+    def fake_run(cmd: list[str], *a: object, **k: object) -> object:
+        # At the instant the restart's subprocess is invoked, read what has
+        # actually been committed to disk so far — exactly the snapshot a
+        # same-cgroup SIGTERM landing right here would leave behind.
+        job_id = job_id_holder.get("id")
+        on_disk = u_mod._load_persisted_job(job_id) if job_id else None
+        convergence_at_restart_time.append((on_disk or {}).get("convergence"))
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(u_mod.subprocess, "run", fake_run)
+
+    job_id_holder: dict[str, str] = {}
+    r = isolated_client.post("/api/updates/commit", json={"version": "0.0.9"})
+    job_id_holder["id"] = r.json()["id"]
+
+    deadline = time.monotonic() + 6.0
+    final: dict = {}
+    while time.monotonic() < deadline:
+        final = isolated_client.get(f"/api/updates/status/{job_id_holder['id']}").json()
+        if final["state"] == "failed" or final.get("restarted") is not None:
+            break
+        time.sleep(0.05)
+
+    assert convergence_at_restart_time, "the restart ran without any job state persisted first"
+    assert convergence_at_restart_time[-1] == convergence_payload, (
+        "convergence was not durable on disk before the restart that can kill this "
+        f"process; convergence persisted by then was {convergence_at_restart_time!r}"
+    )

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -527,6 +527,71 @@ def test_render_notes_none_is_noop(capsys: pytest.CaptureFixture[str]) -> None:
     assert capsys.readouterr().out == ""
 
 
+# ── _print_convergence: post-activation migrations (#1960) ─────────────────────
+
+
+def test_print_convergence_reports_a_failed_post_swap_migration(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A commit() whose post-swap migration subprocess failed must not be
+    reported as a clean success — see Updater.commit()'s #1960 failure-mode
+    note. The CLI has to say so, loudly, and _print_convergence must return
+    False so the caller's exit code reflects it."""
+    converged = uc._print_convergence(
+        {
+            "profile_reset": {"outcome": "no_config"},
+            "slot_enabled_swept": [],
+            "ownership_migrations": {"pending": []},
+            "post_activation_migrations": {
+                "ok": False,
+                "from": 1,
+                "to": 1,
+                "error": "post-activation migrations failed in the newly activated tree "
+                "(rc=1): Hal0Error: kaboom",
+            },
+            "converged": False,
+        }
+    )
+    out = capsys.readouterr().out
+    assert converged is False
+    assert "Migration incomplete" in out
+    assert "kaboom" in out
+
+
+def test_print_convergence_shows_the_migrated_schema_range_on_success(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    converged = uc._print_convergence(
+        {
+            "profile_reset": {"outcome": "no_config"},
+            "slot_enabled_swept": [],
+            "ownership_migrations": {"pending": []},
+            "post_activation_migrations": {"ok": True, "from": 1, "to": 2, "error": None},
+            "converged": True,
+        }
+    )
+    out = capsys.readouterr().out
+    assert converged is True
+    assert "v1" in out and "v2" in out
+
+
+def test_print_convergence_says_nothing_extra_when_schema_unchanged(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No migration ran (already-converged box) — no spurious 'v1 -> v1' line."""
+    uc._print_convergence(
+        {
+            "profile_reset": {"outcome": "no_config"},
+            "slot_enabled_swept": [],
+            "ownership_migrations": {"pending": []},
+            "post_activation_migrations": {"ok": True, "from": 1, "to": 1, "error": None},
+            "converged": True,
+        }
+    )
+    out = capsys.readouterr().out
+    assert "schema migrated" not in out
+
+
 # ── _poll_job across the restart window (#1540) ───────────────────────────────
 #
 # These are the first tests to exercise _poll_job itself. Every pre-existing

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -548,6 +548,7 @@ def test_print_convergence_reports_a_failed_post_swap_migration(
                 "to": 1,
                 "error": "post-activation migrations failed in the newly activated tree "
                 "(rc=1): Hal0Error: kaboom",
+                "pass_warnings": [],
             },
             "converged": False,
         }
@@ -566,13 +567,22 @@ def test_print_convergence_shows_the_migrated_schema_range_on_success(
             "profile_reset": {"outcome": "no_config"},
             "slot_enabled_swept": [],
             "ownership_migrations": {"pending": []},
-            "post_activation_migrations": {"ok": True, "from": 1, "to": 2, "error": None},
+            "post_activation_migrations": {
+                "ok": True,
+                "from": 1,
+                "to": 2,
+                "error": None,
+                "pass_warnings": [],
+            },
             "converged": True,
         }
     )
     out = capsys.readouterr().out
     assert converged is True
-    assert "v1" in out and "v2" in out
+    # N4: tightened from a loose "v1" / "v2" substring check — this pins
+    # the exact rendered phrase so it can't false-positive against
+    # unrelated "v1"/"v2" text elsewhere in the panel.
+    assert "schema migrated v1 → v2" in out
 
 
 def test_print_convergence_says_nothing_extra_when_schema_unchanged(
@@ -584,12 +594,45 @@ def test_print_convergence_says_nothing_extra_when_schema_unchanged(
             "profile_reset": {"outcome": "no_config"},
             "slot_enabled_swept": [],
             "ownership_migrations": {"pending": []},
-            "post_activation_migrations": {"ok": True, "from": 1, "to": 1, "error": None},
+            "post_activation_migrations": {
+                "ok": True,
+                "from": 1,
+                "to": 1,
+                "error": None,
+                "pass_warnings": [],
+            },
             "converged": True,
         }
     )
     out = capsys.readouterr().out
     assert "schema migrated" not in out
+
+
+def test_print_convergence_reports_a_nonfatal_pass_warning(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """#1960 B2: a pass that swallowed its own exception into a warning
+    (rc=0, ok=True, by design non-fatal) must still be visible to the
+    operator, distinct from the red 'Migration incomplete' panel."""
+    converged = uc._print_convergence(
+        {
+            "profile_reset": {"outcome": "no_config"},
+            "slot_enabled_swept": [],
+            "ownership_migrations": {"pending": []},
+            "post_activation_migrations": {
+                "ok": True,
+                "from": 1,
+                "to": 1,
+                "error": None,
+                "pass_warnings": ["updater.mtp_migration_failed"],
+            },
+            "converged": True,
+        }
+    )
+    out = capsys.readouterr().out
+    assert converged is True
+    assert "mtp override cleanup" in out
+    assert "Migration incomplete" not in out
 
 
 # ── _poll_job across the restart window (#1540) ───────────────────────────────

--- a/tests/updater/test_post_activation_migrations.py
+++ b/tests/updater/test_post_activation_migrations.py
@@ -78,6 +78,19 @@ def test_runs_all_six_passes(_stub_every_pass: dict[str, list[Any]]) -> None:
     assert _stub_every_pass["extra_args"] == ["j1"]
 
 
+def test_skip_image_retag_omits_only_that_pass(_stub_every_pass: dict[str, list[Any]]) -> None:
+    """#1960 N2: check_outstanding_migrations passes skip_image_retag=True
+    so the boot-time safety net never runs retag_stale_slot_images — every
+    OTHER pass must still run unaffected."""
+    result = run_post_activation_migrations(job_id="j1", skip_image_retag=True)
+    assert result == (1, 2)
+    assert _stub_every_pass["seed_profiles"] == ["j1"]
+    assert _stub_every_pass["mtp"] == ["j1"]
+    assert _stub_every_pass["vulkan_migration"] == ["j1"]
+    assert _stub_every_pass["image_retag"] == []
+    assert _stub_every_pass["extra_args"] == ["j1"]
+
+
 def test_min_data_version_defaults_to_1(_stub_every_pass: dict[str, list[Any]]) -> None:
     """install.sh has no release manifest to read min_data_version from —
     the default must resolve to "migrate to whatever this code's latest

--- a/tests/updater/test_post_swap_migrations.py
+++ b/tests/updater/test_post_swap_migrations.py
@@ -6,20 +6,35 @@
   process. See ``test_updater.py``'s
   ``test_commit_runs_post_activation_migrations_after_the_swap`` for the
   end-to-end ordering proof against ``commit()`` itself; this file covers
-  the helper's own argument-passing and error-surfacing contract in
-  isolation.
+  the helper's own argument-passing, containment, and error-surfacing
+  contract in isolation.
 * ``check_outstanding_migrations`` — the boot-time safety net that re-runs
-  the same six passes on every ``hal0-api`` start so a box that missed its
+  the same passes on every ``hal0-api`` start so a box that missed its
   migrations (pre-fix, or a failed post-swap subprocess) self-heals.
+
+Independent review of the first version of this PR (comment 5354502220)
+found three blocking gaps, addressed here:
+
+* B1 — ``subprocess.run`` itself can raise (``TimeoutExpired``, ``OSError``)
+  rather than return a non-zero ``CompletedProcess``; the old code only
+  handled the latter shape.
+* B2 — the child's structured log (breadcrumbs #1935 relies on, plus any
+  non-fatal per-pass warning) was captured and discarded, not relayed into
+  the parent's own journal.
+* N1 — the ``ceiling`` int must be derived from the INCOMING tree's
+  ``PROFILE_CATALOG_SCHEMA_VERSION``, not pre-computed from the (still
+  outgoing) parent process's constant.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
 from typing import Any
 
 import pytest
+from structlog.testing import capture_logs
 
 from hal0.updater import updater as updater_module
 from hal0.updater.updater import (
@@ -36,38 +51,42 @@ class _Completed:
         self.stderr = stderr
 
 
-# ── _run_post_activation_migrations_after_swap ──────────────────────────────────
+def _envelope(from_: int, to: int) -> str:
+    """The child script's stdout contract: one JSON line, the result keyed
+    under _MIGRATION_RESULT_KEY."""
+    return json.dumps({updater_module._MIGRATION_RESULT_KEY: {"from": from_, "to": to}})
 
 
-def test_success_parses_the_result_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+# ── _run_post_activation_migrations_after_swap: happy path ─────────────────────
+
+
+def test_success_parses_the_result_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
     def _fake_run(cmd, *a, **k):
-        return _Completed(stdout="HAL0_MIGRATION_RESULT=" + json.dumps({"from": 1, "to": 2}))
+        return _Completed(stdout=_envelope(1, 2))
 
     monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
 
-    result = asyncio.run(_run_post_activation_migrations_after_swap(2, job_id="j1", ceiling=None))
-    assert result == (1, 2)
+    result = asyncio.run(
+        _run_post_activation_migrations_after_swap(2, job_id="j1", reset_outstanding=False)
+    )
+    assert result == {"from": 1, "to": 2, "pass_warnings": []}
 
 
-def test_result_marker_survives_interleaved_log_noise(monkeypatch: pytest.MonkeyPatch) -> None:
-    """structlog's default (unconfigured) logger prints straight to stdout —
-    the same stdout ``capture_output=True`` captures — so the marker line
-    must be found even with ordinary log lines around it."""
+def test_result_envelope_survives_interleaved_log_noise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The envelope is scanned for from the END of stdout, exactly like
+    hal0.updater.privileged._parse_result — an unexpected banner cannot
+    displace the answer."""
 
     def _fake_run(cmd, *a, **k):
-        stdout = (
-            "2026-08-20T00:00:00Z [info] updater.migrations_applied source=1 target=2\n"
-            + "HAL0_MIGRATION_RESULT="
-            + json.dumps({"from": 1, "to": 2})
-            + "\n"
-            "2026-08-20T00:00:01Z [info] updater.seed_profiles_prune_noop\n"
-        )
+        stdout = "some pip warning that escaped to stdout\n" + _envelope(1, 2) + "\n"
         return _Completed(stdout=stdout)
 
     monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
 
-    result = asyncio.run(_run_post_activation_migrations_after_swap(1, job_id=None, ceiling=None))
-    assert result == (1, 2)
+    result = asyncio.run(
+        _run_post_activation_migrations_after_swap(1, job_id=None, reset_outstanding=False)
+    )
+    assert result == {"from": 1, "to": 2, "pass_warnings": []}
 
 
 def test_args_are_passed_through_as_a_single_json_argv_element(
@@ -77,16 +96,162 @@ def test_args_are_passed_through_as_a_single_json_argv_element(
 
     def _fake_run(cmd, *a, **k):
         captured["cmd"] = list(cmd)
-        return _Completed(stdout="HAL0_MIGRATION_RESULT=" + json.dumps({"from": 1, "to": 1}))
+        return _Completed(stdout=_envelope(1, 1))
 
     monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
 
-    asyncio.run(_run_post_activation_migrations_after_swap(3, job_id="job-xyz", ceiling=1))
+    asyncio.run(
+        _run_post_activation_migrations_after_swap(3, job_id="job-xyz", reset_outstanding=True)
+    )
 
     cmd = captured["cmd"]
     assert "run_post_activation_migrations" in cmd[2]
     payload = json.loads(cmd[3])
-    assert payload == {"min_data_version": 3, "job_id": "job-xyz", "ceiling": 1}
+    assert payload == {"min_data_version": 3, "job_id": "job-xyz", "reset_outstanding": True}
+
+
+def test_reset_outstanding_bool_not_a_precomputed_ceiling_int(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1960 N1: the wire payload carries the BOOL, never an int derived
+    from this (outgoing) process's PROFILE_CATALOG_SCHEMA_VERSION — the
+    child derives its own ceiling from its own import of that constant."""
+    captured: dict[str, Any] = {}
+
+    def _fake_run(cmd, *a, **k):
+        captured["script"] = cmd[2]
+        captured["payload"] = json.loads(cmd[3])
+        return _Completed(stdout=_envelope(1, 1))
+
+    monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
+
+    asyncio.run(_run_post_activation_migrations_after_swap(1, job_id=None, reset_outstanding=True))
+
+    assert "ceiling" not in captured["payload"]
+    assert captured["payload"]["reset_outstanding"] is True
+    # The child script re-derives the ceiling from ITS OWN import.
+    assert "PROFILE_CATALOG_SCHEMA_VERSION" in captured["script"]
+    assert "from hal0.updater.updater import" in captured["script"]
+
+
+# ── B2: relay + pass_warnings ────────────────────────────────────────────────
+
+
+def test_relays_the_childs_log_into_the_parent_journal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#1960 B2: the child's breadcrumbs (#1935's contract, and the
+    release-validation kit's post-upgrade grep) must not die in
+    capture_output — they arrive on stderr (the child pins logs there) and
+    must be relayed into the parent's own log."""
+    child_stderr = (
+        "2026-08-20T00:00:00Z [info] updater.migrations_applied source=1 target=2 job_id=j3\n"
+        "2026-08-20T00:00:01Z [warning] updater.slot_vulkan_relabeled_rocm slot=a job_id=j3\n"
+    )
+
+    def _fake_run(cmd, *a, **k):
+        return _Completed(stdout=_envelope(1, 2), stderr=child_stderr)
+
+    monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
+
+    with capture_logs() as logs:
+        asyncio.run(
+            _run_post_activation_migrations_after_swap(1, job_id="j3", reset_outstanding=False)
+        )
+
+    relayed = [e for e in logs if e.get("event") == "updater.privileged_child_log"]
+    assert len(relayed) == 2
+    assert all(e["job_id"] == "j3" for e in relayed)
+    assert all(e["verb"] == "post_swap_migrations" for e in relayed)
+    assert any("migrations_applied" in e["line"] for e in relayed)
+    assert any("slot_vulkan_relabeled_rocm" in e["line"] for e in relayed)
+
+
+def test_pass_warnings_surfaced_when_a_nonfatal_pass_logs_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pass that swallows its own exception into a warning still exits
+    the subprocess with rc=0 (by design) — that warning must not be
+    silently discarded; it belongs in the returned pass_warnings list."""
+    child_stderr = (
+        "2026-08-20T00:00:00Z [warning] updater.mtp_migration_failed error=boom job_id=j4\n"
+    )
+
+    def _fake_run(cmd, *a, **k):
+        return _Completed(stdout=_envelope(1, 1), stderr=child_stderr)
+
+    monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
+
+    result = asyncio.run(
+        _run_post_activation_migrations_after_swap(1, job_id="j4", reset_outstanding=False)
+    )
+    assert result["pass_warnings"] == ["updater.mtp_migration_failed"]
+
+
+def test_no_pass_warnings_on_a_clean_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    child_stderr = "2026-08-20T00:00:00Z [info] updater.migrations_noop source=1 target=1\n"
+
+    def _fake_run(cmd, *a, **k):
+        return _Completed(stdout=_envelope(1, 1), stderr=child_stderr)
+
+    monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
+
+    result = asyncio.run(
+        _run_post_activation_migrations_after_swap(1, job_id=None, reset_outstanding=False)
+    )
+    assert result["pass_warnings"] == []
+
+
+def test_relay_does_not_happen_on_the_failure_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mirrors UpdateSeam._invoke exactly: on failure the stderr goes into
+    the raised error's details (a diagnostic breadcrumb), not into a
+    per-line relay — relaying only ever happens on the success path."""
+    child_stderr = "hal0-migrate: schema migration exploded\n"
+
+    def _fake_run(cmd, *a, **k):
+        return _Completed(returncode=1, stderr=child_stderr)
+
+    monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
+
+    with capture_logs() as logs, pytest.raises(UpdateError):
+        asyncio.run(
+            _run_post_activation_migrations_after_swap(1, job_id=None, reset_outstanding=False)
+        )
+
+    assert [e for e in logs if e.get("event") == "updater.privileged_child_log"] == []
+
+
+# ── B1: containment of every subprocess failure shape ───────────────────────
+
+
+def test_timeout_expired_is_converted_to_update_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """subprocess.run itself raises TimeoutExpired rather than returning a
+    CompletedProcess — the old code did not catch this at all."""
+
+    def _fake_run(cmd, *a, **k):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=300)
+
+    monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
+
+    with pytest.raises(UpdateError) as exc_info:
+        asyncio.run(
+            _run_post_activation_migrations_after_swap(1, job_id="j5", reset_outstanding=False)
+        )
+    assert "timed out" in str(exc_info.value)
+    assert exc_info.value.details["job_id"] == "j5"
+
+
+def test_os_error_launching_the_subprocess_is_converted_to_update_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_run(cmd, *a, **k):
+        raise OSError("Terminated")
+
+    monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
+
+    with pytest.raises(UpdateError) as exc_info:
+        asyncio.run(
+            _run_post_activation_migrations_after_swap(1, job_id=None, reset_outstanding=False)
+        )
+    assert "could not be launched" in str(exc_info.value)
 
 
 def test_nonzero_exit_raises_update_error_with_stderr_reason(
@@ -101,21 +266,25 @@ def test_nonzero_exit_raises_update_error_with_stderr_reason(
     monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
 
     with pytest.raises(UpdateError) as exc_info:
-        asyncio.run(_run_post_activation_migrations_after_swap(1, job_id="j2", ceiling=None))
+        asyncio.run(
+            _run_post_activation_migrations_after_swap(1, job_id="j2", reset_outstanding=False)
+        )
 
     assert "kaboom" in str(exc_info.value)
     assert exc_info.value.details["returncode"] == 1
     assert exc_info.value.details["job_id"] == "j2"
 
 
-def test_zero_exit_with_no_marker_raises_update_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_zero_exit_with_no_envelope_raises_update_error(monkeypatch: pytest.MonkeyPatch) -> None:
     def _fake_run(cmd, *a, **k):
         return _Completed(stdout="some unrelated log line\n")
 
     monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
 
     with pytest.raises(UpdateError) as exc_info:
-        asyncio.run(_run_post_activation_migrations_after_swap(1, job_id=None, ceiling=None))
+        asyncio.run(
+            _run_post_activation_migrations_after_swap(1, job_id=None, reset_outstanding=False)
+        )
 
     assert "no result marker" in str(exc_info.value)
 
@@ -126,7 +295,7 @@ def test_zero_exit_with_no_marker_raises_update_error(monkeypatch: pytest.Monkey
 def test_never_raises_on_internal_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
 
-    def _boom(*, job_id=None, ceiling=None):
+    def _boom(*, job_id=None, ceiling=None, skip_image_retag=False):
         raise RuntimeError("disk full")
 
     monkeypatch.setattr(updater_module, "run_post_activation_migrations", _boom)
@@ -139,7 +308,7 @@ def test_forwards_the_real_migration_result_on_success(monkeypatch: pytest.Monke
     monkeypatch.setattr(
         updater_module,
         "run_post_activation_migrations",
-        lambda *, job_id=None, ceiling=None: (1, 2),
+        lambda *, job_id=None, ceiling=None, skip_image_retag=False: (1, 2),
     )
 
     assert check_outstanding_migrations(job_id="boot") == (1, 2)
@@ -156,7 +325,7 @@ def test_caps_the_ceiling_while_the_profile_catalog_reset_is_outstanding(
     monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": True})
     seen: dict[str, Any] = {}
 
-    def _fake_migrations(*, job_id=None, ceiling=None):
+    def _fake_migrations(*, job_id=None, ceiling=None, skip_image_retag=False):
         seen["ceiling"] = ceiling
         return (1, 1)
 
@@ -170,7 +339,7 @@ def test_no_ceiling_when_the_reset_is_not_due(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
     seen: dict[str, Any] = {}
 
-    def _fake_migrations(*, job_id=None, ceiling=None):
+    def _fake_migrations(*, job_id=None, ceiling=None, skip_image_retag=False):
         seen["ceiling"] = ceiling
         return (1, 1)
 
@@ -187,7 +356,7 @@ def test_never_calls_reset_profile_catalog(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(
         updater_module,
         "run_post_activation_migrations",
-        lambda *, job_id=None, ceiling=None: (1, 1),
+        lambda *, job_id=None, ceiling=None, skip_image_retag=False: (1, 1),
     )
 
     def _unexpected(**kwargs: Any) -> None:
@@ -196,3 +365,21 @@ def test_never_calls_reset_profile_catalog(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(updater_module, "reset_profile_catalog", _unexpected)
 
     assert check_outstanding_migrations() == (1, 1)
+
+
+def test_skips_the_image_retag_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#1960 N2: retag_stale_slot_images must not run on every boot — see
+    run_post_activation_migrations's own docstring for the operator-state
+    risk (#1867-class). check_outstanding_migrations must pass
+    skip_image_retag=True."""
+    monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
+    seen: dict[str, Any] = {}
+
+    def _fake_migrations(*, job_id=None, ceiling=None, skip_image_retag=False):
+        seen["skip_image_retag"] = skip_image_retag
+        return (1, 1)
+
+    monkeypatch.setattr(updater_module, "run_post_activation_migrations", _fake_migrations)
+
+    check_outstanding_migrations()
+    assert seen["skip_image_retag"] is True

--- a/tests/updater/test_post_swap_migrations.py
+++ b/tests/updater/test_post_swap_migrations.py
@@ -1,0 +1,198 @@
+"""Unit tests for the two #1960 primitives:
+
+* ``_run_post_activation_migrations_after_swap`` — the subprocess call
+  ``Updater.commit()`` now makes AFTER ``seam.activate()`` so migrations run
+  the INCOMING version's code, not the outgoing one still loaded in this
+  process. See ``test_updater.py``'s
+  ``test_commit_runs_post_activation_migrations_after_the_swap`` for the
+  end-to-end ordering proof against ``commit()`` itself; this file covers
+  the helper's own argument-passing and error-surfacing contract in
+  isolation.
+* ``check_outstanding_migrations`` — the boot-time safety net that re-runs
+  the same six passes on every ``hal0-api`` start so a box that missed its
+  migrations (pre-fix, or a failed post-swap subprocess) self-heals.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from hal0.updater import updater as updater_module
+from hal0.updater.updater import (
+    UpdateError,
+    _run_post_activation_migrations_after_swap,
+    check_outstanding_migrations,
+)
+
+
+class _Completed:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+# ── _run_post_activation_migrations_after_swap ──────────────────────────────────
+
+
+def test_success_parses_the_result_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_run(cmd, *a, **k):
+        return _Completed(stdout="HAL0_MIGRATION_RESULT=" + json.dumps({"from": 1, "to": 2}))
+
+    monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
+
+    result = asyncio.run(_run_post_activation_migrations_after_swap(2, job_id="j1", ceiling=None))
+    assert result == (1, 2)
+
+
+def test_result_marker_survives_interleaved_log_noise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """structlog's default (unconfigured) logger prints straight to stdout —
+    the same stdout ``capture_output=True`` captures — so the marker line
+    must be found even with ordinary log lines around it."""
+
+    def _fake_run(cmd, *a, **k):
+        stdout = (
+            "2026-08-20T00:00:00Z [info] updater.migrations_applied source=1 target=2\n"
+            + "HAL0_MIGRATION_RESULT="
+            + json.dumps({"from": 1, "to": 2})
+            + "\n"
+            "2026-08-20T00:00:01Z [info] updater.seed_profiles_prune_noop\n"
+        )
+        return _Completed(stdout=stdout)
+
+    monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
+
+    result = asyncio.run(_run_post_activation_migrations_after_swap(1, job_id=None, ceiling=None))
+    assert result == (1, 2)
+
+
+def test_args_are_passed_through_as_a_single_json_argv_element(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_run(cmd, *a, **k):
+        captured["cmd"] = list(cmd)
+        return _Completed(stdout="HAL0_MIGRATION_RESULT=" + json.dumps({"from": 1, "to": 1}))
+
+    monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
+
+    asyncio.run(_run_post_activation_migrations_after_swap(3, job_id="job-xyz", ceiling=1))
+
+    cmd = captured["cmd"]
+    assert "run_post_activation_migrations" in cmd[2]
+    payload = json.loads(cmd[3])
+    assert payload == {"min_data_version": 3, "job_id": "job-xyz", "ceiling": 1}
+
+
+def test_nonzero_exit_raises_update_error_with_stderr_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_run(cmd, *a, **k):
+        return _Completed(
+            returncode=1,
+            stderr="Traceback (most recent call last):\nhal0.errors.Hal0Error: kaboom\n",
+        )
+
+    monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
+
+    with pytest.raises(UpdateError) as exc_info:
+        asyncio.run(_run_post_activation_migrations_after_swap(1, job_id="j2", ceiling=None))
+
+    assert "kaboom" in str(exc_info.value)
+    assert exc_info.value.details["returncode"] == 1
+    assert exc_info.value.details["job_id"] == "j2"
+
+
+def test_zero_exit_with_no_marker_raises_update_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_run(cmd, *a, **k):
+        return _Completed(stdout="some unrelated log line\n")
+
+    monkeypatch.setattr(updater_module.subprocess, "run", _fake_run)
+
+    with pytest.raises(UpdateError) as exc_info:
+        asyncio.run(_run_post_activation_migrations_after_swap(1, job_id=None, ceiling=None))
+
+    assert "no result marker" in str(exc_info.value)
+
+
+# ── check_outstanding_migrations ─────────────────────────────────────────────
+
+
+def test_never_raises_on_internal_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
+
+    def _boom(*, job_id=None, ceiling=None):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(updater_module, "run_post_activation_migrations", _boom)
+
+    assert check_outstanding_migrations(job_id="boot") is None
+
+
+def test_forwards_the_real_migration_result_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
+    monkeypatch.setattr(
+        updater_module,
+        "run_post_activation_migrations",
+        lambda *, job_id=None, ceiling=None: (1, 2),
+    )
+
+    assert check_outstanding_migrations(job_id="boot") == (1, 2)
+
+
+def test_caps_the_ceiling_while_the_profile_catalog_reset_is_outstanding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mirrors Updater.commit()'s own ceiling derivation (#1960): this safety
+    net must not let meta.schema_version race past the profile-catalog
+    watermark on a box that has not gone through the one-shot reset — that
+    would silently consume the gate outside the consent flow.
+    """
+    monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": True})
+    seen: dict[str, Any] = {}
+
+    def _fake_migrations(*, job_id=None, ceiling=None):
+        seen["ceiling"] = ceiling
+        return (1, 1)
+
+    monkeypatch.setattr(updater_module, "run_post_activation_migrations", _fake_migrations)
+
+    check_outstanding_migrations()
+    assert seen["ceiling"] == updater_module.PROFILE_CATALOG_SCHEMA_VERSION - 1
+
+
+def test_no_ceiling_when_the_reset_is_not_due(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
+    seen: dict[str, Any] = {}
+
+    def _fake_migrations(*, job_id=None, ceiling=None):
+        seen["ceiling"] = ceiling
+        return (1, 1)
+
+    monkeypatch.setattr(updater_module, "run_post_activation_migrations", _fake_migrations)
+
+    check_outstanding_migrations()
+    assert seen["ceiling"] is None
+
+
+def test_never_calls_reset_profile_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
+    """This is a read-only status check, not a reset attempt — it must never
+    delete profiles.toml or perform the one-shot reset itself."""
+    monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": True})
+    monkeypatch.setattr(
+        updater_module,
+        "run_post_activation_migrations",
+        lambda *, job_id=None, ceiling=None: (1, 1),
+    )
+
+    def _unexpected(**kwargs: Any) -> None:
+        raise AssertionError("check_outstanding_migrations must not call reset_profile_catalog")
+
+    monkeypatch.setattr(updater_module, "reset_profile_catalog", _unexpected)
+
+    assert check_outstanding_migrations() == (1, 1)

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -1659,7 +1659,8 @@ def test_commit_runs_post_activation_migrations_after_the_swap(
             symlink_targets_when_migrations_ran.append(
                 Path(os.readlink(link)).name if link.is_symlink() else None
             )
-            return _Completed(stdout="HAL0_MIGRATION_RESULT=" + json.dumps({"from": 1, "to": 2}))
+            envelope = json.dumps({updater_module._MIGRATION_RESULT_KEY: {"from": 1, "to": 2}})
+            return _Completed(stdout=envelope)
         return _Completed()
 
     monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
@@ -1683,6 +1684,7 @@ def test_commit_runs_post_activation_migrations_after_the_swap(
         "from": 1,
         "to": 2,
         "error": None,
+        "pass_warnings": [],
     }
 
 
@@ -1728,6 +1730,74 @@ def test_commit_post_activation_migration_failure_is_non_fatal_but_loud(
     assert len(errors) == 1
     assert errors[0]["log_level"] == "error"
     assert "schema migration exploded" in errors[0]["error"]
+
+
+def test_commit_survives_a_migration_subprocess_timeout(
+    synthetic_release: dict[str, Any], cosign_skip: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1960 B1 (reviewer-reproduced): subprocess.run can raise
+    TimeoutExpired rather than return a non-zero CompletedProcess. The old
+    call site only caught UpdateError, so this propagated straight out of
+    commit() — the symlink was already swapped, but the whole update was
+    reported as failed and _try_restart_hal0_api was never reached. The
+    non-fatal-but-loud design has to hold for this failure shape too, the
+    same way _rerender_units_after_swap contains its own subprocess call.
+    """
+    import subprocess as subprocess_mod
+
+    def _fake_run(cmd, *a, **k):
+        cmd = list(cmd)
+        if any("run_post_activation_migrations" in part for part in cmd):
+            raise subprocess_mod.TimeoutExpired(cmd=cmd, timeout=300)
+
+        class _OK:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _OK()
+
+    monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
+    monkeypatch.setattr("hal0.updater.updater.subprocess.run", _fake_run)
+
+    result = asyncio.run(Updater().apply())  # must NOT raise
+
+    assert Path(os.readlink(_current_symlink())).name == "hal0-0.0.1"
+    post = result["convergence"]["post_activation_migrations"]
+    assert post["ok"] is False
+    assert "timed out" in post["error"]
+    assert result["convergence"]["converged"] is False
+
+
+def test_commit_survives_a_migration_subprocess_launch_failure(
+    synthetic_release: dict[str, Any], cosign_skip: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1960 B1 (reviewer-reproduced): subprocess.run can raise OSError
+    (the child interpreter could not even be launched) — same containment
+    gap as the TimeoutExpired case, different exception type."""
+
+    def _fake_run(cmd, *a, **k):
+        cmd = list(cmd)
+        if any("run_post_activation_migrations" in part for part in cmd):
+            raise OSError("Cannot allocate memory")
+
+        class _OK:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _OK()
+
+    monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
+    monkeypatch.setattr("hal0.updater.updater.subprocess.run", _fake_run)
+
+    result = asyncio.run(Updater().apply())  # must NOT raise
+
+    assert Path(os.readlink(_current_symlink())).name == "hal0-0.0.1"
+    post = result["convergence"]["post_activation_migrations"]
+    assert post["ok"] is False
+    assert "could not be launched" in post["error"]
+    assert result["convergence"]["converged"] is False
 
 
 def test_prepare_reads_release_notes(

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -1624,6 +1624,112 @@ def test_prepare_then_commit_swaps(synthetic_release: dict[str, Any], cosign_ski
     assert Path(os.readlink(link)).resolve() == install.resolve()
 
 
+# ── post-activation migrations run post-swap (#1960) ────────────────────────────
+
+
+def test_commit_runs_post_activation_migrations_after_the_swap(
+    synthetic_release: dict[str, Any], cosign_skip: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1960: migrations must execute the INCOMING version's code against the
+    activated tree — a subprocess of the just-repipped venv, run AFTER
+    seam.activate()'s symlink swap, exactly mirroring
+    _rerender_units_after_swap's own reasoning.
+
+    Before the fix, ``run_post_activation_migrations`` ran in-process
+    (``asyncio.to_thread``) BEFORE ``seam.activate()`` — this process's own
+    already-imported modules (the OUTGOING version), never the incoming
+    release's. This test fails against that code two ways: no subprocess
+    call for the migrations exists at all, and even once one exists, it
+    would fire before the symlink pointed at the new tree.
+    """
+    calls: list[list[str]] = []
+    symlink_targets_when_migrations_ran: list[str | None] = []
+
+    class _Completed:
+        def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def _fake_run(cmd, *a, **k):
+        cmd = list(cmd)
+        calls.append(cmd)
+        if any("run_post_activation_migrations" in part for part in cmd):
+            link = _current_symlink()
+            symlink_targets_when_migrations_ran.append(
+                Path(os.readlink(link)).name if link.is_symlink() else None
+            )
+            return _Completed(stdout="HAL0_MIGRATION_RESULT=" + json.dumps({"from": 1, "to": 2}))
+        return _Completed()
+
+    monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
+    monkeypatch.setattr("hal0.updater.updater.subprocess.run", _fake_run)
+
+    result = asyncio.run(Updater().apply())
+
+    migration_calls = [
+        c for c in calls if any("run_post_activation_migrations" in part for part in c)
+    ]
+    assert len(migration_calls) == 1, (
+        f"expected exactly one post-activation-migrations subprocess call, got: {calls}"
+    )
+    assert symlink_targets_when_migrations_ran == ["hal0-0.0.1"], (
+        "post-activation migrations ran before the symlink pointed at the incoming "
+        "release — the outgoing version's code would have executed instead (#1960)"
+    )
+    assert result["migrations"] == {"from": 1, "to": 2}
+    assert result["convergence"]["post_activation_migrations"] == {
+        "ok": True,
+        "from": 1,
+        "to": 2,
+        "error": None,
+    }
+
+
+def test_commit_post_activation_migration_failure_is_non_fatal_but_loud(
+    synthetic_release: dict[str, Any], cosign_skip: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed post-swap migration subprocess must not abort commit() — the
+    tree is already active by that point (the symlink swap and venv re-pip
+    already succeeded), so raising would misreport a completed activation as
+    a failed update (#1960). It must instead be LOUD: an ERROR-level journal
+    line, plus a ``convergence.post_activation_migrations`` block that makes
+    ``hal0 update`` refuse to call the run a clean success.
+    """
+    from structlog.testing import capture_logs
+
+    class _Completed:
+        def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def _fake_run(cmd, *a, **k):
+        cmd = list(cmd)
+        if any("run_post_activation_migrations" in part for part in cmd):
+            return _Completed(returncode=1, stderr="Hal0Error: schema migration exploded")
+        return _Completed()
+
+    monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
+    monkeypatch.setattr("hal0.updater.updater.subprocess.run", _fake_run)
+
+    with capture_logs() as logs:
+        result = asyncio.run(Updater().apply())
+
+    # The swap itself must stand — the release IS active despite the failure.
+    assert Path(os.readlink(_current_symlink())).name == "hal0-0.0.1"
+
+    post = result["convergence"]["post_activation_migrations"]
+    assert post["ok"] is False
+    assert "schema migration exploded" in post["error"]
+    assert result["convergence"]["converged"] is False
+
+    errors = [e for e in logs if e.get("event") == "updater.post_swap_migration_failed"]
+    assert len(errors) == 1
+    assert errors[0]["log_level"] == "error"
+    assert "schema migration exploded" in errors[0]["error"]
+
+
 def test_prepare_reads_release_notes(
     tmp_hal0_home: str,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Fixes #1960: `Updater.commit()` ran `run_post_activation_migrations` in-process (`asyncio.to_thread`) at Step 7, **before** Step 8's `seam.activate()` symlink swap. Python does not hot-swap already-imported modules, so that in-process call executed the currently-running (OUTGOING) version's migration set, never the incoming release's. Concretely: #1934's gpu-vulkan → gpu-rocm/cpu slot-TOML relabel, shipped for rc.7, would have been inert for every rc.6 → rc.7 `hal0 update` — it would only run the *next* time that box updated. The codebase already documents this exact trap in `_rerender_units_after_swap`'s docstring (unit re-render was moved to a subprocess of the just-repipped venv for precisely this reason); migrations were never given the same treatment.

## What changed

- **`_run_post_activation_migrations_after_swap`** (new, `updater.py`): runs `run_post_activation_migrations` in a subprocess of the just-repipped venv — mirrors `_rerender_units_after_swap` exactly (same `sys.executable -c ...` pattern, same reasoning). Args are passed as a single JSON argv element (not interpolated into the script text) so `job_id` can never be mis-parsed as code.
- **`Updater.commit()`**: the migration *call* moves to after `seam.activate()`, before the unit re-render (so units render from already-migrated config — a relabelled device, sanitised `extra_args`, etc). The `ceiling`/profile-catalog-reset-gating derivation is unchanged, just relocated to where it's still needed. `job_id` threading (#1935) is preserved end to end.
- **Failure-mode decision** (the interesting part): a failed post-swap migration subprocess does **not** abort `commit()`. By the time it runs, the tree is already active — the symlink swap and venv re-pip already succeeded — so raising and discarding (the old pre-swap behaviour) would either be wrong (the release *is* running) or actively destructive (the old code path called `seam.discard()` on the target dir, which post-swap is the **active** `current` tree). Instead the failure is made **loud**: an ERROR-level journal line (`updater.post_swap_migration_failed`, louder than `_rerender_units_after_swap`'s own WARNING for its lower-stakes non-fatal failure), a new `convergence.post_activation_migrations` block (`{ok, from, to, error}`) that flips `convergence.converged` to `False` so `hal0 update` refuses to report a clean success, and a red panel in the CLI (`cli/update_commands.py`'s `_print_convergence`) telling the operator what happened and that it self-heals on the next `hal0-api` restart.
- **`check_outstanding_migrations()`** (new, boot-time safety net, wired into `hal0-api`'s `_boot_slot_reconcile` phase, first in that phase): re-runs the same six migration passes on every `hal0-api` boot. Each pass is a documented idempotent "stale? fix it : no-op" sweep, so a converged box pays for one `hal0.toml` read plus five near-instant no-ops. This heals two populations: boxes that upgraded *before* this fix (permanently missed their migrations — there's no later `commit()` to retry them) and boxes whose post-swap subprocess itself failed. It derives its `ceiling` the same way `commit()` does, via the read-only `profile_reset_status()`, so it cannot race `meta.schema_version` past the one-shot profile-catalog-reset gate outside the consent flow.
- `installer/install.sh`'s call site is untouched — `run_post_activation_migrations`'s signature and behaviour are unchanged; only *how* `commit()` invokes it changed. Fresh installs already run the new code with nothing to migrate.

## Verification

Test-first: added `test_commit_runs_post_activation_migrations_after_the_swap` (asserts exactly one subprocess call whose argv contains the migration marker, and that the symlink already points at the incoming version when it fires) and `test_commit_post_activation_migration_failure_is_non_fatal_but_loud` (asserts the swap stands, `convergence.post_activation_migrations.ok is False`, `converged is False`, and an ERROR-level `updater.post_swap_migration_failed` log line) to `tests/updater/test_updater.py`. Confirmed both **fail** against the pre-fix code (no subprocess call exists at all / no `convergence` key), then implemented the fix and confirmed both pass.

- `tests/updater` (307 tests, was 297 — 10 new unit tests in `tests/updater/test_post_swap_migrations.py` covering `_run_post_activation_migrations_after_swap`'s argument-passing/marker-parsing/error-surfacing and `check_outstanding_migrations`'s ceiling derivation + never-raises contract): **all pass**.
- `tests/cli/test_update_commands.py` (34 tests, 3 new for `_print_convergence`'s new panel/success line): **all pass**.
- `ruff check` + `ruff format --check` on all touched files: clean.
- `mypy` on touched files: pre-existing baseline errors only (verified by line-content inspection — none in the new/changed code); not part of the required gate (`make lint` is ruff-only per CI).
- Sanity swept `tests/api` (touched `_boot_slot_reconcile`'s docstring/body): `test_health_degraded.py`, `test_boot_brain_lane_replay.py`, and a 381-test slot/boot/migration/registry-filtered slice all pass — no regression to app boot.

CHANGELOG.md intentionally untouched (consolidated changelog lands separately, #1545).

Closes #1960