### PR TITLE
feat(slots): gate llm slot readiness on an output-sanity probe

### DIFF
--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -245,6 +245,10 @@ Boot start is separate and explicit (`autoload`); a retired `lru` key is still a
 but ignored, with a one-time deprecation warning. See
 [Slot lifecycle → Activation](/docs/reference/slot-lifecycle/#activation).
 
+`output_sanity` (bool, default `true`) is accepted here too, though it is not a typed
+field: `false` exempts this one slot from the
+[output-sanity gate](/docs/reference/slot-lifecycle/#output-sanity-gate).
+
 <Aside type="note">
 A legacy `backend` key on a slot is silently promoted to `device` and dropped on load
 — it is never a schema field itself. On the v1.0 branch (Stream C,

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -61,6 +61,12 @@ code paths (`agents/hermes_provision.py`) default to `http://hal0.local:8080`. I
 rely on the default rather than setting it explicitly, verify which code path applies.
 </Aside>
 
+## Slots
+
+| Variable | Default | Controls |
+|---|---|---|
+| `HAL0_SLOT_OUTPUT_SANITY` | unset (gate ON) | `0`/`false`/`no`/`off` disables the [output-sanity gate](/docs/reference/slot-lifecycle/#output-sanity-gate) box-wide, so a `type = "llm"` slot reaches `READY` on the health probe alone. Per-slot equivalent: `output_sanity = false` in the slot TOML. |
+
 ## Hermes agent
 
 | Variable | Default | Controls |

--- a/docs/reference/slot-lifecycle.mdx
+++ b/docs/reference/slot-lifecycle.mdx
@@ -103,12 +103,23 @@ and is not yet dispatchable. A wrong answer on the raw `/completion` endpoint bu
 retry through `/v1/chat/completions` (with room for a reasoning model's `<think>` block)
 before the load is refused.
 
-Failure is terminal for that load: the slot lands in `ERROR` with a message naming the
-probe, the expected token and what the model actually said, its unit is stopped, and it
-will **not** be re-adopted as `READY` by a later `/api/slots` poll or by the boot-time
-reconcile — a passing gate on a subsequent load is what clears the verdict. A probe
-timeout counts as a failure; "inconclusive, so let it through" is the silent degrade this
-gate exists to remove.
+A **wrong answer** is terminal for that load: the slot lands in `ERROR` with a message
+naming the probe, the expected token and what the model actually said, its unit is stopped
+(best-effort — a stop that does not return is reported in the same message), and it will
+**not** be re-adopted as `READY` by a later `/api/slots` poll or by the boot-time
+reconcile. A passing gate on a subsequent load is what clears the verdict.
+
+A **probe that never answers** is treated differently. A timeout says the answer did not
+arrive inside a wall clock, not that the answer was wrong, so the slot resolves to
+`WARMING` — the same policy the health wait already applies to its own ambiguous outcome.
+Nothing is published as `READY`, nothing is stamped, the unit is left alone, and the next
+load re-runs the gate. Slow hardware is judged on its answer; the budget widens to match on
+a `device = "cpu"` slot, which decodes far slower than the accelerated lane.
+
+<Aside type="note">
+"Inconclusive, so let it through" remains the one thing the gate never does: an
+unanswered probe can only produce `WARMING`, never `READY`.
+</Aside>
 
 Embedding, reranking, TTS, STT and image slots are never gated (they cannot serve a chat
 completion), and the FLM/NPU lane keeps its own `verify_inference` sentinel.

--- a/docs/reference/slot-lifecycle.mdx
+++ b/docs/reference/slot-lifecycle.mdx
@@ -18,7 +18,7 @@ the dashboard SSE stream, and the `state.json` persistence layer.
 | `PULLING` | Model files are being downloaded or verified. systemd unit not yet started. |
 | `STARTING` | systemd unit has been started; waiting for the container to come up. |
 | `WARMING` | Container is up; the health probe is returning non-ready responses while the model loads into VRAM/GTT. |
-| `READY` | Passed the full health probe (non-empty `/v1/models` plus a sentinel completion). Ready to serve. |
+| `READY` | Passed the full health probe (non-empty `/v1/models` plus a sentinel completion) **and**, for a `type = "llm"` slot, the output-sanity probe below. Ready to serve. |
 | `SERVING` | An inference request is actively in-flight on this slot. |
 | `IDLE` | Reached two ways, both render identically on the wire: `warming → idle` (process up but `/v1/models` is empty — launched with `--model ""` or a missing file; routers must not treat this as ready), or `ready → idle` (no request for longer than the idle timeout — eviction candidate). |
 | `UNLOADING` | Graceful shutdown in progress. systemd stop issued; waiting for the container to exit. |
@@ -80,6 +80,7 @@ Each is an HTTP-status-bearing error under the `slot.*` namespace:
 | `SlotNotReady` | 503 | — |
 | `SlotSpawnFailed` | 500 | — |
 | `SlotHealthFailed` | 503 | — |
+| `SlotOutputSanityFailed` | 500 | The server is healthy but its output is not language — see [Output-sanity gate](#output-sanity-gate). |
 | `SlotCrashLooping` | 503 | Reload blocked during exponential backoff, or after too many consecutive failures. Carries `retry_after_s`. |
 | `SlotTerminateTimeout` | 504 | Stop didn't return in time — the request unblocks anyway. |
 | `SlotConfigError` | 400 | — |
@@ -88,6 +89,36 @@ Each is an HTTP-status-bearing error under the `slot.*` namespace:
 
 Health-probe resolution on timeout: unresolved health checks resolve to `WARMING`, not
 `ERROR` — an ambiguous outcome is treated as "still loading," not "failed."
+
+## Output-sanity gate
+
+`/health` proves the runner bound its port and mapped its weights. It does not prove the
+backend turns those weights into coherent text — a GPU backend that mis-computes answers
+`/health`, streams tokens and closes the SSE stream cleanly while emitting garbage.
+
+So a `type = "llm"` slot on the container/llama-server lane runs one last check before it
+is published as `READY`: a single greedy completion whose answer is known
+(`The capital of France is` → `Paris`), once per load, while the slot still holds its lock
+and is not yet dispatchable. A wrong answer on the raw `/completion` endpoint buys one
+retry through `/v1/chat/completions` (with room for a reasoning model's `<think>` block)
+before the load is refused.
+
+Failure is terminal for that load: the slot lands in `ERROR` with a message naming the
+probe, the expected token and what the model actually said, its unit is stopped, and it
+will **not** be re-adopted as `READY` by a later `/api/slots` poll or by the boot-time
+reconcile — a passing gate on a subsequent load is what clears the verdict. A probe
+timeout counts as a failure; "inconclusive, so let it through" is the silent degrade this
+gate exists to remove.
+
+Embedding, reranking, TTS, STT and image slots are never gated (they cannot serve a chat
+completion), and the FLM/NPU lane keeps its own `verify_inference` sentinel.
+
+Escape hatches, both default-ON:
+
+| Scope | How |
+|---|---|
+| Whole box | `HAL0_SLOT_OUTPUT_SANITY=0` in the api environment |
+| One slot | `output_sanity = false` in the slot TOML, or via `PUT /api/slots/{name}/config` |
 
 ## Persistence
 

--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -261,10 +261,25 @@ def merge_slot_config(base: dict[str, Any], updates: dict[str, Any]) -> dict[str
 #:   - ``default_voice`` / ``default_language`` — TTS engine extras written by
 #:     the dashboard voice settings (PUT /api/slots/tts/config).
 #:   - ``slot``           — the nested on-disk [slot] table shape (hoisted on load).
+#:   - ``output_sanity``  — per-slot opt-out for the llm output-sanity gate
+#:     (#1922, ``hal0.slots.output_sanity.SANITY_CFG_KEY``). The gate's own
+#:     failure message tells the operator to set it, so the write boundary has
+#:     to accept it: an escape hatch reachable only by hand-editing the TOML is
+#:     not one.
 TOLERATED_SLOT_CONFIG_KEYS: frozenset[str] = frozenset(
     # image_pin and binary are declared SlotConfig fields but the running backend may
     # predate them — tolerate so the drawer Save always works.
-    {"type", "default", "lru", "default_voice", "default_language", "slot", "image_pin", "binary"}
+    {
+        "type",
+        "default",
+        "lru",
+        "default_voice",
+        "default_language",
+        "slot",
+        "image_pin",
+        "binary",
+        "output_sanity",
+    }
 )
 
 # ── model-owned slot-write partition (spec-hw-slot-ownership §1) ─────────────

--- a/src/hal0/slot_lifecycle_budget.py
+++ b/src/hal0/slot_lifecycle_budget.py
@@ -51,9 +51,39 @@ OUTPUT_SANITY_TIMEOUT_S = 20.0
 #: answer instead of on the clock.
 OUTPUT_SANITY_CHAT_TIMEOUT_S = 45.0
 
+#: Both gate budgets on a ``device="cpu"`` slot, which is a different machine
+#: from the accelerated lane the two constants above are sized for.
+#:
+#: The 20s/45s pair assumes a GPU that decodes a dozen greedy tokens in about
+#: a second. The fleet's own numbers say the CPU lane is two orders of
+#: magnitude away from that: the ``v1.0.0-rc.5`` validation measured ct151
+#: (8 cores, 16 GB, no GPU passthrough) at 0.12 tok/s for a 0.8B model under
+#: exactly the contention a load happens in, and one brain reply took 3m42s.
+#: A no-GPU box is not an exotic case either — ``install.profile_derive.
+#: derive_device`` resolves EVERY seeded slot to ``cpu`` there, and the brain
+#: slot then binds the unquantized F16 variant precisely because the box is
+#: slow.
+#:
+#: Set to :data:`HEALTH_TIMEOUT_S` rather than to a fresh literal: it is the
+#: wall clock the same box already gets to answer ``/health`` after spawning,
+#: so the gate asks for no more patience than the phase before it. That is
+#: 0.067 tok/s for the raw probe's dozen tokens — under the slowest thing the
+#: fleet has measured — and it also covers the chat fallback, whose 256-token
+#: ask is where a reasoning model on a CPU box would otherwise be judged on
+#: an answer it had no room to write.
+#:
+#: Consumed via ``hal0.slots.output_sanity.probe_budget_s``, which returns it
+#: for a cpu-backed slot and ``None`` (module defaults) for everything else.
+OUTPUT_SANITY_CPU_TIMEOUT_S = HEALTH_TIMEOUT_S
+
 #: What the gate can cost ONE load, worst case: the raw probe, then the chat
 #: fallback. A load that passes on the raw probe pays only the first.
-OUTPUT_SANITY_LOAD_ALLOWANCE_S = OUTPUT_SANITY_TIMEOUT_S + OUTPUT_SANITY_CHAT_TIMEOUT_S
+#:
+#: Charged at the CPU lane's budget because a client timeout must cover the
+#: slowest slot the server might be converging, and the client is handed a
+#: slot name — not its device — by every lifecycle verb. An accelerated slot
+#: spends 65s of this and returns early.
+OUTPUT_SANITY_LOAD_ALLOWANCE_S = 2 * OUTPUT_SANITY_CPU_TIMEOUT_S
 
 #: Sequential unloads a single ``load`` may perform before it spawns
 #: anything: ``preload_evict.admit`` awaits ``host.unload(candidate)`` once per
@@ -90,11 +120,14 @@ EVICTION_UNLOAD_ALLOWANCE = 3
 #:     90   3 x 30, ``preload_evict.admit`` unloading eviction candidates in
 #:          series (EVICTION_UNLOAD_ALLOWANCE)
 #:    180   the post-spawn ``/health`` poll (HEALTH_TIMEOUT_S)
-#:     65   the output-sanity gate (#1922): 20 raw probe + 45 chat fallback
+#:    360   the output-sanity gate (#1922), at its CPU-lane budget: 180 raw
+#:          probe + 180 chat fallback (OUTPUT_SANITY_LOAD_ALLOWANCE_S = 2 x
+#:          OUTPUT_SANITY_CPU_TIMEOUT_S). An accelerated slot spends 20 + 45
+#:          instead, but the client cannot know which it is asking about
 #:     30   the failed gate's teardown, which runs before the ERROR stamp and
 #:          therefore still inside the lock
 #:    ---
-#:    395
+#:    690
 LOAD_LOCK_HOLD_S = (
     TERMINATE_TIMEOUT_S
     + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S

--- a/src/hal0/slot_lifecycle_budget.py
+++ b/src/hal0/slot_lifecycle_budget.py
@@ -34,6 +34,21 @@ HEALTH_TIMEOUT_S = 180.0
 #: ``hal0.slots.manager.SlotManager._terminate_timeout_s``.
 TERMINATE_TIMEOUT_S = 30.0
 
+#: Wall-clock bound on ONE output-sanity completion — the probe a ``type=llm``
+#: load runs after ``/health`` converges (#1922 — the gate that turns "the
+#: port answers" into "the model produces language"). Consumed by
+#: ``hal0.slots.output_sanity.probe``; deliberately small, because the probe
+#: asks for a dozen greedy tokens from an already-warm server, so anything
+#: near this bound is itself the failure the gate reports.
+OUTPUT_SANITY_TIMEOUT_S = 20.0
+
+#: Probes a single load can pay for in the worst case. A wrong answer on the
+#: raw ``/completion`` endpoint buys one retry through
+#: ``/v1/chat/completions`` (a template-dependent instruct model can answer
+#: one well and the other poorly), so the failing path costs two budgets. The
+#: happy path costs one.
+OUTPUT_SANITY_PROBES_PER_LOAD = 2
+
 #: Sequential unloads a single ``load`` may perform before it spawns
 #: anything: ``preload_evict.admit`` awaits ``host.unload(candidate)`` once per
 #: evicted candidate, in series, inside the load path. The true count is
@@ -94,13 +109,19 @@ def slot_lifecycle_timeout_s(*, loads: int = 1, unloads: int = 1, slots: int = 1
     (``/api/updates/restart-slots`` loops ``sm.restart`` over every drifted
     slot). Clamped to at least 1.
 
-    A load charges the health poll plus :data:`EVICTION_UNLOAD_ALLOWANCE`
-    terminates for the evictions ``preload_evict.admit`` may run before the
-    spawn; an unload charges one terminate; the whole request additionally
-    charges one :data:`LOCK_WAIT_ALLOWANCE_S` for queueing behind an in-flight
-    op on the same slot.
+    A load charges the health poll, the output-sanity probes that follow it
+    (:data:`OUTPUT_SANITY_PROBES_PER_LOAD` x :data:`OUTPUT_SANITY_TIMEOUT_S`), plus
+    :data:`EVICTION_UNLOAD_ALLOWANCE` terminates for the evictions
+    ``preload_evict.admit`` may run before the spawn; an unload charges one
+    terminate; the whole request additionally charges one
+    :data:`LOCK_WAIT_ALLOWANCE_S` for queueing behind an in-flight op on the
+    same slot.
     """
-    per_slot = loads * (HEALTH_TIMEOUT_S + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S)
+    per_slot = loads * (
+        HEALTH_TIMEOUT_S
+        + OUTPUT_SANITY_PROBES_PER_LOAD * OUTPUT_SANITY_TIMEOUT_S
+        + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S
+    )
     per_slot += unloads * TERMINATE_TIMEOUT_S
     # The lock allowance is charged per lock-acquiring phase, per slot. A
     # compound verb does NOT hold one lock: ``SlotManager.restart`` releases

--- a/src/hal0/slot_lifecycle_budget.py
+++ b/src/hal0/slot_lifecycle_budget.py
@@ -34,20 +34,26 @@ HEALTH_TIMEOUT_S = 180.0
 #: ``hal0.slots.manager.SlotManager._terminate_timeout_s``.
 TERMINATE_TIMEOUT_S = 30.0
 
-#: Wall-clock bound on ONE output-sanity completion — the probe a ``type=llm``
-#: load runs after ``/health`` converges (#1922 — the gate that turns "the
-#: port answers" into "the model produces language"). Consumed by
-#: ``hal0.slots.output_sanity.probe``; deliberately small, because the probe
-#: asks for a dozen greedy tokens from an already-warm server, so anything
-#: near this bound is itself the failure the gate reports.
+#: Wall-clock bound on the RAW ``/completion`` output-sanity probe — the one a
+#: ``type=llm`` load runs after ``/health`` converges (#1922 — the gate that
+#: turns "the port answers" into "the model produces language"). Consumed by
+#: ``hal0.slots.output_sanity.probe``; deliberately small, because it asks for
+#: a dozen greedy tokens from an already-warm server, so anything near this
+#: bound is itself the failure the gate reports.
 OUTPUT_SANITY_TIMEOUT_S = 20.0
 
-#: Probes a single load can pay for in the worst case. A wrong answer on the
-#: raw ``/completion`` endpoint buys one retry through
-#: ``/v1/chat/completions`` (a template-dependent instruct model can answer
-#: one well and the other poorly), so the failing path costs two budgets. The
-#: happy path costs one.
-OUTPUT_SANITY_PROBES_PER_LOAD = 2
+#: Wall-clock bound on the CHAT fallback, which only runs when the raw probe's
+#: answer was wrong. Wider on purpose: that request asks for
+#: ``output_sanity.SANITY_CHAT_MAX_TOKENS`` (256) rather than a dozen, because
+#: a reasoning model spends its first tokens inside ``<think>`` and a tight cap
+#: fails working slots. 256 tokens inside 45s is ~6 tok/s — under the slowest
+#: warm lane we ship (CPU), so a slow-but-correct model is judged on its
+#: answer instead of on the clock.
+OUTPUT_SANITY_CHAT_TIMEOUT_S = 45.0
+
+#: What the gate can cost ONE load, worst case: the raw probe, then the chat
+#: fallback. A load that passes on the raw probe pays only the first.
+OUTPUT_SANITY_LOAD_ALLOWANCE_S = OUTPUT_SANITY_TIMEOUT_S + OUTPUT_SANITY_CHAT_TIMEOUT_S
 
 #: Sequential unloads a single ``load`` may perform before it spawns
 #: anything: ``preload_evict.admit`` awaits ``host.unload(candidate)`` once per
@@ -71,12 +77,37 @@ OUTPUT_SANITY_PROBES_PER_LOAD = 2
 #: estimate; bounding it server-side is the real fix (#1869).
 EVICTION_UNLOAD_ALLOWANCE = 3
 
+#: Worst wall-clock a single ``SlotManager.load`` can hold the slot lock —
+#: every phase it runs between acquiring and releasing, summed. Keep this
+#: derivation exhaustive: it is the number BOTH the per-load charge and the
+#: lock-wait allowance below are built from, so a phase added to ``load``
+#: without a line here silently re-creates #1832 (client reports a timeout on
+#: an op the server is still converging).
+#:
+#:     30   pre-spawn terminate — the drifted re-converge (#1224), the ERROR
+#:          retry and the stale in-flight branches each stop the unit in place
+#:          before re-spawning
+#:     90   3 x 30, ``preload_evict.admit`` unloading eviction candidates in
+#:          series (EVICTION_UNLOAD_ALLOWANCE)
+#:    180   the post-spawn ``/health`` poll (HEALTH_TIMEOUT_S)
+#:     65   the output-sanity gate (#1922): 20 raw probe + 45 chat fallback
+#:     30   the failed gate's teardown, which runs before the ERROR stamp and
+#:          therefore still inside the lock
+#:    ---
+#:    395
+LOAD_LOCK_HOLD_S = (
+    TERMINATE_TIMEOUT_S
+    + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S
+    + HEALTH_TIMEOUT_S
+    + OUTPUT_SANITY_LOAD_ALLOWANCE_S
+    + TERMINATE_TIMEOUT_S
+)
+
 #: Every lifecycle verb takes the per-slot lock (``SlotManager._lock``), so a
 #: request can sit queued behind whatever is already converging that slot
 #: before doing any of its own work. Charged once per request, at the cost of
-#: the worst thing that can hold the lock — a full load, evictions included,
-#: not just its health poll.
-LOCK_WAIT_ALLOWANCE_S = HEALTH_TIMEOUT_S + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S
+#: the worst thing that can hold the lock — a full load, start to finish.
+LOCK_WAIT_ALLOWANCE_S = LOAD_LOCK_HOLD_S
 
 #: Slots one ``POST /api/stacks/{slug}/apply`` may converge in a single request.
 #: ``StackApplyEngine.converge`` walks the stack's entries sequentially
@@ -109,19 +140,13 @@ def slot_lifecycle_timeout_s(*, loads: int = 1, unloads: int = 1, slots: int = 1
     (``/api/updates/restart-slots`` loops ``sm.restart`` over every drifted
     slot). Clamped to at least 1.
 
-    A load charges the health poll, the output-sanity probes that follow it
-    (:data:`OUTPUT_SANITY_PROBES_PER_LOAD` x :data:`OUTPUT_SANITY_TIMEOUT_S`), plus
-    :data:`EVICTION_UNLOAD_ALLOWANCE` terminates for the evictions
-    ``preload_evict.admit`` may run before the spawn; an unload charges one
+    A load charges :data:`LOAD_LOCK_HOLD_S` — every phase it runs while
+    holding the lock, itemised at that constant; an unload charges one
     terminate; the whole request additionally charges one
-    :data:`LOCK_WAIT_ALLOWANCE_S` for queueing behind an in-flight op on the
-    same slot.
+    :data:`LOCK_WAIT_ALLOWANCE_S` per lock-acquiring phase, for queueing behind
+    an in-flight op on the same slot.
     """
-    per_slot = loads * (
-        HEALTH_TIMEOUT_S
-        + OUTPUT_SANITY_PROBES_PER_LOAD * OUTPUT_SANITY_TIMEOUT_S
-        + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S
-    )
+    per_slot = loads * LOAD_LOCK_HOLD_S
     per_slot += unloads * TERMINATE_TIMEOUT_S
     # The lock allowance is charged per lock-acquiring phase, per slot. A
     # compound verb does NOT hold one lock: ``SlotManager.restart`` releases

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -105,6 +105,7 @@ from hal0.slots.state import (
     SlotConfigError,
     SlotCrashLooping,
     SlotNotFound,
+    SlotOutputSanityFailed,
     SlotPinned,
     SlotSpawnFailed,
     SlotState,
@@ -1757,6 +1758,19 @@ class SlotManager:
                             },
                         )
             except Exception as exc:
+                if isinstance(exc, SlotOutputSanityFailed):
+                    # The gate failed on a unit that is ACTIVE and healthy — it
+                    # just talks nonsense. Stamping ERROR is not enough: the
+                    # inverse-drift branch in ``status()`` (and the boot-time
+                    # upstream reconcile) adopt any ERROR/OFFLINE slot whose
+                    # unit is active straight back to READY, so the very next
+                    # /api/slots poll would undo the gate and re-publish the
+                    # garbage slot as dispatchable. Stop the unit, which also
+                    # stops it burning VRAM producing text nobody can use. A
+                    # later ``load`` re-enters the lifecycle and re-runs the
+                    # gate; recovery is never silent.
+                    with contextlib.suppress(Exception):
+                        await self.terminate(slot_name)
                 # Crash-loop bookkeeping: consecutive failures drive the
                 # backoff/park gate above. ``parked`` rides ``extra`` (not a
                 # new enum value — wire/state-machine compatible) so the UI
@@ -3625,7 +3639,9 @@ class SlotManager:
     async def _await_ready(self, slot_name: str, port: int) -> SlotState:
         """Resolve the slot's final readiness state after spawning.
 
-        Polls GET /health on the slot's container port until 200.
+        Polls GET /health on the slot's container port until 200, then — for a
+        chat-capable (``type=llm``) slot — proves the server can actually
+        produce language before it is published as READY (#1922).
 
         Returns:
             SlotState.READY when the container is serving. On a health-wait
@@ -3633,6 +3649,15 @@ class SlotManager:
             than a lying READY: WARMING keeps the slot retryable so the fail
             watcher / next-request reload governs recovery, instead of live
             traffic being forwarded to a wedged server on a false READY.
+
+        Raises:
+            SlotOutputSanityFailed: the server is healthy but its output is
+                not language (garbage/empty/off-topic, or no completion inside
+                the probe budget). Unlike the health-wait timeout this is NOT
+                ambiguous — retrying cannot fix a backend that mis-computes —
+                so it raises into ``load``'s ERROR branch (red dot, actionable
+                message, crash-loop bookkeeping) instead of parking the slot
+                in a retryable WARMING.
         """
         cfg = await self._maybe_load_config(slot_name)
         if not cfg:
@@ -3722,6 +3747,72 @@ class SlotManager:
                     },
                 )
                 return SlotState.WARMING
+            return SlotState.READY
+
+        # ── output-sanity gate (#1922) ───────────────────────────────────────
+        #
+        # The container/llama-server lane's readiness proof stopped at /health
+        # 200 — a TRANSPORT proof. A GPU backend that loads weights and then
+        # mis-computes answers /health, streams at 60-120 tok/s and closes with
+        # a `done` frame while emitting runs of `)` or nothing at all (#1888,
+        # ct151/rc.6: two hours of garbage behind five green surfaces). The FLM
+        # lane already had a one-shot inference gate here; this is the same
+        # promise for every other llm slot — one greedy completion whose answer
+        # is known, run exactly once, where the FLM gate runs and for the same
+        # reasons (slot lock held, not yet dispatchable, warming fail-watcher
+        # skips /health, so there is no contention and no repetition).
+        #
+        # Scoped by ``skip_reason``: llm slots only (an embed/rerank/TTS/STT/
+        # image slot cannot serve a chat completion), and escapable per box or
+        # per slot. A failure RAISES rather than returning WARMING: a wedged
+        # loader may converge on a retry, a backend that computes wrong answers
+        # never will, so this is a red dot with an actionable message — not a
+        # slot that quietly re-loads at request cadence and burns the GPU.
+        if provider is None:
+            from hal0.slots import output_sanity
+
+            # A portless slot cannot be probed at all — that is a config
+            # fault for the health path to report, not something to
+            # mis-attribute to the model's output.
+            skip = output_sanity.skip_reason(cfg) if slot_port > 0 else "no_port"
+            if skip is not None:
+                log.debug(
+                    "slot.output_sanity_skipped",
+                    extra={"slot": slot_name, "reason": skip},
+                )
+            else:
+                sanity = await output_sanity.probe(slot_port)
+                log.info(
+                    "slot.output_sanity",
+                    extra={
+                        "slot": slot_name,
+                        "port": slot_port,
+                        "ok": sanity.ok,
+                        "status": sanity.status,
+                        "sample": sanity.sample,
+                    },
+                )
+                if not sanity.ok:
+                    message = output_sanity.failure_message(sanity)
+                    log.error(
+                        "slot.output_sanity_failed",
+                        extra={
+                            "slot": slot_name,
+                            "port": slot_port,
+                            "status": sanity.status,
+                            "sample": sanity.sample,
+                            "detail": sanity.detail,
+                        },
+                    )
+                    raise SlotOutputSanityFailed(
+                        message,
+                        details={
+                            "slot": slot_name,
+                            "port": slot_port,
+                            "probe_status": sanity.status,
+                            "sample": sanity.sample,
+                        },
+                    )
         return SlotState.READY
 
     # ── adoption / drift reconcile (ISSUE #30) ───────────────────────────────

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -3695,19 +3695,21 @@ class SlotManager:
 
         Returns:
             SlotState.READY when the container is serving. On a health-wait
-            timeout, resolves to SlotState.WARMING (non-dispatchable) rather
-            than a lying READY: WARMING keeps the slot retryable so the fail
-            watcher / next-request reload governs recovery, instead of live
-            traffic being forwarded to a wedged server on a false READY.
+            timeout — or an output-sanity probe that never came back
+            (``output_sanity.AMBIGUOUS_STATUSES``) — resolves to
+            SlotState.WARMING (non-dispatchable) rather than a lying READY:
+            WARMING keeps the slot retryable so the fail watcher /
+            next-request reload governs recovery, instead of live traffic
+            being forwarded to a wedged server on a false READY. One policy,
+            applied to every ambiguous outcome this method can reach.
 
         Raises:
-            SlotOutputSanityFailed: the server is healthy but its output is
-                not language (garbage/empty/off-topic, or no completion inside
-                the probe budget). Unlike the health-wait timeout this is NOT
-                ambiguous — retrying cannot fix a backend that mis-computes —
-                so it raises into ``load``'s ERROR branch (red dot, actionable
-                message, crash-loop bookkeeping) instead of parking the slot
-                in a retryable WARMING.
+            SlotOutputSanityFailed: the server is healthy, ANSWERED, and what
+                it said is not language (garbage / empty / off-topic). Unlike
+                a timeout this is not ambiguous — retrying cannot fix a
+                backend that mis-computes — so it raises into ``load``'s ERROR
+                branch (red dot, actionable message, crash-loop bookkeeping)
+                instead of parking the slot in a retryable WARMING.
         """
         cfg = await self._maybe_load_config(slot_name)
         if not cfg:
@@ -3814,10 +3816,17 @@ class SlotManager:
         #
         # Scoped by ``skip_reason``: llm slots only (an embed/rerank/TTS/STT/
         # image slot cannot serve a chat completion), and escapable per box or
-        # per slot. A failure RAISES rather than returning WARMING: a wedged
-        # loader may converge on a retry, a backend that computes wrong answers
-        # never will, so this is a red dot with an actionable message — not a
-        # slot that quietly re-loads at request cadence and burns the GPU.
+        # per slot.
+        #
+        # A failure that JUDGED THE MODEL raises rather than returning WARMING:
+        # a wedged loader may converge on a retry, a backend that computes
+        # wrong answers never will, so this is a red dot with an actionable
+        # message — not a slot that quietly re-loads at request cadence and
+        # burns the GPU. A failure that judged only the CLOCK
+        # (``output_sanity.AMBIGUOUS_STATUSES``) returns WARMING instead, the
+        # same answer this method already gives an ambiguous health wait: see
+        # that constant for why a timeout is not the #1888 signature and must
+        # not be re-classified as one.
         if provider is None:
             from hal0.slots import output_sanity
 
@@ -3831,7 +3840,12 @@ class SlotManager:
                     extra={"slot": slot_name, "reason": skip},
                 )
             else:
-                sanity = await output_sanity.probe(slot_port)
+                # A cpu-device slot decodes far slower than the accelerated
+                # lane the default budget is sized for, so it is judged on its
+                # answer instead of on the clock.
+                sanity = await output_sanity.probe(
+                    slot_port, timeout_s=output_sanity.probe_budget_s(cfg)
+                )
                 log.info(
                     "slot.output_sanity",
                     extra={
@@ -3842,6 +3856,25 @@ class SlotManager:
                         "sample": sanity.sample,
                     },
                 )
+                if not sanity.ok and output_sanity.is_ambiguous(sanity.status):
+                    # Not a verdict: the answer did not arrive, which is not
+                    # the same as the answer being wrong. WARMING is not
+                    # dispatchable, so nothing is published as READY on this
+                    # path — but nothing is condemned either. The next load
+                    # re-runs the gate (``load``'s stale-in-flight branch
+                    # tears the unit down and re-enters from OFFLINE), and a
+                    # unit systemd has given up on is still converted to ERROR
+                    # by ``load``'s ``unit_failure_reason`` check.
+                    log.warning(
+                        "slot.output_sanity_inconclusive",
+                        extra={
+                            "slot": slot_name,
+                            "port": slot_port,
+                            "status": sanity.status,
+                            "detail": sanity.detail,
+                        },
+                    )
+                    return SlotState.WARMING
                 if not sanity.ok:
                     message = output_sanity.failure_message(sanity)
                     log.error(

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1261,6 +1261,15 @@ class SlotManager:
             self._load_failures.pop(key, None)
             carried_extra.pop("parked", None)
             carried_extra.pop("load_failures", None)
+            # …and the output-sanity verdict (#1922). Reaching READY/IDLE means
+            # a load ran the gate and the model answered (or the operator
+            # switched the gate off for this slot) — the one piece of evidence
+            # that retires a FAIL. Adoption can never clear it by accident: a
+            # slot carrying the mark is refused before it gets this far.
+            from hal0.slots.output_sanity import SANITY_EXTRA_KEYS
+
+            for sanity_key in SANITY_EXTRA_KEYS:
+                carried_extra.pop(sanity_key, None)
         effective_model_id = (
             model_id if model_id is not None else (prior.model_id if prior else None)
         )
@@ -1758,19 +1767,60 @@ class SlotManager:
                             },
                         )
             except Exception as exc:
+                error_message = str(exc)
+                gate_extra: dict[str, Any] = {}
                 if isinstance(exc, SlotOutputSanityFailed):
                     # The gate failed on a unit that is ACTIVE and healthy — it
-                    # just talks nonsense. Stamping ERROR is not enough: the
-                    # inverse-drift branch in ``status()`` (and the boot-time
-                    # upstream reconcile) adopt any ERROR/OFFLINE slot whose
-                    # unit is active straight back to READY, so the very next
-                    # /api/slots poll would undo the gate and re-publish the
-                    # garbage slot as dispatchable. Stop the unit, which also
-                    # stops it burning VRAM producing text nobody can use. A
-                    # later ``load`` re-enters the lifecycle and re-runs the
-                    # gate; recovery is never silent.
-                    with contextlib.suppress(Exception):
+                    # just talks nonsense. Stamping ERROR is not enough on its
+                    # own: the inverse-drift branch in ``status()`` (and the
+                    # boot-time upstream reconcile) adopt any ERROR/OFFLINE slot
+                    # whose unit is active straight back to READY, so the very
+                    # next /api/slots poll would undo the gate and re-publish
+                    # the garbage slot as dispatchable.
+                    #
+                    # Two independent remedies, because they fail differently:
+                    #
+                    #  1. Stop the unit — right on its own merits (a slot that
+                    #     cannot produce language should not hold VRAM), and it
+                    #     removes the "active" half adoption keys on. But
+                    #     ``terminate`` is best-effort by construction: it
+                    #     raises SlotTerminateTimeout when ``systemctl stop``
+                    #     does not return (#1224), which is exactly what a
+                    #     wedged container does. Suppressed, that silently
+                    #     handed the slot back to the adopter.
+                    #  2. Stamp the verdict on the state record. THIS is what
+                    #     the gate's durability rests on: adoption refuses a
+                    #     slot carrying it (see ``_maybe_adopt_running_slot``)
+                    #     whether or not the unit is still up, and the record is
+                    #     on disk, so an api restart cannot forget it either.
+                    #
+                    # A later load that PASSES the gate clears the mark
+                    # (``_transition``), so recovery needs no manual step and is
+                    # never silent.
+                    from hal0.slots import output_sanity
+
+                    unit_stopped = True
+                    try:
                         await self.terminate(slot_name)
+                    except Exception as stop_exc:
+                        unit_stopped = False
+                        log.error(
+                            "slot.output_sanity_teardown_failed",
+                            extra={"slot": slot_name, "error": str(stop_exc)},
+                        )
+                        # terminate() only deregisters the upstream when the
+                        # stop returned; do it here so nothing can route to a
+                        # slot we have just judged unfit to answer.
+                        with contextlib.suppress(Exception):
+                            self._deregister_container_upstream(slot_name)
+                        error_message += output_sanity.teardown_failure_note(
+                            slot_name, str(stop_exc)
+                        )
+                    details = getattr(exc, "details", None) or {}
+                    gate_extra = output_sanity.failure_extra(
+                        str(details.get("probe_status") or ""),
+                        unit_stopped=unit_stopped,
+                    )
                 # Crash-loop bookkeeping: consecutive failures drive the
                 # backoff/park gate above. ``parked`` rides ``extra`` (not a
                 # new enum value — wire/state-machine compatible) so the UI
@@ -1778,7 +1828,7 @@ class SlotManager:
                 key = self._key(slot_name)
                 failures = self._load_failures.get(key, (0, 0.0))[0] + 1
                 self._load_failures[key] = (failures, time.monotonic())
-                err_extra: dict[str, Any] = {"load_failures": failures}
+                err_extra: dict[str, Any] = {"load_failures": failures, **gate_extra}
                 if failures >= _CRASH_LOOP_PARK_AFTER:
                     err_extra["parked"] = True
                 # TIER1: never swallow — record ERROR with details, re-raise.
@@ -1787,7 +1837,7 @@ class SlotManager:
                     SlotState.ERROR,
                     model_id=resolved_model,
                     port=_cfg_port(cfg),
-                    message=str(exc),
+                    message=error_message,
                     extra=err_extra,
                     force=True,
                 )
@@ -3823,6 +3873,13 @@ class SlotManager:
         Checks systemctl is-active (via _is_active). Returns the
         post-adoption Slot snapshot, or ``None`` when the slot is not
         running — caller falls back to the on-disk record.
+
+        Refuses outright for a slot whose record carries a failed
+        output-sanity verdict (#1922): "the unit is active" is the ONLY thing
+        adoption ever proves, and a slot that failed the gate is active by
+        definition — healthy unit, healthy ``/health``, garbage output. Without
+        this the gate lasted exactly one ``/api/slots`` poll whenever stopping
+        the unit did not work.
         """
         port = _cfg_port(cfg)
         model_id = _model_default(cfg) or None
@@ -3832,6 +3889,26 @@ class SlotManager:
 
         active = await self._is_active(slot_name)
         if not active:
+            return None
+
+        # #1922: an active unit that failed the output-sanity gate is not a
+        # slot to recover, it is the slot the gate refused. Read through to
+        # disk — after an api restart nothing is in ``_states`` yet, and that
+        # restart is the exact moment the boot-time reconcile tries to adopt
+        # every active unit it finds.
+        from hal0.slots.output_sanity import SANITY_STATUS_KEY, gate_failed
+
+        prior = self._states.get(self._key(slot_name)) or read_state(
+            self._state_file_for(slot_name)
+        )
+        if prior is not None and gate_failed(prior.extra):
+            log.warning(
+                "slot.adopt_refused_output_sanity",
+                extra={
+                    "slot": slot_name,
+                    "probe_status": prior.extra.get(SANITY_STATUS_KEY),
+                },
+            )
             return None
 
         # #790: an active unit is not necessarily ready. A still-loading or

--- a/src/hal0/slots/output_sanity.py
+++ b/src/hal0/slots/output_sanity.py
@@ -31,6 +31,12 @@ DESIGN RULES (learned from the FLM gate and from #1888)
 * **A timeout is a FAIL.**  A runner that cannot emit 12 greedy tokens inside
   :data:`OUTPUT_SANITY_TIMEOUT_S` is not ready, and "inconclusive → pass" is
   exactly the lie this gate exists to stop.
+* **Never false-fail a working model.**  The gate stops a unit, so a wrong
+  FAIL is worse than the bug it guards.  Concretely, that means judging the
+  whole of what the model emitted (a reasoning model answers in
+  ``reasoning_content``, or inside a ``<think>`` block left in ``content``,
+  depending on the runner build) and giving the chat fallback a token budget
+  and a wall clock big enough to reach the visible answer.
 * **Scoped to chat-capable slots.**  ``type="llm"`` is the capability signal
   (``hal0.model_meta.modality.slot_type_for`` derives the slot type from the
   model's declared modalities), so an embedding / rerank / TTS / STT / image
@@ -48,7 +54,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
-from hal0.slot_lifecycle_budget import OUTPUT_SANITY_TIMEOUT_S
+from hal0.slot_lifecycle_budget import OUTPUT_SANITY_CHAT_TIMEOUT_S, OUTPUT_SANITY_TIMEOUT_S
 
 log = logging.getLogger(__name__)
 
@@ -60,8 +66,29 @@ SANITY_PROMPT = "The capital of France is"
 
 #: Greedy decode, a dozen tokens.  Enough for the answer to appear after a
 #: leading space/newline or a short restatement, cheap enough to be invisible
-#: in the slot lifecycle budget.
+#: in the slot lifecycle budget.  Applies to the RAW ``/completion`` probe
+#: only: with no chat template in play there is no reasoning block to drain
+#: the budget, so the answer is the first thing the model writes.
 SANITY_N_PREDICT = 12
+
+#: Token budget for the CHAT fallback, where a dozen tokens is a trap.  A
+#: thinking model (Qwen3 and every fine-tune of it) opens its turn with a
+#: ``<think>`` block and emits no visible ``content`` until it closes: a
+#: 12-token cap drains entirely into reasoning and the fallback would judge a
+#: healthy model on an answer it was never given room to write, then stop its
+#: unit.  This repo has already paid for that lesson once —
+#: ``hal0.agents.hermes_provision._smoke_chat_completion`` raised its own probe
+#: to 256 for exactly this reason; matching it keeps one number to remember.
+#:
+#: NOT solved with ``chat_template_kwargs: {"enable_thinking": false}``, even
+#: though hal0's dispatcher sends that on production traffic
+#: (``hal0.normalize.thinking``): it is a jinja-only lever.  ``jinja`` is a
+#: tri-state model capability here (``registry.model.ModelDefaults.jinja``), so
+#: some llm slots run a llama-server started WITHOUT ``--jinja``, where a
+#: template kwarg is at best ignored and at worst a 4xx — trading this
+#: false-fail for a different one on a lane we cannot probe from CI.  Reading
+#: both output fields and paying for the tokens works on every runner build.
+SANITY_CHAT_MAX_TOKENS = 256
 
 #: Accepted continuations, matched case-insensitively as substrings.  English
 #: first; the transliterations cover the non-English fine-tunes that would
@@ -83,7 +110,35 @@ EXPECTED_TOKENS: tuple[str, ...] = (
 SANITY_ENV_VAR = "HAL0_SLOT_OUTPUT_SANITY"
 
 #: Per-slot opt-out key in the slot TOML (top level or under ``[slot]``).
+#: Registered in ``hal0.slot_config.TOLERATED_SLOT_CONFIG_KEYS`` so the write
+#: boundary accepts it — an escape hatch that only works via a hand edit is
+#: not an escape hatch.
 SANITY_CFG_KEY = "output_sanity"
+
+#: Keys a failed verdict stamps on the slot's state record ``extra``.
+#:
+#: This is what makes the verdict DURABLE.  Stopping the garbage unit is the
+#: obvious remedy, but a teardown is best-effort by nature —
+#: ``SlotManager.terminate`` raises ``SlotTerminateTimeout`` when
+#: ``systemctl stop`` does not return (#1224), and a wedged podman container is
+#: exactly where that happens.  A verdict that survives only as long as the
+#: stop succeeded is not a verdict: ERROR + an active unit is precisely the
+#: shape ``status()``'s inverse-drift branch and the boot-time upstream
+#: reconcile adopt straight back to READY, re-publishing the garbage slot on
+#: the next ``/api/slots`` poll.  Stamped in the record, the refusal outlives
+#: a failed stop AND an api restart (state.json is on disk), which also closes
+#: the "unit still running from before the upgrade" gap.
+#:
+#: Cleared on any transition to READY/IDLE — a load that passes the gate is
+#: the one piece of evidence that retires the verdict.
+SANITY_FAILED_KEY = "output_sanity_failed"
+SANITY_STATUS_KEY = "output_sanity_status"
+SANITY_UNIT_STOPPED_KEY = "output_sanity_unit_stopped"
+SANITY_EXTRA_KEYS: tuple[str, ...] = (
+    SANITY_FAILED_KEY,
+    SANITY_STATUS_KEY,
+    SANITY_UNIT_STOPPED_KEY,
+)
 
 #: Slot types the gate applies to.  Everything else serves a modality a chat
 #: completion cannot probe.
@@ -162,16 +217,49 @@ def skip_reason(cfg: Mapping[str, Any] | None) -> str | None:
     return None
 
 
+#: Fields of an OpenAI-shaped ``message`` that carry model output.  Judged
+#: TOGETHER — see :func:`_message_text`.  ``reasoning``/``reasoning_content``
+#: are the two spellings hal0 already reads elsewhere
+#: (``cli.chat_commands``, ``providers.hal0.profile``).
+_MESSAGE_TEXT_FIELDS: tuple[str, ...] = ("content", "reasoning_content", "reasoning")
+
+
+def _message_text(message: Mapping[str, Any]) -> str | None:
+    """Everything the model emitted in one chat message, joined.
+
+    A reasoning model spends its first tokens inside a ``<think>`` block, and
+    where that text lands depends on the runner build, not on the model: a
+    llama-server that parses reasoning splits it into ``reasoning_content``
+    and leaves ``content`` empty until the block closes, while an older or
+    ``--jinja``-less one hands the raw ``<think>…</think>`` back inside
+    ``content``.  Reading only ``content`` therefore fails a *working* model
+    on half the fleet — and this gate stops the unit it fails.
+
+    Judging the union is safe in the other direction too: the assertion is
+    positive (did the known answer appear at all), and #1888's backend
+    produced garbage in every field it filled — a model that computes wrong
+    logits cannot reason its way to "Paris" either.
+
+    ``None`` only when the message carries no text field at all; ``""`` when
+    the fields exist and are empty, which stays a reportable failure.
+    """
+    parts = [message.get(field) for field in _MESSAGE_TEXT_FIELDS]
+    present = [part for part in parts if isinstance(part, str)]
+    if not present:
+        return None
+    return "\n".join(present)
+
+
 def _extract_text(body: Any) -> str | None:
     """Pull the generated text out of a completion response body.
 
     Handles llama-server's native ``/completion`` shape (``content``) and the
     OpenAI-compatible shapes (``choices[0].text`` /
-    ``choices[0].message.content``) so the probe survives a runner that
-    answers ``/completion`` with an OpenAI envelope.  ``None`` means "no text
-    field at all" (unparseable); ``""`` means "the field was there and empty",
-    which is a real, reportable failure shape (#1888: bare ``/completion``
-    emitted empty content while streaming a ``done`` frame).
+    ``choices[0].message``) so the probe survives a runner that answers
+    ``/completion`` with an OpenAI envelope.  ``None`` means "no text field at
+    all" (unparseable); ``""`` means "the field was there and empty", which is
+    a real, reportable failure shape (#1888: bare ``/completion`` emitted
+    empty content while streaming a ``done`` frame).
     """
     if not isinstance(body, Mapping):
         return None
@@ -187,9 +275,7 @@ def _extract_text(body: Any) -> str | None:
                 return text
             message = first.get("message")
             if isinstance(message, Mapping):
-                msg_content = message.get("content")
-                if isinstance(msg_content, str):
-                    return msg_content
+                return _message_text(message)
     return None
 
 
@@ -280,16 +366,28 @@ async def probe(port: int, *, timeout_s: float | None = None) -> SanityVerdict:
     rc.6 garbage reproduced on BOTH endpoints (#1888), which is exactly what
     "the backend mis-computes" means.
 
+    The fallback is deliberately more expensive than the raw probe
+    (:data:`SANITY_CHAT_MAX_TOKENS` tokens inside
+    :data:`OUTPUT_SANITY_CHAT_TIMEOUT_S`): a chat turn is where reasoning
+    models spend their budget before saying anything visible, so a tight cap
+    here fails working slots rather than garbage ones.  It costs nothing on a
+    healthy box, which never reaches this line.
+
     Never raises: every transport failure resolves to a verdict so the caller
     owns the state transition.  Failure is the default for anything that is
     not a clean, on-topic answer — with one exception: a runner that serves
     NEITHER endpoint (404 on both) is not a completion server this gate was
     designed to probe, and "cannot judge" must not read as "judged bad".
+
+    ``timeout_s`` overrides BOTH budgets — a caller imposing its own bound
+    means "spend no more than this per request", not "and also re-tune the
+    fallback".
     """
     if port <= 0:
         return SanityVerdict(ok=False, status="no_port")
 
     budget = float(timeout_s if timeout_s is not None else OUTPUT_SANITY_TIMEOUT_S)
+    chat_budget = float(timeout_s if timeout_s is not None else OUTPUT_SANITY_CHAT_TIMEOUT_S)
     verdict = await _post(
         port,
         "/completion",
@@ -312,11 +410,14 @@ async def probe(port: int, *, timeout_s: float | None = None) -> SanityVerdict:
         "/v1/chat/completions",
         {
             "messages": [{"role": "user", "content": SANITY_PROMPT}],
-            "max_tokens": SANITY_N_PREDICT,
+            # NOT SANITY_N_PREDICT — see SANITY_CHAT_MAX_TOKENS: a dozen
+            # tokens is a raw-completion budget, and a thinking model burns
+            # every one of them inside <think> before writing an answer.
+            "max_tokens": SANITY_CHAT_MAX_TOKENS,
             "temperature": 0,
             "stream": False,
         },
-        budget,
+        chat_budget,
     )
     if chat.ok:
         log.info(
@@ -359,17 +460,69 @@ def failure_message(verdict: SanityVerdict) -> str:
     )
 
 
+def failure_extra(status: str, *, unit_stopped: bool) -> dict[str, Any]:
+    """The state-record ``extra`` a failed gate stamps on the slot.
+
+    ``unit_stopped`` records whether the teardown that follows the verdict
+    actually succeeded, so an operator staring at a red slot can tell "stopped,
+    idle" from "still running and still producing garbage" without reading the
+    journal.  Either way the slot is un-adoptable: see
+    :data:`SANITY_EXTRA_KEYS`.
+    """
+    return {
+        SANITY_FAILED_KEY: True,
+        SANITY_STATUS_KEY: status or "unknown",
+        SANITY_UNIT_STOPPED_KEY: bool(unit_stopped),
+    }
+
+
+def gate_failed(extra: Mapping[str, Any] | None) -> bool:
+    """True when this slot's last verdict was a FAIL that nothing has cleared.
+
+    Consulted by the adoption path: a slot carrying this must never be
+    re-published as READY on the strength of an active unit, which is all
+    adoption ever proves.
+    """
+    if not isinstance(extra, Mapping):
+        return False
+    return bool(extra.get(SANITY_FAILED_KEY))
+
+
+def teardown_failure_note(slot_name: str, error: str) -> str:
+    """Appended to the ERROR message when stopping the garbage unit failed.
+
+    Loud, because the box is now in the one state the operator cannot infer
+    from the dashboard: a red slot whose container is still resident and still
+    holding VRAM.  The verdict itself does not depend on this — the record's
+    :data:`SANITY_FAILED_KEY` keeps the slot un-adoptable regardless.
+    """
+    return (
+        f" Stopping the unit ALSO failed ({error}), so the container for {slot_name!r} is still "
+        "active and still holding VRAM — the slot stays in error and will not be re-adopted, "
+        "but stop it by hand before reloading."
+    )
+
+
 __all__ = [
     "EXPECTED_TOKENS",
+    "OUTPUT_SANITY_CHAT_TIMEOUT_S",
     "OUTPUT_SANITY_TIMEOUT_S",
     "SANITY_CFG_KEY",
+    "SANITY_CHAT_MAX_TOKENS",
     "SANITY_ENV_VAR",
+    "SANITY_EXTRA_KEYS",
+    "SANITY_FAILED_KEY",
     "SANITY_N_PREDICT",
     "SANITY_PROMPT",
+    "SANITY_STATUS_KEY",
+    "SANITY_UNIT_STOPPED_KEY",
     "SanityVerdict",
     "classify",
+    "failure_extra",
     "failure_message",
     "gate_disabled_globally",
+    "gate_failed",
     "probe",
     "skip_reason",
+    "teardown_failure_note",
 ]

--- a/src/hal0/slots/output_sanity.py
+++ b/src/hal0/slots/output_sanity.py
@@ -28,9 +28,11 @@ DESIGN RULES (learned from the FLM gate and from #1888)
 * **One shot, off the hot path.**  Runs exactly once per load, inside
   ``_await_ready`` where the slot holds its lock and is not yet dispatchable.
   It must never join the 2s fail-watch or the per-request readiness gate.
-* **A timeout is a FAIL.**  A runner that cannot emit 12 greedy tokens inside
-  :data:`OUTPUT_SANITY_TIMEOUT_S` is not ready, and "inconclusive → pass" is
-  exactly the lie this gate exists to stop.
+* **A timeout is not a PASS — and not a CONDEMNATION either.**  "Inconclusive
+  → ready" is exactly the lie this gate exists to stop, so a timed-out probe
+  never yields READY.  But it does not yield ERROR either: see
+  :data:`AMBIGUOUS_STATUSES`.  Only a completed round-trip whose *answer* fell
+  short is a verdict against the model.
 * **Never false-fail a working model.**  The gate stops a unit, so a wrong
   FAIL is worse than the bug it guards.  Concretely, that means judging the
   whole of what the model emitted (a reasoning model answers in
@@ -54,7 +56,11 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
-from hal0.slot_lifecycle_budget import OUTPUT_SANITY_CHAT_TIMEOUT_S, OUTPUT_SANITY_TIMEOUT_S
+from hal0.slot_lifecycle_budget import (
+    OUTPUT_SANITY_CHAT_TIMEOUT_S,
+    OUTPUT_SANITY_CPU_TIMEOUT_S,
+    OUTPUT_SANITY_TIMEOUT_S,
+)
 
 log = logging.getLogger(__name__)
 
@@ -160,6 +166,44 @@ _SECOND_OPINION_STATUSES: frozenset[str] = frozenset(
     {"empty_output", "incoherent_output", "no_content", "probe_absent"}
 )
 
+#: Failure statuses that are AMBIGUOUS rather than damning — the load path
+#: parks the slot in the retryable ``WARMING`` and stamps nothing.
+#:
+#: DO NOT "fix" ``probe_timeout`` back into a terminal failure. The reflex is
+#: to read a timeout as "the backend is wedged", but #1888 — the defect this
+#: whole module exists for — was never shaped like one: rc.6's garbage box
+#: streamed at 60-120 tok/s and closed with a ``done`` frame. Garbage was
+#: FAST. A timeout is the opposite signature, and on the CPU lane it is the
+#: signature of a box that is merely SLOW: ``/health`` proves nothing about
+#: decode rate (``providers.container`` runs no inference sentinel by design),
+#: so this probe is the first inference that box has ever done, and the fleet
+#: measured 0.12 tok/s there under load-time contention. Condemning that is a
+#: false FAIL — and this module's first rule is that a wrong FAIL is worse
+#: than the bug it guards.
+#:
+#: The line is: a COMPLETED round-trip whose answer fell short (``no_content``
+#: / ``empty_output`` / ``incoherent_output``) is a verdict about the model
+#: and stays terminal, un-adoptable, unit stopped. A round-trip that did not
+#: finish is a fact about the clock. This mirrors ``_await_ready``'s own
+#: health-wait policy ("an ambiguous outcome is treated as still loading, not
+#: failed") and :meth:`hal0.providers.flm.FLMProvider.verify_inference`, which
+#: has asked 1 token in 30s and returned retryable WARMING on failure since
+#: long before this gate existed.
+#:
+#: The remaining ``probe_``-prefixed statuses (transport error, 5xx,
+#: unparseable body) stay terminal deliberately: each is an active, immediate
+#: misbehaviour by the runner rather than an expiring clock, and none of them
+#: is the shape a slow-but-correct box produces.
+AMBIGUOUS_STATUSES: frozenset[str] = frozenset({"probe_timeout"})
+
+
+def is_ambiguous(status: str) -> bool:
+    """True when a failed verdict must NOT be treated as a verdict.
+
+    See :data:`AMBIGUOUS_STATUSES` for why the set is exactly what it is.
+    """
+    return status in AMBIGUOUS_STATUSES
+
 
 @dataclass(frozen=True, slots=True)
 class SanityVerdict:
@@ -215,6 +259,36 @@ def skip_reason(cfg: Mapping[str, Any] | None) -> str | None:
         # cannot claim it is chat-capable.
         return f"slot_type_{slot_type or 'unset'}"
     return None
+
+
+def probe_budget_s(cfg: Mapping[str, Any] | None) -> float | None:
+    """Per-request probe budget for this slot — ``None`` means module defaults.
+
+    The 20s raw / 45s chat pair is sized for a GPU. A ``device="cpu"`` slot
+    decodes one to two orders of magnitude slower (see
+    :data:`~hal0.slot_lifecycle_budget.OUTPUT_SANITY_CPU_TIMEOUT_S`), so it
+    gets the wider budget for BOTH requests — :func:`probe`'s ``timeout_s``
+    overrides the pair, which is exactly the "spend no more than this per
+    request" knob this needs.
+
+    Derived through ``_cfg_effective_backend`` rather than by reading
+    ``device`` directly so a legacy TOML carrying only ``backend`` resolves
+    the same way, and so the token can never diverge from what the load path
+    itself derives.
+
+    A wider budget only ever turns a false FAIL into a PASS or a WARMING; it
+    cannot let garbage through, because garbage answers fast and is judged on
+    its content.
+    """
+    if not isinstance(cfg, Mapping):
+        return None
+    from hal0.slots.config_write import _cfg_effective_backend
+
+    try:
+        backend = _cfg_effective_backend(cfg)
+    except Exception:  # pragma: no cover - a malformed cfg is the health path's problem
+        return None
+    return OUTPUT_SANITY_CPU_TIMEOUT_S if backend == "cpu" else None
 
 
 #: Fields of an OpenAI-shaped ``message`` that carry model output.  Judged
@@ -504,8 +578,10 @@ def teardown_failure_note(slot_name: str, error: str) -> str:
 
 
 __all__ = [
+    "AMBIGUOUS_STATUSES",
     "EXPECTED_TOKENS",
     "OUTPUT_SANITY_CHAT_TIMEOUT_S",
+    "OUTPUT_SANITY_CPU_TIMEOUT_S",
     "OUTPUT_SANITY_TIMEOUT_S",
     "SANITY_CFG_KEY",
     "SANITY_CHAT_MAX_TOKENS",
@@ -522,7 +598,9 @@ __all__ = [
     "failure_message",
     "gate_disabled_globally",
     "gate_failed",
+    "is_ambiguous",
     "probe",
+    "probe_budget_s",
     "skip_reason",
     "teardown_failure_note",
 ]

--- a/src/hal0/slots/output_sanity.py
+++ b/src/hal0/slots/output_sanity.py
@@ -1,0 +1,375 @@
+"""Output-sanity gate for llm slot readiness (#1922).
+
+WHY THIS EXISTS
+---------------
+Every readiness surface hal0 owns is a *transport* proof, not an *output*
+proof.  ``GET /health`` returning 200 means the runner bound its port and
+finished mapping weights; it says nothing about whether the backend can turn
+those weights into coherent logits.  On ct151 during ``v1.0.0-rc.6`` a box
+served two hours of garbage — runs of ``)`` on ``--jinja`` slots, empty
+content on a bare ``/completion`` — while slot state read ``ready``,
+``/api/health`` was green, ``hal0 doctor`` said "OK gpu", the SSE stream
+closed with a ``done`` frame and throughput measured 60-120 tok/s (#1888).
+Five validation lanes reported five different symptoms; all five were that one
+defect.
+
+The generic llama-server lane was the hole: :class:`~hal0.providers.flm.
+FLMProvider` slots already get a one-shot real-inference gate at the
+warm→ready promotion (``verify_inference``), but the container/llama-server
+lane had no inference gate at all — ``wait_ready`` → ``/health`` 200 was the
+whole proof.  This module closes it with one greedy completion whose answer is
+known.
+
+DESIGN RULES (learned from the FLM gate and from #1888)
+------------------------------------------------------
+* **Positive assertion only.**  Never key on the garbage string: its shape
+  varies with argv (``)))))`` vs empty content vs mojibake).  The only stable
+  check is "did the expected token appear".
+* **One shot, off the hot path.**  Runs exactly once per load, inside
+  ``_await_ready`` where the slot holds its lock and is not yet dispatchable.
+  It must never join the 2s fail-watch or the per-request readiness gate.
+* **A timeout is a FAIL.**  A runner that cannot emit 12 greedy tokens inside
+  :data:`OUTPUT_SANITY_TIMEOUT_S` is not ready, and "inconclusive → pass" is
+  exactly the lie this gate exists to stop.
+* **Scoped to chat-capable slots.**  ``type="llm"`` is the capability signal
+  (``hal0.model_meta.modality.slot_type_for`` derives the slot type from the
+  model's declared modalities), so an embedding / rerank / TTS / STT / image
+  slot is never blocked on a chat completion it cannot serve.
+* **Escapable.**  Operators running non-English or non-instruct models can
+  turn the gate off globally (``HAL0_SLOT_OUTPUT_SANITY=0``) or per slot
+  (``output_sanity = false`` in the slot TOML).  Default ON.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from hal0.slot_lifecycle_budget import OUTPUT_SANITY_TIMEOUT_S
+
+log = logging.getLogger(__name__)
+
+#: The probe prompt.  A raw *completion* prompt, not a chat turn: it needs no
+#: chat template, so it behaves identically on instruct and base models and on
+#: slots launched with or without ``--jinja`` (the argv difference that
+#: produced two different garbage shapes in #1888).
+SANITY_PROMPT = "The capital of France is"
+
+#: Greedy decode, a dozen tokens.  Enough for the answer to appear after a
+#: leading space/newline or a short restatement, cheap enough to be invisible
+#: in the slot lifecycle budget.
+SANITY_N_PREDICT = 12
+
+#: Accepted continuations, matched case-insensitively as substrings.  English
+#: first; the transliterations cover the non-English fine-tunes that would
+#: otherwise false-fail on a correct answer.  Extending this list is always
+#: safe — it can only turn a FAIL into a PASS, never the reverse.
+EXPECTED_TOKENS: tuple[str, ...] = (
+    "paris",
+    "parís",
+    "parigi",
+    "parijs",
+    "париж",
+    "巴黎",
+    "パリ",
+    "파리",
+)
+
+#: Global opt-out.  Any of ``0`` / ``false`` / ``no`` / ``off`` disables the
+#: gate for every slot on the box; unset means ON.
+SANITY_ENV_VAR = "HAL0_SLOT_OUTPUT_SANITY"
+
+#: Per-slot opt-out key in the slot TOML (top level or under ``[slot]``).
+SANITY_CFG_KEY = "output_sanity"
+
+#: Slot types the gate applies to.  Everything else serves a modality a chat
+#: completion cannot probe.
+_GATED_SLOT_TYPES: frozenset[str] = frozenset({"llm"})
+
+_FALSEY = frozenset({"0", "false", "no", "off"})
+
+#: Longest sample of the model's actual output carried into the error message
+#: and the log.  Long enough to recognise the failure shape, short enough that
+#: a wall of ``)`` does not swamp the state record's ``message``.
+_SAMPLE_CHARS = 120
+
+#: The only failures worth a second opinion: ones where the round-trip
+#: SUCCEEDED and the model's answer is what fell short (or where the endpoint
+#: simply is not served).  A timeout, a transport error, a 5xx or an
+#: unparseable body are facts about the round-trip; asking a second endpoint
+#: cannot clarify them and would double the failure path's wall clock.
+_SECOND_OPINION_STATUSES: frozenset[str] = frozenset(
+    {"empty_output", "incoherent_output", "no_content", "probe_absent"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SanityVerdict:
+    """Outcome of one output-sanity probe.
+
+    ``ok`` is the only field the caller branches on.  ``status`` is the stable
+    machine-readable reason (logged, and carried in the typed error's
+    ``details``); ``sample`` is the truncated text the model actually produced,
+    which is what an operator needs to recognise a Vulkan-garbage box.
+    """
+
+    ok: bool
+    status: str
+    sample: str = ""
+    detail: str = ""
+
+
+def _falsey(raw: Any) -> bool:
+    """True when ``raw`` reads as an explicit "off"."""
+    if isinstance(raw, bool):
+        return not raw
+    return str(raw).strip().lower() in _FALSEY
+
+
+def gate_disabled_globally() -> bool:
+    """True when :data:`SANITY_ENV_VAR` turns the gate off box-wide."""
+    raw = os.environ.get(SANITY_ENV_VAR, "").strip()
+    return bool(raw) and _falsey(raw)
+
+
+def skip_reason(cfg: Mapping[str, Any] | None) -> str | None:
+    """Why the gate must NOT run for this slot — ``None`` means "run it".
+
+    The string is a log/telemetry reason, never a user-facing message.  Order
+    matters only for the log line: any single reason is sufficient.
+    """
+    if gate_disabled_globally():
+        return "disabled_by_env"
+    if not isinstance(cfg, Mapping):
+        return "no_config"
+    raw = cfg.get(SANITY_CFG_KEY)
+    if raw is None:
+        slot_tbl = cfg.get("slot")
+        if isinstance(slot_tbl, Mapping):
+            raw = slot_tbl.get(SANITY_CFG_KEY)
+    if raw is not None and _falsey(raw):
+        return "disabled_by_slot_config"
+    slot_type = str(cfg.get("type") or "").strip().lower()
+    if slot_type not in _GATED_SLOT_TYPES:
+        # Includes the empty string: a type-less config is healed to "llm" on
+        # load (``_cfg_helpers.heal_missing_llm_type``), so an *unhealed*
+        # blank here means the config never went through the loader and we
+        # cannot claim it is chat-capable.
+        return f"slot_type_{slot_type or 'unset'}"
+    return None
+
+
+def _extract_text(body: Any) -> str | None:
+    """Pull the generated text out of a completion response body.
+
+    Handles llama-server's native ``/completion`` shape (``content``) and the
+    OpenAI-compatible shapes (``choices[0].text`` /
+    ``choices[0].message.content``) so the probe survives a runner that
+    answers ``/completion`` with an OpenAI envelope.  ``None`` means "no text
+    field at all" (unparseable); ``""`` means "the field was there and empty",
+    which is a real, reportable failure shape (#1888: bare ``/completion``
+    emitted empty content while streaming a ``done`` frame).
+    """
+    if not isinstance(body, Mapping):
+        return None
+    content = body.get("content")
+    if isinstance(content, str):
+        return content
+    choices = body.get("choices")
+    if isinstance(choices, list) and choices:
+        first = choices[0]
+        if isinstance(first, Mapping):
+            text = first.get("text")
+            if isinstance(text, str):
+                return text
+            message = first.get("message")
+            if isinstance(message, Mapping):
+                msg_content = message.get("content")
+                if isinstance(msg_content, str):
+                    return msg_content
+    return None
+
+
+def classify(text: str | None) -> SanityVerdict:
+    """Judge one completion's text.  Pure — no I/O, no config.
+
+    ``None`` (no text field in the body) → ``no_content``; whitespace-only →
+    ``empty_output``; text without any :data:`EXPECTED_TOKENS` member →
+    ``incoherent_output``; otherwise pass.
+    """
+    if text is None:
+        return SanityVerdict(ok=False, status="no_content")
+    stripped = text.strip()
+    if not stripped:
+        return SanityVerdict(ok=False, status="empty_output")
+    sample = stripped[:_SAMPLE_CHARS]
+    folded = stripped.casefold()
+    if any(token in folded for token in EXPECTED_TOKENS):
+        return SanityVerdict(ok=True, status="ok", sample=sample)
+    return SanityVerdict(ok=False, status="incoherent_output", sample=sample)
+
+
+async def _post(port: int, path: str, body: dict[str, Any], budget: float) -> SanityVerdict:
+    """POST one probe request and turn the whole round-trip into a verdict.
+
+    Never raises. Every non-content outcome gets a ``probe_``-prefixed status
+    so :func:`probe` can tell "the model said something wrong" (worth a second
+    opinion) from "the round-trip did not happen" (nothing to second-guess).
+    """
+    import httpx
+
+    from hal0.http_client import async_client
+
+    try:
+        async with async_client(timeout=httpx.Timeout(budget)) as client:
+            resp = await client.post(f"http://127.0.0.1:{port}{path}", json=body)
+    except httpx.TimeoutException:
+        # A runner that cannot produce a dozen greedy tokens inside the budget
+        # is wedged. Explicitly a FAIL: "the probe timed out so let it
+        # through" is the exact silent degrade #1922 was filed to remove.
+        return SanityVerdict(
+            ok=False,
+            status="probe_timeout",
+            detail=f"no completion within {budget:g}s",
+        )
+    except (httpx.HTTPError, OSError) as exc:
+        return SanityVerdict(
+            ok=False,
+            status="probe_transport_error",
+            detail=str(exc) or type(exc).__name__,
+        )
+
+    if resp.status_code == 404:
+        # This runner does not serve this endpoint at all.
+        return SanityVerdict(ok=False, status="probe_absent")
+    if resp.status_code != 200:
+        return SanityVerdict(
+            ok=False,
+            status=f"probe_http_{resp.status_code}",
+            detail=(resp.text or "")[:_SAMPLE_CHARS],
+        )
+    try:
+        parsed = resp.json()
+    except ValueError:
+        return SanityVerdict(
+            ok=False,
+            status="probe_unparseable",
+            detail=(resp.text or "")[:_SAMPLE_CHARS],
+        )
+    return classify(_extract_text(parsed))
+
+
+async def probe(port: int, *, timeout_s: float | None = None) -> SanityVerdict:
+    """Judge whether the server on ``port`` produces language.
+
+    Asks ``/completion`` — the raw, template-free endpoint — for a dozen
+    greedy tokens.  If the answer is right, done: one request, no second
+    opinion needed.
+
+    If the answer is WRONG, the model gets exactly one more chance, through
+    ``/v1/chat/completions`` with the same prompt as a user turn.  A raw
+    prompt and a chat-templated prompt are genuinely different inputs, and a
+    heavily template-dependent instruct model can answer one well and the
+    other poorly — so failing a working slot on the strength of a single
+    endpoint is the one mistake this gate must not make.  The retry costs
+    nothing on a healthy box (it only runs on the failing path, where the
+    load is about to be refused anyway) and it does not weaken the gate: the
+    rc.6 garbage reproduced on BOTH endpoints (#1888), which is exactly what
+    "the backend mis-computes" means.
+
+    Never raises: every transport failure resolves to a verdict so the caller
+    owns the state transition.  Failure is the default for anything that is
+    not a clean, on-topic answer — with one exception: a runner that serves
+    NEITHER endpoint (404 on both) is not a completion server this gate was
+    designed to probe, and "cannot judge" must not read as "judged bad".
+    """
+    if port <= 0:
+        return SanityVerdict(ok=False, status="no_port")
+
+    budget = float(timeout_s if timeout_s is not None else OUTPUT_SANITY_TIMEOUT_S)
+    verdict = await _post(
+        port,
+        "/completion",
+        {
+            "prompt": SANITY_PROMPT,
+            "n_predict": SANITY_N_PREDICT,
+            "temperature": 0,
+            "stream": False,
+            # Never seed the runner's prompt cache from a probe: the gate must
+            # measure the model, not warm it.
+            "cache_prompt": False,
+        },
+        budget,
+    )
+    if verdict.ok or verdict.status not in _SECOND_OPINION_STATUSES:
+        return verdict
+
+    chat = await _post(
+        port,
+        "/v1/chat/completions",
+        {
+            "messages": [{"role": "user", "content": SANITY_PROMPT}],
+            "max_tokens": SANITY_N_PREDICT,
+            "temperature": 0,
+            "stream": False,
+        },
+        budget,
+    )
+    if chat.ok:
+        log.info(
+            "slot.output_sanity_recovered_via_chat",
+            extra={"port": port, "raw_status": verdict.status},
+        )
+        return SanityVerdict(ok=True, status="ok_via_chat", sample=chat.sample)
+    if verdict.status == "probe_absent" and chat.status == "probe_absent":
+        # Serves neither endpoint → not a completion server at all. Cannot
+        # judge; see the docstring.
+        return SanityVerdict(ok=True, status="probe_unsupported")
+    # Both endpoints answered badly. Report the RAW verdict — its sample is
+    # the diagnostic one (the operator needs to see the ")))") — annotated
+    # with what the chat endpoint said, so the retry is visible in the log.
+    return SanityVerdict(
+        ok=False,
+        status=verdict.status if verdict.status != "probe_absent" else chat.status,
+        sample=verdict.sample or chat.sample,
+        detail=f"chat endpoint agreed ({chat.status})",
+    )
+
+
+def failure_message(verdict: SanityVerdict) -> str:
+    """Operator-facing one-liner for a failed verdict.
+
+    Names the probe, the expected token and what the model actually said, then
+    points at the escape hatch — an ERROR whose ``message`` reads "health
+    check failed" is what made #1888 take two hours to diagnose.
+    """
+    what = f"output-sanity probe failed ({verdict.status})"
+    detail = f"{SANITY_PROMPT!r} → expected {EXPECTED_TOKENS[0].capitalize()!r}"
+    if verdict.sample:
+        detail += f", got {verdict.sample!r}"
+    if verdict.detail:
+        detail += f" [{verdict.detail}]"
+    return (
+        f"{what}: {detail}. The model server answers /health but does not produce "
+        f"coherent text — check the runner image and GPU backend. Set "
+        f"{SANITY_ENV_VAR}=0 (or {SANITY_CFG_KEY} = false in the slot TOML) to bypass."
+    )
+
+
+__all__ = [
+    "EXPECTED_TOKENS",
+    "OUTPUT_SANITY_TIMEOUT_S",
+    "SANITY_CFG_KEY",
+    "SANITY_ENV_VAR",
+    "SANITY_N_PREDICT",
+    "SANITY_PROMPT",
+    "SanityVerdict",
+    "classify",
+    "failure_message",
+    "gate_disabled_globally",
+    "probe",
+    "skip_reason",
+]

--- a/src/hal0/slots/output_sanity.py
+++ b/src/hal0/slots/output_sanity.py
@@ -193,7 +193,11 @@ _SECOND_OPINION_STATUSES: frozenset[str] = frozenset(
 #: The remaining ``probe_``-prefixed statuses (transport error, 5xx,
 #: unparseable body) stay terminal deliberately: each is an active, immediate
 #: misbehaviour by the runner rather than an expiring clock, and none of them
-#: is the shape a slow-but-correct box produces.
+#: is the shape a slow-but-correct box produces. That rests on ``/health`` 200
+#: strictly preceding ``/completion`` availability — structurally possible to
+#: violate (``wait_ready`` accepts a ``/v1/models`` 200 fallback) and not yet
+#: empirically settled against the pinned runner: tracked as #1969. If that
+#: window turns out to be real the fix is upstream of this set, not inside it.
 AMBIGUOUS_STATUSES: frozenset[str] = frozenset({"probe_timeout"})
 
 
@@ -272,7 +276,7 @@ def probe_budget_s(cfg: Mapping[str, Any] | None) -> float | None:
     request" knob this needs.
 
     Derived through ``_cfg_effective_backend`` rather than by reading
-    ``device`` directly so a legacy TOML carrying only ``backend`` resolves
+    ``device`` directly so an older TOML carrying only ``backend`` resolves
     the same way, and so the token can never diverge from what the load path
     itself derives.
 
@@ -503,9 +507,36 @@ async def probe(port: int, *, timeout_s: float | None = None) -> SanityVerdict:
         # Serves neither endpoint → not a completion server at all. Cannot
         # judge; see the docstring.
         return SanityVerdict(ok=True, status="probe_unsupported")
-    # Both endpoints answered badly. Report the RAW verdict — its sample is
-    # the diagnostic one (the operator needs to see the ")))") — annotated
-    # with what the chat endpoint said, so the retry is visible in the log.
+    if is_ambiguous(chat.status):
+        # The second opinion never ARRIVED, so there is no second opinion to
+        # convict on. Composing the raw status here would launder a timeout
+        # into a content verdict — ``empty_output`` + ``probe_timeout`` read
+        # out as a plain ``empty_output`` and went terminal, walking straight
+        # around AMBIGUOUS_STATUSES with the timeout demoted to prose in
+        # ``detail``.
+        #
+        # This is not a technicality, it is this function's premise: the
+        # fallback exists BECAUSE one endpoint's bad answer is not proof
+        # ("failing a working slot on the strength of a single endpoint is
+        # the one mistake this gate must not make" — see the docstring). No
+        # corroboration, no conviction.
+        #
+        # It costs #1888 nothing, for the same reason the raw-probe carve-out
+        # does: garbage is FAST. A backend that mis-computes streams its
+        # nonsense at 60-120 tok/s and answers the fallback well inside any
+        # budget, landing a real ``incoherent_output`` below. The only slot
+        # that reaches THIS line is one that was too slow to answer twice —
+        # which is the slot that must be retried, not condemned.
+        return SanityVerdict(
+            ok=False,
+            status=chat.status,
+            sample=verdict.sample,
+            detail=f"raw probe said {verdict.status}; the chat second opinion never arrived",
+        )
+    # Both endpoints answered, and both answered badly. Report the RAW verdict
+    # — its sample is the diagnostic one (the operator needs to see the ")))")
+    # — annotated with what the chat endpoint said, so the retry is visible in
+    # the log.
     return SanityVerdict(
         ok=False,
         status=verdict.status if verdict.status != "probe_absent" else chat.status,

--- a/src/hal0/slots/state.py
+++ b/src/hal0/slots/state.py
@@ -238,6 +238,25 @@ class SlotHealthFailed(SlotError):
     status = 503
 
 
+class SlotOutputSanityFailed(SlotError):
+    """The slot serves HTTP but does not produce coherent language (#1922).
+
+    Raised by the one-shot output-sanity gate at the warm→ready promotion:
+    ``/health`` is green, the port answers, tokens stream — and the model
+    emits ``)))))``/empty/off-topic text instead of the known answer (see
+    :mod:`hal0.slots.output_sanity`). Deliberately NOT ``SlotHealthFailed``:
+    the health probe passed, and conflating the two is what let a garbage box
+    read green on every surface for two hours (#1888).
+
+    Terminal for this load, not retryable in place — the caller's ERROR
+    transition + crash-loop breaker govern re-loading, so a broken backend
+    fails loudly once instead of burning the GPU in a retry loop.
+    """
+
+    code = "slot.output_sanity_failed"
+    status = 500
+
+
 class SlotCrashLooping(SlotError):
     """Load refused by the crash-loop breaker (issue i4).
 
@@ -444,6 +463,7 @@ __all__ = [
     "SlotHealthFailed",
     "SlotNotFound",
     "SlotNotReady",
+    "SlotOutputSanityFailed",
     "SlotPinned",
     "SlotSpawnFailed",
     "SlotState",

--- a/tests/cli/test_slot_commands.py
+++ b/tests/cli/test_slot_commands.py
@@ -197,10 +197,7 @@ def _server_load_lock_hold_s() -> float:
     added to ``load`` without a matching budget edit fails here.
     """
     from hal0.providers.container import _HEALTH_TIMEOUT_S
-    from hal0.slot_lifecycle_budget import (
-        OUTPUT_SANITY_CHAT_TIMEOUT_S,
-        OUTPUT_SANITY_TIMEOUT_S,
-    )
+    from hal0.slot_lifecycle_budget import OUTPUT_SANITY_CPU_TIMEOUT_S
     from hal0.slots.manager import SlotManager
 
     terminate = float(SlotManager._terminate_timeout_s)
@@ -212,9 +209,12 @@ def _server_load_lock_hold_s() -> float:
         + _MIN_EVICTION_UNLOADS * terminate
         # The post-spawn /health poll.
         + float(_HEALTH_TIMEOUT_S)
-        # The output-sanity gate (#1922): raw probe, then the chat fallback.
-        + float(OUTPUT_SANITY_TIMEOUT_S)
-        + float(OUTPUT_SANITY_CHAT_TIMEOUT_S)
+        # The output-sanity gate (#1922): raw probe, then the chat fallback —
+        # at the CPU lane's budget, which is what both requests get on a
+        # device="cpu" slot (output_sanity.probe_budget_s). The client is
+        # handed a slot NAME by every lifecycle verb and cannot know which
+        # lane it is waiting on, so the floor has to charge the slower one.
+        + 2 * float(OUTPUT_SANITY_CPU_TIMEOUT_S)
         # A failed gate stops the unit before the ERROR stamp, still in-lock.
         + terminate
     )

--- a/tests/cli/test_slot_commands.py
+++ b/tests/cli/test_slot_commands.py
@@ -180,14 +180,62 @@ def test_restart_budget_charges_both_lock_acquisitions() -> None:
     """
     from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
 
-    from hal0.providers.container import _HEALTH_TIMEOUT_S  # isort: skip
     from hal0.slots.manager import SlotManager  # isort: skip
 
     terminate = float(SlotManager._terminate_timeout_s)
-    load_phase = float(_HEALTH_TIMEOUT_S) + _MIN_EVICTION_UNLOADS * terminate
+    load_phase = _server_load_lock_hold_s()
     # Two lock waits (each capped by a full load) plus the verb's own work.
     floor = 2 * load_phase + terminate + load_phase
     assert slot_lifecycle_timeout_s(loads=1, unloads=1) >= floor
+
+
+def _server_load_lock_hold_s() -> float:
+    """Worst wall-clock a single ``load`` can hold the slot lock, server-side.
+
+    Summed from the server modules that actually spend it, not from
+    ``slot_lifecycle_budget``'s own composite — the point is that a phase
+    added to ``load`` without a matching budget edit fails here.
+    """
+    from hal0.providers.container import _HEALTH_TIMEOUT_S
+    from hal0.slot_lifecycle_budget import (
+        OUTPUT_SANITY_CHAT_TIMEOUT_S,
+        OUTPUT_SANITY_TIMEOUT_S,
+    )
+    from hal0.slots.manager import SlotManager
+
+    terminate = float(SlotManager._terminate_timeout_s)
+    return (
+        # Pre-spawn teardown: the drifted re-converge / ERROR-retry / stale
+        # in-flight branches all terminate in place before re-spawning.
+        terminate
+        # preload_evict.admit unloads candidates in series, inside the lock.
+        + _MIN_EVICTION_UNLOADS * terminate
+        # The post-spawn /health poll.
+        + float(_HEALTH_TIMEOUT_S)
+        # The output-sanity gate (#1922): raw probe, then the chat fallback.
+        + float(OUTPUT_SANITY_TIMEOUT_S)
+        + float(OUTPUT_SANITY_CHAT_TIMEOUT_S)
+        # A failed gate stops the unit before the ERROR stamp, still in-lock.
+        + terminate
+    )
+
+
+def test_load_budget_covers_a_contended_load_that_fails_the_gate() -> None:
+    """One contender in front of you, both loads failing the gate (#1922).
+
+    ``POST /api/slots/{name}/load`` charges one lock wait plus its own work,
+    and both are now wider than they were: the output-sanity gate runs inside
+    the lock and its failure path stops the unit before stamping ERROR. If the
+    lock allowance is not recomputed when a phase is added to ``load``, the
+    CLI/MCP client reports a timeout on a load the server is still converging
+    — the #1832 shape, re-introduced from the inside.
+    """
+    from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
+
+    floor = 2 * _server_load_lock_hold_s()
+    assert slot_lifecycle_timeout_s(loads=1, unloads=0) >= floor, (
+        "the load budget no longer covers one queued load plus your own"
+    )
 
 
 def test_slot_logs_one_shot_prints_hint_when_logs_empty(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,6 +213,31 @@ def _no_static_slot_seed(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _slot_output_sanity_passes_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Answer the slot output-sanity gate (#1922) without a model server.
+
+    Every ``load()`` of a ``type=llm`` slot now ends with one real completion
+    against the slot's port — the gate that stops a garbage backend from being
+    published as READY (#1888). No unit test has a llama-server behind that
+    port: the probe would resolve to a connection error and fail every load in
+    the suite, which is a fact about the test environment, not about the code
+    under test. Default the verdict to "the model answered correctly", the
+    same claim every container-provider double already makes about its unit.
+
+    Tests that exercise the gate override this: ``tests/slots/conftest.py``'s
+    ``container_stub`` routes the probe at the fake provider's ``sanity_output``,
+    and ``tests/slots/test_output_sanity_gate.py`` drives the real probe
+    against a real loopback server.
+    """
+    from hal0.slots.output_sanity import SanityVerdict
+
+    async def _passing_probe(port: int, **_kw: object) -> SanityVerdict:
+        return SanityVerdict(ok=True, status="ok", sample="Paris")
+
+    monkeypatch.setattr("hal0.slots.output_sanity.probe", _passing_probe)
+
+
+@pytest.fixture(autouse=True)
 def _store_not_nfs_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Force ``hal0.config.store.is_nfs_path`` to False for the whole suite.
 

--- a/tests/slots/conftest.py
+++ b/tests/slots/conftest.py
@@ -43,6 +43,10 @@ class FakeContainerProvider:
         ``discard()`` an entry to simulate the unit stopping out-of-band.
       * ``load_calls`` / ``unload_calls`` — recorded dispatches.
       * ``fail_load`` — when set, ``load_sync`` raises it (spawn failure).
+      * ``fail_unload`` — when set, ``unload_sync`` raises it and the unit
+        stays in ``active``: the real "``systemctl stop`` did not return"
+        shape (#1224), where ``SlotManager.terminate`` abandons the wait and
+        raises ``SlotTerminateTimeout`` over a still-running container.
       * ``unit_failure_by_slot`` — systemd's verdict per slot (#1791). A
         non-empty string is the manager's PROOF that systemd gave up on the
         unit (crash loop / ``start-limit-hit`` / unit gone); the default empty
@@ -59,6 +63,7 @@ class FakeContainerProvider:
         self.load_calls: list[tuple[dict[str, Any], dict[str, Any]]] = []
         self.unload_calls: list[dict[str, Any]] = []
         self.fail_load: Exception | None = None
+        self.fail_unload: Exception | None = None
         self.running_argv_by_slot: dict[str, list[str] | None] = {}
         self.expected_argv_by_slot: dict[str, list[str] | None] = {}
         # /health probe result. Default True: an active unit is also ready.
@@ -87,6 +92,10 @@ class FakeContainerProvider:
 
     def unload_sync(self, cfg: dict[str, Any]) -> None:
         self.unload_calls.append(dict(cfg))
+        if self.fail_unload is not None:
+            # The stop never completed, so the unit is still running — leave
+            # it in ``active``, which is the whole point of this shape.
+            raise self.fail_unload
         self.active.discard(str(cfg.get("name")))
 
     # — probes —

--- a/tests/slots/conftest.py
+++ b/tests/slots/conftest.py
@@ -48,6 +48,10 @@ class FakeContainerProvider:
         unit (crash loop / ``start-limit-hit`` / unit gone); the default empty
         string is the "unit is fine or the probe was inconclusive" answer that
         every pre-#1791 test implicitly relied on.
+      * ``sanity_output`` — what the fake slot server's model emits for the
+        output-sanity probe (#1922). The default is the correct answer, i.e.
+        "this fake box works"; set it to garbage / ``""`` / ``None`` to drive
+        the gate's failure paths through ``load()``.
     """
 
     def __init__(self) -> None:
@@ -66,6 +70,12 @@ class FakeContainerProvider:
         # test keeps the old "nothing is wrong with the unit" behaviour.
         self.unit_failure_by_slot: dict[str, str] = {}
         self.reset_failed_calls: list[str] = []
+        # #1922 — the fake slot server's completion output. "Paris" is the
+        # right answer to the gate's prompt, so the default double models a
+        # box whose model actually works, exactly as ``healthy = True`` models
+        # a unit that actually serves. ``None`` = no content field at all.
+        self.sanity_output: str | None = "Paris"
+        self.sanity_probes: list[int] = []
 
     # — SlotManager._spawn_locked / terminate (sync, executor-run) —
 
@@ -101,6 +111,20 @@ class FakeContainerProvider:
         # real-inference probe in production.
         return {"ok": self.healthy}
 
+    async def output_sanity_probe(self, port: int, **_kw: Any) -> Any:
+        """Stand in for ``hal0.slots.output_sanity.probe`` (#1922).
+
+        The real gate POSTs ``/completion`` to the slot's port; with no server
+        behind the fake provider that would be a connection error, i.e. every
+        load in this suite would fail the gate. The double answers with
+        ``sanity_output`` through the REAL classifier, so the pass/fail
+        decision under test is production code — only the transport is faked.
+        """
+        from hal0.slots.output_sanity import classify
+
+        self.sanity_probes.append(port)
+        return classify(self.sanity_output)
+
     # — slot_view container_enrichment extras —
 
     def running_image(self, slot: Any) -> str | None:
@@ -125,11 +149,20 @@ def container_stub(monkeypatch: pytest.MonkeyPatch) -> FakeContainerProvider:
     SlotManager imports ``container_provider`` lazily from
     ``hal0.providers.container`` inside each method, so patching the
     module attribute covers every dispatch site.
+
+    Also redirects the output-sanity gate's HTTP probe (#1922) at the same
+    double: a faked container has no model server to complete against, so
+    without this every ``load()`` in this suite would fail the gate on a
+    connection error. Tests drive the gate via ``container_stub.sanity_output``.
     """
     fake = FakeContainerProvider()
     monkeypatch.setattr(
         "hal0.providers.container.container_provider",
         lambda: fake,
+    )
+    monkeypatch.setattr(
+        "hal0.slots.output_sanity.probe",
+        fake.output_sanity_probe,
     )
     return fake
 

--- a/tests/slots/test_output_sanity_gate.py
+++ b/tests/slots/test_output_sanity_gate.py
@@ -251,11 +251,13 @@ async def test_probe_accepts_a_model_that_only_answers_through_its_template(
 async def test_probe_fails_on_never_terminating_server(
     slot_server: FakeSlotServer,
 ) -> None:
-    """A timeout is a FAIL, not a pass.
+    """A timeout is not a pass.
 
     "The probe was inconclusive so let the slot through" is precisely the
-    silent degrade this gate exists to remove — a runner that cannot emit a
-    dozen greedy tokens is not ready by any definition.
+    silent degrade this gate exists to remove. The verdict layer therefore
+    reports ``ok=False``; what the *load path* does with an ambiguous failure
+    is a separate decision, pinned by
+    ``test_a_slow_server_parks_the_slot_warming_instead_of_condemning_it``.
     """
     await slot_server.start(lambda path, body: None)
 
@@ -726,12 +728,73 @@ async def test_load_reaches_ready_when_the_slot_answers(
     assert container_stub.sanity_probes == [8081], "the gate runs exactly once per load"
 
 
-async def test_load_errors_when_the_probe_times_out(
+async def test_a_slow_server_parks_the_slot_warming_instead_of_condemning_it(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    slot_server: FakeSlotServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CPU-lane shape: a real server that is merely SLOW must stay retryable.
+
+    A probe timeout is ambiguous — it says the answer did not arrive inside a
+    wall clock, not that the answer was wrong. Treating it as terminal turned
+    the gate into a false-fail machine on exactly the box the release gets
+    validated on: ct151 measured 0.12 tok/s under load-time contention, the
+    container health probe runs no inference sentinel (so the gate is that
+    box's first-ever inference), and a no-GPU box binds the unquantized F16
+    brain variant. An ERROR there is not recoverable by retrying; it also
+    stamps the durable un-adoptable mark.
+
+    Real never-answering socket, real httpx round-trip, real timeout — only
+    the wall clock is shrunk, so this is the production path.
+    """
+    await slot_server.start(lambda path, body: None)
+    (slot_root / "chat.toml").write_text(
+        "\n".join(
+            [
+                'name = "chat"',
+                f"port = {slot_server.port}",
+                'device = "cpu"',
+                'provider = "llama-server"',
+                "[model]",
+                'default = "qwen3-4b-q4_k_m"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    async def _slow(port: int, **_kw: Any) -> output_sanity.SanityVerdict:
+        return await _probe(port, timeout_s=0.3)
+
+    monkeypatch.setattr("hal0.slots.output_sanity.probe", _slow)
+    sm = SlotManager()
+
+    slot = await sm.load("chat")
+
+    # Retryable, non-dispatchable, and NOT a lying READY.
+    assert slot.state is SlotState.WARMING
+    record = sm._states[sm._key("chat")]
+    # No durable verdict: nothing here is proven bad, so nothing may be made
+    # un-adoptable.
+    for key in output_sanity.SANITY_EXTRA_KEYS:
+        assert key not in record.extra
+    # And the unit is left alone — the teardown belongs to a condemned slot.
+    assert "chat" in container_stub.active
+    assert container_stub.unload_calls == []
+
+
+async def test_a_probe_timeout_leaves_the_slot_adoptable(
     slot_root: Path,
     container_stub: FakeContainerProvider,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A probe timeout must fail the load, not fall through to READY."""
+    """WARMING must not poison the adoption path the way a real verdict does.
+
+    The durable mark is what makes a FAILED gate survive a restart. An
+    ambiguous outcome earns none of that: the next load re-runs the gate and
+    the slot converges on evidence, not on a stamp nothing cleared.
+    """
 
     async def _timeout(port: int, **_kw: Any) -> output_sanity.SanityVerdict:
         return output_sanity.SanityVerdict(ok=False, status="probe_timeout")
@@ -739,10 +802,173 @@ async def test_load_errors_when_the_probe_times_out(
     monkeypatch.setattr("hal0.slots.output_sanity.probe", _timeout)
     sm = SlotManager()
 
+    await sm.load("chat")
+
+    assert sm._current_state("chat") is SlotState.WARMING
+    cfg = await sm._maybe_load_config("chat")
+    assert cfg is not None
+    assert await sm._maybe_adopt_running_slot("chat", cfg) is not None
+
+
+async def test_a_slot_parked_warming_re_runs_the_gate_on_the_next_load(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Convergence: WARMING is a retry, not a resting place.
+
+    ``load``'s stale-in-flight branch (PULLING/STARTING/WARMING) tears the
+    unit down and re-enters the lifecycle from OFFLINE, so the gate runs
+    again on every retry. Without that the slot would sit un-judged forever
+    behind an ambiguous verdict.
+    """
+    timeouts = True
+
+    async def _probe_then_recover(port: int, **_kw: Any) -> output_sanity.SanityVerdict:
+        if timeouts:
+            return output_sanity.SanityVerdict(ok=False, status="probe_timeout")
+        return output_sanity.classify(" Paris.")
+
+    monkeypatch.setattr("hal0.slots.output_sanity.probe", _probe_then_recover)
+    sm = SlotManager()
+    await sm.load("chat")
+    assert sm._current_state("chat") is SlotState.WARMING
+
+    timeouts = False
+    slot = await sm.load("chat")
+
+    assert slot.state is SlotState.READY
+
+
+async def test_a_dead_backend_still_converges_to_error_in_the_same_load(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """WARMING must not become a hiding place for a genuinely dead slot.
+
+    The ambiguity carve-out only says "the probe cannot tell". Something else
+    still can: ``load`` asks systemd directly whenever the readiness resolve
+    comes back WARMING (#1791), and a unit parked in ``failed`` / gone is
+    proof no retry will help. That converts the ambiguous outcome into ERROR
+    inside the same load, with the crash-loop bookkeeping the breaker needs —
+    so a dead backend never rides a timeout into an unbounded retry loop.
+    """
+
+    async def _timeout(port: int, **_kw: Any) -> output_sanity.SanityVerdict:
+        return output_sanity.SanityVerdict(ok=False, status="probe_timeout")
+
+    monkeypatch.setattr("hal0.slots.output_sanity.probe", _timeout)
+    container_stub.unit_failure_by_slot["chat"] = "start-limit-hit"
+    sm = SlotManager()
+
+    with pytest.raises(Exception) as excinfo:
+        await sm.load("chat")
+
+    assert "start-limit-hit" in str(excinfo.value)
+    assert sm._current_state("chat") is SlotState.ERROR
+    assert sm._load_failures[sm._key("chat")][0] == 1
+
+
+async def test_garbage_stays_terminal_even_though_a_timeout_does_not(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    slot_server: FakeSlotServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The #1888 signature is untouched by the timeout carve-out.
+
+    rc.6's garbage box streamed at 60-120 tok/s and closed with a ``done``
+    frame: garbage was FAST. A timeout was never its signature, so exempting
+    timeouts removes false failures without weakening a single true positive.
+    This pins the pair against one real server so the distinction cannot rot
+    into "any probe failure is survivable".
+    """
+    await slot_server.start(_completion(")))))))))))))"))
+    (slot_root / "chat.toml").write_text(
+        "\n".join(
+            [
+                'name = "chat"',
+                f"port = {slot_server.port}",
+                'provider = "llama-server"',
+                "[model]",
+                'default = "qwen3-4b-q4_k_m"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    async def _real(port: int, **_kw: Any) -> output_sanity.SanityVerdict:
+        return await _probe(port, timeout_s=5.0)
+
+    monkeypatch.setattr("hal0.slots.output_sanity.probe", _real)
+    sm = SlotManager()
+
     with pytest.raises(SlotOutputSanityFailed):
         await sm.load("chat")
 
     assert sm._current_state("chat") is SlotState.ERROR
+    record = sm._states[sm._key("chat")]
+    assert record.extra.get(output_sanity.SANITY_FAILED_KEY) is True
+
+
+def test_a_cpu_slot_gets_a_wider_probe_budget() -> None:
+    """A slow-but-correct box must be judged on its answer, not on the clock.
+
+    The accelerated lane's 20s is a fine bound for a GPU that decodes a dozen
+    tokens instantly. A ``device="cpu"`` slot is the lane the fleet's own
+    measurements say cannot clear it — and on a no-GPU box every seeded slot
+    is derived to ``cpu`` (``install.profile_derive.derive_device``), so this
+    is the default shape there, not an exotic one.
+    """
+    from hal0.slot_lifecycle_budget import OUTPUT_SANITY_CPU_TIMEOUT_S, OUTPUT_SANITY_TIMEOUT_S
+
+    assert output_sanity.probe_budget_s({"device": "cpu"}) == OUTPUT_SANITY_CPU_TIMEOUT_S
+    assert OUTPUT_SANITY_CPU_TIMEOUT_S > OUTPUT_SANITY_TIMEOUT_S
+    # An accelerated slot keeps the module defaults (both of them — the raw
+    # probe's and the chat fallback's), which ``None`` is the signal for.
+    assert output_sanity.probe_budget_s({"device": "gpu-rocm"}) is None
+    assert output_sanity.probe_budget_s({"device": "npu"}) is None
+    assert output_sanity.probe_budget_s(None) is None
+    # Legacy TOMLs carry only ``backend``; the cpu lane must be recognised
+    # there too or the widening misses every un-migrated box.
+    assert output_sanity.probe_budget_s({"backend": "cpu"}) == OUTPUT_SANITY_CPU_TIMEOUT_S
+
+
+async def test_the_load_path_hands_the_probe_the_slot_s_budget(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The derived budget is worthless if the gate does not pass it through."""
+    from hal0.slot_lifecycle_budget import OUTPUT_SANITY_CPU_TIMEOUT_S
+
+    (slot_root / "chat.toml").write_text(
+        "\n".join(
+            [
+                'name = "chat"',
+                "port = 8081",
+                'device = "cpu"',
+                'provider = "llama-server"',
+                "[model]",
+                'default = "qwen3-4b-q4_k_m"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    seen: list[float | None] = []
+
+    async def _record(port: int, *, timeout_s: float | None = None) -> output_sanity.SanityVerdict:
+        seen.append(timeout_s)
+        return output_sanity.classify(" Paris.")
+
+    monkeypatch.setattr("hal0.slots.output_sanity.probe", _record)
+
+    await SlotManager().load("chat")
+
+    assert seen == [OUTPUT_SANITY_CPU_TIMEOUT_S]
 
 
 async def test_load_skips_the_gate_for_non_llm_slots(

--- a/tests/slots/test_output_sanity_gate.py
+++ b/tests/slots/test_output_sanity_gate.py
@@ -270,6 +270,99 @@ async def test_probe_fails_on_never_terminating_server(
     assert len(slot_server.seen) == 1
 
 
+async def test_a_second_opinion_that_never_arrives_does_not_compose_a_verdict(
+    slot_server: FakeSlotServer,
+) -> None:
+    """The MIXED case: raw answered badly, the chat fallback never answered.
+
+    The composition used to report the RAW verdict's status, so
+    ``empty_output`` + ``probe_timeout`` laundered into a plain
+    ``empty_output`` — terminal, unit stopped, durable mark — with the
+    timeout visible only in a prose ``detail``. That walks straight around
+    :data:`~hal0.slots.output_sanity.AMBIGUOUS_STATUSES`.
+
+    It is also the one thing this module says it must never do: "failing a
+    working slot on the strength of a single endpoint is the one mistake this
+    gate must not make." The fallback exists *because* one endpoint's bad
+    answer is not enough — so when the second opinion does not arrive, there
+    is no second verdict to condemn on.
+    """
+
+    def _respond(path: str, body: dict[str, Any]) -> tuple[int, Any] | None:
+        if path == "/completion":
+            return 200, {"content": "", "stop": True}
+        return None  # the chat fallback hangs
+
+    await slot_server.start(_respond)
+
+    verdict = await _probe(slot_server.port, timeout_s=0.4)
+
+    assert verdict.ok is False
+    assert output_sanity.is_ambiguous(verdict.status), (
+        f"a missing second opinion must stay ambiguous, got {verdict.status!r}"
+    )
+    # Both endpoints really were tried — this is the mixed case, not an early
+    # return.
+    assert [path for path, _ in slot_server.seen] == [
+        "/completion",
+        "/v1/chat/completions",
+    ]
+    # The raw endpoint's finding is still carried for the operator.
+    assert "empty_output" in verdict.detail
+
+
+async def test_a_mixed_verdict_parks_the_slot_warming_without_condemning_it(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    slot_server: FakeSlotServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mixed case, all the way through ``load``.
+
+    This is the CPU lane's shape by construction: the chat fallback asks 256
+    tokens, so a box slow enough to fail the raw probe is a box whose second
+    opinion times out. If that composes to a terminal verdict, the widened
+    raw budget rescues nothing — the slot the fallback exists to protect is
+    the slot it kills.
+    """
+
+    def _respond(path: str, body: dict[str, Any]) -> tuple[int, Any] | None:
+        if path == "/completion":
+            return 200, {"content": "", "stop": True}
+        return None
+
+    await slot_server.start(_respond)
+    (slot_root / "chat.toml").write_text(
+        "\n".join(
+            [
+                'name = "chat"',
+                f"port = {slot_server.port}",
+                'device = "cpu"',
+                'provider = "llama-server"',
+                "[model]",
+                'default = "qwen3-4b-q4_k_m"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    async def _fast(port: int, **_kw: Any) -> output_sanity.SanityVerdict:
+        return await _probe(port, timeout_s=0.4)
+
+    monkeypatch.setattr("hal0.slots.output_sanity.probe", _fast)
+    sm = SlotManager()
+
+    slot = await sm.load("chat")
+
+    assert slot.state is SlotState.WARMING
+    record = sm._states[sm._key("chat")]
+    for key in output_sanity.SANITY_EXTRA_KEYS:
+        assert key not in record.extra
+    assert "chat" in container_stub.active
+    assert container_stub.unload_calls == []
+
+
 async def test_probe_fails_on_dead_port() -> None:
     """Nothing listening → a fail verdict, never an exception."""
     server = FakeSlotServer()
@@ -883,6 +976,12 @@ async def test_garbage_stays_terminal_even_though_a_timeout_does_not(
     timeouts removes false failures without weakening a single true positive.
     This pins the pair against one real server so the distinction cannot rot
     into "any probe failure is survivable".
+
+    It also pins the property that makes the ambiguity carve-outs SUFFICIENT
+    rather than merely safe: because garbage answers quickly, a garbage
+    backend corroborates on BOTH endpoints well inside the budget and still
+    composes to a terminal verdict. Only a genuinely slow box fails to answer
+    twice — and that is the box that must be retried, not condemned.
     """
     await slot_server.start(_completion(")))))))))))))"))
     (slot_root / "chat.toml").write_text(
@@ -911,6 +1010,61 @@ async def test_garbage_stays_terminal_even_though_a_timeout_does_not(
     assert sm._current_state("chat") is SlotState.ERROR
     record = sm._states[sm._key("chat")]
     assert record.extra.get(output_sanity.SANITY_FAILED_KEY) is True
+    # Both endpoints answered — the second opinion ARRIVED and agreed, which
+    # is what a fast-but-wrong backend always does and what the terminal
+    # composition requires.
+    assert [path for path, _ in slot_server.seen] == [
+        "/completion",
+        "/v1/chat/completions",
+    ]
+
+
+def test_the_chat_budget_is_not_shrunk_on_the_cpu_lane() -> None:
+    """Why the cpu lane widens the CLOCK but never narrows the TOKEN cap.
+
+    Shrinking ``SANITY_CHAT_MAX_TOKENS`` so the fallback fits the cpu budget
+    looks like the obvious complement to the wider wall clock — 256 tokens
+    inside 180s is a 1.42 tok/s floor, which the fleet's slowest measured box
+    (0.12 tok/s) cannot clear, so the fallback times out there by
+    construction.
+
+    It is a trap. A truncated generation is not reported as a truncation: a
+    thinking model that spends its whole cap inside ``<think>`` returns
+    ``content=""`` with a partial thought in ``reasoning_content``, and
+    ``_message_text`` judges the union — so a smaller cap turns a SAFE
+    outcome (``probe_timeout`` → ambiguous → WARMING) into ``incoherent_output``,
+    which is terminal: ERROR, unit stopped, durable un-adoptable mark. That is
+    a hard false-fail inflicted on precisely the population the fallback exists
+    to protect, in exchange for removing a deferral that costs nothing.
+
+    The timeout is the right lever, and it is already pulled: a fallback that
+    cannot finish now defers instead of convicting. Nothing is lost by letting
+    it time out, because the slot that times out is by definition the SLOW one
+    — a garbage backend streams at 60-120 tok/s and corroborates fast (pinned
+    by ``test_garbage_stays_terminal_even_though_a_timeout_does_not``).
+    """
+    body = {
+        "choices": [
+            {
+                "message": {
+                    "content": "",
+                    "reasoning_content": (
+                        "Okay, the user is asking about the capital of France. Let me recall"
+                    ),
+                },
+                "finish_reason": "length",
+            }
+        ]
+    }
+
+    verdict = output_sanity.classify(output_sanity._extract_text(body))
+
+    # THE trap, pinned: a cap-truncated think block is indistinguishable from
+    # garbage to the classifier, and garbage is terminal.
+    assert verdict.status == "incoherent_output"
+    assert not output_sanity.is_ambiguous(verdict.status)
+    # So the cap must stay big enough to contain a real reasoning preamble.
+    assert output_sanity.SANITY_CHAT_MAX_TOKENS >= 256
 
 
 def test_a_cpu_slot_gets_a_wider_probe_budget() -> None:

--- a/tests/slots/test_output_sanity_gate.py
+++ b/tests/slots/test_output_sanity_gate.py
@@ -1,0 +1,530 @@
+"""Output-sanity gate: a slot may not reach READY on transport proof alone.
+
+Regression for #1922 / #1888. On ct151 during rc.6 a box read green on every
+surface hal0 owns — slot ``ready``, ``/api/health`` green, ``hal0 doctor`` "OK
+gpu", an SSE ``done`` frame, 60-120 tok/s — while producing two hours of
+garbage (runs of ``)`` with ``--jinja``, empty content on a bare
+``/completion``). Every one of those surfaces proves the *port answers*; none
+proves the *model produces language*.
+
+The tests below pin both halves of the fix:
+
+* the probe itself, against a REAL loopback HTTP server that plays each of the
+  four failure shapes from the issue (``Paris`` / ``)))))`` / empty content /
+  never terminating), so the httpx call, the JSON parse and the timeout are
+  exercised rather than mocked away;
+* the gate's placement in ``SlotManager._await_ready``, so a garbage slot ends
+  in ERROR with an actionable message instead of a lying READY — and an
+  embedding slot, or an operator who opted out, is never blocked on a chat
+  completion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from collections.abc import AsyncIterator, Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.slots import output_sanity
+from hal0.slots.manager import SlotManager
+from hal0.slots.state import SlotOutputSanityFailed, SlotState
+from tests.slots.conftest import FakeContainerProvider
+
+# A responder maps (path, request_body) → (status, json_body), or None to
+# model a server that accepts the request and never answers.
+Responder = Callable[[str, dict[str, Any]], tuple[int, Any] | None]
+
+_REASONS = {200: "OK", 404: "Not Found", 500: "Internal Server Error"}
+
+#: The REAL probe, bound at import — before the suite-wide autouse stub in
+#: ``tests/conftest.py`` (which answers the gate for every OTHER test, none of
+#: which has a model server) can replace the module attribute. The probe tests
+#: below are the one place the actual httpx round-trip must run.
+_probe = output_sanity.probe
+
+
+class FakeSlotServer:
+    """A minimal loopback HTTP server standing in for llama-server.
+
+    Deliberately not an httpx mock transport: the never-terminating case (the
+    fourth shape the issue asks for) is only a real test if a real socket is
+    open with nothing coming back on it.
+    """
+
+    def __init__(self) -> None:
+        self.port = 0
+        self.seen: list[tuple[str, dict[str, Any]]] = []
+        self._tasks: set[asyncio.Task[None]] = set()
+        self._server: asyncio.AbstractServer | None = None
+
+    async def start(self, responder: Responder) -> None:
+        async def _client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            task = asyncio.current_task()
+            if task is not None:
+                self._tasks.add(task)
+            try:
+                request_line = await reader.readline()
+                if not request_line:
+                    return
+                path = request_line.decode("latin-1").split(" ")[1]
+                length = 0
+                while True:
+                    line = await reader.readline()
+                    if line in (b"\r\n", b"\n", b""):
+                        break
+                    name, _, value = line.decode("latin-1").partition(":")
+                    if name.strip().lower() == "content-length":
+                        length = int(value.strip())
+                raw = await reader.readexactly(length) if length else b""
+                body = json.loads(raw) if raw else {}
+                self.seen.append((path, body))
+                reply = responder(path, body)
+                if reply is None:
+                    # Never-terminating server: hold the connection open with
+                    # no response until the test tears the fixture down.
+                    await asyncio.sleep(300)
+                    return
+                status, payload = reply
+                encoded = json.dumps(payload).encode()
+                head = (
+                    f"HTTP/1.1 {status} {_REASONS.get(status, 'OK')}\r\n"
+                    "Content-Type: application/json\r\n"
+                    f"Content-Length: {len(encoded)}\r\n"
+                    "Connection: close\r\n\r\n"
+                ).encode()
+                writer.write(head + encoded)
+                await writer.drain()
+            except (asyncio.CancelledError, ConnectionError):
+                raise
+            finally:
+                with contextlib.suppress(Exception):
+                    writer.close()
+
+        self._server = await asyncio.start_server(_client, "127.0.0.1", 0)
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        for task in self._tasks:
+            task.cancel()
+        if self._server is not None:
+            self._server.close()
+            with contextlib.suppress(Exception):
+                await self._server.wait_closed()
+
+
+@pytest.fixture
+async def slot_server() -> AsyncIterator[FakeSlotServer]:
+    server = FakeSlotServer()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+def _completion(text: str, *, chat_text: str | None = None) -> Responder:
+    """A server whose model emits ``text`` on ``/completion``.
+
+    ``chat_text`` is what the same model emits on ``/v1/chat/completions``,
+    which the probe only asks when the raw endpoint's answer was wrong; it
+    defaults to the same text (one model, one opinion).
+    """
+
+    def _respond(path: str, body: dict[str, Any]) -> tuple[int, Any]:
+        if path == "/completion":
+            return 200, {"content": text, "stop": True}
+        if path == "/v1/chat/completions":
+            answer = text if chat_text is None else chat_text
+            return 200, {"choices": [{"message": {"content": answer}}]}
+        return 404, {"error": f"no route {path}"}
+
+    return _respond
+
+
+# ── the probe, against a real server ────────────────────────────────────────
+
+
+async def test_probe_passes_on_paris(slot_server: FakeSlotServer) -> None:
+    """A working slot answers the prompt with the expected token → ok."""
+    await slot_server.start(_completion(" Paris, and it has been since 987."))
+
+    verdict = await _probe(slot_server.port, timeout_s=5.0)
+
+    assert verdict.ok is True
+    assert verdict.status == "ok"
+
+
+async def test_probe_sends_the_prescribed_greedy_request(
+    slot_server: FakeSlotServer,
+) -> None:
+    """The probe must be greedy and bounded, or its verdict means nothing.
+
+    Temperature 0 makes the answer deterministic (a sampled model can produce
+    a correct-looking token by luck); ``n_predict`` keeps the gate inside the
+    slot lifecycle budget.
+    """
+    await slot_server.start(_completion(" Paris"))
+
+    await _probe(slot_server.port, timeout_s=5.0)
+
+    path, body = slot_server.seen[0]
+    assert path == "/completion"
+    assert body["prompt"] == "The capital of France is"
+    assert body["temperature"] == 0
+    assert body["n_predict"] == output_sanity.SANITY_N_PREDICT
+    assert body["stream"] is False
+
+
+async def test_probe_fails_on_paren_garbage(slot_server: FakeSlotServer) -> None:
+    """The rc.6 ``--jinja`` failure shape: fluent-looking, meaningless.
+
+    The rc.6 garbage reproduced on both endpoints, so the second opinion
+    agrees and the slot still fails.
+    """
+    await slot_server.start(_completion(")))))))))))"))
+
+    verdict = await _probe(slot_server.port, timeout_s=5.0)
+
+    assert verdict.ok is False
+    assert verdict.status == "incoherent_output"
+    # The operator has to be able to SEE the garbage, not just be told "failed".
+    assert ")))" in verdict.sample
+    assert [p for p, _ in slot_server.seen] == ["/completion", "/v1/chat/completions"]
+
+
+async def test_probe_fails_on_empty_content(slot_server: FakeSlotServer) -> None:
+    """The rc.6 bare-``/completion`` failure shape: 200 with nothing in it."""
+    await slot_server.start(_completion(""))
+
+    verdict = await _probe(slot_server.port, timeout_s=5.0)
+
+    assert verdict.ok is False
+    assert verdict.status == "empty_output"
+
+
+async def test_probe_accepts_a_model_that_only_answers_through_its_template(
+    slot_server: FakeSlotServer,
+) -> None:
+    """A working slot must never be failed on one endpoint's opinion.
+
+    A heavily template-dependent instruct model can wander on a raw prompt and
+    answer correctly through its chat template. Parking THAT slot in ERROR
+    would make the gate worse than the bug it guards against, so a wrong raw
+    answer buys exactly one retry through ``/v1/chat/completions``.
+    """
+    await slot_server.start(_completion("<|im_start|>assistant", chat_text="Paris."))
+
+    verdict = await _probe(slot_server.port, timeout_s=5.0)
+
+    assert verdict.ok is True
+    assert verdict.status == "ok_via_chat"
+
+
+async def test_probe_fails_on_never_terminating_server(
+    slot_server: FakeSlotServer,
+) -> None:
+    """A timeout is a FAIL, not a pass.
+
+    "The probe was inconclusive so let the slot through" is precisely the
+    silent degrade this gate exists to remove — a runner that cannot emit a
+    dozen greedy tokens is not ready by any definition.
+    """
+    await slot_server.start(lambda path, body: None)
+
+    verdict = await _probe(slot_server.port, timeout_s=0.5)
+
+    assert verdict.ok is False
+    assert verdict.status == "probe_timeout"
+    # No second opinion on a timeout: a wedged runner must not cost the load
+    # path two full probe budgets.
+    assert len(slot_server.seen) == 1
+
+
+async def test_probe_fails_on_dead_port() -> None:
+    """Nothing listening → a fail verdict, never an exception."""
+    server = FakeSlotServer()
+    await server.start(_completion(" Paris"))
+    port = server.port
+    await server.stop()
+    # Give the listener a beat to actually go away.
+    await asyncio.sleep(0.05)
+
+    verdict = await _probe(port, timeout_s=2.0)
+
+    assert verdict.ok is False
+    assert verdict.status in ("probe_transport_error", "probe_timeout")
+
+
+async def test_probe_fails_on_http_error(slot_server: FakeSlotServer) -> None:
+    """A 500 from the runner is a failure, not an inconclusive pass."""
+    await slot_server.start(lambda path, body: (500, {"error": "context shift failed"}))
+
+    verdict = await _probe(slot_server.port, timeout_s=5.0)
+
+    assert verdict.ok is False
+    assert verdict.status == "probe_http_500"
+    assert len(slot_server.seen) == 1, "a 5xx is a round-trip fact — no second opinion"
+
+
+async def test_probe_passes_when_neither_endpoint_exists(
+    slot_server: FakeSlotServer,
+) -> None:
+    """404 on both = not a completion server at all → cannot judge.
+
+    The ONE inconclusive-passes branch, and it is narrow on purpose: a runtime
+    family that serves neither endpoint was never in this gate's scope, and
+    failing it would break slots the gate was not designed to probe.
+    """
+    await slot_server.start(lambda path, body: (404, {"error": "not found"}))
+
+    verdict = await _probe(slot_server.port, timeout_s=5.0)
+
+    assert verdict.ok is True
+    assert verdict.status == "probe_unsupported"
+
+
+async def test_probe_falls_back_to_chat_when_only_completion_is_absent(
+    slot_server: FakeSlotServer,
+) -> None:
+    """An OpenAI-only runner is judged on the endpoint it does serve."""
+
+    def _respond(path: str, body: dict[str, Any]) -> tuple[int, Any]:
+        if path == "/completion":
+            return 404, {"error": "not found"}
+        return 200, {"choices": [{"message": {"content": "Paris"}}]}
+
+    await slot_server.start(_respond)
+
+    verdict = await _probe(slot_server.port, timeout_s=5.0)
+
+    assert verdict.ok is True
+    assert verdict.status == "ok_via_chat"
+
+
+async def test_probe_reads_openai_shaped_bodies(slot_server: FakeSlotServer) -> None:
+    """A runner that answers /completion with an OpenAI envelope still parses."""
+
+    def _respond(path: str, body: dict[str, Any]) -> tuple[int, Any]:
+        return 200, {"choices": [{"text": " Paris."}]}
+
+    await slot_server.start(_respond)
+
+    verdict = await _probe(slot_server.port, timeout_s=5.0)
+
+    assert verdict.ok is True
+
+
+# ── classification (pure) ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text",
+    [" Paris", "PARIS", "paris, France", "The capital of France is Paris."],
+)
+def test_classify_accepts_the_answer_in_any_casing(text: str) -> None:
+    assert output_sanity.classify(text).ok is True
+
+
+@pytest.mark.parametrize("text", ["París", "Parigi", "巴黎", "Париж"])
+def test_classify_accepts_non_english_spellings(text: str) -> None:
+    """False-failing a correct answer in another language would be worse than
+    the bug: it would park a working slot in ERROR."""
+    assert output_sanity.classify(text).ok is True
+
+
+def test_classify_rejects_missing_content_field() -> None:
+    """No text field at all is distinct from an empty one — both fail."""
+    assert output_sanity.classify(None).status == "no_content"
+    assert output_sanity.classify("   ").status == "empty_output"
+
+
+def test_classify_never_keys_on_the_garbage_shape() -> None:
+    """Any off-topic text fails, whatever shape the garbage takes.
+
+    #1888: the garbage varies with argv, so a blocklist of known-bad strings
+    would have caught one lane and missed the others. Only the positive
+    assertion is stable.
+    """
+    for garbage in (")))))))", "!!!!!!", "的的的的的", "London", "���"):
+        assert output_sanity.classify(garbage).ok is False
+
+
+def test_failure_message_names_probe_expected_and_actual() -> None:
+    """An ERROR that says "health check failed" is what cost two hours."""
+    verdict = output_sanity.classify(")))))))")
+
+    message = output_sanity.failure_message(verdict)
+
+    assert "The capital of France is" in message
+    assert "Paris" in message
+    assert ")))" in message
+    assert output_sanity.SANITY_ENV_VAR in message
+
+
+# ── scoping / escape hatches ────────────────────────────────────────────────
+
+
+def test_gate_applies_to_llm_slots() -> None:
+    assert output_sanity.skip_reason({"type": "llm"}) is None
+
+
+@pytest.mark.parametrize(
+    "slot_type", ["embedding", "reranking", "tts", "transcription", "image", ""]
+)
+def test_gate_skips_non_chat_slot_types(slot_type: str) -> None:
+    """An embedding slot cannot serve a chat completion — gating it on one
+    would take out every embed/rerank/TTS/STT/image slot on the box."""
+    assert output_sanity.skip_reason({"type": slot_type}) is not None
+
+
+def test_gate_honours_the_env_opt_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(output_sanity.SANITY_ENV_VAR, "0")
+    assert output_sanity.skip_reason({"type": "llm"}) == "disabled_by_env"
+
+
+def test_gate_is_on_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(output_sanity.SANITY_ENV_VAR, raising=False)
+    assert output_sanity.gate_disabled_globally() is False
+
+
+def test_gate_honours_the_per_slot_opt_out() -> None:
+    """One weird model on a box must not force the operator to disable the
+    gate for every other slot."""
+    flat = {"type": "llm", output_sanity.SANITY_CFG_KEY: False}
+    nested = {"type": "llm", "slot": {output_sanity.SANITY_CFG_KEY: "off"}}
+
+    assert output_sanity.skip_reason(flat) == "disabled_by_slot_config"
+    assert output_sanity.skip_reason(nested) == "disabled_by_slot_config"
+
+
+# ── the gate inside the load path ───────────────────────────────────────────
+
+
+async def test_load_errors_when_the_slot_emits_garbage(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """THE regression. Unit active, /health 200, tokens flowing — and the
+    output is garbage. The slot must NOT be published as READY."""
+    container_stub.sanity_output = ")))))))))))))"
+    sm = SlotManager()
+
+    with pytest.raises(SlotOutputSanityFailed) as excinfo:
+        await sm.load("chat")
+
+    assert sm._current_state("chat") is SlotState.ERROR
+    record = sm._states[sm._key("chat")]
+    # Actionable: names the probe, the expected token, and what came back.
+    assert "The capital of France is" in record.message
+    assert "Paris" in record.message
+    assert ")))" in record.message
+    assert excinfo.value.code == "slot.output_sanity_failed"
+
+
+async def test_failed_gate_survives_the_next_status_poll(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """A gate verdict that one dashboard poll can undo is not a gate.
+
+    ``status()``'s inverse-drift branch adopts any ERROR/OFFLINE slot whose
+    unit is ACTIVE straight to READY — and a slot that fails the sanity gate
+    is exactly that shape (healthy unit, healthy /health, garbage output). So
+    the failing load must also stop the unit; otherwise the very next
+    ``/api/slots`` poll re-publishes the garbage slot as dispatchable and the
+    box is back to reading green.
+    """
+    container_stub.sanity_output = ")))))))"
+    sm = SlotManager()
+
+    with pytest.raises(SlotOutputSanityFailed):
+        await sm.load("chat")
+
+    assert "chat" not in container_stub.active, "the garbage unit must be stopped"
+
+    slot = await sm.status("chat")
+
+    assert slot.state is SlotState.ERROR
+    assert "Paris" in str(slot.metadata.get("message") or "")
+
+
+async def test_load_reaches_ready_when_the_slot_answers(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """The gate must not cost a working box its slot."""
+    container_stub.sanity_output = " Paris."
+    sm = SlotManager()
+
+    slot = await sm.load("chat")
+
+    assert slot.state is SlotState.READY
+    assert container_stub.sanity_probes == [8081], "the gate runs exactly once per load"
+
+
+async def test_load_errors_when_the_probe_times_out(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A probe timeout must fail the load, not fall through to READY."""
+
+    async def _timeout(port: int, **_kw: Any) -> output_sanity.SanityVerdict:
+        return output_sanity.SanityVerdict(ok=False, status="probe_timeout")
+
+    monkeypatch.setattr("hal0.slots.output_sanity.probe", _timeout)
+    sm = SlotManager()
+
+    with pytest.raises(SlotOutputSanityFailed):
+        await sm.load("chat")
+
+    assert sm._current_state("chat") is SlotState.ERROR
+
+
+async def test_load_skips_the_gate_for_non_llm_slots(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """An embedding slot loads without ever being asked to chat."""
+    (slot_root / "embed.toml").write_text(
+        "\n".join(
+            [
+                'name = "embed"',
+                "port = 8093",
+                'type = "embedding"',
+                'provider = "llama-server"',
+                "[model]",
+                'default = "nomic-embed-text"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    # A model that would fail the chat probe outright.
+    container_stub.sanity_output = ""
+    sm = SlotManager()
+
+    slot = await sm.load("embed")
+
+    assert slot.state is SlotState.READY
+    assert container_stub.sanity_probes == []
+
+
+async def test_load_skips_the_gate_when_disabled_by_env(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The escape hatch has to actually reach the load path."""
+    monkeypatch.setenv(output_sanity.SANITY_ENV_VAR, "0")
+    container_stub.sanity_output = ")))))))"
+    sm = SlotManager()
+
+    slot = await sm.load("chat")
+
+    assert slot.state is SlotState.READY
+    assert container_stub.sanity_probes == []

--- a/tests/slots/test_output_sanity_gate.py
+++ b/tests/slots/test_output_sanity_gate.py
@@ -32,7 +32,7 @@ import pytest
 
 from hal0.slots import output_sanity
 from hal0.slots.manager import SlotManager
-from hal0.slots.state import SlotOutputSanityFailed, SlotState
+from hal0.slots.state import SlotOutputSanityFailed, SlotState, SlotTerminateTimeout
 from tests.slots.conftest import FakeContainerProvider
 
 # A responder maps (path, request_body) → (status, json_body), or None to
@@ -140,6 +140,30 @@ def _completion(text: str, *, chat_text: str | None = None) -> Responder:
         if path == "/v1/chat/completions":
             answer = text if chat_text is None else chat_text
             return 200, {"choices": [{"message": {"content": answer}}]}
+        return 404, {"error": f"no route {path}"}
+
+    return _respond
+
+
+def _thinking_model(raw_text: str, *, reasoning: str, content: str = "") -> Responder:
+    """A reasoning model: the chat turn answers in ``reasoning_content``.
+
+    Qwen3-class models emit a ``<think>`` block before any visible content;
+    llama-server (and every OpenAI-compatible runner that splits reasoning
+    out) reports it as ``message.reasoning_content`` with ``content`` empty
+    until the block closes. ``raw_text`` is what the same model says on the
+    raw ``/completion`` endpoint — wrong, which is what sends the probe to the
+    chat fallback in the first place.
+    """
+
+    def _respond(path: str, body: dict[str, Any]) -> tuple[int, Any]:
+        if path == "/completion":
+            return 200, {"content": raw_text, "stop": True}
+        if path == "/v1/chat/completions":
+            return (
+                200,
+                {"choices": [{"message": {"content": content, "reasoning_content": reasoning}}]},
+            )
         return 404, {"error": f"no route {path}"}
 
     return _respond
@@ -305,6 +329,120 @@ async def test_probe_falls_back_to_chat_when_only_completion_is_absent(
     assert verdict.status == "ok_via_chat"
 
 
+async def test_probe_accepts_a_thinking_model_answering_in_reasoning_content(
+    slot_server: FakeSlotServer,
+) -> None:
+    """A working reasoning model must not be failed for thinking out loud.
+
+    The chat fallback exists to serve exactly the template-dependent model
+    that wanders on a raw prompt — and a Qwen3-class model spends its budget
+    inside ``reasoning_content`` before emitting any ``content`` at all. Read
+    only ``content`` and this healthy slot is stamped ERROR and its unit
+    stopped: a false FAIL, which is worse than the bug the gate guards
+    (``hermes_provision._smoke_chat_completion`` documents the same trap).
+    """
+    await slot_server.start(
+        _thinking_model(
+            "<|im_start|>assistant",
+            reasoning="Okay, the user is asking about France. Its capital is Paris.",
+        )
+    )
+
+    verdict = await _probe(slot_server.port, timeout_s=5.0)
+
+    assert verdict.ok is True
+    assert verdict.status == "ok_via_chat"
+
+
+async def test_probe_fails_a_thinking_model_that_reasons_in_garbage(
+    slot_server: FakeSlotServer,
+) -> None:
+    """Reading ``reasoning_content`` must not blunt the gate.
+
+    The rc.6 garbage was garbage in every field the runner emits; a backend
+    that mis-computes cannot produce the expected token in its reasoning
+    either. If this ever passes, the fix for the thinking-model false-fail has
+    turned the gate into a no-op.
+    """
+    await slot_server.start(_thinking_model(")))))))))", reasoning=")))))))))))))))))"))
+
+    verdict = await _probe(slot_server.port, timeout_s=5.0)
+
+    assert verdict.ok is False
+
+
+async def test_probe_reads_a_think_block_left_inline_in_content(
+    slot_server: FakeSlotServer,
+) -> None:
+    """Older/non-splitting runners leave the reasoning inside ``content``.
+
+    ``reasoning_content`` is a convention, not a guarantee: llama.cpp builds
+    (and ``--jinja``-less slots) hand back the raw ``<think>…</think>`` text in
+    ``content``. Both shapes have to read as language, or the gate's verdict
+    depends on the runner build rather than on the model.
+    """
+    await slot_server.start(
+        _completion(
+            "<|im_start|>",
+            chat_text="<think>The user wants the capital of France. That is Paris.</think>",
+        )
+    )
+
+    verdict = await _probe(slot_server.port, timeout_s=5.0)
+
+    assert verdict.ok is True
+
+
+async def test_chat_fallback_asks_for_more_tokens_than_the_raw_probe(
+    slot_server: FakeSlotServer,
+) -> None:
+    """A dozen tokens is a raw-completion budget, not a chat one.
+
+    A reasoning model drains a 12-token cap entirely into its ``<think>``
+    block and returns empty ``content`` — the fallback then judges a working
+    model on an answer it was never given room to write.
+    """
+    await slot_server.start(_completion("<|im_start|>", chat_text="Paris"))
+
+    await _probe(slot_server.port, timeout_s=5.0)
+
+    chat_path, chat_body = slot_server.seen[1]
+    assert chat_path == "/v1/chat/completions"
+    assert chat_body["max_tokens"] == output_sanity.SANITY_CHAT_MAX_TOKENS
+    assert chat_body["max_tokens"] > output_sanity.SANITY_N_PREDICT
+    assert chat_body["temperature"] == 0
+
+
+async def test_chat_fallback_gets_its_own_wider_wall_clock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """More tokens need more seconds, or the budget raise is a new false FAIL.
+
+    Charging a 256-token chat turn against the raw probe's tight bound would
+    just move the false failure from ``empty_output`` to ``probe_timeout`` on
+    any slot that generates slowly (the CPU lane).
+    """
+    seen: list[tuple[str, float]] = []
+
+    async def _fake_post(
+        port: int, path: str, body: dict[str, Any], budget: float
+    ) -> output_sanity.SanityVerdict:
+        seen.append((path, budget))
+        if path == "/completion":
+            return output_sanity.SanityVerdict(ok=False, status="empty_output")
+        return output_sanity.SanityVerdict(ok=True, status="ok", sample="Paris")
+
+    monkeypatch.setattr(output_sanity, "_post", _fake_post)
+
+    await _probe(8080)
+
+    assert seen == [
+        ("/completion", output_sanity.OUTPUT_SANITY_TIMEOUT_S),
+        ("/v1/chat/completions", output_sanity.OUTPUT_SANITY_CHAT_TIMEOUT_S),
+    ]
+    assert output_sanity.OUTPUT_SANITY_CHAT_TIMEOUT_S > output_sanity.OUTPUT_SANITY_TIMEOUT_S
+
+
 async def test_probe_reads_openai_shaped_bodies(slot_server: FakeSlotServer) -> None:
     """A runner that answers /completion with an OpenAI envelope still parses."""
 
@@ -401,6 +539,21 @@ def test_gate_honours_the_per_slot_opt_out() -> None:
     assert output_sanity.skip_reason(nested) == "disabled_by_slot_config"
 
 
+def test_the_per_slot_opt_out_is_writable_through_the_api() -> None:
+    """The advertised escape hatch has to survive the write boundary.
+
+    ``failure_message`` tells the operator to set ``output_sanity = false`` in
+    the slot TOML — but ``POST /api/slots`` and ``PUT /api/slots/{name}/config``
+    reject any key that is neither a ``SlotConfig`` field nor tolerated, so
+    without registration the only way to take the hatch was a hand edit on the
+    box (Codex P2 on this PR).
+    """
+    from hal0.slot_config import unknown_slot_config_keys
+
+    assert unknown_slot_config_keys({output_sanity.SANITY_CFG_KEY: False}) == []
+    assert unknown_slot_config_keys({"slot": {output_sanity.SANITY_CFG_KEY: False}}) == []
+
+
 # ── the gate inside the load path ───────────────────────────────────────────
 
 
@@ -450,6 +603,113 @@ async def test_failed_gate_survives_the_next_status_poll(
 
     assert slot.state is SlotState.ERROR
     assert "Paris" in str(slot.metadata.get("message") or "")
+
+
+async def test_failed_gate_survives_a_teardown_that_does_not_return(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """The verdict must not depend on a stop that can fail (#1224).
+
+    ``terminate()`` raises ``SlotTerminateTimeout`` when ``systemctl stop``
+    does not return inside its bound — documented, observed, and exactly what
+    a wedged podman container does. If stopping the unit is the only thing
+    keeping the gate's verdict, that failure hands the garbage slot straight
+    back to the inverse-drift adopter: unit ACTIVE + record ERROR is precisely
+    the shape it re-publishes as READY.
+    """
+    container_stub.sanity_output = ")))))))"
+    container_stub.fail_unload = SlotTerminateTimeout("stopping slot 'chat' did not return")
+    sm = SlotManager()
+
+    with pytest.raises(SlotOutputSanityFailed):
+        await sm.load("chat")
+
+    # The unit really is still up — this is the durability question, not a
+    # test of the teardown.
+    assert "chat" in container_stub.active
+
+    slot = await sm.status("chat")
+
+    assert slot.state is SlotState.ERROR
+    # ``adopted`` is the flag ``_maybe_adopt_running_slot`` stamps on the way
+    # to READY — its absence is the proof the adopter stood down.
+    assert slot.metadata.get("adopted") is not True
+    assert "Paris" in str(slot.metadata.get("message") or "")
+
+
+async def test_failed_gate_is_not_adopted_by_a_later_api_process(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """The refusal has to live on disk, not in the manager that stamped it.
+
+    A gate failure whose only memory is in-process is undone by the next
+    ``systemctl restart hal0-api``: boot-time upstream reconcile finds an
+    active unit with an ERROR record and adopts it. Same hole as the status
+    poll, one restart later — and it is the pre-upgrade-unit gap too.
+    """
+    container_stub.sanity_output = ")))))))"
+    container_stub.fail_unload = SlotTerminateTimeout("stopping slot 'chat' did not return")
+    with pytest.raises(SlotOutputSanityFailed):
+        await SlotManager().load("chat")
+
+    # A brand-new manager: nothing in memory, state.json and a live unit on
+    # disk — the api-restart shape.
+    fresh = SlotManager()
+
+    slot = await fresh.status("chat")
+
+    assert slot.state is SlotState.ERROR
+    cfg = await fresh._maybe_load_config("chat")
+    assert cfg is not None
+    assert await fresh._maybe_adopt_running_slot("chat", cfg) is None
+
+
+async def test_failed_teardown_is_recorded_not_swallowed(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """ "Stop failed" must be visible, because the unit is still burning VRAM.
+
+    Suppressing the teardown error left an operator with a red slot, an
+    active unit and no hint that the two were related.
+    """
+    container_stub.sanity_output = ")))))))"
+    container_stub.fail_unload = SlotTerminateTimeout("stopping slot 'chat' did not return")
+    sm = SlotManager()
+
+    with pytest.raises(SlotOutputSanityFailed):
+        await sm.load("chat")
+
+    record = sm._states[sm._key("chat")]
+    assert record.extra.get("output_sanity_failed") is True
+    assert record.extra.get("output_sanity_unit_stopped") is False
+    assert "still active" in record.message
+
+
+async def test_a_passing_gate_clears_the_refusal(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """The marker is a verdict, not a tombstone.
+
+    Once a load proves the model produces language, adoption must work again —
+    otherwise a fixed box needs a hand-edited state.json. ``restart`` is the
+    operator's verb here: it clears the crash-loop breaker the failed load
+    armed, and re-enters the same lifecycle (and the same gate).
+    """
+    container_stub.sanity_output = ")))))))"
+    sm = SlotManager()
+    with pytest.raises(SlotOutputSanityFailed):
+        await sm.load("chat")
+
+    container_stub.sanity_output = " Paris."
+    slot = await sm.restart("chat")
+
+    assert slot.state is SlotState.READY
+    record = sm._states[sm._key("chat")]
+    assert "output_sanity_failed" not in record.extra
 
 
 async def test_load_reaches_ready_when_the_slot_answers(


### PR DESCRIPTION
## What changed

`type=llm` slots must now prove they produce language before they are published as `ready`.

At the end of a load — after `/health` converges, before the READY transition — a container/llama-server llm slot gets one greedy completion whose answer is known:

```
POST /completion  {"prompt": "The capital of France is", "n_predict": 12, "temperature": 0}
```

A response containing `Paris` (case-insensitive, plus a few non-English spellings) passes. Anything else fails the load: the slot lands in `error` with a message naming the probe, the expected token and what the model actually said, and its unit is stopped.

New: `src/hal0/slots/output_sanity.py` (the probe, the classifier, the scoping and the escape hatches), `SlotOutputSanityFailed` (`slot.output_sanity_failed`), `OUTPUT_SANITY_TIMEOUT_S` in the lifecycle budget, and the gate call in `SlotManager._await_ready`.

## Why — and what the root cause actually was

Every readiness surface hal0 owns is a **transport** proof. `/health` returning 200 means the runner bound its port and mapped its weights; it says nothing about whether the backend can turn those weights into coherent logits. On ct151 during v1.0.0-rc.6 a box served two hours of garbage while slot state read `ready`, `/api/health` was green, `hal0 doctor` said "OK gpu", the SSE stream closed with a `done` frame and throughput measured 60-120 tok/s (#1888). Five validation lanes reported five different symptoms; all five were that one defect.

The root cause is narrower and more embarrassing than "no coherence check exists": the FLM/NPU lane **already had** a one-shot real-inference gate at exactly this point in `_await_ready` (`FLMProvider.verify_inference`). The generic llama-server lane — every GPU llm slot on every box — had none. This PR closes that asymmetry rather than inventing a new mechanism: same place, same one-shot discipline, same reasons it is safe there (slot lock held, slot not yet dispatchable, warming fail-watcher skips `/health`, so no contention and no repetition).

**A second defect surfaced while testing the fix, and is fixed here too.** Stamping ERROR was not enough. `status()`'s inverse-drift branch (and the boot-time upstream reconcile) adopt any ERROR/OFFLINE slot whose unit is *active* straight back to READY — and a slot that fails this gate is exactly that shape: healthy unit, healthy `/health`, garbage output. Without stopping the unit, the very next `/api/slots` poll re-published the garbage slot as dispatchable and the box was green again. Pinned by `test_failed_gate_survives_the_next_status_poll`, which fails on `main`+gate-only.

## Design decisions worth reviewing

- **Positive assertion only.** The garbage form varies with argv (runs of `)` on `--jinja` slots, empty content on a bare `/completion`), so a blocklist would have caught one lane and missed the others.
- **One retry through the chat endpoint before failing.** A wrong answer on raw `/completion` buys exactly one `/v1/chat/completions` attempt with the same prompt. A template-dependent instruct model can answer one well and the other poorly, and false-failing a working slot would make this gate worse than the bug it guards. The retry runs only on the failing path (the load is about to be refused anyway) and does not weaken the gate — the rc.6 garbage reproduced on both endpoints.
- **Scoped to `type="llm"`.** The slot type is derived from the model's declared modalities (`model_meta.modality.slot_type_for`), so it *is* the chat-capability signal. Embedding / rerank / TTS / STT / image slots are never asked to chat.
- **A timeout is a FAIL.** "Inconclusive, so let it through" is the exact silent degrade this issue was filed to remove. The one inconclusive-passes branch is a runner that 404s *both* completion endpoints — not a completion server this gate was designed to judge.
- **Failure raises rather than parking in WARMING.** A wedged loader may converge on a retry; a backend that computes wrong answers never will. Raising routes it through `load`'s ERROR branch, which also gives it crash-loop bookkeeping — loud once, not a retry loop burning the GPU.
- **Escape hatches, default ON:** `HAL0_SLOT_OUTPUT_SANITY=0` box-wide, `output_sanity = false` per slot TOML.
- **Budget:** one probe is bounded at `OUTPUT_SANITY_TIMEOUT_S = 20s`, worst case two; the client-side lifecycle budget charges both, so `slot_lifecycle_timeout_s` still clears the server's worst case.

## How it was verified

- `tests/slots/test_output_sanity_gate.py` — 38 cases. The probe runs against a **real loopback HTTP server** (not a mock transport) playing all four shapes the issue asks for: `Paris`, `)))))`, empty content, and a server that accepts the connection and never answers.
- Red-before-green, confirmed by reverting each hunk in turn: the load-path cases fail without the gate (`DID NOT RAISE SlotOutputSanityFailed`), and `test_failed_gate_survives_the_next_status_poll` fails without the unit teardown.
- `uv run pytest tests` — 10969 passed, 16 skipped, 1 xfailed.
- `uv run ruff check src tests` and `uv run ruff format --check src tests` — clean. `python3 scripts/check_sunset.py` — clean.

Test-suite plumbing: no unit test has a llama-server behind a slot port, so an autouse fixture in `tests/conftest.py` answers the probe with the correct answer by default (the same claim every container-provider double already makes about its unit), and `tests/slots/conftest.py` routes it at `container_stub.sanity_output` so gate behaviour can be driven through `load()`.

## Deliberately out of scope

- **Real-box proof.** The gate is only truly proven on a box without `/dev/kfd` (or forced onto the Vulkan lane), where the slot must land in `error` naming the probe. That belongs to the validation run, not CI.
- **The FLM/NPU sentinel still checks only that `choices` is non-empty**, not the content. Making the NPU lane assert the answer is a real improvement, but it changes the sentinel prompt on hardware this PR cannot exercise; it should be its own change.
- **Adoption is not gated.** `_maybe_adopt_running_slot` runs inside the `/api/slots` status poll, where a real completion per adopted slot would be a hot-path cost — the same reason the FLM gate stays off `health()`. A unit adopted at api start was launched by a load that ran the gate (post-upgrade); a pre-upgrade unit still running from before is the residual gap.
- No `CHANGELOG.md` hunk, per the fix-wave rule (#1545).

Closes #1922
Refs #1888
