### PR TITLE
fix(slots): stop painting cleanly-stopped slots and services as crashed

### DIFF
--- a/src/hal0/api/routes/doctor.py
+++ b/src/hal0/api/routes/doctor.py
@@ -95,7 +95,7 @@ async def get_doctor(request: Request) -> DoctorResponse:
     urls_payload = await _safe(get_urls(request))
     system_payload = await _safe(health_system(request))
     memory_payload = await _safe(engine_status(request))
-    services_payload = await _safe(services_health())
+    services_payload = await _safe(services_health(request))
 
     capabilities_payload: dict[str, Any] | None
     try:

--- a/src/hal0/api/routes/services_health.py
+++ b/src/hal0/api/routes/services_health.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import httpx
 import structlog
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 # In-process callables reused from existing routes — no HTTP self-calls.
 from hal0.api.routes.comfyui import (
@@ -56,6 +56,75 @@ def _openwebui_url() -> str | None:
     """Configured public URL for OpenWebUI, or None when absent."""
     public = os.environ.get("HAL0_OPENWEBUI_PUBLIC_URL", "").strip().rstrip("/")
     return public or None
+
+
+async def _unit_active_state(unit: str) -> str:
+    """Raw ``systemctl is-active`` output for *unit* (``active`` / ``inactive``
+    / ``failed`` / ``unknown`` on any probe error).
+
+    Down is not one state: ``failed`` means the unit crashed and needs
+    attention; ``inactive`` means it was stopped on purpose (or never
+    started) and will come back on demand. The dashboard renders those
+    differently — red vs grey — so the distinction must survive the probe.
+    """
+    import asyncio
+    import shutil
+
+    systemctl = shutil.which("systemctl")
+    if not systemctl:
+        return "unknown"
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            systemctl,
+            "is-active",
+            unit,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=2.0)
+    except (TimeoutError, OSError):
+        return "unknown"
+    return out.decode("utf-8", "replace").strip() or "unknown"
+
+
+def _down_state(unit_state: str, fallback_detail: str) -> tuple[str, str]:
+    """Map a not-up unit's is-active output to (service state, detail).
+
+    ``inactive`` → ("stopped", on-demand wording) — deliberate, grey.
+    ``failed``   → ("down", crash wording) — needs attention, red.
+    Anything else (``unknown``, ``activating``, or an ``active`` unit whose
+    HTTP probe still failed) → ("down", *fallback_detail*): we can't prove
+    the stop was deliberate, so keep the honest probe detail and stay red.
+    """
+    if unit_state == "inactive":
+        return "stopped", "stopped — starts on demand"
+    if unit_state == "failed":
+        return "down", "crashed — systemd unit failed"
+    return "down", fallback_detail
+
+
+_IMG_SLOT_UNIT = "hal0-slot@img.service"
+_OPENWEBUI_UNIT = "hal0-openwebui.service"
+
+
+async def _img_unit_state(request: Request) -> str:
+    """is-active state of the img slot's unit, resolved through the naming
+    seam (#1417: on an id-keyed box the unit is ``hal0-slot@<id>``, not
+    ``hal0-slot@img``). Falls back to the name-keyed unit when the slot
+    manager or config is unavailable.
+    """
+    unit = _IMG_SLOT_UNIT
+    manager = getattr(request.app.state, "slot_manager", None)
+    if manager is not None and hasattr(manager, "get_config"):
+        try:
+            cfg = await manager.get_config("img")
+            from hal0.slots.naming import slot_instance_token, slot_unit_name
+
+            unit = slot_unit_name(slot_instance_token(cfg))
+        except Exception:
+            pass
+    return await _unit_active_state(unit)
 
 
 # ── per-service probes ────────────────────────────────────────────────────────
@@ -126,8 +195,8 @@ async def _probe_openwebui() -> tuple[bool, str]:
 
 
 @router.get("/health")
-async def services_health() -> dict[str, Any]:
-    """Aggregate health of the four known hal0 companion services.
+async def services_health(request: Request) -> dict[str, Any]:
+    """Aggregate health of the known hal0 companion services.
 
     Response shape::
 
@@ -137,6 +206,7 @@ async def services_health() -> dict[str, Any]:
               "id":     "comfyui"|"hermes"|"openwebui",
               "name":   str,
               "up":     bool,
+              "state":  "up"|"stopped"|"down",
               "detail": str,
               "url":    str | null,
               "stat":   {"label": str, "value": str} | null
@@ -144,6 +214,10 @@ async def services_health() -> dict[str, Any]:
             ...
           ]
         }
+
+    ``state`` splits not-up into ``stopped`` (deliberate — unit inactive,
+    comes back on demand, renders grey) and ``down`` (unit failed /
+    unknown — renders red). ``up`` stays for older consumers.
 
     Never returns 500 — every probe failure degrades to up=false.
     """
@@ -156,11 +230,23 @@ async def services_health() -> dict[str, Any]:
         log.warning("services_health.comfyui_probe_error", exc=repr(exc))
         cu_up, cu_detail, cu_stat, cu_url = False, type(exc).__name__, None, None
 
+    cu_state = "up"
+    if not cu_up:
+        # ComfyUI runs as the img slot's container — a cleanly-stopped slot
+        # (idle-evicted / never started) is not an error condition. Only
+        # consult the unit when the probe saw NOTHING listening; an HTTP-level
+        # failure means something is running and stays down/red as-is.
+        if cu_detail == "unreachable":
+            cu_state, cu_detail = _down_state(await _img_unit_state(request), cu_detail)
+        else:
+            cu_state = "down"
+
     services.append(
         {
             "id": "comfyui",
             "name": "ComfyUI",
             "up": cu_up,
+            "state": cu_state,
             "detail": cu_detail,
             "url": cu_url,
             "stat": cu_stat,
@@ -174,11 +260,16 @@ async def services_health() -> dict[str, Any]:
         log.warning("services_health.hermes_probe_error", exc=repr(exc))
         h_up, h_detail = False, type(exc).__name__
 
+    h_state = "up"
+    if not h_up:
+        h_state, h_detail = _down_state(await _unit_active_state(_HERMES_UNIT), h_detail)
+
     services.append(
         {
             "id": "hermes",
             "name": "Hermes",
             "up": h_up,
+            "state": h_state,
             "detail": h_detail,
             "url": None,  # loopback-only, no browser-reachable URL
             "stat": None,
@@ -192,11 +283,21 @@ async def services_health() -> dict[str, Any]:
         log.warning("services_health.openwebui_probe_error", exc=repr(exc))
         ow_up, ow_detail = False, type(exc).__name__
 
+    ow_state = "up"
+    if not ow_up:
+        # Same rule as comfyui: only reinterpret pure unreachability. A non-2xx
+        # /health answer means the service is up-but-unhealthy — stays red.
+        if ow_detail.startswith("unreachable"):
+            ow_state, ow_detail = _down_state(await _unit_active_state(_OPENWEBUI_UNIT), ow_detail)
+        else:
+            ow_state = "down"
+
     services.append(
         {
             "id": "openwebui",
             "name": "OpenWebUI",
             "up": ow_up,
+            "state": ow_state,
             "detail": ow_detail,
             "url": _openwebui_url(),
             "stat": None,

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -2497,6 +2497,18 @@ class ContainerProvider(Provider):
         if unit_path.exists():
             _SYSTEMCTL_SEAM.remove_quadlet(unit_path)
             self._run("systemctl", "daemon-reload", timeout=_UNIT_STOP_TIMEOUT_S)
+        # A DELIBERATE stop must not leave the unit parked in `failed`.
+        # The bounded stop above escalates to SIGKILL (exit 137) — and a
+        # container that traps SIGTERM exits 143 — so systemd records
+        # Result=exit-code and keeps the failed unit resident in memory
+        # even after the Quadlet source is gone (daemon-reload does NOT
+        # clear failed runtime state, contrary to what this teardown used
+        # to assume). The slot-view status probe reads that as "crashed"
+        # and the dashboard painted every cleanly-stopped slot red.
+        # reset-failed marks the stop as intentional; a unit that failed
+        # on its own (crash, OOM) never passes through this teardown and
+        # stays `failed` → red.
+        self._run("systemctl", "reset-failed", unit, check=False, timeout=_UNIT_STOP_TIMEOUT_S)
 
     def is_active(self, slot: Mapping[str, Any] | str) -> bool:
         """Return True if the slot's systemd unit is in an active state.

--- a/tests/api/test_services_health.py
+++ b/tests/api/test_services_health.py
@@ -188,6 +188,9 @@ def test_openwebui_unreachable_up_false(svc_client: TestClient) -> None:
             new_callable=AsyncMock,
             return_value=(False, "systemd unit inactive or absent"),
         ),
+        # Unit state deliberately "unknown" — an unprovable stop keeps the
+        # honest probe detail and stays down (never fabricated "stopped").
+        patch(f"{_BASE}._unit_active_state", new_callable=AsyncMock, return_value="unknown"),
         patch("httpx.AsyncClient.get", new_callable=AsyncMock, side_effect=conn_err),
     ):
         r = svc_client.get("/api/services/health")
@@ -195,6 +198,7 @@ def test_openwebui_unreachable_up_false(svc_client: TestClient) -> None:
     assert r.status_code == 200
     ow = _services_by_id(r.json())["openwebui"]
     assert ow["up"] is False
+    assert ow["state"] == "down"
     assert "unreachable" in ow["detail"]
 
 
@@ -218,4 +222,97 @@ def test_openwebui_non_2xx_up_false(svc_client: TestClient) -> None:
     assert r.status_code == 200
     ow = _services_by_id(r.json())["openwebui"]
     assert ow["up"] is False
+    # HTTP-level failure = something IS listening — never softened to
+    # "stopped", the honest status-code detail survives.
+    assert ow["state"] == "down"
     assert "503" in ow["detail"]
+
+
+# ── stopped-vs-crashed split (state field) ────────────────────────────────────
+# A deliberately stopped service (unit `inactive`) renders grey, not red;
+# only a `failed` unit reads as crashed. #1974-era operator report: every
+# cleanly-stopped slot/service pip was painted red.
+
+
+def _patch_probes_all_down():
+    return (
+        patch(
+            f"{_BASE}._probe_comfyui",
+            new_callable=AsyncMock,
+            return_value=(False, "unreachable", None, None),
+        ),
+        patch(
+            f"{_BASE}._probe_hermes",
+            new_callable=AsyncMock,
+            return_value=(False, "systemd unit inactive or absent"),
+        ),
+        patch(
+            f"{_BASE}._probe_openwebui",
+            new_callable=AsyncMock,
+            return_value=(False, "unreachable (ConnectError)"),
+        ),
+    )
+
+
+def test_inactive_units_report_stopped(svc_client: TestClient) -> None:
+    p1, p2, p3 = _patch_probes_all_down()
+    with (
+        p1,
+        p2,
+        p3,
+        patch(f"{_BASE}._unit_active_state", new_callable=AsyncMock, return_value="inactive"),
+    ):
+        r = svc_client.get("/api/services/health")
+
+    assert r.status_code == 200
+    for svc in r.json()["services"]:
+        assert svc["up"] is False
+        assert svc["state"] == "stopped"
+        assert svc["detail"] == "stopped — starts on demand"
+
+
+def test_failed_units_report_down_crashed(svc_client: TestClient) -> None:
+    p1, p2, p3 = _patch_probes_all_down()
+    with (
+        p1,
+        p2,
+        p3,
+        patch(f"{_BASE}._unit_active_state", new_callable=AsyncMock, return_value="failed"),
+    ):
+        r = svc_client.get("/api/services/health")
+
+    assert r.status_code == 200
+    for svc in r.json()["services"]:
+        assert svc["up"] is False
+        assert svc["state"] == "down"
+        assert svc["detail"] == "crashed — systemd unit failed"
+
+
+def test_up_services_report_state_up(svc_client: TestClient) -> None:
+    with (
+        patch(
+            f"{_BASE}._probe_comfyui",
+            new_callable=AsyncMock,
+            return_value=(
+                True,
+                "running — 0 job(s) active",
+                {"label": "jobs", "value": "0/0"},
+                None,
+            ),
+        ),
+        patch(
+            f"{_BASE}._probe_hermes",
+            new_callable=AsyncMock,
+            return_value=(True, "systemd unit active"),
+        ),
+        patch(
+            f"{_BASE}._probe_openwebui",
+            new_callable=AsyncMock,
+            return_value=(True, "reachable — /health ok"),
+        ),
+    ):
+        r = svc_client.get("/api/services/health")
+
+    assert r.status_code == 200
+    for svc in r.json()["services"]:
+        assert svc["state"] == "up"

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -964,6 +964,11 @@ class TestLoadSync:
 
         cmds = [" ".join(c) for c in calls_made]
         assert any("stop" in c for c in cmds), f"stop not in {cmds}"
+        # A deliberate stop must clear failed runtime state: the bounded stop
+        # escalates to SIGKILL (exit 137) and daemon-reload does NOT drop a
+        # failed unit from memory, so without reset-failed every cleanly
+        # stopped slot rendered "crashed"/red on the dashboard.
+        assert any("reset-failed" in c for c in cmds), f"reset-failed not in {cmds}"
         # Unit file must be deleted
         assert not unit_file.exists()
         # #1224: every teardown verb is bounded — an unbounded `systemctl stop`

--- a/tests/slots/test_query_path_token_keying.py
+++ b/tests/slots/test_query_path_token_keying.py
@@ -279,8 +279,9 @@ def test_lifecycle_and_query_halves_agree_on_one_token(tmp_path: Path) -> None:
         provider.unload_sync(cfg)  # lifecycle half
 
     # The probe and the teardown target the SAME unit — that is the whole
-    # point of routing every artefact name through one token.
-    assert units == [_UNIT, _UNIT], units
+    # point of routing every artefact name through one token. Teardown now
+    # emits two unit-bearing calls (stop + reset-failed), both on the token.
+    assert units == [_UNIT] * 3, units
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/ui/src/api/hooks/useServicesHealth.ts
+++ b/ui/src/api/hooks/useServicesHealth.ts
@@ -21,6 +21,9 @@ export interface ServiceEntry {
   id: string
   name: string
   up: boolean
+  /** 'stopped' = deliberate (unit inactive, grey) vs 'down' = failed (red).
+   *  Absent on older backends — consumers fall back to `up`. */
+  state?: 'up' | 'stopped' | 'down'
   detail: string
   url: string | null
   stat: ServiceStat | null

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -722,8 +722,9 @@ const _shortTs = (ts) => {
 
 // Slot pips reuse slotIndicatorFromPhase (slot-status.js) so the footer
 // matches the slot-card indicator dots exactly — no parallel vocabulary.
-// A service indicator's tone (up/warn/err) → LED tone (ok/warm/err).
-const _svcPip = (tone) => (tone === 'up' ? 'ok' : tone === 'warn' ? 'warm' : 'err');
+// A service indicator's tone (up/warn/off/err) → LED tone (ok/warm/off/err).
+const _svcPip = (tone) =>
+  tone === 'up' ? 'ok' : tone === 'warn' ? 'warm' : tone === 'off' ? 'off' : 'err';
 
 // ─── Footer ───
 // Phase 3 of #322: the journal pane reads `useLogsStream` against
@@ -846,7 +847,10 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
       : (serviceHealth.services || []).map((s) => ({
           id: s.id,
           label: s.name || s.id,
-          tone: s.up ? 'up' : 'err',
+          // 'stopped' is deliberate (grey pip, out of the ready count);
+          // only a failed/unknown service reads red. Older backends omit
+          // `state` — fall back to the boolean.
+          tone: s.state === 'stopped' ? 'off' : (s.state ? (s.state === 'up' ? 'up' : 'err') : (s.up ? 'up' : 'err')),
           title: s.detail || `${s.name || s.id} down`,
         }))),
   ];
@@ -859,7 +863,10 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
   const slotPips = configuredSlots
     .map((s) => ({ slot: s, ind: slotIndicatorFromPhase(s) }))
     .filter(({ ind }) => ind.cls !== 'offline');
-  const servicesReady = footerIndicators.filter((s) => s.tone === 'up').length;
+  // Deliberately-stopped services keep a grey pip but leave the ready
+  // fraction — "2 / 2 ready" with a grey comfyui pip, not "2 / 3".
+  const servicesActive = footerIndicators.filter((s) => s.tone !== 'off');
+  const servicesReady = servicesActive.filter((s) => s.tone === 'up').length;
 
   return (
     <div className={"footer" + (expanded ? " expanded" : "")}>
@@ -1025,8 +1032,8 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
           </span>
           <span className="lbl">
             <span className="k">services</span>
-            <span className={"v" + (servicesReady < footerIndicators.length ? " warn" : "")}>
-              <b>{servicesReady} / {footerIndicators.length}</b> ready
+            <span className={"v" + (servicesReady < servicesActive.length ? " warn" : "")}>
+              <b>{servicesReady} / {servicesActive.length}</b> ready
             </span>
           </span>
         </div>


### PR DESCRIPTION
## What
Deliberately stopped slots rendered red 'crashed' dots across the dashboard, and the footer services group painted a stopped ComfyUI red. Two fixes:

1. **Slot units**: the bounded `systemctl stop` in `unload_sync` escalates to SIGKILL (exit 137; SIGTERM-trapping containers exit 143), systemd records `Result=exit-code`, and `daemon-reload` does **not** clear failed runtime state from memory — contrary to what the teardown comment assumed. The slot-view probe then read `is-active=failed` as 'crashed'. `unload_sync` now runs a best-effort `systemctl reset-failed` after teardown; a unit that failed on its own never passes through teardown and stays red.
2. **Services**: `/api/services/health` gains a `state` field (`up` | `stopped` | `down`). Unreachable + unit `inactive` → 'stopped' (grey pip, out of the ready fraction); `failed` or unprovable → 'down' (red, honest probe detail preserved — HTTP-level failures never soften to 'stopped'). ComfyUI resolves the img slot's unit through the naming seam (#1417 id-keyed boxes). `up` boolean retained for older consumers.

Note: touches the same footer block as #1976 — whichever merges second will need a trivial rebase (identical-content regions).

## Why
Operator report on CT105: `flm`/`flm-embed`/`flm-stt` showed red while merely stopped — live box confirms units parked in `failed` with exit 137/143 from clean stops.

## Verified
- `tests/providers/test_container.py` — unload_sync now asserts reset-failed; `tests/api/test_services_health.py` — 3 new state-mapping tests + 2 updated; 185 passed
- ruff + eslint + vite build clean on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)