### PR TITLE
fix(ui): footer slot pips show only active slots with slot-card dot colors

### DIFF
--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -14,6 +14,7 @@ import { useMemoryEnabled } from '@/api/hooks/useMemory'
 import { useUpdateState, useSlotDrift, useRestartDriftedSlots } from '@/api/hooks/useUpdates'
 import { useApprovalList, useApproveApproval, useDenyApproval } from '@/api/hooks/useAgents'
 import { useServicesHealth } from '@/api/hooks/useServicesHealth'
+import { slotIndicatorFromPhase } from './slot-status.js'
 import { useConfigUrls } from '@/api/hooks/useConfigUrls'
 import { useNotifications, hal0Notify, dismissNotifMessage, NOTIF_KIND_HUE } from './notifications.jsx'
 
@@ -719,14 +720,8 @@ const _shortTs = (ts) => {
   return m ? (m[2] ? `${m[1]}.${m[2]}` : m[1]) : String(ts ?? '');
 };
 
-// A slot's LED tone for the `runtimes` group: green ready · amber warming ·
-// grey offline. Mirrors useRuntimeRollup's readiness rule.
-const _slotPip = (s) => {
-  const st = String(s?.state ?? '').toLowerCase();
-  if (s?.container_status === 'running' || ['ready', 'serving', 'idle'].includes(st)) return 'ok';
-  if (['warming', 'starting', 'loading', 'connecting'].includes(st)) return 'warm';
-  return 'off';
-};
+// Slot pips reuse slotIndicatorFromPhase (slot-status.js) so the footer
+// matches the slot-card indicator dots exactly — no parallel vocabulary.
 // A service indicator's tone (up/warn/err) → LED tone (ok/warm/err).
 const _svcPip = (tone) => (tone === 'up' ? 'ok' : tone === 'warn' ? 'warm' : 'err');
 
@@ -855,9 +850,15 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
           title: s.detail || `${s.name || s.id} down`,
         }))),
   ];
-  // runtimes group — one LED pip per CONFIGURED slot (a model bound is what
-  // makes a slot real, #1369), plus the ready count.
+  // slots group — one LED pip per ACTIVE configured slot (a model bound is
+  // what makes a slot real, #1369). Stopped slots render no pip — the ready
+  // count already says how many of the total are up. Pip colours mirror the
+  // slot-card indicator dot exactly (slotIndicatorFromPhase: serving green
+  // pulse · ready yellow · warming amber pulse · error red).
   const configuredSlots = (useSlots().data || []).filter((s) => !!(s.model || s.model_default));
+  const slotPips = configuredSlots
+    .map((s) => ({ slot: s, ind: slotIndicatorFromPhase(s) }))
+    .filter(({ ind }) => ind.cls !== 'offline');
   const servicesReady = footerIndicators.filter((s) => s.tone === 'up').length;
 
   return (
@@ -989,15 +990,20 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
         </>
       )}
       <div className="foot-chips">
-        {/* runtimes — one LED pip per enabled slot + ready count */}
+        {/* slots — one LED pip per ACTIVE slot (stopped slots hidden) + ready
+            count; pip colours mirror the slot-card indicator dots */}
         <div className="foot-health" data-testid="foot-health-runtimes" title={runtimeTitle}>
           <span className="pips" aria-hidden="true">
-            {configuredSlots.map((s, i) => (
-              <span key={s.name ?? i} className={"pip " + _slotPip(s)} />
+            {slotPips.map(({ slot: s, ind }, i) => (
+              <span
+                key={s.name ?? i}
+                className={"pip " + ind.cls}
+                title={`${s.name ?? "slot"} — ${ind.label}`}
+              />
             ))}
           </span>
           <span className="lbl">
-            <span className="k">runtimes</span>
+            <span className="k">slots</span>
             <span className={"v" + (L.ready < L.total ? " warn" : "")}>
               <b>{L.ready} / {L.total}</b> ready
             </span>

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -772,6 +772,16 @@ a { color: inherit; text-decoration: none; }
 .foot-health .pip.warm { background: var(--warn); border-color: transparent; box-shadow: 0 0 6px var(--warn); animation: pulse 1.5s var(--ease) infinite; }
 .foot-health .pip.err { background: var(--err); border-color: transparent; box-shadow: 0 0 6px var(--err); }
 .foot-health .pip.off { background: var(--bg-4); border-color: var(--line-strong); }
+/* Slot pips mirror the slot-card indicator dot vocabulary
+   (slotIndicatorFromPhase): serving green pulse · stale/ready yellow ·
+   warming amber pulse · error red. Stopped slots render no pip at all. */
+.foot-health .pip.serving { background: var(--ok); border-color: transparent; box-shadow: 0 0 6px var(--ok); animation: pulse 1.2s ease-in-out infinite; }
+.foot-health .pip.stale { background: var(--warn); border-color: transparent; box-shadow: 0 0 6px rgba(232, 185, 78, 0.45); }
+.foot-health .pip.warming { background: var(--warn); border-color: transparent; box-shadow: 0 0 6px var(--warn); animation: pulse 1.2s ease-in-out infinite; }
+.foot-health .pip.error { background: var(--err); border-color: transparent; box-shadow: 0 0 6px var(--err); }
+@media (prefers-reduced-motion: reduce) {
+  .foot-health .pip.serving, .foot-health .pip.warming { animation: none; }
+}
 .foot-health .lbl { display: inline-flex; flex-direction: column; gap: 1px; line-height: 1.15; }
 .foot-health .lbl .k { font-size: 9px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-5); }
 .foot-health .lbl .v { font-size: 11.5px; color: var(--fg-2); }

--- a/ui/tests/e2e/specs/footer-chips-v3.spec.ts
+++ b/ui/tests/e2e/specs/footer-chips-v3.spec.ts
@@ -23,11 +23,12 @@ test.describe('Footer runtime chip reflects container readiness (#221)', () => {
 
     const runtimes = footer.locator('[data-testid="foot-health-runtimes"]')
     await expect(runtimes).toBeVisible()
-    // HAL0_DATA seeds 8 model-bound slots (legacy has no model, #1369); all ready
-    // → "8 / 8 ready", all LED pips lit green.
+    // HAL0_DATA seeds 8 model-bound slots (legacy has no model, #1369); all
+    // active → "8 / 8 ready" with one pip per ACTIVE slot, coloured by the
+    // slot-card indicator vocabulary (serving/stale) — never the old ok/off.
     await expect(runtimes.locator('.lbl .v')).toContainText('8 / 8 ready')
-    await expect(runtimes.locator('.pip.ok')).toHaveCount(8)
-    await expect(runtimes.locator('.pip.off')).toHaveCount(0)
+    await expect(runtimes.locator('.pip')).toHaveCount(8)
+    await expect(runtimes.locator('.pip.serving, .pip.stale')).toHaveCount(8)
   })
 
   test('runtime chip counts drop when containers stop', async ({ page }) => {
@@ -54,7 +55,8 @@ test.describe('Footer runtime chip reflects container readiness (#221)', () => {
 
     const runtimes = footer.locator('[data-testid="foot-health-runtimes"]')
     await expect(runtimes).toBeVisible()
+    // Stopped slots render NO pip — the count line alone carries the total.
     await expect(runtimes.locator('.lbl .v')).toContainText('0 / 8 ready')
-    await expect(runtimes.locator('.pip.off')).toHaveCount(8)
+    await expect(runtimes.locator('.pip')).toHaveCount(0)
   })
 })


### PR DESCRIPTION
## What
The footer 'runtimes' LED group rendered a grey pip for every configured slot and used its own ad-hoc ok/warm/off palette. Renamed the group to **slots**, dropped the parallel `_slotPip` classifier, and drove each pip from `slotIndicatorFromPhase` — the same single source of truth as the slot-card indicator dots (serving green pulse · ready yellow · warming amber pulse · error red). Stopped slots render no pip at all; the ready/total count line still carries fleet size. Each pip gains a name+state tooltip.

## Why
Operator report: the footer strip was really showing slots (not runtimes), a mostly-stopped fleet read as a wall of dead dots, and pip colors diverged from the slot cards.

## Verified
- eslint + vite build clean
- `footer-chips-v3.spec.ts` updated (active-only pips, indicator classes); footer e2e specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)