### PR TITLE
fix(tests): remove the durability-test's own race in test_updater_routes

### DIFF
--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -1235,9 +1235,29 @@ def test_commit_convergence_is_durable_before_the_restart_that_can_kill_us(
         # At the instant the restart's subprocess is invoked, read what has
         # actually been committed to disk so far — exactly the snapshot a
         # same-cgroup SIGTERM landing right here would leave behind.
-        job_id = job_id_holder.get("id")
-        on_disk = u_mod._load_persisted_job(job_id) if job_id else None
-        convergence_at_restart_time.append((on_disk or {}).get("convergence"))
+        #
+        # Resolved from the jobs directory itself, NOT from a job id
+        # captured by the test's own main thread after the POST returns
+        # (the original version of this test did that, and was flaky on
+        # loaded CI runners — see #1966). TestClient runs the app on its
+        # own portal event loop; once the request handler returns, that
+        # loop is free to run the background commit task it just
+        # scheduled, and that task can reach this call before the test's
+        # main thread finishes crossing back over the transport and
+        # executing `r.json()["id"] = ...` — on a contended runner it
+        # reliably did, so the captured id was still None and this
+        # assertion raced to a false negative regardless of what was
+        # actually on disk. The jobs directory has no such race: the route
+        # handler (`commit_update`) persists the job SYNCHRONOUSLY —
+        # `_persist_job(jobs[job_id])` — before it ever spawns the
+        # background task, so by the time that task could possibly reach
+        # the restart, the (single) job file this test creates already
+        # exists on disk.
+        job_files = list(u_mod._jobs_dir().glob("*.json"))
+        on_disk: dict[str, Any] = {}
+        if job_files:
+            on_disk = json.loads(job_files[0].read_text(encoding="utf-8"))
+        convergence_at_restart_time.append(on_disk.get("convergence"))
 
         class _R:
             returncode = 0
@@ -1248,14 +1268,13 @@ def test_commit_convergence_is_durable_before_the_restart_that_can_kill_us(
 
     monkeypatch.setattr(u_mod.subprocess, "run", fake_run)
 
-    job_id_holder: dict[str, str] = {}
     r = isolated_client.post("/api/updates/commit", json={"version": "0.0.9"})
-    job_id_holder["id"] = r.json()["id"]
+    job_id = r.json()["id"]
 
     deadline = time.monotonic() + 6.0
     final: dict = {}
     while time.monotonic() < deadline:
-        final = isolated_client.get(f"/api/updates/status/{job_id_holder['id']}").json()
+        final = isolated_client.get(f"/api/updates/status/{job_id}").json()
         if final["state"] == "failed" or final.get("restarted") is not None:
             break
         time.sleep(0.05)


### PR DESCRIPTION
## Summary

Main is red: `tests/api/test_updater_routes.py::test_commit_convergence_is_durable_before_the_restart_that_can_kill_us` (added in #1961 to prove the B3 durability fix — `convergence` lands on disk before the restart that can SIGTERM `hal0-api` mid-flight) is itself racy and fails intermittently on `main` (confirmed at `3cb0a717` and `49e2cf48`) and on unrelated PR branches (#1954), blocking the land train.

**Root cause is in the test's own bookkeeping, not the route.** `routes/updater.py`'s `_run_commit_job` already does convergence-assign → `_persist_job` → restart in the correct order (verified directly, this is exactly what #1961's B3 fix put in place — no regression there). The test's `fake_run` read `job_id_holder.get("id")`, a dict populated on the test's **main thread** only after `isolated_client.post(...)` returns and `r.json()` is parsed. `TestClient` runs the ASGI app on its own portal event loop; once the request handler returns, that loop is free to run the background commit task it just scheduled — including reaching `fake_run` (the mocked restart subprocess) — and that can happen before the main thread finishes crossing back over the transport and executing `job_id_holder["id"] = r.json()["id"]`. On a contended runner it reliably did, so `fake_run` read `job_id=None` and appended `None` to its evidence list regardless of what was actually already on disk — a false negative independent of any real production timing.

**Fix:** resolve the on-disk state from the jobs directory itself instead of a job id captured by the racing main thread. `commit_update`'s route handler persists the job **synchronously** (`_persist_job(jobs[job_id])`) before it ever spawns the background task — so by the time that task could possibly reach the restart, the (single) job file this test creates is guaranteed to already exist. No dependency on which thread wins any race.

## Verification

Followed the requested red-before/green-after protocol:

- Serial `uv run pytest` invocations (20x sequential, and 20x-in-one-process via a temporary `@pytest.mark.parametrize`) did **not** reproduce the race locally — each run starts cold, with no contention, on this sandbox.
- Added artificial contention to reproduce reliably: **8 parallel pytest processes × 20 repeats each (160 executions)**, with 16 CPU-burner threads running concurrently to simulate a loaded CI runner.
  - **Pre-fix**: 7 of 8 parallel runs hit at least one failure, with the exact `convergence persisted by then was [None]` / `[None, None]` signature reported from CI.
  - **Post-fix**: identical 160-execution run under the same contention — **0 failures**.
- `tests/api/test_updater_routes.py`: 59 passed (single run).
- `ruff check` + `ruff format --check`: clean.

This branch touches exactly one file/one test. (Note: this worktree currently carries unrelated uncommitted drift across several other files, unconnected to this fix and to #1961 — left untouched and out of scope here.)

Closes the main-red blocker referenced by the #1950/#1954 land train.