### PR TITLE
fix(slots): make card tok/s and ctx metrics live for non-streaming traffic

### DIFF
--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -916,7 +916,11 @@ async def slot_metrics(request: Request) -> dict[str, Any]:
     from hal0.api.routes.hardware import stats_slots
 
     merged = await stats_slots(request)
-    for name, tps in _per_slot_local_tps(request).items():
+    # 30s lookback (not the 5s streaming default): non-streaming callers
+    # land one event per completed request, often tens of seconds apart —
+    # a 5s window made their tok/s flash briefly then read 0 between
+    # requests even while the slot was visibly working.
+    for name, tps in _per_slot_local_tps(request, window_s=30.0).items():
         if tps <= 0:
             continue
         entry = merged.get(name)

--- a/src/hal0/slots/metrics_collect.py
+++ b/src/hal0/slots/metrics_collect.py
@@ -60,6 +60,15 @@ def tps_from_events(events: Any, window_s: float = 5.0) -> float:
     than ``tokens / window_s`` so short bursts read at their real rate
     instead of being smeared across the full lookback. Decays to 0 once
     all events age out.
+
+    A single in-window event still yields a rate (smeared across the
+    window). Non-streaming completions land as ONE event carrying the
+    whole ``usage.completion_tokens`` count, so the old ``< 2 → 0.0``
+    guard meant a slot doing steady non-streaming work (graph
+    extraction, embeddings callers, curl scripts) read 0 tok/s forever
+    while /api/stats/throughput/history — which buckets the same store
+    — showed real throughput. Smearing matches the history endpoint's
+    tokens-per-bucket semantics.
     """
     import time
 
@@ -67,8 +76,10 @@ def tps_from_events(events: Any, window_s: float = 5.0) -> float:
         return 0.0
     now = time.monotonic()
     in_window = [(ts, tok) for ts, tok in events if now - ts <= window_s]
-    if len(in_window) < 2:
+    if not in_window:
         return 0.0
+    if len(in_window) == 1:
+        return in_window[0][1] / window_s
     total_tokens = sum(tok for _, tok in in_window)
     span = in_window[-1][0] - in_window[0][0]
     # Bias slightly toward the window so a stale-but-recent burst still
@@ -242,18 +253,17 @@ async def llama_metrics(port: int) -> dict[str, Any]:
             except (ValueError, TypeError):
                 continue
 
-    # --- /slots: KV-cache % via max(n_prompt_tokens)/n_ctx. -------------
+    # --- /slots: context occupancy + synthesised KV-cache %. -------------
     #
     # Newer llama-server (post-server.cpp refactor, b9000-ish onward)
     # exposes ``n_prompt_tokens`` per parallel sub-slot when busy, plus
     # ``n_ctx`` always. Older builds only return id/n_ctx/is_processing,
-    # in which case the max is 0 and we skip the synthesised gauge so
-    # the UI renders '—' rather than a misleading 0%.
-    if (
-        "kv_cache_usage" not in out
-        and not isinstance(slots_resp, BaseException)
-        and getattr(slots_resp, "status_code", 0) == 200
-    ):
+    # in which case the max is 0 and we skip both derived values so the
+    # UI renders '—' rather than a misleading 0. Parsed unconditionally
+    # (not only as a kv fallback): ``ctx`` — the fullest sub-slot's used
+    # tokens — feeds the card's "used / max" context readout, which sat
+    # permanently at '—' because nothing ever produced the key.
+    if not isinstance(slots_resp, BaseException) and getattr(slots_resp, "status_code", 0) == 200:
         try:
             payload = slots_resp.json()
         except (ValueError, TypeError):
@@ -286,7 +296,9 @@ async def llama_metrics(port: int) -> dict[str, Any]:
                         used = iv
                 if used > max_used:
                     max_used = used
-            if n_ctx > 0 and max_used > 0:
+            if max_used > 0:
+                out["ctx"] = max_used
+            if n_ctx > 0 and max_used > 0 and "kv_cache_usage" not in out:
                 ratio = max_used / float(n_ctx)
                 # Clamp — n_prompt_tokens can briefly exceed n_ctx during
                 # shift; surfacing >1.0 would look broken in the UI.
@@ -420,6 +432,8 @@ async def collect_local(sm: Any) -> dict[str, dict[str, Any]]:
                 out["requests_deferred"] = int(llm_metrics["requests_deferred"])
             if "kv_cache_usage" in llm_metrics:
                 out["kv_cache_usage"] = float(llm_metrics["kv_cache_usage"])
+            if "ctx" in llm_metrics:
+                out["ctx"] = int(llm_metrics["ctx"])
         return slot.name, out
 
     pairs = await asyncio.gather(*(_one(s) for s in slots), return_exceptions=True)

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -1544,6 +1544,72 @@ async def test_scrape_llama_metrics_clamps_overrun(
 
 
 @pytest.mark.asyncio
+async def test_scrape_llama_metrics_surfaces_ctx_used(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fullest sub-slot's used tokens surface as ``ctx`` so the card's
+    "used / max" context readout gets a live numerator (it read '—'
+    forever because nothing produced the key)."""
+    from hal0.api.routes.slots import _scrape_llama_metrics
+
+    metrics_text = "llamacpp:requests_processing 1\n"
+    slots_json = [
+        {"id": 0, "n_ctx": 4096, "n_prompt_tokens": 512},
+        {"id": 1, "n_ctx": 4096, "n_prompt_tokens": 2048},
+    ]
+    _patch_httpx(
+        monkeypatch,
+        _StubResponse(text=metrics_text),
+        _StubResponse(json_data=slots_json),
+    )
+
+    out = await _scrape_llama_metrics(8081)
+    assert out["ctx"] == 2048
+
+
+@pytest.mark.asyncio
+async def test_scrape_llama_metrics_omits_ctx_when_idle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Idle /slots payload leaves ``ctx`` absent — the UI renders '—',
+    not a fabricated 0."""
+    from hal0.api.routes.slots import _scrape_llama_metrics
+
+    metrics_text = "llamacpp:requests_processing 0\n"
+    slots_json = [{"id": 0, "n_ctx": 4096, "is_processing": False}]
+    _patch_httpx(
+        monkeypatch,
+        _StubResponse(text=metrics_text),
+        _StubResponse(json_data=slots_json),
+    )
+
+    out = await _scrape_llama_metrics(8081)
+    assert "ctx" not in out
+
+
+def test_tps_from_events_single_event_smears_over_window() -> None:
+    """One in-window event (a non-streaming completion's whole token count)
+    yields tokens/window_s instead of 0 — steady non-streaming traffic
+    used to read 0 tok/s forever while the history endpoint showed real
+    throughput from the same store."""
+    import time
+
+    from hal0.slots.metrics_collect import tps_from_events
+
+    now = time.monotonic()
+    assert tps_from_events([(now - 1.0, 600)], window_s=30.0) == pytest.approx(20.0)
+
+
+def test_tps_from_events_all_aged_out_decays_to_zero() -> None:
+    import time
+
+    from hal0.slots.metrics_collect import tps_from_events
+
+    now = time.monotonic()
+    assert tps_from_events([(now - 120.0, 600)], window_s=30.0) == 0.0
+
+
+@pytest.mark.asyncio
 async def test_scrape_llama_metrics_501_returns_empty_and_warns_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What
Slot cards showed '—' for tok/s, ttft, and ctx even while a slot was visibly serving and the throughput hero reported real numbers. Two causes fixed:

1. **tok/s**: `tps_from_events` required ≥2 in-window events. Non-streaming completions (graph extraction, embedding callers, scripts) land as ONE event carrying the whole `usage.completion_tokens` count, so those slots read 0 tok/s forever — while `/api/stats/throughput/history` (bucketing the same store) showed real throughput. A single in-window event now smears tokens across the window, and the `/api/slots/metrics` merge uses a 30s lookback instead of the 5s streaming default so sparse completions stay visible between requests.
2. **ctx**: nothing ever produced the `ctx` key — the llama-server `/slots` payload was only parsed as a `kv_cache_usage` fallback. The scrape now always surfaces the fullest sub-slot's used tokens as `ctx`, feeding the card's 'used / max' readout.

TTFT unchanged: only measurable on the streaming path; stays '—' rather than fabricating a number from non-streaming latency.

## Why
Operator report: all three card metrics dead on live box (CT105) while `utility` was serving extraction traffic. Verified against the live API: `/api/slots/metrics` rows had no `tokens_per_sec`/`ctx` despite `requests_processing: 4` and history showing 30 tok/s.

## Verified
- `tests/api/test_slots_routes.py` — 4 new tests (ctx surfaced/omitted-when-idle, single-event smear, age-out decay); full file passes (97 passed)
- ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)