### PR TITLE
docs(release-validation): kit v8 — Vulkan-restoration coverage for the rc.7 fold

### DIFF
--- a/.claude/workflows/rc-validate.js
+++ b/.claude/workflows/rc-validate.js
@@ -33,9 +33,9 @@ const KIT = `${REPO}/tests/release-validation`
 const RUN = `/mnt/mintdev/artifacts/hal0-release-validation/${VERSION}`
 
 // Box id -> role. Mirrors tests/release-validation/boxes.toml.
+// ct152-cpu-fresh was destroyed 2026-08-21 (kit v8) — there is no CPU-only fresh box left.
 const BOX_ROLES = {
   'ct151-cpu-fresh': 'fresh',
-  'ct152-cpu-fresh': 'fresh',
   'ct163-cpu-fresh': 'fresh-alt',
   'ct150-update': 'update',
   'ct105-prod': 'prod',
@@ -479,13 +479,16 @@ relitigates it.
 
 Also judge \`other_hardware_applicability\`: would a GPU box, a privileged container, or an
 upgraded (rather than freshly installed) box hit this? No box in the fleet is BOTH a fresh
-install AND has /dev/kfd visible (the fresh boxes lack /dev/kfd, so post-#1923 their
-gpu-rocm LLM slots REFUSE to start — the Vulkan LLM lane is retired and there is no CPU
-fallback for a gpu-device slot; LLM coverage on those boxes means slots explicitly set to
-device=cpu. The boxes with /dev/kfd — update and prod — are not fresh installs), so a
-read-only cross-check
-against the production box is the best available evidence — use it when the finding touches
-backend selection, profile flags, hardware probing, or native tool calling.
+install AND has /dev/kfd visible (the fresh boxes lack /dev/kfd, so their gpu-rocm LLM slots
+REFUSE to start — no ROCm compute node, no CPU fallback for a gpu-device slot). As of the rc.7
+Vulkan-restoration fold (#1948), that is no longer the whole story for the Vulkan LLM lane: a
+fresh box WITHOUT /dev/kfd (ct151) now DOES run gpu-vulkan LLM slots, gated on the runner image
+being at or after the signed :0822 pin rather than refused outright — so a fresh-install
+Vulkan-lane finding CAN be reproduced fleet-side, on ct151, and does not automatically need the
+production cross-check. gpu-rocm LLM slots remain fresh-install-untestable (still no fresh box
+with /dev/kfd) — use the production box or the update box (both have /dev/kfd but are not
+fresh installs) for anything that is specifically about the ROCm lane, backend selection,
+profile flags, hardware probing, or native tool calling on a kfd-visible box.
 
 Non-destructive repro only. If you load a slot, restore what you found. Set key="${c.key}".`,
   { label: `verify:${c.key}`, phase: 'Verify', schema: VERDICT, model: 'opus', effort: 'high' })))).filter(Boolean)

--- a/tests/release-validation/README.md
+++ b/tests/release-validation/README.md
@@ -130,6 +130,77 @@ known-issues, or regressions, and add a line to the changelog below. A report re
 
 ### Kit changelog
 
+* **8** (2026-08-21) — Vulkan-restoration coverage for the rc.7 fold (#1948), FINALIZED against
+  the landed fold chain: #1954 (kfd identity by runner uid + device gid, `e5e5925a`), #1973 (the
+  `gpu-vulkan` lane re-enable behind an explicit image allowlist, `3474ec03`), #1959 (repin to
+  `ghcr.io/hal0ai/hal0-combined:0822`, `8f23afba`). Composed with v6/v7's `image_status`
+  tri-state work rather than duplicated — the api.md/slots.md tri-state checks stay exactly as
+  v6/v7 wrote them; this version only adds the Vulkan-specific checks and resolves the five
+  `FINALIZE-AFTER-PHASE-D` markers a v6 draft (written in parallel with the lane re-enable PR)
+  had left open, against the actual merged mechanics rather than a guess:
+    1. **The gate is an explicit allowlist, not a version comparison.**
+       `VULKAN_CAPABLE_IMAGE_REFS` (`config/schema.py`) is a `frozenset` earned per-image by the
+       #1948 §3-C matrix — deliberately NOT "the pin or later", because the tags have no total
+       order (git shortrefs, date stamps, names) and Vulkan correctness was empirically NOT
+       monotonic in build recency (the bisect found an OLDER tree correct and a NEWER one
+       broken). `image_serves_vulkan_lane()` checks membership; `effective_runner_image()` looks
+       THROUGH a pending retag so a migration decision and a live-load decision can never
+       disagree; `vulkan_lane_serves()` composes the two and is the one predicate the
+       derivation ladders, the bench harness, the installer's shell-mirrored preflight, and the
+       updater's migration all share.
+    2. **Preflight refusal is `require_kfd_for_gpu_slot`'s `gpu-vulkan` branch**
+       (`providers/_gpu.py`), which on the `llama` runtime lane on an AMD host now delegates to
+       `_require_vulkan_lane_prerequisites`: gate 1 is the image allowlist above (refuses by
+       name, cites #1888, names `VULKAN_FIXED_IMAGE` as the fix), gate 2 is
+       `render_node_present()` for the runner identity (uid 0, the rootful slot container — not
+       whoever calls the function). `/dev/kfd` is NOT consulted on this path at all — Vulkan
+       needs no compute node, which is the whole point of the kfd-less-box restoration.
+    3. **The capabilities catalog OFFERS the lane without gating on image** — confirmed
+       `capabilities/catalog.py`'s llama.cpp fan-out: `gpu-vulkan` is offered whenever the host
+       advertises that backend (a render node exists), independent of which image is installed.
+       "The picker is an OFFER, not a promise" is the source's own comment; a slot created on
+       that row still has to clear the load-time image gate and then #1922's readiness probe.
+       api.md 6c rewritten to state this as fact, not a maybe.
+    4. **`ENV_ALLOW_VULKAN_FALLBACK` survives unchanged** and now downgrades TWO correctness
+       refusals to a warning — missing `/dev/kfd` on the ROCm path, and an unvalidated Vulkan
+       image on the restored path — never the render-node check, which is a passthrough fact no
+       env var can change. `boxes.toml` wording finalized accordingly.
+    5. **Seeds stay `gpu-rocm` by operator ruling.** `install/profile_derive.derive_device`
+       still derives ROCm first whenever `/dev/kfd` is usable, even though the §3-C matrix shows
+       Vulkan is FASTER on the reference hardware (+13.96% prefill, +20.45% decode — the
+       corrected direction from the old ade07ba-era "Vulkan ~-10%" expectation kit v5 carried;
+       drop that stale expectation everywhere it appears). ROCm is offered first in the picker
+       because it has the longer validation history and is what MTP/speculative decode is tuned
+       on. The documented way to run Vulkan deliberately is `hal0 slot edit <slot> --hardware
+       vulkan` — a manual opt-in, not a new default. Kit checks must not flag "seeded slot is
+       still gpu-rocm on a box that could run Vulkan" as a defect.
+
+  `boxes.toml`: `[boxes.ct152-cpu-fresh]` REMOVED — the box was destroyed 2026-08-21. There is
+  now no CPU-only fresh box in the fleet at all; the fleet-coverage note says so plainly instead
+  of the old "do not claim no CPU-only box remains" hedge, since that claim is now simply true.
+  ct151's note and the fleet-coverage note both drop their `FINALIZE-AFTER-PHASE-D` HTML
+  comments and state the real gate: an explicit `VULKAN_CAPABLE_IMAGE_REFS` allowlist, not a
+  version/tag comparison.
+  `lanes/stateful/slots.md` 8c/8d finalized: 8c names `_require_vulkan_lane_prerequisites`'s two
+  gates explicitly instead of hedging on the wording; 8d's repro now greps
+  `_require_vulkan_lane_prerequisites` and `image_serves_vulkan_lane` by name and expects the
+  `GpuPreflightError` naming both #1888 and `VULKAN_FIXED_IMAGE`.
+  `lanes/readonly/api.md` 6c finalized per point 3 above; the speculative 6b from the v6 draft
+  (written before #1968 merged, hedging on whether it would) is DROPPED — v6/v7's check 6 and
+  the `image-status-wrong-podman-store` expect clause already cover the tri-state fully and a
+  second check saying the same thing would duplicate rather than compose.
+  `lanes/update/upgrade.md` gains a check verifying the rc.6 -> rc.7 retag on ct150 actually
+  lands `image_pin = ghcr.io/hal0ai/hal0-combined:0822` (both the legacy `image` key and the
+  newer `image_pin` key are checked, with `image_pin` taking precedence per #1959's final
+  commit, and the perf-row numbers are recorded as the new reference envelope — Vulkan ahead of
+  ROCm, not behind).
+  `regressions.yaml`'s two new entries keep their `from: v1.0.0-rc.7` (that is when the fold
+  landed) even though this kit version is 8; `updater-image-pin-retag-blind-spot` gets its issue
+  number confirmed against #1959's merged commit, and `vulkan-lane-stale-image-preflight-refusal`
+  gets `issue: 1973` (the lane re-enable PR that actually implemented the check it describes).
+  `.claude/workflows/rc-validate.js`'s verify-prompt fleet note is unchanged from the v6 draft —
+  it was written to be correct once the fold landed and still is.
+
 * **7** (2026-08-21) — follow-up to 6, landed before its first run. `readonly/api.md` check 6
   now names both `reason=` values on `slot_view.image_probe_failed` (`probe-error` when the
   probe raised, `probe-timeout` when the slot probe blew its deadline first). v6 promised that

--- a/tests/release-validation/boxes.toml
+++ b/tests/release-validation/boxes.toml
@@ -30,15 +30,35 @@ This is the BEST fresh box in the fleet — the only one with snapshots. Two res
   * `rc6-installed`  — hal0 1.0.0-rc.6 immediately post-install (2026-08-15): api + hermes
                        active, installer-seeded brain model present and serving. Do NOT assert
                        "no models on a fresh install" — the installer pulls the brain model.
-(`rc5-installed` no longer exists.) Prefer this box over ct152, which has no snapshot and
-carries residue.
+(`rc5-installed` no longer exists.) The only fresh box in the fleet — ct152-cpu-fresh was
+destroyed 2026-08-21 and there is no other CPU-only fresh box to fall back to.
 
-GPU PASSTHROUGH since the rc.5 era (boxes' oldest gotchas predate it): the box has the
-rocmfpx runner in root's podman store but NO /dev/kfd — and post-#1923 the Vulkan LLM lane is
-RETIRED: gpu-rocm llama.cpp slots refuse to start here (loud preflight), they do not fall
-back. LLM work on this box runs on slots explicitly set to device=cpu; non-llama GPU
-runtimes (TTS/whisper/ComfyUI) may still use Vulkan. Run the coherence canary (_shared.md)
-before trusting any generated text. Do not frame findings as "CPU-only box".
+GPU PASSTHROUGH since the rc.5 era, NO /dev/kfd (render node only: dev0 /dev/dri/renderD128
++ dev3 /dev/accel/accel0). As of the rc.7 Vulkan-restoration fold (#1948, landed as #1954 +
+#1973 + #1959), this is once again ct151's PRIMARY Vulkan LLM lane box: the release pin moved
+to `ghcr.io/hal0ai/hal0-combined:0822` (`VULKAN_FIXED_IMAGE` in config/schema.py — correct
+Vulkan output, MiniCPM5 parser restored), and `gpu-vulkan` llama.cpp slots on this kfd-less AMD
+render node are gated on an EXPLICIT ALLOWLIST, not a version/tag comparison:
+`require_kfd_for_gpu_slot`'s `gpu-vulkan` branch (`providers/_gpu.py`) checks the slot's
+resolved image against `VULKAN_CAPABLE_IMAGE_REFS` and the render node's openability by the
+runner identity (uid 0) — `/dev/kfd` is never consulted on this path. Any image not in the
+allowlist (the outgoing `ade07ba` pin, still the concrete case) is refused loudly, naming
+#1888 and `VULKAN_FIXED_IMAGE` — see `lanes/stateful/slots.md` 8c/8d. #1922's output-sanity
+readiness gate (merged, PR #1962, live on main) is the permanent net under this: any slot that
+reaches `ready` on this box, on any backend, has already passed a temp-0 "Paris" probe. Run the
+coherence canary (_shared.md) anyway before trusting generated text — the gate proves
+readiness, not that every later request stays sane. `gpu-rocm` llama.cpp slots still refuse
+here (no /dev/kfd, no ROCm compute node — that gate is untouched and unrelated to the image
+allowlist). Non-llama GPU runtimes (TTS/whisper/ComfyUI) continue to use Vulkan as before.
+Seeded slots still derive `gpu-rocm` wherever `/dev/kfd` is usable and fall to `gpu-vulkan`
+only when it is not (operator ruling — ROCm stays the default despite Vulkan measuring faster
+in #1948's §3-C matrix); on this box, with no `/dev/kfd`, seeded chat/coder/embed slots derive
+`gpu-vulkan` directly. `ENV_ALLOW_VULKAN_FALLBACK` (`HAL0_ALLOW_VULKAN_FALLBACK`) is STILL a
+finding if set: post-fold it downgrades BOTH correctness refusals to a warning — missing
+`/dev/kfd` on the ROCm path, and an unvalidated image on this box's Vulkan path — never the
+render-node check. Its presence on any box is itself a finding, and if found, the #1922 gate
+must be the thing that catches the resulting garbage (never a silent `ready`) — see
+`lanes/stateful/slots.md` check 8e.
 
 GOTCHAS, in order:
   1. The pristine snapshot has broken DNS — /etc/resolv.conf points at an unreachable
@@ -55,42 +75,10 @@ GOTCHAS, in order:
      reads "API unreachable" when this was skipped; this is the fix to name in the blocker.
 """
 
-[boxes.ct152-cpu-fresh]
-role = "fresh"
-ctid = 152
-hostname = "hal0-rc5-fresh-2604"
-ip = "10.0.1.152"
-os = "ubuntu 26.04"
-privileged = false
-gpu = false
-cores = 8
-ram_gb = 16
-snapshot = "none"
-api = "http://10.0.1.152:8080"
-auth_required = false
-notes = """
-Stand-in fresh box built for the rc.5 run, from `local:vztmpl/ubuntu-26.04-standard_26.04-1`
-rather than from a snapshot, because ct151's `pct rollback` wedged on a pool-wide ZFS
-`z_zrele` deadlock (every `zfs unmount` on rpool blocks; needs a hypervisor reboot to clear).
-Same profile as ct151-cpu-fresh: 26.04, unprivileged, CPU-only, 8c/16G/200G.
-GOTCHAS:
-  1. The PVE standard template ships WITHOUT curl — `curl | bash` fails with
-     "curl: command not found" before hal0 is reached. Install curl + ca-certificates first.
-  2. No GPU passthrough: the install needs HAL0_ALLOW_CPU_ONLY=1.
-  3. No NFS mount; rsync -L test models to /mnt/ai-models. NOTE: /mnt/ai-models is NOT in hal0's
-     model roots (`[models] roots = ["/var/lib/hal0/models"]`), so a staged gguf is invisible to
-     hal0 until a stateful lane runs `hal0 model add`. Read-only lanes must record this as
-     `skipped`, not `fail`.
-  4. STILL NO SNAPSHOT, and it is now carrying two runs of residue. Every stateful mutation is
-     permanent for the whole run — take a `pristine` snapshot immediately after the next clean
-     install, before any lane runs. Known residue after the rc.5 run: a `not-found/failed`
-     `hal0-slot@zzskeptic.service` job in `systemctl --failed`; an orphaned
-     /var/lib/hal0/models/zzbroken/zzbroken.gguf (2 MB of non-model bytes, handy as a
-     deliberately unloadable model); activity.db / hal0.db / .hermes carrying prior history, so
-     nothing may assert "no prior activity".
-  5. /proc/loadavg is not namespaced in this LXC — it reflects the hypervisor. Use %Cpu and
-     per-process CPU, never load average, when arguing about contention.
-"""
+# ct152-cpu-fresh (the CPU-only fresh box, no GPU passthrough) was DESTROYED 2026-08-21. There
+# is no other CPU-only fresh box in the fleet — ct151 is now the ONLY fresh-install box, and it
+# has GPU passthrough (no /dev/kfd). A CPU-only fresh install cannot currently be exercised at
+# all; note this explicitly in any report rather than silently dropping that coverage.
 
 [boxes.ct150-update]
 role = "update"
@@ -122,6 +110,29 @@ misread it as a regression (this happened in rc.6). #1845 (convergence panel rem
 Seed drift is expected box state, NOT a defect: agent.toml pins context_size = 4096 from an old
 seed — upgrades never reconcile slot seeds, which is why Hermes fails here for a DIFFERENT
 reason than on a fresh box (see #1827/#1867).
+
+rc.7 UPDATE-LANE ADDITION (#1959 B1, landed in the repin commit `8f23afba`): this box's slot
+TOMLs are the right place to prove the retag migration is not just fixed on paper. Before
+upgrading, record every slot's image pin under BOTH the legacy top-level/`[slot]` `image` key
+AND the newer `image_pin` key (`grep -n 'image_pin\\|^image' /var/lib/hal0/slots/*.toml`, plus
+any custom profile in `profiles.toml`) — `hal0 slot migrate-hw --apply` folds an old `image` pin
+into `image_pin` and drops the bare key, so a box that ran that migration carries `image_pin`
+only. `retag_stale_slot_images` (updater.py) now checks BOTH keys and, on a slot carrying both,
+binds `image_pin` FIRST — matching `_resolve_image_ref`'s own precedence, which no longer reads
+the bare key at all (the B1 fix's own review found and fixed a precedence mismatch here: the
+sweep originally judged the bare key while the resolver serves `image_pin`, so it could clear
+the WRONG value and leave the served pin stale behind the release replacing it). After the
+rc.6 -> rc.7 upgrade, every slot whose SERVED pin (image_pin if present, else image) exactly
+equalled a known former default must read the new `:0822` ref, and `image_pin` specifically
+(not just `image`) is the field to check first. Any pin that was NOT a stale former default (a
+deliberate operator override, a debug build) must be untouched under either key — the escape
+hatch is not a bug. See `regressions.yaml: updater-image-pin-retag-blind-spot`.
+
+rc.7 PERF-ROW REFERENCE: the #1948 §3-C matrix on this box (kfd present) measured the restored
+Vulkan lane FASTER than ROCm on both metrics — +13.96% prefill, +20.45% decode. This REPLACES
+the old ade07ba-era expectation ("Vulkan ~-10% decode vs ROCm") that earlier kit versions
+carried; do not flag a Vulkan-ahead-of-ROCm result as a regression, and treat the new numbers as
+the reference envelope for a >20% variance check on future releases.
 """
 
 [boxes.ct163-cpu-fresh]
@@ -166,20 +177,37 @@ Use it to answer "is this CPU-only or hardware-independent?", never "does a fres
 work?".
 """
 
-# Fleet coverage note (updated 2026-08-20 for the post-#1923 posture): ct151 has iGPU+NPU
-# passthrough but NO /dev/kfd, and the Vulkan LLM lane is RETIRED — on fresh installs its
-# gpu-rocm llama.cpp slots refuse to start (loud preflight), so ct151's LLM coverage is
-# device=cpu slots; its GPU passthrough still exercises non-llama Vulkan runtimes and the
-# refusal path itself. ct152-cpu-fresh (gpu=false, no /dev/dri) still exists and is CPU-only —
-# do not claim "no CPU-only box remains"; it has no snapshot and carries residue, so treat it
-# as read-only-usable only (stateful lanes must not run there without a fresh install first).
-# The actual remaining gap is a GPU fresh-install box WITH /dev/kfd: ct150/ct105 both have
-# /dev/kfd but are not fresh installs (update/prod) — no box in the fleet is both freshly
-# installed and representative of a bare-metal AMD host with amdkfd loaded, which is precisely
-# how the rc.6 Vulkan garbage-output defect survived undetected. Also: only prod (ct105) has
-# host rocm-smi, so compute_capable=true exists on exactly one box — capability-flag findings
-# need that cross-check. LLM slots run the ROCm lane where /dev/kfd is visible and REFUSE
-# elsewhere (no Vulkan fallback since #1923) — by DEFAULT: ENV_ALLOW_VULKAN_FALLBACK
-# downgrades the refusal to a warning, and since that env re-opens the exact #1888 failure
-# mode, its presence on any box is itself a finding. Record what a box's slots actually
-# execute (podman exec <slot ctr> ls /dev/kfd) in every preflight.
+# Fleet coverage note (updated 2026-08-21 for the rc.7 Vulkan-restoration fold, #1948, landed as
+# #1954 + #1973 + #1959): ct151 has iGPU+NPU passthrough but NO /dev/kfd, and it is once again
+# the fleet's PRIMARY Vulkan LLM lane box on a fresh install — it is also now the ONLY fresh
+# box in the fleet: ct152-cpu-fresh (the CPU-only fresh box) was DESTROYED 2026-08-21, so a
+# CPU-only fresh install cannot be exercised at all this release; say so plainly rather than
+# treating ct151 as interchangeable with it. `gpu-vulkan` llama.cpp slots on ct151's kfd-less AMD
+# render node are gated on an EXPLICIT ALLOWLIST, not a version/tag comparison and not retired
+# outright: `VULKAN_CAPABLE_IMAGE_REFS` (config/schema.py) names the specific image refs whose
+# Vulkan backend passed the #1948 §3-C matrix (currently just `VULKAN_FIXED_IMAGE`, the signed
+# `:0822` pin) — deliberately not "the pin or later", because Vulkan correctness was NOT
+# monotonic in build recency during the bisect (an older tree was correct, a newer one broken).
+# `require_kfd_for_gpu_slot`'s `gpu-vulkan` branch (providers/_gpu.py) checks this allowlist plus
+# render-node openability; it does not touch `/dev/kfd` at all on this path. Any image not in the
+# allowlist still REFUSES, loudly, naming #1888 — exactly as it did under #1923's retire-only
+# posture, just keyed on the image now instead of the device. `gpu-rocm` llama.cpp slots still
+# refuse everywhere without /dev/kfd — that gate is untouched by the fold. The remaining coverage
+# gap is a GPU fresh-install box WITH /dev/kfd: ct150/ct105 both have /dev/kfd but are not fresh
+# installs (update/prod) — no box in the fleet is both freshly installed and representative of a
+# bare-metal AMD host with amdkfd loaded, so ct151 (render-node-only) and ct150/ct105
+# (kfd-visible, ROCm-serving) remain the only two Vulkan-adjacent cross-checks available; use
+# ct150/ct105 to answer "does ROCm still work", never "does a fresh Vulkan-only install work".
+# Also: only prod (ct105) has host rocm-smi, so compute_capable=true exists on exactly one box —
+# capability-flag findings need that cross-check. #1922's output-sanity readiness gate (merged,
+# PR #1962, live on main) is the permanent net regardless of image or backend: no slot reaches
+# `ready` without passing the temp-0 "Paris" probe first, so a stale/broken image reaching this
+# box's Vulkan lane is a terminal `error`, never a silent `ready`. `ENV_ALLOW_VULKAN_FALLBACK`
+# (`HAL0_ALLOW_VULKAN_FALLBACK`) remains a finding wherever it is set: it downgrades BOTH
+# correctness refusals to a warning — missing `/dev/kfd` on the ROCm path, and an unvalidated
+# image on the restored Vulkan path — never the render-node check, which no env var can change.
+# Seeded slots still derive `gpu-rocm` first wherever `/dev/kfd` is usable (operator ruling —
+# ROCm stays the default despite the §3-C matrix measuring Vulkan faster, +13.96% prefill /
+# +20.45% decode); a seeded slot landing on `gpu-vulkan` on a kfd-PRESENT box is a finding, not a
+# pass. Record what a box's slots actually execute (podman exec <slot ctr> ls /dev/kfd; and, for
+# gpu-vulkan slots, the resolved runner image ref) in every preflight.

--- a/tests/release-validation/kit.toml
+++ b/tests/release-validation/kit.toml
@@ -4,7 +4,7 @@
 # scripts cannot read the filesystem, so when you add a lane here you must also add it to the
 # LANES table in the script. The brief itself is only ever read by the agent that runs it.
 
-kit_version = 7
+kit_version = 8
 
 [defaults]
 # Model tier per phase. Rationale in README "Phases".

--- a/tests/release-validation/lanes/readonly/api.md
+++ b/tests/release-validation/lanes/readonly/api.md
@@ -55,6 +55,22 @@ Probe the REST surface from the workstation with curl against `$API` (from `CONT
    a finding. A whole fleet reading `unknown` is a broken install
    even though no field is lying. Conversely, `unknown` where the seam is demonstrably healthy
    is itself a defect — the probe should have gotten an answer.
+   * **6c. Vulkan capabilities fan-out, restored (#1948, landed as #1973).** On an AMD box
+     (ct151, ct150), `GET /api/capabilities` must offer `gpu-vulkan` again as a valid device for
+     LLM/llama runtimes, not just the non-llama runtimes it was never removed for — cross-check
+     against `/api/hardware`'s `vulkan_capable` flag for the same box. This is confirmed
+     offer-not-promise, by source (`capabilities/catalog.py`'s llama.cpp fan-out): the picker
+     offers `gpu-vulkan` whenever the host advertises that backend at all (a usable render node
+     exists), with NO dependency on which runner image is installed. So a box that lacks the
+     signed `:0822`-or-later image (`VULKAN_CAPABLE_IMAGE_REFS` in `config/schema.py`) still
+     shows the row — the load-time gate (`slots.md` 8d) is what refuses, not the catalog. That
+     split (offered-but-refusable) is the shipped design, not a bug; only flag it if the
+     capability is offered nowhere at all on a box that should support it, or if it silently
+     drops to a different device with no error. Also confirm ordering: `gpu-rocm` is offered
+     BEFORE `gpu-vulkan` on a kfd-present AMD box (operator ruling — ROCm keeps the longer
+     validation history and MTP tuning as the default row, even though the §3-C matrix measured
+     Vulkan faster on both prefill and decode); a kfd-less box shows `gpu-vulkan` with no
+     `gpu-rocm` row at all.
 7. **Error shape.** Probe malformed requests: unknown slot name, bad query params, unknown model
    in a GET. Expect clean structured 4xx JSON. A 200 with zeroed data for a nonexistent resource
    is a finding.

--- a/tests/release-validation/lanes/stateful/slots.md
+++ b/tests/release-validation/lanes/stateful/slots.md
@@ -59,20 +59,59 @@ at the ends.
    ~180 s is by-design (`known-issues.yaml: crash-loop-warming-180s-window`) — the finding is a
    state that never converges, an empty message on `error`, or a death nothing surfaces in
    `hal0 status` / `hal0 doctor`. Then swap it to a good model and clean it up.
-   * **8b. Output-sanity gate fires (#1922).** The gate that answers rc.6's #1888 class
-     (garbage output behind green health). First confirm it exists and is wired into the ready
-     path: grep the installed tree for the readiness probe call site (slots/manager.py or
-     wherever it landed) and confirm it runs before a slot is marked `ready`, with the
-     temp-0 "The capital of France is" → "Paris" shape. Then, if a synthetic bad case can be
+   * **8b. Output-sanity gate fires (#1922) — now a shipped product gate, not a to-do.** #1922
+     merged as PR #1962 (main `b78b3ffc`) and is the permanent net under the rc.7 Vulkan
+     restoration (#1948): confirm it exists and is wired into the ready path — grep the
+     installed tree for the readiness probe call site (`slots/manager.py` or wherever it
+     landed) and confirm it runs before a slot is marked `ready`, with the temp-0 "The capital
+     of France is" -> "Paris" shape, on BOTH endpoints (timeouts land in a retryable `warming`
+     with a device-derived budget, not a silent pass). Then, if a synthetic bad case can be
      constructed on this box (a degenerate/non-instruct model file, or any still-existing
      explicit override onto a broken backend), load it and confirm the slot lands in `error`
      with a message naming the probe and the expected token — never `ready`, never a silent
      degrade, never an infinite retry. If no bad case can be forced on this box, say so
      explicitly and record it as a coverage gap rather than a pass — a healthy slot's canary
-     passing does NOT verify the gate. If the grep finds NO gate in the installed tree,
-     first check whether #1922 shipped in the release under test: if it did not, record
-     against the open #1922 rather than filing a duplicate; if it did, the missing call site
-     is its own finding.
+     passing does NOT verify the gate.
+
+   * **8c. gpu-vulkan LLM lane, restored — the positive case.** On this box (render node, no
+     /dev/kfd), assign a small chat model to a throwaway slot with `device=gpu-vulkan` and load
+     it. Preflight must PASS: `require_kfd_for_gpu_slot`'s `gpu-vulkan` branch
+     (`providers/_gpu.py`) delegates the `llama` runtime lane on an AMD host to
+     `_require_vulkan_lane_prerequisites`, which does NOT consult `/dev/kfd` at all — it checks
+     (1) `image_serves_vulkan_lane()`, membership of the slot's resolved image in the
+     `VULKAN_CAPABLE_IMAGE_REFS` allowlist (`config/schema.py`, currently just
+     `VULKAN_FIXED_IMAGE = ghcr.io/hal0ai/hal0-combined:0822`), and (2) `render_node_present()`
+     for the runner identity (uid 0, the rootful `hal0-slot@` container). Record the resolved
+     image ref (`systemctl cat hal0-slot@<slot> | grep '^Image='`) alongside the pass. The #1922
+     sanity gate (check 8b) must run and pass before `ready`. Confirm output is coherent past the
+     canary: a second, different prompt through the same slot's own port, not just the gate's
+     internal probe. Clean the slot up when done.
+
+   * **8d. gpu-vulkan LLM lane, negative case — a stale/broken image must be REFUSED at
+     preflight.** Force (or simulate, if the box cannot hold two runner images at once — say so
+     either way) a `gpu-vulkan` slot's resolved image onto a ref NOT in `VULKAN_CAPABLE_IMAGE_REFS`
+     (the outgoing `ghcr.io/hal0ai/hal0-rocmfpx:ade07ba` pin — a member of
+     `STALE_ROCMFPX_IMAGE_REFS` — is the concrete example, #1888's defect). Loading it must raise
+     `GpuPreflightError` from `_require_vulkan_lane_prerequisites`'s image gate (`providers/
+     _gpu.py`), citing #1888 by number and naming `VULKAN_FIXED_IMAGE` as the repin target —
+     confirm both appear in the CLI/API error text, not just the journal. This gate fires BEFORE
+     the render-node check, so a box with no render node at all still gets the image-specific
+     message when the image is also bad. Grep to confirm the call site:
+     `grep -n '_require_vulkan_lane_prerequisites\|image_serves_vulkan_lane' providers/_gpu.py`.
+
+   * **8e. The deliberately-garbage lane — THE single most important check of this release.**
+     `ENV_ALLOW_VULKAN_FALLBACK` (`HAL0_ALLOW_VULKAN_FALLBACK` in the environment) downgrades
+     BOTH correctness refusals in `require_kfd_for_gpu_slot` to a warning — missing `/dev/kfd` on
+     the ROCm path, and the 8d image-allowlist refusal on the restored Vulkan path — never the
+     render-node check, which is a passthrough fact no env var changes. Set it, force a
+     `gpu-vulkan` slot onto a stale/broken image (as in 8d) with a valid render node, and load.
+     Preflight now WARNS (`gpu_slot_vulkan_lane_unvalidated_image_allowed` in the journal) and
+     admits the load instead of refusing. The #1922 output-sanity gate (8b) MUST then convict it:
+     the slot lands in a terminal `error` naming the failed probe, NEVER `ready`, regardless of
+     the env override. This is the check that proves the permanent net actually holds even when
+     every earlier refusal in the chain has been deliberately defeated — if this one fails,
+     nothing else in this lane matters. Record the exact env/command combination used so it is
+     reproducible blind.
 9. **Reject a bad model file.** Feed `hal0 model add` a file with a `.gguf` name and no GGUF
    magic (`head -c 2000000 /dev/urandom`). The registration-with-warning outcome is now
    by-design (`known-issues: model-add-detection-surfacing`) — what you assert is the warning

--- a/tests/release-validation/lanes/stateful/slots.md
+++ b/tests/release-validation/lanes/stateful/slots.md
@@ -111,7 +111,10 @@ at the ends.
      the env override. This is the check that proves the permanent net actually holds even when
      every earlier refusal in the chain has been deliberately defeated — if this one fails,
      nothing else in this lane matters. Record the exact env/command combination used so it is
-     reproducible blind.
+     reproducible blind. Same honest-failure rule as 8b: if you cannot construct the fixture on
+     this box (no stale image in the store to force, or the override is refused for another
+     reason), say so explicitly and record it as a coverage gap rather than a pass — do not
+     invent a verdict for a check you could not run.
 9. **Reject a bad model file.** Feed `hal0 model add` a file with a `.gguf` name and no GGUF
    magic (`head -c 2000000 /dev/urandom`). The registration-with-warning outcome is now
    by-design (`known-issues: model-add-detection-surfacing`) — what you assert is the warning

--- a/tests/release-validation/lanes/update/upgrade.md
+++ b/tests/release-validation/lanes/update/upgrade.md
@@ -71,6 +71,27 @@ the fact otherwise:
    record the digest and signer identity.
 5. **Migrations.** Which migrations ran? Do they log what they changed? Re-run the upgrade (or
    the activation step) and confirm migrations are idempotent.
+   * **5b. The rc.7 image-pin retag (#1959 B1).** Before upgrading, record every slot's image
+     pin under BOTH the legacy `image` key AND the newer `image_pin` key
+     (`grep -n 'image_pin\|^image\b' /var/lib/hal0/slots/*.toml`, plus any custom entry in
+     `profiles.toml`) — `hal0 slot migrate-hw --apply` folds an old `image` pin into `image_pin`
+     and drops the bare key, so a box that ran that migration carries `image_pin` only. After
+     the upgrade, every SERVED pin (`image_pin` if present, else `image`) that exactly equalled
+     a known former default must read `ghcr.io/hal0ai/hal0-combined:0822`, with a matching
+     `updater.slot_image_retagged` journal line. On any slot carrying BOTH keys, confirm
+     `image_pin` — not `image` — is the one actually judged and rewritten (`_resolve_image_ref`
+     reads `image_pin` first and no longer reads the bare key at all; the retag sweep binds in
+     the same order after the B1 review's precedence fix). A pin that was a deliberate operator
+     override (not an exact former default, under either key) must be byte-identical before and
+     after. See `regressions.yaml: updater-image-pin-retag-blind-spot`.
+   * **5c. Perf-row reference envelope, now inverted.** If bench numbers are captured for this
+     upgrade (`hal0 bench` or the #1948 §3-C matrix commands), record decode/prefill for BOTH
+     `gpu-rocm` and `gpu-vulkan` on this box (kfd present, so both lanes are reachable — Vulkan
+     via `hal0 slot edit <slot> --hardware vulkan`). The reference envelope as of `:0822` is
+     Vulkan AHEAD of ROCm on both metrics (+13.96% prefill, +20.45% decode per #1948's matrix on
+     this box) — this REPLACES the old ade07ba-era expectation ("Vulkan ~-10% decode vs ROCm")
+     carried by earlier kit versions. A >20% variance from the new envelope, in either
+     direction, needs explanation; do not flag "Vulkan is faster than ROCm" as a regression.
 6. **Rollback.** `hal0 update --rollback`. Does it return the box to the previous version with
    its state intact? Then roll forward again. If rollback is not exercised here it is not
    exercised anywhere. (`updater.*` journal lines from the ROLLBACK path legitimately carry

--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -1553,7 +1553,7 @@ regressions:
     repro: |
       # Force (or simulate, if the box cannot hold two runner images at once — record which)
       # a gpu-vulkan slot's resolved image onto a ref NOT in VULKAN_CAPABLE_IMAGE_REFS:
-      hal0 slot edit <throwaway> --device gpu-vulkan --model <small chat model>
+      hal0 slot edit <throwaway> --hardware vulkan --model <small chat model>
       # ... with the slot's image_pin forced to a known-stale ref (e.g. ade07ba) ...
       hal0 slot load <throwaway>
       # Expect a preflight refusal (GpuPreflightError) naming #1888 and VULKAN_FIXED_IMAGE,

--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -947,39 +947,65 @@ regressions:
   # ── Filed from v1.0.0-rc.6 (mode=report — issue numbers pending) ────────────
 
   - id: brain-vulkan-backend-garbage-output
-    issue: 1888   # GA-blocker — filed by rc.6 fix wave
+    issue: 1888   # GA-blocker — filed by rc.6 fix wave; folded into the rc.7 Vulkan restoration
     from: v1.0.0-rc.6
     severity: ga-blocker
     tier: judgment
     lane: brain
+    rc7_note: >-
+      SUPERSEDED, not simply fixed. Between rc.6 and rc.7 the lane went RETIRED (#1923/#1934 —
+      gpu-rocm llama.cpp slots refuse to start without /dev/kfd, no CPU fallback, no Vulkan
+      lane offered at all) and is now RESTORED behind an explicit image allowlist (#1948,
+      operator decision 2026-08-21 "HOLD FOR FOLD", landed as three PRs: #1954 kfd identity by
+      runner uid + device gid `e5e5925a`, #1973 the lane re-enable itself `3474ec03`, #1959 the
+      repin to `ghcr.io/hal0ai/hal0-combined:0822` `8f23afba`). The image was bisected on real
+      hardware to a `ciru-ai/ROCmFPX` port-onto-newer-upstream defect (not hal0's build, driver,
+      gfx1151, or llama.cpp mainline — see #1948's evidence table), and #1922's output-sanity
+      readiness gate (merged PR #1962) now stands permanently under BOTH backends regardless of
+      which image is installed. The expectation below is REWRITTEN accordingly — it no longer
+      describes "the lane is retired, stay off it" but "the lane is back, serves coherent output
+      on the signed pin, and anything that reaches a stale/broken image is convicted by the gate
+      before READY, never silently." Also confirmed post-fold: seeded slots still derive
+      `gpu-rocm` first wherever `/dev/kfd` is usable (operator ruling — ROCm stays the picker's
+      default row despite the §3-C matrix measuring Vulkan faster, +13.96% prefill / +20.45%
+      decode); Vulkan is reached by explicit choice (`hal0 slot edit <slot> --hardware vulkan`)
+      or because no ROCm compute node exists at all.
     summary: >-
-      The Vulkan backend of the release-pinned runner image ghcr.io/hal0ai/hal0-rocmfpx:ade07ba
-      emits invalid tokens for EVERY model it serves, at full speed, while HTTP 200, container
+      The Vulkan backend of the then-pinned runner image ghcr.io/hal0ai/hal0-rocmfpx:ade07ba
+      emitted invalid tokens for EVERY model it served, at full speed, while HTTP 200, container
       health, `hal0 doctor` and tok/s all read green. llama.cpp picks ROCm when /dev/kfd is
       visible in the container and falls back to Vulkan otherwise; hal0 passes /dev/kfd only if
       it exists on the host (providers/_gpu.resolve_gpu_device_paths), so every box without
-      /dev/kfd runs the broken Vulkan lane. Consequences: slots seeded `device="gpu-vulkan"`
-      actually execute on ROCm wherever /dev/kfd exists (the advertised Vulkan lane has never
-      been exercised by validation), the install guide RECOMMENDS the broken lane for Strix
-      Halo, bench harness lane `vulkan_radv` pins `-dev Vulkan0` and benchmarks garbage, and no
-      layer between "container healthy" and "slot ready" validates output sanity. Workaround:
-      expose /dev/kfd to the box/container. Separately observed: the blessed FPX brain model has
-      no working CPU fallback (`-ngl 0` segfaults, exit 139).
+      /dev/kfd ran the broken Vulkan lane. Consequences at the time: slots seeded
+      `device="gpu-vulkan"` actually executed on ROCm wherever /dev/kfd existed (the advertised
+      Vulkan lane had never been exercised by validation), the install guide RECOMMENDED the
+      broken lane for Strix Halo, bench harness lane `vulkan_radv` pinned `-dev Vulkan0` and
+      benchmarked garbage, and no layer between "container healthy" and "slot ready" validated
+      output sanity. The FPX brain model's CPU fallback bug (`-ngl 0` segfaults, exit 139) is
+      unrelated and still open — do not fold it into this entry's verdict.
     repro: |
       # Coherence canary — run on every box, every release, against each serving llm slot port:
       curl -s -X POST http://127.0.0.1:<port>/completion \
         -d '{"prompt":"The capital of France is","n_predict":12,"temperature":0}'
-      # 'Paris' must appear. Do NOT key on the ')' garbage string — the garbage form varies
+      # 'Paris' must appear. Do NOT key on the ')' garbage string — the garbage form varied
       # with argv (--jinja slots emit ')' runs; bare /completion emits empty content).
       # A/B the backend on one box, identical argv except -dev:
-      #   -dev ROCm0   -> correct text        -dev Vulkan0 -> garbage
-      # /dev/kfd present in the slot container decides which lane actually runs:
+      #   -dev ROCm0   -> correct text        -dev Vulkan0 -> now also correct on :0822+
+      # /dev/kfd present in the slot container still decides which lane actually runs on a
+      # kfd-visible box; on a render-node-only box (ct151) Vulkan is now the only llama.cpp
+      # lane and must itself pass:
       podman exec hal0-slot-brain ls /dev/kfd
+      # Resolved runner image, to confirm which side of the version gate is being tested:
+      systemctl cat hal0-slot@brain | grep '^Image='
     expect: >-
       Temp-0 "The capital of France is" contains "Paris" on BOTH the ROCm and Vulkan lanes of
-      the pinned runner image, with an unrelated non-FPX gguf as a second sample. Until this is
-      fixed, every text-generation result from a box whose only llama.cpp device is Vulkan0 is
-      untrusted — gate every lane that elicits a completion on this canary first.
+      the signed `:0822`-or-later runner image, with an unrelated non-FPX gguf as a second
+      sample. A slot on an image BEFORE `:0822` (the outgoing `ade07ba` pin is the concrete
+      case) must be refused at preflight before it ever reaches a completion request — see
+      `lanes/stateful/slots.md` 8d. And the #1922 output-sanity gate must convict a slot that
+      somehow still reaches a broken backend (stale image + `ENV_ALLOW_VULKAN_FALLBACK`): a
+      terminal `error`, never `ready` — see `lanes/stateful/slots.md` 8e, the single most
+      important check of this release.
 
   - id: hermes-stream-no-stall-guard
     issue: 1893   # filed by rc.6 fix wave — residue of the hermes-cannot-chat candidate (dup of the garbage finding, merged into #1888)
@@ -1458,3 +1484,89 @@ regressions:
       leaking the upstream's raw 500. Still by-design (do not re-file) unless a CHAT-capable
       model is routed to a non-chat slot, the 500 occurs with embed OFFLINE, or /v1/models stops
       disclosing per-model labels/recipe — those clauses escalate per the known-issues entry.
+
+  # ── Filed from the rc.7 Vulkan-restoration fold (#1948, kit v8) ──────────────
+
+  - id: updater-image-pin-retag-blind-spot
+    issue: 1959   # repin PR (8f23afba) — includes the B1 image_pin retag fix + precedence fix
+    from: v1.0.0-rc.7
+    severity: major
+    tier: mechanical
+    lane: upgrade
+    promote_ready: true
+    summary: >-
+      `retag_stale_slot_images` (updater.py) rewrites a slot's stale former-default runner pin
+      on upgrade, but as of the rc.6 fix wave it only ever checked the legacy `image` /
+      `[slot].image` string. Slot TOMLs and custom `profiles.toml` entries can carry the SAME
+      pin under the newer, TYPED `image_pin` key (config/schema.py) instead — `hal0 slot
+      migrate-hw --apply` folds an old `image` pin into `image_pin` and drops the bare key
+      entirely — and that key was completely invisible to the retag: a folded slot pinned via
+      `image_pin` to a known former default (e.g. the outgoing `ade07ba` ref) survived an
+      rc.6 -> rc.7 upgrade untouched and kept running the broken pre-fold Vulkan backend after
+      the upgrade claimed to have fixed it. #1959's B1 fix (commit `8f23afba`) extends
+      `retag_stale_slot_images` to check both keys AND fixes a precedence bug the fix's own
+      review found: the sweep originally bound the bare `image` key first while
+      `_resolve_image_ref` (the function that decides what actually RUNS) reads `image_pin`
+      first and no longer reads the bare key at all — so on a slot carrying both, the sweep
+      could judge and clear a value the runtime never serves while the served pin stayed stale.
+      Precedence is now `image_pin` first, matching the resolver. A deliberate per-slot override
+      (a pin that is NOT exactly equal to a known former default) must still survive untouched
+      under either key — the escape hatch is not the bug.
+    repro: |
+      # On the update box, BEFORE upgrading: record every slot's pin under both keys.
+      grep -n 'image_pin\|^image\b' /var/lib/hal0/slots/*.toml
+      grep -n 'image_pin\|^image\b' /var/lib/hal0/profiles.toml 2>/dev/null
+      # Upgrade rc.6 -> rc.7, then re-check the same files:
+      grep -n 'image_pin\|^image\b' /var/lib/hal0/slots/*.toml
+      journalctl -u hal0-api --since <upgrade-start> | grep updater.slot_image_retagged
+      # On any slot carrying BOTH keys, confirm image_pin (not image) is the one the retag
+      # actually judged and rewrote — that is the precedence fix under test.
+    expect: >-
+      Every SERVED pin (image_pin if present, else image) that exactly equalled a known former
+      default before the upgrade reads the new `ghcr.io/hal0ai/hal0-combined:0822` ref after it,
+      with a matching `updater.slot_image_retagged` journal line. A pin that was a deliberate
+      override (not a known former default, under either key) is byte-identical before and
+      after. A pin held only in `image_pin` that matched a stale former default and did NOT get
+      retagged — or one where `image` got rewritten while a stale `image_pin` was left behind —
+      is the regression this entry exists to catch.
+
+  - id: vulkan-lane-stale-image-preflight-refusal
+    issue: 1973   # lane re-enable PR (3474ec03) — implements the checked gate
+    from: v1.0.0-rc.7
+    severity: ga-blocker
+    tier: judgment
+    lane: slots
+    summary: >-
+      Phase D of the rc.7 Vulkan restoration (#1948, landed as #1973) re-enables `gpu-vulkan`
+      llama.cpp slots on kfd-less AMD render nodes, gated on an EXPLICIT ALLOWLIST of runner
+      images: `VULKAN_CAPABLE_IMAGE_REFS` (config/schema.py), earned per-image by the #1948 §3-C
+      matrix, currently containing only `VULKAN_FIXED_IMAGE`
+      (`ghcr.io/hal0ai/hal0-combined:0822`). Deliberately NOT a version/tag ordering comparison
+      — the tags have no total order and Vulkan correctness was empirically NOT monotonic in
+      build recency during the bisect (an older tree was correct, a newer one broken). This
+      entry exists to catch the failure mode where that gate is missing, mis-scoped, or silently
+      bypassable — i.e. a stale/broken image (the outgoing `ade07ba` pin, a member of
+      `STALE_ROCMFPX_IMAGE_REFS`, is the concrete case, #1888) reaches a `gpu-vulkan` slot load
+      with no refusal at all, or the refusal fires on the wrong predicate (device class alone,
+      or a tag/date comparison that would wrongly refuse a later-added allowlist member or
+      wrongly admit a rolled-back one).
+    repro: |
+      # Force (or simulate, if the box cannot hold two runner images at once — record which)
+      # a gpu-vulkan slot's resolved image onto a ref NOT in VULKAN_CAPABLE_IMAGE_REFS:
+      hal0 slot edit <throwaway> --device gpu-vulkan --model <small chat model>
+      # ... with the slot's image_pin forced to a known-stale ref (e.g. ade07ba) ...
+      hal0 slot load <throwaway>
+      # Expect a preflight refusal (GpuPreflightError) naming #1888 and VULKAN_FIXED_IMAGE,
+      # raised from _require_vulkan_lane_prerequisites's image gate — BEFORE the render-node
+      # check, so it fires even on a box with no render node at all:
+      grep -n '_require_vulkan_lane_prerequisites\|image_serves_vulkan_lane\|VULKAN_CAPABLE_IMAGE_REFS' \
+        /usr/lib/hal0/venv/lib/python3*/site-packages/hal0/providers/_gpu.py \
+        /usr/lib/hal0/venv/lib/python3*/site-packages/hal0/config/schema.py
+    expect: >-
+      Loading a `gpu-vulkan` llama.cpp slot whose resolved image is not in
+      `VULKAN_CAPABLE_IMAGE_REFS` is refused at preflight, loudly, naming #1888 and
+      `VULKAN_FIXED_IMAGE` as the repin target — never a silent load onto the broken backend,
+      and never merely a warning unless `ENV_ALLOW_VULKAN_FALLBACK`
+      (`HAL0_ALLOW_VULKAN_FALLBACK`) is explicitly set (in which case the #1922 output-sanity
+      gate, not this preflight check, is what must convict the resulting garbage — see
+      `brain-vulkan-backend-garbage-output` and `lanes/stateful/slots.md` 8e).


### PR DESCRIPTION
## Summary

Kit v8 finalizes release-validation coverage for the rc.7 Vulkan-restoration fold (#1948) against the LANDED fold chain — this PR was originally drafted (as kit v6) in parallel with the lane re-enable PR; it has now been rebased onto current `main` and every provisional marker resolved against real merged code:

- **#1954** — kfd identity by runner uid + device gid (`e5e5925a`)
- **#1973** — `gpu-vulkan` LLM lane re-enable behind an explicit image allowlist (`3474ec03`)
- **#1959** — repin to `ghcr.io/hal0ai/hal0-combined:0822` + the B1 `image_pin` retag fix (`8f23afba`)

Also composed with kit v6/v7's `image_status` tri-state work (#1968, #1980) that landed on `main` in the meantime, rather than duplicated.

### What's covered

- `boxes.toml`: ct151 is the fleet's PRIMARY Vulkan LLM lane box again (render node, no /dev/kfd), with the real gate mechanics named — `VULKAN_CAPABLE_IMAGE_REFS`, an explicit per-image allowlist earned by the #1948 §3-C matrix, NOT a tag/version comparison (Vulkan correctness was not monotonic in build recency). `[boxes.ct152-cpu-fresh]` REMOVED — the box was destroyed 2026-08-21; there is now no CPU-only fresh box in the fleet at all, stated plainly. ct150 update-box note gains the `image_pin` retag + precedence verification and the perf-row reference (Vulkan now measures AHEAD of ROCm, +13.96% prefill / +20.45% decode — replacing the old ade07ba-era "-10%" expectation).
- `lanes/stateful/slots.md`: Vulkan check set 8b-8e, finalized against `require_kfd_for_gpu_slot`'s `gpu-vulkan` branch and `_require_vulkan_lane_prerequisites` (`providers/_gpu.py`) by name — 8b (the #1922 gate, shipped), 8c (positive load, gates named), 8d (negative case — stale image refused, citing #1888 + `VULKAN_FIXED_IMAGE`), 8e (the deliberately-garbage lane: stale image + `ENV_ALLOW_VULKAN_FALLBACK`, the #1922 gate must convict it — called out as the single most important check of the release).
- `lanes/readonly/api.md`: 6c finalized — the capabilities catalog OFFERS `gpu-vulkan` without gating on image version (confirmed by source: "the picker is an OFFER, not a promise"), refusal happens at slot load.
- `lanes/update/upgrade.md`: new checks 5b (image_pin retag + precedence, #1959 B1) and 5c (the inverted perf-row reference envelope).
- `regressions.yaml`: `brain-vulkan-backend-garbage-output` gets a finalized `rc7_note` naming all three landed PRs; two new entries — `updater-image-pin-retag-blind-spot` (issue #1959) and `vulkan-lane-stale-image-preflight-refusal` (issue #1973, filled in from the earlier `issue: null` placeholder).
- `README.md`: kit changelog rewritten as v8, composed alongside (not replacing) the intervening v6/v7 entries. `kit.toml` bumped to `kit_version = 8`.
- `.claude/workflows/rc-validate.js`: verify-prompt fleet note (unchanged from the draft, already correct); `BOX_ROLES` map drops the dead `ct152-cpu-fresh` entry to match `boxes.toml`.

All five original `FINALIZE-AFTER-PHASE-D` markers are resolved — none remain live in the kit files.

## Test plan

- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/release -q` — 112 passed (workflow-contract + kit-contract tests, which pin `kit.toml [defaults]` against the script's model pins).
- [x] `node --check .claude/workflows/rc-validate.js`
- [x] `uv run ruff check tests/release-validation tests/release .claude/workflows` — all checks passed.
- [x] `regressions.yaml` / `boxes.toml` / `kit.toml` parse clean (47 regression entries, 4 boxes, `kit_version = 8`).

Refs #1948.