### PR TITLE
fix(ui): collapse bank activity pills into spinner + graph-card task list

### DIFF
--- a/ui/src/dash/agents/memory-tab.jsx
+++ b/ui/src/dash/agents/memory-tab.jsx
@@ -81,6 +81,61 @@ function MemoryTab({ subsection } = {}) { // eslint-disable-line no-unused-vars
   );
 }
 
+// ── Active extraction tasks (per bank) ───────────────────────────────
+//
+// Detailed live view of every bank's in-flight operations, rendered
+// below the Built/Errors/Live stat grid in the graph-extraction card.
+// Bank cards themselves only carry a small spinner + count; this list
+// is where the operator sees WHAT is running WHERE. One row per bank
+// with work in flight: spinner, bank id, and in-flight task types
+// grouped with counts (e.g. "extraction ×18 · consolidation ×1").
+function GraphBankTasksRow({ bank }) {
+  const useBankOperations = window.__hal0UseBankOperations;
+  const summarize = window.__hal0MemSummarizeOps;
+  const q = useBankOperations ? useBankOperations(bank) : { data: null };
+  if (!q.data || !summarize) return null;
+  const a = summarize(q.data);
+  if (a.inFlight === 0) return null;
+  const inFlightOps = (q.data.operations || []).filter(
+    (o) => o.status === "pending" || o.status === "processing",
+  );
+  const byType = {};
+  for (const o of inFlightOps) byType[o.task_type || "unknown"] = (byType[o.task_type || "unknown"] || 0) + 1;
+  const detail = Object.entries(byType)
+    .map(([t, n]) => (n > 1 ? `${t} ×${n}` : t))
+    .join(" · ");
+  return (
+    <div className="graph-task-row" data-testid={`graph-task-row-${bank}`}>
+      <span className="mem-spin" aria-hidden="true" />
+      <span className="mono graph-task-bank">{bank}</span>
+      <span className="mono graph-task-detail" title={`${a.processing} processing · ${a.pending} pending`}>
+        {detail}
+      </span>
+      <span className="mono graph-task-counts num">
+        {a.processing > 0 && <span className="graph-task-proc">{a.processing} active</span>}
+        {a.pending > 0 && <span className="graph-task-pend">{a.pending} queued</span>}
+      </span>
+    </div>
+  );
+}
+
+function GraphActiveTasks() {
+  const useMemoryBanks = window.__hal0UseMemoryBanks;
+  const banksQuery = useMemoryBanks ? useMemoryBanks() : { data: null };
+  const banks = (banksQuery.data && banksQuery.data.banks) || [];
+  if (banks.length === 0) return null;
+  return (
+    <div className="graph-tasks" data-testid="graph-active-tasks">
+      <div className="mono graph-tasks-h">Active tasks</div>
+      {banks.map((b) => (
+        <GraphBankTasksRow key={b.bank_id} bank={b.bank_id} />
+      ))}
+      {/* Hidden via CSS :has() whenever at least one task row renders. */}
+      <div className="mono graph-tasks-quiet">no active tasks</div>
+    </div>
+  );
+}
+
 // ── ADR-0023 Graph extraction panel ──────────────────────────────────
 // Extraction is routed to a single local enabled-llm slot (extraction_slot).
 function MemoryGraphPanel() {
@@ -197,6 +252,7 @@ function MemoryGraphPanel() {
               </div>
             ))}
           </div>
+          <GraphActiveTasks />
           {lastBuilt && (
             <div className="mono" style={{fontSize: 11, color: "var(--fg-4)", marginBottom: 10}}>
               Last build: {lastBuilt}

--- a/ui/src/dash/memory-overhaul.css
+++ b/ui/src/dash/memory-overhaul.css
@@ -313,6 +313,25 @@
 .mem-failed-h { font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--fg-4); margin-bottom: 2px; }
 .mem-failed-row { font-size: 11px; color: var(--err); }
 
+/* Compact bank-card activity — a single spinner + in-flight count beside the
+   bank name (the full breakdown lives in the tooltip and in the
+   graph-extraction card's active-tasks list). */
+.mem-act-inline { flex-wrap: nowrap; gap: 6px; }
+.mem-act-inline .mem-spin { width: 10px; height: 10px; }
+.mem-act-inline-n { font-size: 10.5px; color: var(--accent); }
+
+/* Graph-extraction card — per-bank active tasks (below the stat grid). */
+.graph-tasks { display: flex; flex-direction: column; gap: 7px; border: 1px solid var(--line); border-radius: var(--rad); padding: 10px 12px; margin-bottom: 12px; }
+.graph-tasks-h { font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.08em; }
+.graph-task-row { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.graph-task-bank { font-size: 12px; font-weight: 500; color: var(--fg); flex-shrink: 0; }
+.graph-task-detail { flex: 1; min-width: 0; font-size: 11px; color: var(--fg-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.graph-task-counts { display: inline-flex; gap: 8px; font-size: 10.5px; flex-shrink: 0; }
+.graph-task-proc { color: var(--accent); }
+.graph-task-pend { color: var(--warn); }
+.graph-tasks-quiet { font-size: 11px; color: var(--fg-5); }
+.graph-tasks:has(.graph-task-row) .graph-tasks-quiet { display: none; }
+
 /* Spinner — self-contained (no cross-file keyframe dependency). */
 .mem-spin { width: 11px; height: 11px; border: 1.5px solid var(--line-strong); border-top-color: var(--accent); border-radius: 50%; animation: mem-spin 0.7s linear infinite; flex-shrink: 0; }
 @keyframes mem-spin { to { transform: rotate(360deg); } }

--- a/ui/src/dash/memory.jsx
+++ b/ui/src/dash/memory.jsx
@@ -327,10 +327,12 @@ function MemTimeseries({ bank, period, setPeriod }) {
 //
 // Polls GET /api/memory/banks/{bank}/operations via the shared, adaptive
 // useBankOperations query (fast while work is in flight, backing off when
-// idle) so the operator can SEE what's happening and WHERE. Renders a spinner
-// "N working" badge while pending+processing > 0, plus pending/processing/
-// completed/failed counts. Failed count is a button that reveals the failed
-// operation types (affordance for "extraction failed, roughly why").
+// idle) so the operator can SEE what's happening and WHERE. Full mode renders
+// a spinner "N working" badge while pending+processing > 0, plus pending/
+// processing/completed/failed counts; compact mode (bank cards) collapses to
+// a spinner + in-flight count with the breakdown in the tooltip. In both, the
+// failed count is a button that reveals the failed operation types
+// (affordance for "extraction failed, roughly why").
 function MemBankActivity({ bank, active = true, compact = false }) {
   const useBankOperations = window.__hal0UseBankOperations;
   const summarize = window.__hal0MemSummarizeOps;
@@ -351,6 +353,51 @@ function MemBankActivity({ bank, active = true, compact = false }) {
     setShowFailed(v => !v);
   }
 
+  // Compact (bank-card) mode: one small spinner + in-flight count beside the
+  // bank name. The full pending/processing breakdown lives in the tooltip and
+  // in the graph-extraction sidebar's active-tasks list; failed ops keep
+  // their clickable red affordance — they need attention even at a glance.
+  if (compact) {
+    if (a.inFlight === 0 && a.failed === 0) return null;
+    const parts = [];
+    if (a.processing > 0) parts.push(`${a.processing} processing`);
+    if (a.pending > 0) parts.push(`${a.pending} pending`);
+    if (a.failed > 0) parts.push(`${a.failed} failed`);
+    return (
+      <span className="mem-activity mem-act-inline mono" data-testid={`mem-activity-${bank}`} title={parts.join(' · ')}>
+        {a.inFlight > 0 && (
+          <>
+            <span className="mem-spin" aria-hidden="true" />
+            <span className="mem-act-inline-n num">{a.inFlight}</span>
+          </>
+        )}
+        {a.failed > 0 && (
+          <button
+            type="button"
+            className={'mem-act-chip failed' + (showFailed ? ' open' : '')}
+            onClick={toggleFailed}
+            title="failed operations — click to see which"
+            data-testid={`mem-failed-${bank}`}
+          >
+            {a.failed} failed
+          </button>
+        )}
+        {showFailed && a.failed > 0 && (
+          <span
+            className="mem-failed-pop mono"
+            data-testid={`mem-failed-pop-${bank}`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <span className="mem-failed-h">failed operations</span>
+            {a.failedTypes.map((t, i) => (
+              <span key={i} className="mem-failed-row">{t}</span>
+            ))}
+          </span>
+        )}
+      </span>
+    );
+  }
+
   return (
     <span className="mem-activity mono" data-testid={`mem-activity-${bank}`}>
       {a.inFlight > 0 && (
@@ -361,7 +408,7 @@ function MemBankActivity({ bank, active = true, compact = false }) {
       )}
       {a.processing > 0 && <span className="mem-act-chip proc" title="processing">{a.processing} proc</span>}
       {a.pending > 0 && <span className="mem-act-chip pend" title="queued / pending">{a.pending} pending</span>}
-      {!compact && a.completed > 0 && (
+      {a.completed > 0 && (
         <span className="mem-act-chip done" title="completed">{a.completed} done</span>
       )}
       {a.failed > 0 && (

--- a/ui/tests/e2e/specs/memory-view-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-view-v3.spec.ts
@@ -193,10 +193,11 @@ test.describe('Memory view — Hindsight surface', () => {
     await expect(primary).toContainText('world')
     await expect(primary).toContainText('experience')
     await expect(primary).toContainText('observation')
-    // primary has a pending op in flight → live spinner "working" badge + a
-    // pending activity chip (driven by /operations, not stats).
-    await expect(primary.locator('.mem-act-badge.working')).toBeVisible()
-    await expect(primary.locator('.mem-act-chip.pend')).toContainText('pending')
+    // primary has a pending op in flight → compact spinner + in-flight count
+    // beside the bank name (driven by /operations, not stats); the full
+    // breakdown lives in the graph-extraction card's active-tasks list.
+    await expect(primary.locator('.mem-act-inline .mem-spin')).toBeVisible()
+    await expect(primary.locator('.mem-act-inline-n')).toContainText('1')
 
     // ingest bank carries a failed op → a red failed affordance that reveals
     // the failed operation type(s) on click.


### PR DESCRIPTION
## What
Memory-page bank cards stacked working/proc/pending pills around the bank name, wrapping awkwardly. Compact mode now renders a single small spinner + in-flight count beside the bank name (breakdown in the tooltip; failed ops keep their clickable red affordance + popover).

The detailed view moves into the graph-extraction sidebar card: a new **Active tasks** section below the Built/Errors/Live grid lists every bank with in-flight work — spinner, bank id, task types grouped with counts (e.g. `extraction ×18 · consolidation ×1`), and active/queued totals. Idle state shows a quiet 'no active tasks' line via a CSS :has() rule. Reuses the existing shared per-bank operations poll — no extra request load.

## Why
Operator UI/UX pass on the memory dashboard: the pill cluster was visually noisy and hid the per-bank detail.

## Verified
- eslint + vite build clean
- `memory-view-v3.spec.ts` updated to pin the compact indicator; all memory e2e specs pass (52 passed, 3 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)