### PR TITLE
fix(ui): size dashboard unified-memory against the shared pool total

### DIFF
--- a/ui/src/dash/dashboard-redesign.jsx
+++ b/ui/src/dash/dashboard-redesign.jsx
@@ -272,6 +272,9 @@ function HealthStrip({ slots, heroTps, attentionItems }) {
   ].filter(Boolean).join(' · ')
   const stats = useStatsHardware()
   const st = stats.data
+  // Shared memory-map model — the same pool total the Slots-page map and
+  // the memory hero card render, so the three figures can never diverge.
+  const mm = useMemoryMapModel()
 
   const readyCount = slots.filter((s) => {
     const cls = slotIndicatorFromPhase(s).cls
@@ -280,6 +283,7 @@ function HealthStrip({ slots, heroTps, attentionItems }) {
 
   const ramUsedGb = st?.ram_used_mb != null ? mbToGb(st.ram_used_mb) : null
   const ramTotalGb = st?.ram_total_mb != null ? mbToGb(st.ram_total_mb) : null
+  const memTotalGb = (mm.pool.kind === 'unified' ? mm.pool.totalGb : 0) || ramTotalGb
   const gpuPct = typeof st?.gpu_util === 'number' ? Math.round(st.gpu_util * 100) : null
   const gpuTemp = typeof st?.gpu_temp_c === 'number' ? Math.round(st.gpu_temp_c) : null
 
@@ -300,8 +304,8 @@ function HealthStrip({ slots, heroTps, attentionItems }) {
       <div className="rd-health-cell">
         <div className="rd-health-k mono">unified memory</div>
         <div className="rd-health-v mono num">
-          {ramUsedGb != null && ramTotalGb != null
-            ? <>{ramUsedGb.toFixed(1)}<span className="dim2">/{Math.round(ramTotalGb)} GB</span></>
+          {ramUsedGb != null && memTotalGb != null && memTotalGb > 0
+            ? <>{ramUsedGb.toFixed(1)}<span className="dim2">/{Math.round(memTotalGb)} GB</span></>
             : '—'}
         </div>
       </div>
@@ -394,7 +398,14 @@ function MemoryHeroCard({ swap, onGo }) {
   const ramTotalGb =
     (stats.data?.ram_total_mb != null ? mbToGb(stats.data.ram_total_mb) : 0) ||
     hw.data?.ram?.total || 0
-  const totalGb = pveConfigured ? (mm.host.totalGb || ramTotalGb) : ramTotalGb
+  // On a UMA/GPU box the pool ceiling is the shared memory-map model's GTT
+  // cap (live ttm.pages_limit) — the SAME total the Slots-page map renders.
+  // This card used to size the bar off ram_total_mb, so raising the GTT
+  // ceiling showed 116 GB on the Slots page and a stale 96 GB here.
+  const poolGb = mm.pool.kind === 'unified' ? (mm.pool.totalGb || 0) : 0
+  const totalGb = pveConfigured
+    ? (mm.host.totalGb || poolGb || ramTotalGb)
+    : (poolGb || ramTotalGb)
   const ramUsedGb = stats.data?.ram_used_mb != null ? mbToGb(stats.data.ram_used_mb) : null
 
   // Per-slot allocations (BE-METRICS mem_mb, via the shared memory-map

--- a/ui/tests/e2e/specs/memory-map-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-map-v3.spec.ts
@@ -128,14 +128,18 @@ test.describe('Unified memory hero (dashboard)', () => {
   })
 
   test('health strip mirrors the unified-memory used/total reading', async ({ page }) => {
-    // The 5-cell health strip's "unified memory" cell reads the same
-    // ram_used/ram_total counters the hero frames — never a fabricated 0.
+    // The 5-cell health strip's "unified memory" cell reads ram_used against
+    // the shared memory-map pool total (the SAME figure the Slots-page map
+    // renders) — never the container's ram_total_mb, which diverged from the
+    // pool whenever the operator raised the GTT ceiling.
     await mockStatsHardware(page, { configured: false, detected: false })
     await page.goto('/#dashboard')
     const cell = page.locator('.rd-health-cell', { hasText: 'unified memory' })
     await expect(cell).toBeVisible()
-    // 40000 MB used / 96000 MB total → "39.1/94 GB" (mb→GB, round1/round).
+    // 40000 MB used → 39.1; mock pool = unified_memory_mb 131072 → /128 GB
+    // (the mocked stats carry no gpu_vram_total_mb, so the probe fallback
+    // supplies the pool cap — same path memory-map's own header uses).
     await expect(cell.locator('.rd-health-v')).toContainText('39.1')
-    await expect(cell.locator('.rd-health-v')).toContainText('/94 GB')
+    await expect(cell.locator('.rd-health-v')).toContainText('/128 GB')
   })
 })


### PR DESCRIPTION
## What
The main dashboard's memory hero bar and the health strip's 'unified memory' cell sized themselves off `ram_total_mb` (96 GB), while the Slots-page map renders the GTT pool cap (116 GB after the operator raised `ttm.pages_limit`) from the shared memory-map model. Both dashboard surfaces now take the pool total from `useMemoryMapModel` (`mm.pool.totalGb` when the pool kind is unified), falling back to RAM total on non-GPU boxes exactly like the Slots page — the figures can no longer diverge.

## Why
Operator report: dashboard showed 67.6/96 GB and '96 GB pool · uma' while the slots page correctly showed the raised 116 GB pool. Not a hardcode — a divergent data source.

## Verified
- eslint + vite build clean
- `memory-map-v3.spec.ts` health-strip test updated to pin the pool-total source; memory-map + dashboard e2e specs pass (17 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)