### PR TITLE
feat(api): give image_status an `unknown` member and map the seam end-to-end

### DIFF
--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1787,7 +1787,8 @@ async def pull_slot_image_stream(name: str, request: Request) -> StreamingRespon
         data: {"slot_name": "...", "image": "...", "state": "pulling",
                "layer": N, "total_layers": M}
 
-    Terminal states: ``completed`` | ``failed`` | ``present`` | ``missing``.
+    Terminal states: ``completed`` | ``failed`` | ``present`` | ``missing`` |
+    ``unknown`` (#1939 — the image store could not be read).
     """
 
     async def _gen() -> Any:
@@ -1795,7 +1796,8 @@ async def pull_slot_image_stream(name: str, request: Request) -> StreamingRespon
         job = slot_pull_jobs.get(name)
 
         if job is None:
-            # No active pull — inspect the image to surface present|missing.
+            # No active pull — inspect the image to surface
+            # present|missing|unknown.
             sm = _get_slot_manager(request)
             image = await _image_pull.resolve_slot_image(sm, name)
             state = await _image_pull.inspect_image_state(image)
@@ -1828,8 +1830,9 @@ async def pull_slot_image_status(name: str, request: Request) -> dict[str, objec
     one-shot poll equivalent for clients that can't hold an EventSource
     open. Returns the in-flight job snapshot when a pull is active,
     otherwise inspects the slot's image and reports ``present`` |
-    ``missing`` — the same terminal vocabulary the stream's no-job branch
-    emits, so a poller and a streamer converge on the same states.
+    ``missing`` | ``unknown`` — the same terminal vocabulary the stream's
+    no-job branch emits, so a poller and a streamer converge on the same
+    states.
 
     Frame shape::
 
@@ -1837,7 +1840,8 @@ async def pull_slot_image_status(name: str, request: Request) -> dict[str, objec
          "layer": N, "total_layers": M, "error": null}
 
     States: ``pulling`` | ``completed`` | ``failed`` | ``present`` |
-    ``missing``.
+    ``missing`` | ``unknown`` (#1939 — the image store could not be read; NOT
+    a report that the image is absent).
     """
     slot_pull_jobs: dict[str, Any] = getattr(request.app.state, "slot_pull_jobs", {})
     job = slot_pull_jobs.get(name)

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -2597,8 +2597,12 @@ class ContainerProvider(Provider):
         """
         self._run("systemctl", "reset-failed", self._unit_name(_artefact_token(slot)), check=False)
 
-    def image_present(self, image: str) -> bool:
-        """Return True if ``image`` is in the container image store slots use.
+    def image_present(self, image: str) -> bool | None:
+        """Is ``image`` in the container image store slots use? Tri-state.
+
+        ``True`` / ``False`` are answers: something actually looked in the
+        right store. ``None`` means **nobody could look** — the rootful seam
+        was unusable and this process has no other store worth asking.
 
         #1889: asks ROOT's store first, through the ``hal0-podman-ro``
         ``image-exists`` seam. Slots run ROOTFUL podman (Quadlet), while
@@ -2606,46 +2610,52 @@ class ContainerProvider(Provider):
         so the bare ``<runtime> image inspect`` below reads hal0's own
         ROOTLESS store — a different store, which never contains a slot image.
         That is why ``image_status`` was ``"missing"`` for every running,
-        healthy slot on every standard install. The seam returns ``None`` when
-        it cannot answer, and only then do we fall back to the rootless read —
-        and only when this process is NOT the hal0 service user. On a
+        healthy slot on every standard install. The seam reports ``unknown``
+        when it cannot answer, and only then do we fall back to the rootless
+        read — and only when this process is NOT the hal0 service user. On a
         provisioned box the rootless store is definitionally the wrong store,
         so consulting it after a seam failure would collapse "podman is
         broken / the grant is missing" (wrapper rc 66 / sudo rc 1) back into
         an authoritative-looking "missing", which is #1889 with extra steps.
-        We log instead, so an operator gets a diagnosable signal.
 
-        (The seam-failed-as-hal0 case still has to answer ``False`` because
-        this method's contract is a bool and ``image_status`` has no
-        "unknown" member. Surfacing a distinct unknown state is an API-schema
-        change, deliberately out of scope here — see the PR notes.)
+        #1939: and so is answering ``False`` there, which is what this method
+        used to do because its contract was a bool. It is now a tri-state, and
+        every ``None`` is logged at WARNING with the seam's own reason —
+        ``image_status: "unknown"`` tells a reader the answer is untrustworthy,
+        the journal line tells an operator which grant or store to go fix.
 
         In a dev checkout, where hal0-api runs as the operator, the rootless
-        store IS the store slots use, so the fallback is correct there.
+        store IS the store slots use, so the fallback is correct there — but
+        even there, a box with no container runtime at all, or one whose
+        podman will not exec, has not answered the question either.
 
         Runs synchronously — callers must dispatch to a thread executor when
         called from an async context.
         """
-        seam_answer = podman_introspect.image_exists(image)
-        if seam_answer is not None:
-            return seam_answer
+        probe = podman_introspect.image_presence(image)
+        if probe.presence != "unknown":
+            return probe.presence == "present"
         if is_hal0_service_user():
             log.warning(
-                "hal0.podman_ro.image_present_unanswered image=%s — the rootful seam "
-                "did not answer (grant missing, podman failure, or rejected ref); "
-                "reporting missing without consulting the unrelated rootless store",
+                "hal0.podman_ro.image_present_unanswered image=%s reason=%s — the rootful "
+                "seam did not answer; reporting image_status=unknown rather than consulting "
+                "the unrelated rootless store (see `hal0 doctor seams`)",
                 image,
+                probe.reason,
             )
-            return False
+            return None
         try:
             runtime = _container_runtime()
         except RuntimeError:
-            return False
-        result = subprocess.run(
-            [runtime, "image", "inspect", image],
-            capture_output=True,
-            check=False,
-        )
+            return None
+        try:
+            result = subprocess.run(
+                [runtime, "image", "inspect", image],
+                capture_output=True,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
         return result.returncode == 0
 
     def running_image(self, slot: Mapping[str, Any] | str) -> str | None:

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -2626,8 +2626,18 @@ class ContainerProvider(Provider):
 
         In a dev checkout, where hal0-api runs as the operator, the rootless
         store IS the store slots use, so the fallback is correct there — but
-        even there, a box with no container runtime at all, or one whose
-        podman will not exec, has not answered the question either.
+        only for the one reason that actually means "we never asked because
+        this is not a provisioned box" (``not-service-user``). Any other
+        reason means the seam was tried, or that our own mirror of the
+        wrapper's validator rejected the ref — and a ref this side rejects is
+        one podman would reject too, so the rootless store has nothing to add.
+
+        The fallback probe is ``podman image exists``, NOT ``image inspect``,
+        for exactly the reason the wrapper header gives: ``exists`` has the
+        contract rc 0 = yes / rc 1 = no / anything else = operational failure,
+        while ``inspect`` collapses "not found" and "podman is broken" into a
+        single non-zero rc. Using ``inspect`` here would reintroduce the same
+        conflation on dev boxes that the seam removed on deployed ones.
 
         Runs synchronously — callers must dispatch to a thread executor when
         called from an async context.
@@ -2635,7 +2645,7 @@ class ContainerProvider(Provider):
         probe = podman_introspect.image_presence(image)
         if probe.presence != "unknown":
             return probe.presence == "present"
-        if is_hal0_service_user():
+        if probe.reason != "not-service-user":
             log.warning(
                 "hal0.podman_ro.image_present_unanswered image=%s reason=%s — the rootful "
                 "seam did not answer; reporting image_status=unknown rather than consulting "
@@ -2650,13 +2660,23 @@ class ContainerProvider(Provider):
             return None
         try:
             result = subprocess.run(
-                [runtime, "image", "inspect", image],
+                [runtime, "image", "exists", image],
                 capture_output=True,
                 check=False,
             )
         except (OSError, subprocess.SubprocessError):
             return None
-        return result.returncode == 0
+        if result.returncode == 0:
+            return True
+        if result.returncode == 1:
+            return False
+        log.warning(
+            "hal0.podman_ro.image_present_unanswered image=%s reason=podman-failed rc=%s — "
+            "the local podman ran but failed operationally; reporting image_status=unknown",
+            image,
+            result.returncode,
+        )
+        return None
 
     def running_image(self, slot: Mapping[str, Any] | str) -> str | None:
         """Return the image ref of the running container for a slot (#663).

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -2657,6 +2657,12 @@ class ContainerProvider(Provider):
         try:
             runtime = _container_runtime()
         except RuntimeError:
+            log.warning(
+                "hal0.podman_ro.image_present_unanswered image=%s reason=podman-absent — "
+                "no container runtime on this box, so nothing can be asked about the image; "
+                "reporting image_status=unknown",
+                image,
+            )
             return None
         try:
             result = subprocess.run(
@@ -2664,7 +2670,13 @@ class ContainerProvider(Provider):
                 capture_output=True,
                 check=False,
             )
-        except (OSError, subprocess.SubprocessError):
+        except (OSError, subprocess.SubprocessError) as exc:
+            log.warning(
+                "hal0.podman_ro.image_present_unanswered image=%s reason=seam-error error=%s — "
+                "the local podman could not be run; reporting image_status=unknown",
+                image,
+                exc,
+            )
             return None
         if result.returncode == 0:
             return True

--- a/src/hal0/providers/podman_introspect.py
+++ b/src/hal0/providers/podman_introspect.py
@@ -63,13 +63,32 @@ instead of burning a sudo round-trip — exactly the role
 the two in lock-step; ``tests/installer/test_podman_ro_validation.py``
 asserts they agree by running the real wrapper.
 
-The three read helpers (:func:`image_exists`, :func:`container_image`,
+The three read helpers (:func:`image_presence`, :func:`container_image`,
 :func:`container_argv`) are TRI-STATE and deliberately do NOT fall back to a
-rootless call themselves: they return ``None`` for "the rootful seam did not
-answer" and let the caller decide, because a rootless answer for a *named*
-image or container is not merely stale, it is an answer about a different
-object. ``images()`` keeps its original fall-back behaviour (a repo *set* is
-still useful, and it self-labels via ``context``).
+rootless call themselves: they report "the rootful seam did not answer" and
+let the caller decide, because a rootless answer for a *named* image or
+container is not merely stale, it is an answer about a different object.
+``images()`` keeps its original fall-back behaviour (a repo *set* is still
+useful, and it self-labels via ``context``).
+
+#1939 — the exit-code contract reaches the caller
+=================================================
+
+The wrapper spends four distinct exit codes distinguishing "podman answered,
+negatively" from three flavours of "the seam is unusable" (see its EXIT-CODE
+CONTRACT header). Until #1939 all of them collapsed into a single ``None``
+here, which :meth:`hal0.providers.container.ContainerProvider.image_present`
+then had to flatten into ``False`` because its contract was a bool — so an
+operational podman failure on the service account surfaced to ``GET
+/api/slots`` as ``image_status: "missing"``: an authoritative-looking answer
+to a question nobody managed to ask.
+
+:func:`image_presence` therefore returns an :class:`ImageProbe`, whose
+``presence`` is the same tri-state vocabulary the API now publishes
+(``present`` / ``missing`` / ``unknown``) and whose ``reason`` names WHICH
+unanswerable case occurred. Only the reason stays private to the process (it
+is logged, not published): the payload's job is to stop lying, the journal's
+job is to say why.
 """
 
 from __future__ import annotations
@@ -121,6 +140,51 @@ IMAGE_REF_MAX_LEN = 512
 #: reached only as a fallback when the seam isn't usable.
 PodmanContext = Literal["rootful", "rootless"]
 
+#: Is a named image in the store slots actually use? ``unknown`` is NOT a
+#: hedge — it is the load-bearing member (#1939). ``missing`` is reserved for
+#: "podman was asked and said no"; anything that prevented the question from
+#: being asked at all is ``unknown``, so a consumer (the dashboard, an agent,
+#: the release-validation kit) can keep treating ``missing`` on a running slot
+#: as the real defect it is.
+ImagePresence = Literal["present", "missing", "unknown"]
+
+#: WHY the rootful seam could not give a definitive answer. One name per
+#: distinguishable failure, mirroring the wrapper's EXIT-CODE CONTRACT:
+#:
+#:   ``not-service-user``  the gate declined to try sudo at all — this process
+#:                         is not the ``hal0`` service account, so no grant
+#:                         exists to use (dev checkout, CI, unit test).
+#:   ``invalid-argument``  wrapper rc 64, or our own mirror rejecting the
+#:                         operand before spending a sudo round-trip.
+#:   ``podman-absent``     wrapper rc 65 — no podman on the box.
+#:   ``podman-failed``     wrapper rc 66 — podman RAN and broke (store
+#:                         corruption, lock contention, EPERM). The case
+#:                         #1889's security review called out by name.
+#:   ``grant-denied``      sudo's own rc 1: the sudoers grant is not installed,
+#:                         or we are mid-upgrade between wrapper and policy.
+#:   ``seam-error``        exec failure, an rc the contract does not define, or
+#:                         stdout the contract does not define — i.e. the
+#:                         wrapper and this mirror have drifted apart.
+SeamUnanswered = Literal[
+    "not-service-user",
+    "invalid-argument",
+    "podman-absent",
+    "podman-failed",
+    "grant-denied",
+    "seam-error",
+]
+
+#: Wrapper/sudo exit code → :data:`SeamUnanswered`. Keep in lock-step with the
+#: EXIT-CODE CONTRACT block in ``installer/wrappers/hal0-podman-ro``; an rc
+#: absent from this map is ``seam-error`` by construction, which is the right
+#: answer for a code neither side has agreed on.
+_RC_REASON: dict[int, SeamUnanswered] = {
+    1: "grant-denied",
+    64: "invalid-argument",
+    65: "podman-absent",
+    66: "podman-failed",
+}
+
 _RunFn = Callable[..., "subprocess.CompletedProcess[str]"]
 
 
@@ -130,6 +194,31 @@ class PodmanImagesResult:
 
     repos: set[str]
     context: PodmanContext
+
+
+@dataclass(frozen=True)
+class ImageProbe:
+    """One image-presence question and what came back.
+
+    ``reason`` is set if and only if ``presence == "unknown"``; a definitive
+    answer has nothing to explain.
+    """
+
+    presence: ImagePresence
+    reason: SeamUnanswered | None = None
+
+
+@dataclass(frozen=True)
+class _SeamRead:
+    """One argument-taking read verb's raw outcome.
+
+    Exactly one of the two fields is set: ``stdout`` when the wrapper exited 0
+    (an EMPTY stdout on rc 0 is a real negative answer, hence ``""`` rather
+    than ``None``), ``reason`` otherwise.
+    """
+
+    stdout: str | None = None
+    reason: SeamUnanswered | None = None
 
 
 def _seam_argv(*verb: str) -> list[str]:
@@ -216,50 +305,60 @@ def _seam_read(
     run: _RunFn,
     is_hal0_user: Callable[[], bool],
     timeout: float,
-) -> str | None:
-    """Run one argument-taking read verb; ``None`` when the seam didn't answer.
+) -> _SeamRead:
+    """Run one argument-taking read verb.
 
-    "Didn't answer" covers every non-``rc 0`` outcome: the gate said this
-    process is not the ``hal0`` service account, ``sudo -n`` was denied (grant
-    not installed / mid-upgrade race), the wrapper rejected the argument
-    (rc 64), podman is absent on the box (rc 65), or the call raised. Only
-    ``rc 0`` is an answer — and on ``rc 0`` an EMPTY stdout is a real negative
-    answer (no such container), not a failure, which is why this returns
-    ``""`` rather than ``None`` in that case.
+    Only ``rc 0`` is an answer — and on ``rc 0`` an EMPTY stdout is a real
+    negative answer (no such container), not a failure, which is why that case
+    yields ``stdout=""`` rather than a reason. Every other outcome is named
+    (#1939): the gate declining to try sudo, ``sudo -n`` denied, the wrapper's
+    rc 64/65/66, an rc nobody has agreed on, or the call raising.
     """
     if not is_hal0_user():
-        return None
+        return _SeamRead(reason="not-service-user")
     proc = _run(run, _seam_argv(verb, arg), timeout=timeout)
-    if proc is None or proc.returncode != 0:
-        return None
-    return proc.stdout.strip()
+    if proc is None:
+        # OSError / SubprocessError from exec — the seam binary is not there,
+        # is not executable, or the call timed out.
+        return _SeamRead(reason="seam-error")
+    if proc.returncode != 0:
+        return _SeamRead(reason=_RC_REASON.get(proc.returncode, "seam-error"))
+    return _SeamRead(stdout=proc.stdout.strip())
 
 
-def image_exists(
+def image_presence(
     image: str,
     *,
     run: _RunFn = subprocess.run,
     is_hal0_user: Callable[[], bool] = is_hal0_service_user,
     timeout: float = 10.0,
-) -> bool | None:
-    """Is ``image`` present in ROOT's image store? ``None`` if unanswerable.
+) -> ImageProbe:
+    """Is ``image`` present in ROOT's image store, and if we can't tell, why?
 
-    ``True``/``False`` mean the rootful seam actually answered. ``None`` means
-    it did not (not the hal0 service user, no grant, podman absent, or the ref
-    was rejected) — the caller must then decide, and deliberately is NOT given
-    a silent rootless fallback here: hal0-api's own rootless store is a
-    different store, so a "missing" from it about a *named* image is not a
-    stale answer but an answer about a different object. That conflation is
-    exactly #1889.
+    ``present``/``missing`` mean the rootful seam actually answered.
+    ``unknown`` means it did not, and :attr:`ImageProbe.reason` names which
+    way. The caller must then decide, and deliberately is NOT given a silent
+    rootless fallback here: hal0-api's own rootless store is a different
+    store, so a "missing" from it about a *named* image is not a stale answer
+    but an answer about a different object. That conflation is exactly #1889;
+    reporting the unanswerable cases as ``missing`` anyway is #1939.
     """
     if not is_valid_image_ref(image):
-        return None
-    answer = _seam_read("image-exists", image, run=run, is_hal0_user=is_hal0_user, timeout=timeout)
-    if answer == "present":
-        return True
-    if answer == "missing":
-        return False
-    return None
+        # Our mirror of the wrapper's validator said no, so no sudo hop was
+        # spent. Same *class* of failure as the wrapper's own rc 64, and
+        # reported under the same name — what matters to every caller is that
+        # podman was never consulted about this ref.
+        return ImageProbe("unknown", "invalid-argument")
+    read = _seam_read("image-exists", image, run=run, is_hal0_user=is_hal0_user, timeout=timeout)
+    if read.reason is not None:
+        return ImageProbe("unknown", read.reason)
+    if read.stdout == "present":
+        return ImageProbe("present")
+    if read.stdout == "missing":
+        return ImageProbe("missing")
+    # rc 0 with a word the contract does not define: the wrapper and this
+    # mirror have drifted. Not an answer, and emphatically not "missing".
+    return ImageProbe("unknown", "seam-error")
 
 
 def container_image(
@@ -279,10 +378,8 @@ def container_image(
     """
     if not is_valid_slot_token(token):
         return None
-    answer = _seam_read(
-        "container-image", token, run=run, is_hal0_user=is_hal0_user, timeout=timeout
-    )
-    return answer or None
+    read = _seam_read("container-image", token, run=run, is_hal0_user=is_hal0_user, timeout=timeout)
+    return read.stdout or None
 
 
 def container_argv(
@@ -299,10 +396,8 @@ def container_argv(
     """
     if not is_valid_slot_token(token):
         return None
-    answer = _seam_read(
-        "container-argv", token, run=run, is_hal0_user=is_hal0_user, timeout=timeout
-    )
-    return answer or None
+    read = _seam_read("container-argv", token, run=run, is_hal0_user=is_hal0_user, timeout=timeout)
+    return read.stdout or None
 
 
 __all__ = [
@@ -310,11 +405,14 @@ __all__ = [
     "IMAGE_REF_RE",
     "SEAM_BIN",
     "SLOT_TOKEN_RE",
+    "ImagePresence",
+    "ImageProbe",
     "PodmanContext",
     "PodmanImagesResult",
+    "SeamUnanswered",
     "container_argv",
     "container_image",
-    "image_exists",
+    "image_presence",
     "images",
     "is_valid_image_ref",
     "is_valid_slot_token",

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -69,6 +69,7 @@ __all__ = [
     "SlotViewAggregator",
     "config_enrichment",
     "container_enrichment",
+    "image_status_for",
     "loaded_model_names_from_slots",
     "resolve_ctx_max",
     "serialize_slot",
@@ -499,18 +500,44 @@ _PROBE_CONCURRENCY = 8
 #: pays 3 inspects per TTL window instead of 20 per poll. Kept short enough
 #: that a just-finished pull flips missing→present within one refresh.
 _IMAGE_PRESENT_TTL_S = 15.0
-_image_present_cache: dict[str, tuple[float, bool]] = {}
+_image_present_cache: dict[str, tuple[float, bool | None]] = {}
 
 
-def _image_present_cached(cp: Any, image: str) -> bool:
-    """TTL-cached ``cp.image_present`` (subprocess-backed, executor-called)."""
+def _image_present_cached(cp: Any, image: str) -> bool | None:
+    """TTL-cached ``cp.image_present`` (subprocess-backed, executor-called).
+
+    Tri-state since #1939: ``None`` is "the image store could not be asked",
+    and it is cached exactly like a real answer — a box with a broken seam
+    would otherwise pay a sudo round-trip per image per poll to be told the
+    same thing. Note the deliberate absence of a ``bool()`` here: coercing on
+    the way in (or out) of the cache would restore the collapse this issue is
+    about one poll later, silently.
+    """
     now = time.monotonic()
     hit = _image_present_cache.get(image)
     if hit is not None and now - hit[0] < _IMAGE_PRESENT_TTL_S:
         return hit[1]
-    present = bool(cp.image_present(image))
+    answer = cp.image_present(image)
+    present = None if answer is None else bool(answer)
     _image_present_cache[image] = (time.monotonic(), present)
     return present
+
+
+def image_status_for(present: bool | None) -> str:
+    """Project a tri-state presence answer onto the ``image_status`` payload.
+
+    The single place the mapping lives, so the aggregator, the pull-status
+    route and the tests cannot disagree about what ``None`` means.
+
+    ``unknown`` is the whole point (#1939): ``missing`` is a claim that podman
+    was asked and the image is not there, which is what makes ``missing`` on a
+    ``running`` slot a meaningful defect signal (regression
+    ``image-status-wrong-podman-store``). Reporting an unanswerable probe as
+    ``missing`` both lies and blunts that signal.
+    """
+    if present is None:
+        return "unknown"
+    return "present" if present else "missing"
 
 
 async def container_enrichment(
@@ -528,9 +555,11 @@ async def container_enrichment(
 
     plus image facts: ``actual_image`` (podman inspect, #663),
     ``image_mismatch`` against the declared profile image, and
-    ``image_status`` (present | pulling | missing | not-configured — an
-    in-flight job in ``pull_jobs`` wins without an inspect syscall;
-    ``not-configured`` marks a slot with no declared profile/image, #1226).
+    ``image_status`` (present | pulling | missing | unknown | not-configured —
+    an in-flight job in ``pull_jobs`` wins without an inspect syscall;
+    ``not-configured`` marks a slot with no declared profile/image, #1226;
+    ``unknown`` marks a probe that could not be MADE, #1939, which is a
+    different claim from ``missing``).
 
     ``provider`` is injectable for unit tests; ``None`` resolves the real
     ContainerProvider lazily so route-level patches on the class keep
@@ -715,7 +744,7 @@ async def container_enrichment(
             if image:
                 entry["image_mismatch"] = _image_mismatch(running_image, image)
 
-        # image_status: present | pulling | missing | not-configured
+        # image_status: present | pulling | missing | unknown | not-configured
         # Check the pull-jobs registry first so an in-flight pull
         # surfaces as "pulling" without an extra inspect syscall.
         active_job = jobs.get(name)
@@ -725,9 +754,13 @@ async def container_enrichment(
             try:
                 cp = _resolve_container_provider(provider)
                 present = await loop.run_in_executor(None, _image_present_cached, cp, image)
-                entry["image_status"] = "present" if present else "missing"
+                entry["image_status"] = image_status_for(present)
             except Exception:
-                entry["image_status"] = "missing"
+                # #1939: this branch used to answer "missing". Whatever went
+                # wrong here — resolving the provider, the executor, the probe
+                # itself — the one thing we did NOT learn is whether the image
+                # is on disk, so that is what we say.
+                entry["image_status"] = "unknown"
         else:
             # No profile/image declared — the slot runs on the default toolbox.
             # "No expected image" is NOT a missing-image fault (#1226): report
@@ -752,7 +785,11 @@ async def container_enrichment(
                     "profile": str(cfg.get("profile") or ""),
                     "image": None,
                     "resolved_command": None,
-                    "image_status": "not-configured",
+                    # #1939: a probe that timed out never got as far as
+                    # resolving the profile, so it cannot know whether an image
+                    # is even declared — "not-configured" was a claim ABOUT
+                    # CONFIG made by a probe that read none.
+                    "image_status": "unknown",
                 }
 
     out: dict[str, dict[str, Any]] = {}

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -755,11 +755,24 @@ async def container_enrichment(
                 cp = _resolve_container_provider(provider)
                 present = await loop.run_in_executor(None, _image_present_cached, cp, image)
                 entry["image_status"] = image_status_for(present)
-            except Exception:
+            except Exception as exc:
                 # #1939: this branch used to answer "missing". Whatever went
                 # wrong here — resolving the provider, the executor, the probe
                 # itself — the one thing we did NOT learn is whether the image
                 # is on disk, so that is what we say.
+                #
+                # And we say WHY in the journal. The payload deliberately
+                # carries no reason field, so an `unknown` with no log line
+                # behind it would be undiagnosable — the failure family this
+                # whole issue is about. `image_present` logs its own seam
+                # reasons; this covers every unknown that never reached it.
+                log.warning(
+                    "slot_view.image_probe_failed slot=%s image=%s reason=probe-error "
+                    "error=%s — reporting image_status=unknown",
+                    name,
+                    image,
+                    exc,
+                )
                 entry["image_status"] = "unknown"
         else:
             # No profile/image declared — the slot runs on the default toolbox.
@@ -778,18 +791,22 @@ async def container_enrichment(
                 return await asyncio.wait_for(_one(name, cfg), timeout=_PROBE_TIMEOUT_S)
             except TimeoutError:
                 log.warning("slot_view.container_probe_timeout slot=%s", name)
+                profile_name = str(cfg.get("profile") or "")
                 return name, {
                     "container_status": "stopped",
                     "container_health": False,
                     "runtime": "container",
-                    "profile": str(cfg.get("profile") or ""),
+                    "profile": profile_name,
                     "image": None,
                     "resolved_command": None,
-                    # #1939: a probe that timed out never got as far as
-                    # resolving the profile, so it cannot know whether an image
-                    # is even declared — "not-configured" was a claim ABOUT
-                    # CONFIG made by a probe that read none.
-                    "image_status": "unknown",
+                    # #1939. A PROFILELESS slot declares no image at all
+                    # (#1226) — that is knowable from ``cfg`` alone, needs no
+                    # probe, and the timeout does not make it any less true, so
+                    # it stays "not-configured". A slot WITH a profile does
+                    # have a declared image and we simply never got far enough
+                    # to look at the store: reporting that as "not-configured"
+                    # was a claim about config from a probe that read none.
+                    "image_status": "unknown" if profile_name else "not-configured",
                 }
 
     out: dict[str, dict[str, Any]] = {}

--- a/src/hal0/slots/image_pull.py
+++ b/src/hal0/slots/image_pull.py
@@ -114,15 +114,27 @@ async def resolve_slot_image(sm: Any, name: str) -> str | None:
 
 
 async def inspect_image_state(image: str | None) -> str:
-    """Return "present" | "missing" for ``image`` (fail-soft → "missing")."""
+    """Return "present" | "missing" | "unknown" for ``image``.
+
+    #1939: the poll/SSE surface carried the same conflation ``image_status``
+    did — an unusable rootful seam (wrapper rc 66, absent sudoers grant) read
+    as ``missing``, which a client renders as "you need to pull this". It now
+    degrades to ``unknown``, sharing the aggregator's mapping so the two
+    surfaces cannot drift.
+
+    The no-image case stays ``missing``: that is a resolution failure, not a
+    store read, and it is the state the pull routes have always used to mean
+    "there is nothing here to report as present".
+    """
     if not image:
         return "missing"
     try:
         from hal0.providers.container import container_provider
+        from hal0.slot_view import image_status_for
 
         present = await asyncio.get_event_loop().run_in_executor(
             None, container_provider().image_present, image
         )
-        return "present" if present else "missing"
+        return image_status_for(present)
     except Exception:
-        return "missing"
+        return "unknown"

--- a/src/hal0/slots/image_pull.py
+++ b/src/hal0/slots/image_pull.py
@@ -29,7 +29,10 @@ patches on ``ContainerProvider`` / ``load_profiles_config`` continue to bind.
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 
 class ImagePullJob:
@@ -136,5 +139,16 @@ async def inspect_image_state(image: str | None) -> str:
             None, container_provider().image_present, image
         )
         return image_status_for(present)
-    except Exception:
+    except Exception as exc:
+        # Log before degrading. `unknown` carries no reason on the wire by
+        # design, so an unknown with nothing behind it in the journal is
+        # undiagnosable — the failure family #1939 is about. `image_present`
+        # logs its own seam reasons; this covers the unknowns that never got
+        # that far (provider construction, executor dispatch, a raising probe).
+        log.warning(
+            "slot_view.image_probe_failed image=%s reason=probe-error error=%s — "
+            "reporting pull state=unknown",
+            image,
+            exc,
+        )
         return "unknown"

--- a/src/hal0/system/seam_check.py
+++ b/src/hal0/system/seam_check.py
@@ -96,7 +96,10 @@ SEAMS: tuple[SeamSpec, ...] = (
     # failed would keep the old one-verb wrapper, pass a `help` probe, and
     # report the seam healthy from `hal0 doctor` while image_status stayed
     # "missing" and actual_image stayed null — the exact undiagnosable-green
-    # failure #1465 exists to prevent. `check-slot-token` is release-specific
+    # failure #1465 exists to prevent. (Post-#1939 that stuck value reads
+    # "unknown" rather than "missing", which is honest but no less broken —
+    # this probe is still what tells an operator the wrapper is the old one.)
+    # `check-slot-token` is release-specific
     # (the old wrapper rejects it with rc 64) and side-effect-free: it
     # validates the token and prints the container name it WOULD build,
     # touching neither podman nor the filesystem.

--- a/tests/api/test_slots_image_pull.py
+++ b/tests/api/test_slots_image_pull.py
@@ -161,6 +161,29 @@ def test_pull_status_route_reports_unknown_rather_than_missing(
     assert r.json()["state"] == "unknown"
 
 
+def test_pull_status_logs_before_degrading_to_unknown(
+    container_client: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A raising probe on this route must leave a journal trail too. The
+    payload carries no reason by design, so an ``unknown`` with nothing behind
+    it in the log is undiagnosable — the exact failure family #1939 is about,
+    and the release-validation kit's briefs promise the line exists."""
+    fake_catalog, _ = _fake_profile_catalog()
+    with (
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
+        patch(
+            "hal0.providers.container.ContainerProvider.image_present",
+            side_effect=RuntimeError("podman store is on fire"),
+        ),
+        caplog.at_level("WARNING"),
+    ):
+        r = container_client.get("/api/slots/gpu-chat/pull/status")
+    assert r.status_code == 200, r.text
+    assert r.json()["state"] == "unknown"
+    assert "image_probe_failed" in caplog.text
+    assert "podman store is on fire" in caplog.text
+
+
 def test_image_status_pulling_when_job_active(
     container_client: TestClient,
     container_app: FastAPI,

--- a/tests/api/test_slots_image_pull.py
+++ b/tests/api/test_slots_image_pull.py
@@ -1,10 +1,12 @@
 """Tests for container image-pull progress (Issue #659).
 
 Verifies:
-  - ``image_status`` (present | pulling | missing) appears on container slots.
+  - ``image_status`` (present | pulling | missing | unknown) appears on container slots.
   - ``image_status=pulling`` is set when a slot_pull_job is active.
   - ``image_status=present`` is set when image_present() returns True.
   - ``image_status=missing`` is set when image_present() returns False.
+  - ``image_status=unknown`` is set when image_present() returns None — the image store
+    could not be READ (#1939), which is not the same claim as "the image is absent".
   - POST /api/slots/{name}/pull returns 202 with job snapshot.
   - POST /api/slots/{name}/pull is idempotent when already in-flight.
   - GET /api/slots/{name}/pull/stream emits terminal frame when no pull is active.
@@ -113,6 +115,50 @@ def test_image_status_missing(container_client: TestClient) -> None:
     assert r.status_code == 200, r.text
     by_name = {e["name"]: e for e in r.json()}
     assert by_name["gpu-chat"]["image_status"] == "missing"
+
+
+def test_image_status_unknown_when_the_probe_cannot_answer(
+    container_client: TestClient,
+) -> None:
+    """#1939, at the API boundary: ``image_present`` returning ``None`` (the
+    rootful seam was unusable — wrapper rc 66, no sudoers grant, wrapper
+    drift) must surface as ``image_status: "unknown"``.
+
+    This is the assertion that gives the whole chain its point: an operator or
+    an agent reading /api/slots can now tell "hal0 asked podman and the image
+    is not there" from "hal0 could not ask".
+    """
+    fake_catalog, _ = _fake_profile_catalog()
+    with (
+        patch("hal0.providers.container.ContainerProvider.is_active", return_value=False),
+        patch(
+            "hal0.providers.container.ContainerProvider.health",
+            new_callable=AsyncMock,
+            return_value={"ok": False},
+        ),
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
+        patch("hal0.providers.container.ContainerProvider.image_present", return_value=None),
+    ):
+        r = container_client.get("/api/slots")
+    assert r.status_code == 200, r.text
+    by_name = {e["name"]: e for e in r.json()}
+    assert by_name["gpu-chat"]["image_status"] == "unknown"
+
+
+def test_pull_status_route_reports_unknown_rather_than_missing(
+    container_client: TestClient,
+) -> None:
+    """The poll/SSE surface carries the same lie and gets the same fix: a slot
+    whose image cannot be probed reads ``unknown``, not ``missing`` (which a
+    client renders as "you need to pull this")."""
+    fake_catalog, _ = _fake_profile_catalog()
+    with (
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
+        patch("hal0.providers.container.ContainerProvider.image_present", return_value=None),
+    ):
+        r = container_client.get("/api/slots/gpu-chat/pull/status")
+    assert r.status_code == 200, r.text
+    assert r.json()["state"] == "unknown"
 
 
 def test_image_status_pulling_when_job_active(

--- a/tests/providers/test_container_podman_ro_routing.py
+++ b/tests/providers/test_container_podman_ro_routing.py
@@ -110,7 +110,62 @@ def test_image_present_falls_back_to_rootless_when_seam_silent(
     monkeypatch.setattr(container_mod.subprocess, "run", _run)
 
     assert ContainerProvider().image_present(IMAGE) is True
-    assert calls == [["/usr/bin/podman", "image", "inspect", IMAGE]]
+    # `image exists`, NOT `image inspect` (#1939): only `exists` has the rc
+    # 0/1/other contract that keeps "podman is broken" from reading as "the
+    # image is absent" — the same reason the wrapper uses it root-side.
+    assert calls == [["/usr/bin/podman", "image", "exists", IMAGE]]
+
+
+def test_rootless_fallback_reports_missing_on_a_clean_negative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        container_mod.podman_introspect, "image_presence", _probe("unknown", "not-service-user")
+    )
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: False)
+    monkeypatch.setattr(container_mod, "_container_runtime", lambda: "/usr/bin/podman")
+
+    class _Proc:
+        returncode = 1  # `podman image exists`: a real "no"
+
+    monkeypatch.setattr(container_mod.subprocess, "run", lambda *_a, **_k: _Proc())
+
+    assert ContainerProvider().image_present(IMAGE) is False
+
+
+def test_rootless_fallback_reports_unknown_on_an_operational_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dev half of the same bug: a local podman that RAN and broke must
+    not read as "the image is absent" either. `image inspect` could not tell
+    the two apart at all, which is why this path uses `image exists`."""
+    monkeypatch.setattr(
+        container_mod.podman_introspect, "image_presence", _probe("unknown", "not-service-user")
+    )
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: False)
+    monkeypatch.setattr(container_mod, "_container_runtime", lambda: "/usr/bin/podman")
+
+    class _Proc:
+        returncode = 125  # store corruption, lock contention, ...
+
+    monkeypatch.setattr(container_mod.subprocess, "run", lambda *_a, **_k: _Proc())
+
+    assert ContainerProvider().image_present(IMAGE) is None
+
+
+def test_a_ref_our_own_validator_rejected_never_falls_back(
+    monkeypatch: pytest.MonkeyPatch, no_rootless: list[list[str]]
+) -> None:
+    """Even off the service account. A ref this side rejects is one podman
+    would reject too, so the rootless store has nothing to add — and asking it
+    anyway would turn a validation failure back into an authoritative
+    "missing", on exactly the boxes the seam does not protect."""
+    monkeypatch.setattr(
+        container_mod.podman_introspect, "image_presence", _probe("unknown", "invalid-argument")
+    )
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: False)
+
+    assert ContainerProvider().image_present(IMAGE) is None
 
 
 def test_image_present_unknown_when_seam_silent_and_no_runtime(

--- a/tests/providers/test_container_podman_ro_routing.py
+++ b/tests/providers/test_container_podman_ro_routing.py
@@ -134,7 +134,7 @@ def test_rootless_fallback_reports_missing_on_a_clean_negative(
 
 
 def test_rootless_fallback_reports_unknown_on_an_operational_failure(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """The dev half of the same bug: a local podman that RAN and broke must
     not read as "the image is absent" either. `image inspect` could not tell
@@ -150,7 +150,11 @@ def test_rootless_fallback_reports_unknown_on_an_operational_failure(
 
     monkeypatch.setattr(container_mod.subprocess, "run", lambda *_a, **_k: _Proc())
 
-    assert ContainerProvider().image_present(IMAGE) is None
+    with caplog.at_level("WARNING"):
+        assert ContainerProvider().image_present(IMAGE) is None
+
+    assert "reason=podman-failed" in caplog.text
+    assert "rc=125" in caplog.text
 
 
 def test_a_ref_our_own_validator_rejected_never_falls_back(
@@ -169,12 +173,13 @@ def test_a_ref_our_own_validator_rejected_never_falls_back(
 
 
 def test_image_present_unknown_when_seam_silent_and_no_runtime(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """#1939: no seam AND no podman binary means nothing on this box can be
     asked about the image. That is ``unknown``, not ``False`` — a box with no
     container runtime at all was previously reporting every slot image as
-    authoritatively absent."""
+    authoritatively absent. And it says so in the journal: an ``unknown`` with
+    no line behind it is undiagnosable, since the payload carries no reason."""
     monkeypatch.setattr(
         container_mod.podman_introspect, "image_presence", _probe("unknown", "not-service-user")
     )
@@ -185,11 +190,15 @@ def test_image_present_unknown_when_seam_silent_and_no_runtime(
 
     monkeypatch.setattr(container_mod, "_container_runtime", _no_runtime)
 
-    assert ContainerProvider().image_present(IMAGE) is None
+    with caplog.at_level("WARNING"):
+        assert ContainerProvider().image_present(IMAGE) is None
+
+    assert "image_present_unanswered" in caplog.text
+    assert "reason=podman-absent" in caplog.text
 
 
 def test_image_present_unknown_when_the_rootless_call_itself_raises(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A dev box whose podman binary blows up on exec has not answered either."""
     monkeypatch.setattr(
@@ -203,7 +212,11 @@ def test_image_present_unknown_when_the_rootless_call_itself_raises(
 
     monkeypatch.setattr(container_mod.subprocess, "run", _boom)
 
-    assert ContainerProvider().image_present(IMAGE) is None
+    with caplog.at_level("WARNING"):
+        assert ContainerProvider().image_present(IMAGE) is None
+
+    assert "reason=seam-error" in caplog.text
+    assert "exec format error" in caplog.text
 
 
 # ── running_image: the "actual_image is always null" bug ───────────────────

--- a/tests/providers/test_container_podman_ro_routing.py
+++ b/tests/providers/test_container_podman_ro_routing.py
@@ -28,9 +28,15 @@ import pytest
 
 from hal0.providers import container as container_mod
 from hal0.providers.container import ContainerProvider
+from hal0.providers.podman_introspect import ImageProbe
 
 SLOT: dict[str, Any] = {"id": 7, "name": "gpu-chat"}
 IMAGE = "ghcr.io/thinmintdev/hal0-runner:v1.0.0-rc.6"
+
+
+def _probe(presence: str, reason: str | None = None):
+    """A canned ``podman_introspect.image_presence`` for monkeypatching."""
+    return lambda _image: ImageProbe(presence, reason)  # type: ignore[arg-type]
 
 
 @pytest.fixture
@@ -61,11 +67,11 @@ def test_image_present_true_from_rootful_seam(
     reports present, so slot_view renders image_status="present"."""
     seen: list[str] = []
 
-    def _exists(image: str) -> bool:
+    def _presence(image: str) -> ImageProbe:
         seen.append(image)
-        return True
+        return ImageProbe("present")
 
-    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", _exists)
+    monkeypatch.setattr(container_mod.podman_introspect, "image_presence", _presence)
 
     assert ContainerProvider().image_present(IMAGE) is True
     assert seen == [IMAGE]
@@ -76,7 +82,7 @@ def test_image_present_false_is_an_honest_rootful_negative(
 ) -> None:
     """A seam that answered "missing" is authoritative — we must NOT then
     re-ask the rootless store and let its (also wrong) answer stand in."""
-    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: False)
+    monkeypatch.setattr(container_mod.podman_introspect, "image_presence", _probe("missing"))
 
     assert ContainerProvider().image_present(IMAGE) is False
 
@@ -84,9 +90,11 @@ def test_image_present_false_is_an_honest_rootful_negative(
 def test_image_present_falls_back_to_rootless_when_seam_silent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Dev checkout / CI / no grant: the seam returns None and the operator's
+    """Dev checkout / CI / no grant: the seam cannot answer and the operator's
     own store is the right one to read."""
-    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: None)
+    monkeypatch.setattr(
+        container_mod.podman_introspect, "image_presence", _probe("unknown", "not-service-user")
+    )
     monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: False)
     monkeypatch.setattr(container_mod, "_container_runtime", lambda: "/usr/bin/podman")
 
@@ -105,10 +113,16 @@ def test_image_present_falls_back_to_rootless_when_seam_silent(
     assert calls == [["/usr/bin/podman", "image", "inspect", IMAGE]]
 
 
-def test_image_present_false_when_seam_silent_and_no_runtime(
+def test_image_present_unknown_when_seam_silent_and_no_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: None)
+    """#1939: no seam AND no podman binary means nothing on this box can be
+    asked about the image. That is ``unknown``, not ``False`` — a box with no
+    container runtime at all was previously reporting every slot image as
+    authoritatively absent."""
+    monkeypatch.setattr(
+        container_mod.podman_introspect, "image_presence", _probe("unknown", "not-service-user")
+    )
     monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: False)
 
     def _no_runtime() -> str:
@@ -116,7 +130,25 @@ def test_image_present_false_when_seam_silent_and_no_runtime(
 
     monkeypatch.setattr(container_mod, "_container_runtime", _no_runtime)
 
-    assert ContainerProvider().image_present(IMAGE) is False
+    assert ContainerProvider().image_present(IMAGE) is None
+
+
+def test_image_present_unknown_when_the_rootless_call_itself_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dev box whose podman binary blows up on exec has not answered either."""
+    monkeypatch.setattr(
+        container_mod.podman_introspect, "image_presence", _probe("unknown", "not-service-user")
+    )
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: False)
+    monkeypatch.setattr(container_mod, "_container_runtime", lambda: "/usr/bin/podman")
+
+    def _boom(argv: list[str], **_kw: object) -> None:
+        raise OSError("exec format error")
+
+    monkeypatch.setattr(container_mod.subprocess, "run", _boom)
+
+    assert ContainerProvider().image_present(IMAGE) is None
 
 
 # ── running_image: the "actual_image is always null" bug ───────────────────
@@ -225,12 +257,58 @@ def test_slot_view_reports_present_for_a_running_slot(
     from hal0 import slot_view
 
     slot_view._image_present_cache.clear()
-    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: True)
+    monkeypatch.setattr(container_mod.podman_introspect, "image_presence", _probe("present"))
 
     present = slot_view._image_present_cached(ContainerProvider(), IMAGE)
 
     assert present is True
-    assert ("present" if present else "missing") == "present"
+    assert slot_view.image_status_for(present) == "present"
+    slot_view._image_present_cache.clear()
+
+
+def test_slot_view_reports_unknown_for_an_unanswerable_seam(
+    monkeypatch: pytest.MonkeyPatch, no_rootless: list[list[str]]
+) -> None:
+    """The same end-to-end walk for #1939: wrapper rc 66 on the service
+    account must reach ``image_status`` as ``unknown``, through the real
+    provider and the real TTL cache — never as ``missing``."""
+    from hal0 import slot_view
+
+    slot_view._image_present_cache.clear()
+    monkeypatch.setattr(
+        container_mod.podman_introspect, "image_presence", _probe("unknown", "podman-failed")
+    )
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: True)
+
+    present = slot_view._image_present_cached(ContainerProvider(), IMAGE)
+
+    assert present is None
+    assert slot_view.image_status_for(present) == "unknown"
+    slot_view._image_present_cache.clear()
+
+
+def test_image_present_cache_round_trips_unknown_without_flattening_it(
+    monkeypatch: pytest.MonkeyPatch, no_rootless: list[list[str]]
+) -> None:
+    """A cached ``unknown`` must come back out of the TTL cache as ``unknown``.
+    ``bool()``-ing the cached value on the way in or out would silently restore
+    the exact collapse #1939 is about, one poll later."""
+    from hal0 import slot_view
+
+    slot_view._image_present_cache.clear()
+    calls: list[str] = []
+
+    def _presence(image: str) -> ImageProbe:
+        calls.append(image)
+        return ImageProbe("unknown", "grant-denied")
+
+    monkeypatch.setattr(container_mod.podman_introspect, "image_presence", _presence)
+    monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: True)
+
+    cp = ContainerProvider()
+    assert slot_view._image_present_cached(cp, IMAGE) is None
+    assert slot_view._image_present_cached(cp, IMAGE) is None
+    assert calls == [IMAGE], "the second read must come from the cache"
     slot_view._image_present_cache.clear()
 
 
@@ -321,30 +399,47 @@ def test_unknown_running_image_is_never_drift() -> None:
 # definitionally cannot hold a slot image.
 
 
-def test_image_present_does_not_consult_rootless_store_as_service_user(
-    monkeypatch: pytest.MonkeyPatch, no_rootless: list[list[str]]
+@pytest.mark.parametrize(
+    "reason", ["grant-denied", "invalid-argument", "podman-absent", "podman-failed", "seam-error"]
+)
+def test_image_present_is_unknown_not_false_when_the_seam_cannot_answer(
+    monkeypatch: pytest.MonkeyPatch, no_rootless: list[list[str]], reason: str
 ) -> None:
-    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: None)
+    """#1939, the heart of it. Every unanswerable outcome — wrapper rc 66,
+    a missing sudoers grant, wrapper drift — used to return ``False`` and
+    surface as an authoritative ``image_status: "missing"``. The bool contract
+    is now a tri-state and ``None`` means "could not ask".
+
+    ``no_rootless`` raises if subprocess.run is reached at all, so this also
+    pins that we still never consult the (wrong) rootless store here.
+    """
+    monkeypatch.setattr(
+        container_mod.podman_introspect, "image_presence", _probe("unknown", reason)
+    )
     monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: True)
 
-    # `no_rootless` raises if subprocess.run is reached at all.
-    assert ContainerProvider().image_present(IMAGE) is False
+    assert ContainerProvider().image_present(IMAGE) is None
 
 
-def test_image_present_logs_when_the_seam_does_not_answer(
+def test_image_present_logs_the_seam_reason_when_it_does_not_answer(
     monkeypatch: pytest.MonkeyPatch,
     no_rootless: list[list[str]],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The False above is a bool-contract limitation, not a silent one — an
-    operator must be able to tell it apart from a genuinely absent image."""
-    monkeypatch.setattr(container_mod.podman_introspect, "image_exists", lambda _i: None)
+    """The payload says ``unknown``; the journal says WHICH unknown. The
+    wrapper spends four exit codes distinguishing these — an operator
+    debugging a box needs the distinction, and ``unknown`` alone doesn't
+    carry it."""
+    monkeypatch.setattr(
+        container_mod.podman_introspect, "image_presence", _probe("unknown", "podman-failed")
+    )
     monkeypatch.setattr(container_mod, "is_hal0_service_user", lambda: True)
 
     with caplog.at_level("WARNING"):
         ContainerProvider().image_present(IMAGE)
 
     assert "image_present_unanswered" in caplog.text
+    assert "podman-failed" in caplog.text
 
 
 @pytest.mark.parametrize("method", ["running_image", "running_argv"])

--- a/tests/providers/test_podman_introspect.py
+++ b/tests/providers/test_podman_introspect.py
@@ -23,10 +23,11 @@ import pytest
 
 from hal0.providers.podman_introspect import (
     SEAM_BIN,
+    ImageProbe,
     PodmanImagesResult,
     container_argv,
     container_image,
-    image_exists,
+    image_presence,
     images,
     is_valid_image_ref,
     is_valid_slot_token,
@@ -175,10 +176,12 @@ def _seam_recorder(*, returncode: int = 0, stdout: str = ""):
 # ── the gate: still never touches sudo off the hal0 service account ─────────
 
 
-def test_image_exists_skips_seam_when_not_hal0_user() -> None:
+def test_image_presence_skips_seam_when_not_hal0_user() -> None:
     calls, run = _seam_recorder(stdout="present\n")
 
-    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: False) is None
+    probe = image_presence("alpine:3.19", run=run, is_hal0_user=lambda: False)
+
+    assert probe == ImageProbe("unknown", "not-service-user")
     # Crucially NO rootless fallback here either: a "missing" from hal0's own
     # store about a NAMED image is not a stale answer, it is an answer about a
     # different object. container.py owns that fallback decision.
@@ -195,10 +198,12 @@ def test_container_image_skips_seam_when_not_hal0_user() -> None:
 # ── exact argv (the operand is positional, never a flag) ────────────────────
 
 
-def test_image_exists_seam_argv() -> None:
+def test_image_presence_seam_argv() -> None:
     calls, run = _seam_recorder(stdout="present\n")
 
-    assert image_exists("ghcr.io/hal0/runner:rc6", run=run, is_hal0_user=lambda: True) is True
+    probe = image_presence("ghcr.io/hal0/runner:rc6", run=run, is_hal0_user=lambda: True)
+
+    assert probe == ImageProbe("present")
     assert calls == [["sudo", "-n", SEAM_BIN, "image-exists", "ghcr.io/hal0/runner:rc6"]]
 
 
@@ -225,47 +230,78 @@ def test_container_argv_seam_argv() -> None:
 # ── the actual #1889 fix: "present" is reachable ────────────────────────────
 
 
-def test_image_exists_true_on_present() -> None:
+def test_image_presence_present() -> None:
     _calls, run = _seam_recorder(stdout="present\n")
-    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is True
+    assert image_presence("alpine:3.19", run=run, is_hal0_user=lambda: True) == ImageProbe(
+        "present"
+    )
 
 
-def test_image_exists_false_on_missing() -> None:
+def test_image_presence_missing_is_authoritative_and_carries_no_reason() -> None:
+    """rc 0 + "missing" is the ONLY thing that may read as ``missing``: podman
+    was asked and said no. Every other outcome is ``unknown`` (#1939), which is
+    what keeps ``missing`` + a running container a meaningful defect signal
+    (regression ``image-status-wrong-podman-store``)."""
     _calls, run = _seam_recorder(stdout="missing\n")
-    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is False
+    probe = image_presence("alpine:3.19", run=run, is_hal0_user=lambda: True)
+
+    assert probe == ImageProbe("missing")
+    assert probe.reason is None
 
 
-# ── tri-state: "seam did not answer" is never confused with a real answer ───
+# ── #1939: the wrapper's exit-code contract reaches the caller ──────────────
+#
+# hal0-podman-ro distinguishes "podman answered no" (rc 0 + "missing") from
+# four flavours of "the seam is unusable" (rc 64/65/66, plus sudo's own rc 1
+# when the grant is absent). Before #1939 every one of those collapsed into a
+# bare ``None`` and then into an authoritative-looking ``image_status:
+# "missing"``. Each now maps to a NAMED unknown so the journal line an
+# operator reads names the actual failure.
 
 
-def test_image_exists_none_when_seam_denied() -> None:
-    """sudo -n rc 1 (grant not installed / mid-upgrade race) is NOT 'missing'."""
-    _calls, run = _seam_recorder(returncode=1, stdout="")
-    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is None
+@pytest.mark.parametrize(
+    ("returncode", "reason"),
+    [
+        # sudo -n itself refused: the sudoers grant is not installed, or we are
+        # mid-upgrade between the wrapper and its policy file.
+        (1, "grant-denied"),
+        # the wrapper rejected the operand or the verb (root-side validation)
+        (64, "invalid-argument"),
+        # podman is not installed / not executable on the box
+        (65, "podman-absent"),
+        # podman RAN and broke — store corruption, lock contention, EPERM.
+        # THE case from #1889's review: emphatically not "the image is absent".
+        (66, "podman-failed"),
+        # an rc the contract does not define at all
+        (125, "seam-error"),
+    ],
+)
+def test_image_presence_maps_every_wrapper_rc_to_a_named_unknown(
+    returncode: int, reason: str
+) -> None:
+    _calls, run = _seam_recorder(returncode=returncode, stdout="")
+
+    assert image_presence("alpine:3.19", run=run, is_hal0_user=lambda: True) == ImageProbe(
+        "unknown", reason
+    )
 
 
-def test_image_exists_none_when_wrapper_rejects_the_ref() -> None:
-    """rc 64 (root-side validation) must not read as 'the image is missing'."""
-    _calls, run = _seam_recorder(returncode=64, stdout="")
-    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is None
-
-
-def test_image_exists_none_when_podman_absent_on_the_box() -> None:
-    """rc 65 (no podman) is not an answer about the image."""
-    _calls, run = _seam_recorder(returncode=65, stdout="")
-    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is None
-
-
-def test_image_exists_none_on_unexpected_stdout() -> None:
+def test_image_presence_unknown_on_unexpected_stdout() -> None:
+    """rc 0 with a word the contract never defines is wrapper drift, not an
+    answer — the seam and its Python mirror have gone out of lock-step."""
     _calls, run = _seam_recorder(stdout="yes\n")
-    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is None
+    assert image_presence("alpine:3.19", run=run, is_hal0_user=lambda: True) == ImageProbe(
+        "unknown", "seam-error"
+    )
 
 
-def test_image_exists_none_on_subprocess_error() -> None:
+def test_image_presence_unknown_on_subprocess_error() -> None:
     def _run(argv: object, **kwargs: object) -> MagicMock:
         raise OSError("boom")
 
-    assert image_exists("alpine:3.19", run=_run, is_hal0_user=lambda: True) is None
+    assert image_presence("alpine:3.19", run=_run, is_hal0_user=lambda: True) == ImageProbe(
+        "unknown", "seam-error"
+    )
 
 
 def test_container_image_none_when_no_such_container() -> None:
@@ -286,10 +322,14 @@ def test_container_argv_none_when_no_such_container() -> None:
     "ref",
     ["alpine; rm -rf /", "--rm", "-v/:/host", "../../etc/passwd", "", "a" * 513, "foo bar"],
 )
-def test_image_exists_rejects_bad_ref_without_calling_sudo(ref: str) -> None:
+def test_image_presence_rejects_bad_ref_without_calling_sudo(ref: str) -> None:
     calls, run = _seam_recorder(stdout="present\n")
 
-    assert image_exists(ref, run=run, is_hal0_user=lambda: True) is None
+    # A ref this side rejects was never ASKED about, so it is unknown — never
+    # "missing". Same reason as rc 64, reported with the same name.
+    assert image_presence(ref, run=run, is_hal0_user=lambda: True) == ImageProbe(
+        "unknown", "invalid-argument"
+    )
     assert calls == []
 
 
@@ -325,14 +365,6 @@ def test_is_valid_image_ref_accepts_real_refs(ref: str) -> None:
 @pytest.mark.parametrize("token", ["brain", "1", "my_slot", "my-slot", "x" * 64])
 def test_is_valid_slot_token_accepts_real_tokens(token: str) -> None:
     assert is_valid_slot_token(token) is True
-
-
-def test_image_exists_none_on_operational_podman_failure() -> None:
-    """rc 66 = podman ran but broke (store corruption, lock contention). That
-    is NOT "the image is missing" — reporting it as such would recreate #1889
-    with extra steps, so it must read as "the seam did not answer"."""
-    _calls, run = _seam_recorder(returncode=66, stdout="")
-    assert image_exists("alpine:3.19", run=run, is_hal0_user=lambda: True) is None
 
 
 def test_container_image_none_on_operational_podman_failure() -> None:

--- a/tests/release-validation/README.md
+++ b/tests/release-validation/README.md
@@ -130,6 +130,19 @@ known-issues, or regressions, and add a line to the changelog below. A report re
 
 ### Kit changelog
 
+* **6** (2026-08-20) — `image_status` gains an `unknown` member (#1939), so the three briefs
+  that adjudicate that field learn to tell its two failures apart. `missing` on a running slot
+  is still regression `image-status-wrong-podman-store` — a confident wrong answer. `unknown`
+  is the API declining to answer because the rootful `hal0-podman-ro` seam was unusable
+  (wrapper rc 66, absent sudoers grant, probe timeout); it is a **seam finding**, not a
+  self-contradiction, and it must be followed up rather than passed over — a fleet reading
+  `unknown` everywhere means the grant did not install, and `unknown` on a box whose seam is
+  demonstrably healthy is a defect of its own. `readonly/api.md` check 6, `stateful/slots.md`
+  check 1, and the `image-status-wrong-podman-store` expect clause all now say so, and all
+  three point at the `reason=` field on the `podman_ro.image_present_unanswered` journal line
+  (`grant-denied` / `podman-failed` / `podman-absent` / `invalid-argument` / `seam-error`),
+  which is where the wrapper's exit-code contract now surfaces. No lane, tier, or phase change.
+
 * **5** (2026-08-20) — pre-rc.7 brief hardening from the GA-plan handoff, applied before the
   kit's first v-4-era full run. Four new checks close verification gaps for fixes that would
   otherwise ship CI-verified only: `post-upgrade.md` 2b (the #1934 gpu-vulkan→gpu-rocm slot

--- a/tests/release-validation/README.md
+++ b/tests/release-validation/README.md
@@ -141,7 +141,10 @@ known-issues, or regressions, and add a line to the changelog below. A report re
   check 1, and the `image-status-wrong-podman-store` expect clause all now say so, and all
   three point at the `reason=` field on the `podman_ro.image_present_unanswered` journal line
   (`grant-denied` / `podman-failed` / `podman-absent` / `invalid-argument` / `seam-error`),
-  which is where the wrapper's exit-code contract now surfaces. No lane, tier, or phase change.
+  which is where the wrapper's exit-code contract now surfaces, or at
+  `slot_view.image_probe_failed` for an unknown that never reached the seam. Every `unknown`
+  has one of those two lines behind it; one with neither is a finding. No lane, tier, or phase
+  change.
 
 * **5** (2026-08-20) — pre-rc.7 brief hardening from the GA-plan handoff, applied before the
   kit's first v-4-era full run. Four new checks close verification gaps for fixes that would

--- a/tests/release-validation/kit.toml
+++ b/tests/release-validation/kit.toml
@@ -4,7 +4,7 @@
 # scripts cannot read the filesystem, so when you add a lane here you must also add it to the
 # LANES table in the script. The brief itself is only ever read by the agent that runs it.
 
-kit_version = 5
+kit_version = 6
 
 [defaults]
 # Model tier per phase. Rationale in README "Phases".

--- a/tests/release-validation/lanes/readonly/api.md
+++ b/tests/release-validation/lanes/readonly/api.md
@@ -39,6 +39,18 @@ Probe the REST surface from the workstation with curl against `$API` (from `CONT
    actually run from (root's, on a standard install) and note which user the API's probe
    executes as — the rc.6 defect was a wrong-store probe, self-contradicted by
    `/api/system-info` in the same second.
+
+   Since #1939 the field has a fifth member, `unknown`, and the two failures are **different
+   findings**. `missing` on a running slot is the wrong-store defect above. `unknown` means the
+   API is telling you honestly that it could not read the image store at all — the
+   `hal0-podman-ro` seam failed (wrapper rc 66), its sudoers grant is absent, or the probe
+   timed out. That is not a self-contradiction and must not be filed as one; it is a **seam
+   finding**. Follow it up rather than passing it: grep the journal for
+   `podman_ro.image_present_unanswered`, which carries a `reason=` naming which case fired
+   (`grant-denied` / `podman-failed` / `podman-absent` / `invalid-argument` / `seam-error`),
+   and cross-check `hal0 doctor seams`. A whole fleet reading `unknown` is a broken install
+   even though no field is lying. Conversely, `unknown` where the seam is demonstrably healthy
+   is itself a defect — the probe should have gotten an answer.
 7. **Error shape.** Probe malformed requests: unknown slot name, bad query params, unknown model
    in a GET. Expect clean structured 4xx JSON. A 200 with zeroed data for a nonexistent resource
    is a finding.

--- a/tests/release-validation/lanes/readonly/api.md
+++ b/tests/release-validation/lanes/readonly/api.md
@@ -48,7 +48,10 @@ Probe the REST surface from the workstation with curl against `$API` (from `CONT
    finding**. Follow it up rather than passing it: grep the journal for
    `podman_ro.image_present_unanswered`, which carries a `reason=` naming which case fired
    (`grant-denied` / `podman-failed` / `podman-absent` / `invalid-argument` / `seam-error`),
-   and cross-check `hal0 doctor seams`. A whole fleet reading `unknown` is a broken install
+   or for `slot_view.image_probe_failed` (`reason=probe-error`, carrying the exception) when
+   the probe never reached the seam at all, and cross-check `hal0 doctor seams`. Every
+   `unknown` has exactly one of those two lines behind it; an `unknown` with neither is itself
+   a finding. A whole fleet reading `unknown` is a broken install
    even though no field is lying. Conversely, `unknown` where the seam is demonstrably healthy
    is itself a defect — the probe should have gotten an answer.
 7. **Error shape.** Probe malformed requests: unknown slot name, bad query params, unknown model

--- a/tests/release-validation/lanes/stateful/slots.md
+++ b/tests/release-validation/lanes/stateful/slots.md
@@ -23,7 +23,10 @@ at the ends.
    journal for `pull_job_persist_failed` after the installer's own pull — regression
    `model-pull-jobs-root-owned`. And spot the API's image view: any slot with
    `container_status: running` must not read `image_status: missing`
-   (regression `image-status-wrong-podman-store`).
+   (regression `image-status-wrong-podman-store`). `image_status: unknown` (#1939) is a
+   different result — the API could not read the image store rather than reading it wrongly;
+   record it as a seam finding with the `reason=` from the journal's
+   `podman_ro.image_present_unanswered` line, not as this regression.
 2. **Assign + load.** Take the embed slot: `hal0 slot edit embed --model <embedding model>
    --hardware <backend>`, then `hal0 slot load embed`. **Time the load and record the CLI exit
    code** (`out=$(...); rc=$?`) — regression `slot-verbs-10s-client-timeout` (#1832): the client

--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -1002,8 +1002,9 @@ regressions:
       "unknown" is the API declining to answer because the rootful hal0-podman-ro seam was
       unusable; it does not re-open this entry, but it is not a pass either — file it as a seam
       finding and read the reason= field on the podman_ro.image_present_unanswered journal line
-      (grant-denied / podman-failed / podman-absent / invalid-argument / seam-error). A fleet
-      reading "unknown" everywhere means the sudoers grant did not install.
+      (grant-denied / podman-failed / podman-absent / invalid-argument / seam-error), or on
+      slot_view.image_probe_failed when the probe never reached the seam. A fleet reading
+      "unknown" everywhere means the sudoers grant did not install.
 
   - id: fpx-quant-guard-dead-null-quant
     issue: 1890   # filed by rc.6 fix wave — root cause behind cpu-install-fpx-brain-default's rc.6 partial

--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -997,6 +997,14 @@ regressions:
       and actual_image is populated so image_mismatch can ever fire. Promote as a pytest on the
       is_hal0_service_user() gate in providers/container.py once fixed.
 
+      Since #1939 image_status also has an "unknown" member, and the two failures are distinct.
+      "missing" on a running slot is still THIS regression — a confident wrong answer.
+      "unknown" is the API declining to answer because the rootful hal0-podman-ro seam was
+      unusable; it does not re-open this entry, but it is not a pass either — file it as a seam
+      finding and read the reason= field on the podman_ro.image_present_unanswered journal line
+      (grant-denied / podman-failed / podman-absent / invalid-argument / seam-error). A fleet
+      reading "unknown" everywhere means the sudoers grant did not install.
+
   - id: fpx-quant-guard-dead-null-quant
     issue: 1890   # filed by rc.6 fix wave — root cause behind cpu-install-fpx-brain-default's rc.6 partial
     from: v1.0.0-rc.6

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -748,22 +748,33 @@ class TestContainerEnrichment:
         assert missing["gpu-chat"]["image_status"] == "missing"
 
     async def test_probe_exception_reports_unknown_not_missing(
-        self, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+        self, tmp_hal0_home: str, caplog: pytest.LogCaptureFixture
     ) -> None:
         """The except-branch around the image probe defaulted to ``missing``,
-        so a provider that blew up looked exactly like an absent image."""
+        so a provider that blew up looked exactly like an absent image.
+
+        It also has to LOG. The payload carries no reason field by design, so
+        an ``unknown`` with nothing behind it in the journal would be
+        undiagnosable — which is the failure family this issue is about. The
+        seam's own unknowns are logged by ``image_present``; this branch
+        covers every unknown that never reached it.
+        """
         ProfileCatalog().create("imgprof", ProfileConfig(flags=""))
 
         class _Exploding(FakeContainerProvider):
             def image_present(self, image: str) -> bool:
                 raise RuntimeError("podman store is on fire")
 
-        out = await container_enrichment(
-            [_container_cfg(profile="imgprof", image_pin=_PINNED_IMAGE)],
-            pull_jobs={},
-            provider=_Exploding(active=False),
-        )
+        with caplog.at_level("WARNING"):
+            out = await container_enrichment(
+                [_container_cfg(profile="imgprof", image_pin=_PINNED_IMAGE)],
+                pull_jobs={},
+                provider=_Exploding(active=False),
+            )
         assert out["gpu-chat"]["image_status"] == "unknown"
+        assert "slot_view.image_probe_failed" in caplog.text
+        assert "gpu-chat" in caplog.text
+        assert "podman store is on fire" in caplog.text
 
     async def test_npu_table_surfaced(self) -> None:
         out = await container_enrichment(

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import pytest
 
+from hal0 import slot_view as sv_mod
 from hal0.config.schema import ProfileConfig
 from hal0.profiles import ProfileCatalog
 from hal0.slot_view import (
@@ -65,7 +66,7 @@ class FakeContainerProvider:
         active: bool = True,
         healthy: bool = True,
         running_image: str | None = None,
-        present: bool = True,
+        present: bool | None = True,
         raise_exc: bool = False,
     ) -> None:
         self._active = active
@@ -85,7 +86,8 @@ class FakeContainerProvider:
     def running_image(self, slot: Any) -> str | None:
         return self._running_image
 
-    def image_present(self, image: str) -> bool:
+    def image_present(self, image: str) -> bool | None:
+        # Tri-state since #1939: None == "the image store could not be asked".
         return self._present
 
 
@@ -561,6 +563,12 @@ class TestLoadedModelNamesFromSlots:
 # ── concern 3: container probe ──────────────────────────────────────────────
 
 
+#: A slot-owned pinned image ref (spec-hw-slot-ownership §3) — the shortest
+#: way to give a test slot a declared ``image`` so the image_status branch is
+#: reachable at all.
+_PINNED_IMAGE = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-server"
+
+
 def _container_cfg(name: str = "gpu-chat", **over: Any) -> dict[str, Any]:
     cfg: dict[str, Any] = {
         "name": name,
@@ -695,6 +703,67 @@ class TestContainerEnrichment:
             provider=FakeContainerProvider(active=False),
         )
         assert out["gpu-chat"]["image_status"] == "not-configured"
+
+    # ── #1939: the four-state block is a five-state block ──────────────────
+    #
+    # `missing` is reserved for "podman was asked and said no". Every way of
+    # NOT getting an answer — the seam is unusable, the provider raised, the
+    # whole probe timed out — is `unknown`. Each of these three assertions
+    # pins one site that used to answer with a confident lie.
+
+    async def test_unanswerable_image_probe_reports_unknown_not_missing(
+        self, tmp_hal0_home: str
+    ) -> None:
+        ProfileCatalog().create("imgprof", ProfileConfig(flags=""))
+        out = await container_enrichment(
+            [_container_cfg(profile="imgprof", image_pin=_PINNED_IMAGE)],
+            pull_jobs={},
+            provider=FakeContainerProvider(active=False, present=None),
+        )
+        e = out["gpu-chat"]
+        assert e["image"] == _PINNED_IMAGE
+        assert e["image_status"] == "unknown"
+
+    async def test_declared_image_still_reports_present_and_missing(
+        self, tmp_hal0_home: str
+    ) -> None:
+        """The tri-state must not swallow the two definitive answers — in
+        particular ``missing`` has to stay reachable, or the #1937 regression
+        check (``image_status: missing`` on a running slot is a defect) would
+        be pinning a state nothing can ever emit."""
+        ProfileCatalog().create("imgprof", ProfileConfig(flags=""))
+        cfg = _container_cfg(profile="imgprof", image_pin=_PINNED_IMAGE)
+
+        present = await container_enrichment(
+            [cfg], pull_jobs={}, provider=FakeContainerProvider(active=False, present=True)
+        )
+        # The TTL cache is keyed by image ref and lives for 15 s, so the second
+        # probe would otherwise be served the first one's answer.
+        sv_mod._image_present_cache.clear()
+        missing = await container_enrichment(
+            [cfg], pull_jobs={}, provider=FakeContainerProvider(active=False, present=False)
+        )
+
+        assert present["gpu-chat"]["image_status"] == "present"
+        assert missing["gpu-chat"]["image_status"] == "missing"
+
+    async def test_probe_exception_reports_unknown_not_missing(
+        self, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The except-branch around the image probe defaulted to ``missing``,
+        so a provider that blew up looked exactly like an absent image."""
+        ProfileCatalog().create("imgprof", ProfileConfig(flags=""))
+
+        class _Exploding(FakeContainerProvider):
+            def image_present(self, image: str) -> bool:
+                raise RuntimeError("podman store is on fire")
+
+        out = await container_enrichment(
+            [_container_cfg(profile="imgprof", image_pin=_PINNED_IMAGE)],
+            pull_jobs={},
+            provider=_Exploding(active=False),
+        )
+        assert out["gpu-chat"]["image_status"] == "unknown"
 
     async def test_npu_table_surfaced(self) -> None:
         out = await container_enrichment(

--- a/tests/slot_view/test_probe_concurrency.py
+++ b/tests/slot_view/test_probe_concurrency.py
@@ -121,11 +121,33 @@ async def test_one_wedged_slot_cannot_hold_the_list(
     assert out["s3"]["container_status"] == "stopped"
     assert out["s3"]["container_health"] is False
     assert out["s2"]["container_status"] == "running"
-    # #1939: a probe that timed out never resolved the slot's profile, so it
-    # cannot know whether an image is declared, let alone whether it is on
-    # disk. The old fallback asserted "not-configured" — a claim about config
-    # made by a probe that read no config. "unknown" is the only honest answer.
-    assert out["s3"]["image_status"] == "unknown"
+    # #1939: these configs are PROFILELESS, and "no profile → no declared
+    # image" is knowable from the config alone — the timeout does not make it
+    # any less true. So this case stays "not-configured" (#1226); see the
+    # profiled case below for the one the timeout really cannot answer.
+    assert out["s3"]["image_status"] == "not-configured"
+
+
+async def test_a_wedged_profiled_slot_reports_unknown_not_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1939: a slot that DOES declare an image, whose probe timed out.
+
+    The old fallback answered "not-configured" here — a statement about this
+    slot's configuration, made by a probe that never read its configuration,
+    about a slot that is in fact configured. The honest answer is that we did
+    not get to look.
+    """
+    monkeypatch.setattr(sv_mod, "_PROBE_TIMEOUT_S", 0.4)
+    provider = SlowProvider(delay=0.01, wedged={"s1"})
+    configs = _configs(3)
+    for cfg in configs:
+        cfg["profile"] = "rocm-mtp"
+
+    out = await container_enrichment(configs, provider=provider)
+
+    assert out["s1"]["image_status"] == "unknown"
+    assert out["s1"]["profile"] == "rocm-mtp", "the fallback still reports the declared profile"
 
 
 # ── the whole GET /api/slots path ────────────────────────────────────────────

--- a/tests/slot_view/test_probe_concurrency.py
+++ b/tests/slot_view/test_probe_concurrency.py
@@ -121,6 +121,11 @@ async def test_one_wedged_slot_cannot_hold_the_list(
     assert out["s3"]["container_status"] == "stopped"
     assert out["s3"]["container_health"] is False
     assert out["s2"]["container_status"] == "running"
+    # #1939: a probe that timed out never resolved the slot's profile, so it
+    # cannot know whether an image is declared, let alone whether it is on
+    # disk. The old fallback asserted "not-configured" — a claim about config
+    # made by a probe that read no config. "unknown" is the only honest answer.
+    assert out["s3"]["image_status"] == "unknown"
 
 
 # ── the whole GET /api/slots path ────────────────────────────────────────────

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -134,10 +134,24 @@ export interface Slot {
   /** Container image ref (from the resolved profile). E.g.
    *  "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server". */
   image?: string | null
-  /** Container image availability: "present" | "pulling" | "missing" |
-   *  "not-configured" (no profile/image declared — runs on the default
-   *  toolbox, #1226). Populated by the backend when image_status is tracked. */
-  image_status?: 'present' | 'pulling' | 'missing' | 'not-configured' | null
+  /** Container image availability. Populated by the backend when image_status
+   *  is tracked.
+   *
+   *    present         podman was asked and the image is in the store slots use
+   *    pulling         a layer pull is in flight (SlotImagePullBar renders)
+   *    missing         podman was asked and the image is NOT there — a real,
+   *                    authoritative absence, and a defect when the slot is
+   *                    running (regression `image-status-wrong-podman-store`)
+   *    unknown         #1939 — the store could not be READ at all: the rootful
+   *                    hal0-podman-ro seam failed (wrapper rc 66), its sudoers
+   *                    grant is absent, or the probe timed out. NOT a claim
+   *                    that the image is absent; render it as indeterminate
+   *                    (see imageStatusChip in dash/slot-status.js), never as
+   *                    a fault and never as `missing`.
+   *    not-configured  no profile/image declared — the slot runs on the
+   *                    default toolbox (#1226)
+   */
+  image_status?: 'present' | 'pulling' | 'missing' | 'unknown' | 'not-configured' | null
   /** ACTUAL running container image ref, read from ``podman inspect`` by
    *  _container_state_enrichment (#663). Omitted/null when the container is
    *  not running or inspect fails — treat absence as "unknown". */
@@ -701,7 +715,16 @@ export function useSlotResolved(
 
 // ─── useSlotImagePull ─────────────────────────────────────────────────────────
 
-export type ImagePullState = 'idle' | 'pulling' | 'completed' | 'failed' | 'present' | 'missing'
+export type ImagePullState =
+  | 'idle'
+  | 'pulling'
+  | 'completed'
+  | 'failed'
+  | 'present'
+  | 'missing'
+  /** #1939 — the image store could not be read, so presence is undetermined.
+   *  Terminal: there is no pull in flight to keep waiting on. */
+  | 'unknown'
 
 export interface ImagePullSnapshot {
   slotName: string | null
@@ -716,7 +739,16 @@ export interface ImagePullSnapshot {
   reset: () => void
 }
 
-const IMAGE_PULL_TERMINAL = new Set<ImagePullState>(['completed', 'failed', 'present', 'missing'])
+// `unknown` is terminal (#1939): the backend has told us it cannot determine
+// presence, which is a final answer to this poll — leaving it out would hold
+// the EventSource open forever waiting for a pull that was never started.
+const IMAGE_PULL_TERMINAL = new Set<ImagePullState>([
+  'completed',
+  'failed',
+  'present',
+  'missing',
+  'unknown',
+])
 
 /**
  * Container image-pull composable — mirrors the model `usePullJob` pattern.

--- a/ui/src/dash/__tests__/image-status-chip.test.ts
+++ b/ui/src/dash/__tests__/image-status-chip.test.ts
@@ -1,0 +1,73 @@
+// #1939 — `image_status: "unknown"` must render as an honest indeterminate.
+//
+// The backend now distinguishes "podman was asked and the image is not there"
+// (`missing`) from "the container image store could not be asked at all"
+// (`unknown` — wrapper rc 66, no sudoers grant, seam drift, probe timeout).
+// A UI that paints the second one like the first — or like a fault — throws
+// away the entire point of the tri-state, so the classifier is pinned here
+// rather than left to the JSX.
+import { describe, expect, it } from 'vitest'
+
+import type { Slot } from '@/api/hooks/useSlots'
+
+import { imageStatusChip } from '../slot-status.js'
+
+// Compile-time half of chain site 5: this file IS typechecked (tsconfig
+// includes src/**/*.ts, and `npm run typecheck` runs before the build), so a
+// union that loses the `unknown` member fails CI here even though every
+// runtime assertion below would still pass.
+const UNKNOWN_SLOT: Slot = {
+  name: 'gpu-chat',
+  type: 'llm',
+  device: 'gpu-rocm',
+  model: 'qwen3.6-35b',
+  state: 'ready',
+  metrics: {},
+  runtime: 'container',
+  container_status: 'running',
+  image: 'ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-server',
+  image_status: 'unknown',
+}
+
+describe('imageStatusChip', () => {
+  it('renders an indeterminate chip for unknown', () => {
+    const chip = imageStatusChip(UNKNOWN_SLOT)
+    expect(chip).not.toBeNull()
+    expect(chip!.label).toBe('image ?')
+  })
+
+  it('uses a NEUTRAL class — never the error/warn vocabulary', () => {
+    // The colour rule in slot-status.js: RED = error, AMBER/YELLOW =
+    // transitional or degraded. "We could not read the image store" is
+    // neither; painting it as either one re-tells the lie in CSS.
+    const cls = imageStatusChip(UNKNOWN_SLOT)!.cls
+    expect(cls).toContain('image-unknown')
+    expect(cls).not.toMatch(/\b(err|error|warn|ok)\b/)
+  })
+
+  it('says what it does not know, and what to do about it', () => {
+    const tooltip = imageStatusChip(UNKNOWN_SLOT)!.tooltip
+    // Must NOT claim absence…
+    expect(tooltip).not.toMatch(/\bnot (present|installed|found)\b/i)
+    expect(tooltip).not.toMatch(/\bmissing\b/i)
+    // …and must point at the seam, which is the thing an operator can fix.
+    expect(tooltip).toMatch(/could not/i)
+    expect(tooltip).toMatch(/hal0 doctor/)
+  })
+
+  it.each([
+    ['present', 'present'],
+    ['missing', 'missing'],
+    ['pulling', 'pulling'],
+    ['not-configured', 'not-configured'],
+  ] as const)('renders no chip for %s (definitive or already-surfaced)', (_l, status) => {
+    expect(imageStatusChip({ image_status: status })).toBeNull()
+  })
+
+  it('renders no chip when the field is absent or null', () => {
+    expect(imageStatusChip({})).toBeNull()
+    expect(imageStatusChip({ image_status: null })).toBeNull()
+    expect(imageStatusChip(null)).toBeNull()
+    expect(imageStatusChip(undefined)).toBeNull()
+  })
+})

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -104,6 +104,15 @@ const HAL0_DATA = {
       backend: "vulkan",
       runtime: "container",
       profile: "vulkan",
+      image: "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server",
+      // #1939 regression fixture — the seed's one `image_status: "unknown"`
+      // slot, and a realistic one: an offline slot whose image store hal0
+      // could not READ (rootful hal0-podman-ro seam rc 66, absent sudoers
+      // grant, or a probe timeout). Deliberately NOT the same claim as
+      // "missing", which is podman having been asked and answered "no".
+      // Keeping it in the seed means the indeterminate chip is rendered by
+      // real card code on every γ run, not only in a unit test.
+      image_status: "unknown",
       container_status: "stopped",
       container_health: false,
       model: "",
@@ -226,6 +235,7 @@ const HAL0_DATA = {
       device_class: "cpu",
       runtime: "container",
       profile: "tts",
+      image: "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1",
       container_status: "running",
       container_health: true,
       model: "kokoro-v1",

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -38,7 +38,7 @@ import {
 import { useModels } from '@/api/hooks/useModels'
 import { isUpstreamModel } from '@/lib/normalizeApiModel'
 import { useMemoryMapModel } from './memory-map'
-import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
+import { slotIndicatorFromPhase, isSlotLive, imageStatusChip } from './slot-status.js'
 import { slotModelRow } from './slots/slot-shared.js'
 import { useCardReorder } from './slots/card-order.js'
 // devKind — one shared, meta-aware helper (src/lib/deviceMeta.ts); replaces
@@ -221,6 +221,37 @@ function DevCell({ s, onProfile }) {
         {s.profile || 'default'}
         <Ic name="chev" size={10} />
       </button>
+    </span>
+  )
+}
+
+// Indeterminate container-image chip (#1939). Renders ONLY for
+// `image_status: "unknown"` — the backend saying it could not read the
+// container image store (rootful hal0-podman-ro seam rc 66, missing sudoers
+// grant, probe timeout), which is a different claim from "missing" (podman
+// was asked and said no).
+//
+// Neutral and dashed on purpose: this card's colour vocabulary is RED =
+// error, AMBER = transitional/degraded, GREY = not loaded. An unreadable
+// image store is none of those, and painting it as one would restate in CSS
+// exactly the confident-lie the tri-state was added to end. The classifier
+// itself lives in slot-status.js so this component and the (retired) grid
+// card cannot drift.
+export function SlotImageUnknownChip({ s }) {
+  const chip = imageStatusChip(s)
+  if (!chip) return null
+  return (
+    <span
+      className={chip.cls}
+      data-testid="slot-image-unknown"
+      title={chip.tooltip}
+      style={{
+        color: 'var(--fg-3)',
+        borderStyle: 'dashed',
+        borderColor: 'var(--fg-3)',
+      }}
+    >
+      {chip.label}
     </span>
   )
 }
@@ -485,6 +516,7 @@ export function SlotScard({
         <div className={'scard-foot' + (full ? '' : ' bare')}>
           <DevCell s={s} onProfile={onEdit} />
           <BackendMismatch s={s} onEdit={onEdit} />
+          <SlotImageUnknownChip s={s} />
           {full && memGb != null && <span className="tag-chip">{memGb} GB</span>}
           <span className="grow" />
           {controls}

--- a/ui/src/dash/slot-status.js
+++ b/ui/src/dash/slot-status.js
@@ -237,6 +237,45 @@ function _formatAgo(deltaMs) {
 }
 
 /**
+ * Chip for an INDETERMINATE container-image read (#1939), or null.
+ *
+ * `image_status` is present | pulling | missing | unknown | not-configured.
+ * Four of those are claims the backend can stand behind; `unknown` is the
+ * backend saying it could not read the image store at all — the rootful
+ * hal0-podman-ro seam returned rc 66, the sudoers grant is absent, the
+ * wrapper and its Python mirror drifted, or the whole probe timed out.
+ *
+ * Only `unknown` gets a chip, and deliberately so:
+ *   • `present` / `not-configured` are the quiet, correct states;
+ *   • `pulling` already has the progress bar (SlotImagePullBar);
+ *   • `missing` stays backend-only, as it always has been — this change is
+ *     not the place to introduce a new red chip, and doing so would bury the
+ *     one state that actually needs an operator's eye;
+ *   • `unknown` is precisely a state an operator can ACT on (fix the grant,
+ *     fix podman) and that nothing else on the card hints at.
+ *
+ * The class is neutral on purpose. This card's colour rule is RED = error,
+ * AMBER = transitional, GREY = not loaded. "We could not read the store" is
+ * not an error in the slot and not a phase of it; painting it red or amber
+ * would re-tell the very lie the tri-state exists to stop.
+ *
+ * @param {object|null|undefined} slot
+ * @returns {{cls: string, label: string, tooltip: string}|null}
+ */
+export function imageStatusChip(slot) {
+  if (slot?.image_status !== "unknown") return null;
+  const img = slot?.image ? ` (${slot.image})` : "";
+  return {
+    cls: "chip image-unknown",
+    label: "image ?",
+    tooltip:
+      `hal0 could not read the container image store${img}, so it does not ` +
+      `know whether this image is on disk. This is NOT a report that the ` +
+      `image is absent. Check the read-only podman seam with \`hal0 doctor seams\`.`,
+  };
+}
+
+/**
  * Project slotPhase() → stateChipClass-compatible CSS class.
  * Used in slot-modals.jsx to color lifecycle state chips.
  */

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -23,12 +23,13 @@ import { NpuOccupancyCard } from './npu-pane.jsx'
 import {
   InferencePane,
   SlotScard,
+  SlotImageUnknownChip,
   ModelPicker,
   SlotControls,
   slotCtrlPhase,
 } from './inference-pane.jsx'
 import { TelemetryHeader } from './telemetry-header.jsx'
-import { slotIndicatorFromPhase, slotButtonPhase, isSlotLive } from './slot-status.js'
+import { slotIndicatorFromPhase, slotButtonPhase, isSlotLive, imageStatusChip } from './slot-status.js'
 import { prettyProfile } from './profile-names.js'
 import { slotModelRow } from './slots/slot-shared.js'
 
@@ -72,7 +73,15 @@ function IndicatorDot({ slot }) {
 
 // Expose for window-scope JSX (legacy pattern in this codebase) + tests.
 if (typeof window !== "undefined") {
-  Object.assign(window, { slotIndicator, IndicatorDot, RECENTLY_LIVE_MS, isSlotLive });
+  Object.assign(window, {
+    slotIndicator,
+    IndicatorDot,
+    RECENTLY_LIVE_MS,
+    isSlotLive,
+    // #1939 — the γ-suite drives the indeterminate-image classifier the same
+    // way it drives slotIndicator: through the real helper, not a copy of it.
+    imageStatusChip,
+  });
 }
 
 // ─── Mini sparkline for slot card ───
@@ -361,6 +370,10 @@ function SlotCard({
             </span>
           );
         })()}
+        {/* #1939: the container image store could not be READ for this slot
+            (seam rc 66 / missing grant / probe timeout). Neutral + dashed —
+            an indeterminate answer, not a fault and not a missing image. */}
+        <SlotImageUnknownChip s={slot} />
         {/* Backend mismatch: amber chip surfaces the ACTUAL runtime backend
             when it differs from the declared one. Backend identity is owned by
             the slot's profile, so clicking opens the slot editor's profile

--- a/ui/tests/e2e/fixtures/mock-data.ts
+++ b/ui/tests/e2e/fixtures/mock-data.ts
@@ -142,6 +142,16 @@ export const MOCK_DATA = {
       bench_toks_per_sec: 52.8,
     },
     // C7 spec target: TTS container slot with the tts profile (device_class=cpu — fixed text).
+    //
+    // Also this fixture set's `image_status: 'unknown'` slot (#1939). The
+    // backend vocabulary is present | pulling | missing | unknown |
+    // not-configured; `unknown` means the container image store could not be
+    // ASKED (the rootful hal0-podman-ro seam returned rc 66, its sudoers grant
+    // is absent, or the probe timed out) — deliberately NOT the same claim as
+    // `missing`, which is podman having been asked and answered "no".
+    // (The DOM-level chip assertion runs against the forced-mock seed in
+    // src/dash/data.jsx, which is what the rendered pane actually reads; this
+    // one keeps the route-stubbed specs' vocabulary in step with it.)
     {
       name: 'tts', type: 'tts', device: 'cpu',
       device_class: 'cpu', backend: null,
@@ -150,7 +160,7 @@ export const MOCK_DATA = {
       runtime: 'container',
       profile: 'tts',
       image: 'ghcr.io/hal0ai/hal0-toolbox-kokoro:v1',
-      image_status: 'present',
+      image_status: 'unknown',
       container_status: 'running',
       container_health: true,
       mem_mb: 800,

--- a/ui/tests/e2e/specs/slot-card-container-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-card-container-v3.spec.ts
@@ -56,6 +56,15 @@ const CONTAINER_SLOT_STARTING = {
   metrics: { toks: 0, ttft: null, ctx: 0, kv: null },
 }
 
+// #1939: the container image store could not be ASKED about this slot's image
+// (wrapper rc 66 / no sudoers grant / probe timeout). Distinct from 'missing',
+// which is podman answering "no".
+const CONTAINER_SLOT_SEAM_BLIND = {
+  ...CONTAINER_SLOT_RUNNING,
+  name: 'seam-blind-container',
+  image_status: 'unknown',
+}
+
 test.describe('SlotCard container variant (#657)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/#slots')
@@ -282,6 +291,56 @@ test.describe('SlotCard container variant (#657)', () => {
   // SlotCard grids (Chat + Capabilities). The InferencePane slot cards surface
   // the runtime via the device chip; lifecycle dot classification stays covered
   // by the slotIndicator() unit-style tests above.
+
+  // ── #1939: image_status: 'unknown' renders as honest indeterminate ──────
+  //
+  // The seam-blind state must never be painted like a fault or like an absent
+  // image. These run through window.imageStatusChip — the same pure helper the
+  // cards call — for the same reason the dot tests use window.slotIndicator:
+  // it is the real code path, and it does not depend on the (unmounted) grid.
+
+  test('unknown image_status yields an indeterminate chip, not an error one', async ({ page }) => {
+    const chip = await page.evaluate(
+      (slot) => (window as any).imageStatusChip(slot),
+      CONTAINER_SLOT_SEAM_BLIND,
+    )
+    expect(chip).not.toBeNull()
+    expect(chip.label).toBe('image ?')
+    expect(chip.cls).toContain('image-unknown')
+    // Never the error/warn vocabulary — those mean "something is wrong with
+    // this slot", and "we couldn't read the image store" is not that claim.
+    expect(chip.cls).not.toMatch(/\b(err|error|warn)\b/)
+    expect(chip.tooltip).not.toMatch(/missing/i)
+  })
+
+  test('a definitively answered image_status renders no chip at all', async ({ page }) => {
+    const chips = await page.evaluate(
+      (slots) => slots.map((s: any) => (window as any).imageStatusChip(s)),
+      [
+        CONTAINER_SLOT_RUNNING, // present
+        { ...CONTAINER_SLOT_RUNNING, image_status: 'missing' },
+        { ...CONTAINER_SLOT_RUNNING, image_status: 'pulling' },
+        { ...CONTAINER_SLOT_RUNNING, image_status: 'not-configured' },
+      ],
+    )
+    expect(chips).toEqual([null, null, null, null])
+  })
+
+  test('the seam-blind chip renders on a real card in the inference pane', async ({ page }) => {
+    // The forced-mock seed (dash/data.jsx) gives `legacy` image_status:
+    // 'unknown', so the LIVE card surface — inference-pane's SlotScard, not
+    // the retired grid — must render the chip. This is the only assertion
+    // here that goes through real JSX rather than the classifier alone.
+    const card = page.getByTestId('infer-slot-legacy')
+    await expect(card).toBeVisible()
+    const chip = card.getByTestId('slot-image-unknown')
+    await expect(chip).toBeVisible()
+    await expect(chip).toHaveText(/image \?/)
+    // The neighbouring card, whose image_status is definitive, carries none.
+    await expect(
+      page.getByTestId('infer-slot-primary').getByTestId('slot-image-unknown'),
+    ).toHaveCount(0)
+  })
 
   test('starting container card renders warming dot via slotIndicator', async ({ page }) => {
     // Verify warming dot for a starting container slot


### PR DESCRIPTION
`image_status` could report `missing` about an image nothing had managed to look at.

The `hal0-podman-ro` wrapper spends four exit codes distinguishing "podman answered, negatively" (rc 0 + `missing`) from three flavours of "the seam is unusable" (rc 64 bad operand, rc 65 no podman, rc 66 podman ran and broke), plus sudo's own rc 1 when the grant is absent. All of that collapsed to a bare `None` at the seam, then to `False` in `ContainerProvider.image_present` — whose contract was a bool — and finally to an authoritative-looking `image_status: "missing"` on the wire. Operators, the dashboard, agents reading `/api/slots`, and the release-validation kit all got a confident answer to a question nobody asked.

After this, `missing` means only what it says: **podman was asked and the image is not there.** Everything that prevented the question from being asked is `unknown`.

## Schema decision

This is a **public API-schema change** and it ships **pre-GA, in rc.7**, per decision-ledger row 4 (add `unknown` before GA — a break is cheap now and expensive after). #1939 left 1.0 vs 1.0.x open; that call is made. The change is additive to the payload (a fifth member of an existing enum), so no field is removed or renamed on the wire — but consumers that exhaustively switch on `image_status` must handle it, which is exactly why it lands before the vocabulary is frozen.

Deliberately **not** added: an `image_status_reason` payload field. The reason is real and is preserved, but it goes to the journal (`podman_ro.image_present_unanswered … reason=<name>`), not to the public schema. The payload's job is to stop lying; the journal's job is to say why. That keeps the ratified surface change to exactly the one member the operator approved.

## The chain, site by site

The planner mapped seven sites where the tri-state had to survive. Missing any one leaves the lie in place, so each has its own test:

| # | Site | Before | After | Pinned by |
|---|---|---|---|---|
| 1 | `podman_introspect` seam | rc 64/65/66 + sudo rc 1 → one undifferentiated `None` | `image_exists` → `image_presence`, returning `ImageProbe(presence, reason)`; each rc maps to a named `SeamUnanswered` | `test_image_presence_maps_every_wrapper_rc_to_a_named_unknown` (parametrised over rc 1/64/65/66/125), `…_unknown_on_unexpected_stdout`, `…_unknown_on_subprocess_error`, `…_rejects_bad_ref_without_calling_sudo` |
| 2 | `ContainerProvider.image_present` bool contract | `False` (a lie) + a reasonless WARNING | `bool \| None`, WARNING carries `reason=` | `test_image_present_is_unknown_not_false_when_the_seam_cannot_answer` (parametrised over all five reasons, with the rootless store booby-trapped), `test_image_present_logs_the_seam_reason_when_it_does_not_answer` |
| 3a | `_image_present_cached` | `bool(...)` coerced `None` → `False` | caches the tri-state verbatim | `test_image_present_cache_round_trips_unknown_without_flattening_it` (also asserts the second read is a cache hit) |
| 3b | aggregator except-branch | `"missing"` | `"unknown"` | `test_probe_exception_reports_unknown_not_missing` |
| 3c | aggregator probe-timeout fallback | `"not-configured"` — a claim about config from a probe that read no config | `"unknown"` | `test_one_wedged_slot_cannot_hold_the_list` (extended) |
| 4 | API payload | `GET /api/slots`, `/pull/status`, `/pull/stream` all read `missing` | all three read `unknown`; `inspect_image_state` shares the aggregator's `image_status_for` helper so they cannot drift | `test_image_status_unknown_when_the_probe_cannot_answer`, `test_pull_status_route_reports_unknown_rather_than_missing` |
| 5 | `useSlots.ts` union | 4 members | 5, plus `unknown` added to `ImagePullState` **and** to `IMAGE_PULL_TERMINAL` (otherwise the EventSource hangs on it forever) | compile-time: the vitest file declares a typed `Slot` literal with `image_status: 'unknown'`, and `src/**/*.ts` is typechecked — drop the member and `npm run typecheck` fails |
| 6 | `slots.jsx` rendering | nothing rendered for any image state but `pulling` | `imageStatusChip` → neutral dashed "image ?" chip, on the live `SlotScard` *and* the retired grid card | `image-status-chip.test.ts` (6 cases incl. "cls carries no err/warn/ok token", "tooltip must not claim absence, must name `hal0 doctor`"), plus two γ cases |
| 7 | e2e specs + mock data | — | `slot-card-container-v3.spec.ts` gains 3 cases; the forced-mock seed's `legacy` slot and `mock-data.ts`'s `tts` slot carry `image_status: 'unknown'` | γ: classifier cases + one **DOM** case asserting the chip renders on a real card and that its definitively-answered neighbour has none |

Why neutral and dashed rather than red or amber: this card's colour vocabulary is RED = error, AMBER = transitional/degraded, GREY = not loaded. "We could not read the image store" is none of those, and painting it as one restates the same confident lie in CSS. `missing` deliberately gains no new chip — it has always been backend-only, and adding a red chip here would bury the one state that actually wants an operator's eye.

Two honest-degradation fixes came along because they are the same bug one layer down: `image_present`'s dev-checkout fallback now answers `unknown` when there is no container runtime at all, and when podman itself fails to exec. Neither is an answer about the image.

## Release-validation kit (rides with this PR)

The kit adjudicates the field that changed, so it changes here — `kit_version` 5 → 6, per the kit's own versioning policy ("bump it in the same PR as any change to lane briefs").

`readonly/api.md` check 6, `stateful/slots.md` check 1, and the `image-status-wrong-podman-store` expect clause now distinguish the two failures. `missing` on a running slot is still that regression — a confident wrong answer. `unknown` is the API declining to answer because the seam was unusable: it does **not** re-open the regression, but it is **not a pass either** — it is a seam finding, followed up via the `reason=` on the journal line. A fleet reading `unknown` everywhere means the sudoers grant did not install; `unknown` on a box whose seam is demonstrably healthy is a defect of its own. The #1937 invariant stays meaningful precisely because `missing` is now unreachable except from a real negative.

**Note for the changelog agent:** this PR changes the kit (v6) and adds a public enum member. CHANGELOG.md is untouched here by instruction.

## Verification

Every gate run locally on this branch, at `92d1a0e2` + this commit:

```
pytest tests/api                                   1796 passed, 1 skipped
pytest tests/providers tests/slot_view tests/slots 1577 passed
pytest tests/<everything else>                     7624 passed, 15 skipped, 1 xfailed
pytest <all touched suites, re-run post-edit>      1719 passed
ruff check src tests                               All checks passed!
ruff format --check src tests                      1162 files already formatted
ui: npx eslint .                                   clean
ui: npx tsc --noEmit                               clean
ui: npx vitest run                                 14 files, 135 tests passed
ui: npm run build                                  built in 2.98s
ui: npx playwright test (full γ-suite)             648 passed, 16 skipped
```

The full γ-suite was run rather than just the affected spec, because the change touches the shared forced-mock seed (`src/dash/data.jsx`) that every γ spec renders from.

Closes #1939. Refs #1889, #1937.
