### PR TITLE
fix(slots): close the last two unknown-image gaps from the #1968 review

### DIFF
--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -792,6 +792,22 @@ async def container_enrichment(
             except TimeoutError:
                 log.warning("slot_view.container_probe_timeout slot=%s", name)
                 profile_name = str(cfg.get("profile") or "")
+                if profile_name:
+                    # This is the third way to reach image_status="unknown",
+                    # and it needs the same reason-bearing line as the other
+                    # two: the release-validation kit tells operators that
+                    # every `unknown` has one behind it and that an `unknown`
+                    # with none is itself a finding. A timeout is a legitimate
+                    # unknown, so it must be diagnosable through the documented
+                    # route rather than only via the generic timeout line above.
+                    log.warning(
+                        "slot_view.image_probe_failed slot=%s profile=%s reason=probe-timeout — "
+                        "the slot probe exceeded %ss before the image store was read; "
+                        "reporting image_status=unknown",
+                        name,
+                        profile_name,
+                        _PROBE_TIMEOUT_S,
+                    )
                 return name, {
                     "container_status": "stopped",
                     "container_health": False,

--- a/tests/release-validation/README.md
+++ b/tests/release-validation/README.md
@@ -130,6 +130,13 @@ known-issues, or regressions, and add a line to the changelog below. A report re
 
 ### Kit changelog
 
+* **7** (2026-08-21) — follow-up to 6, landed before its first run. `readonly/api.md` check 6
+  now names both `reason=` values on `slot_view.image_probe_failed` (`probe-error` when the
+  probe raised, `probe-timeout` when the slot probe blew its deadline first). v6 promised that
+  every `unknown` has a reason-bearing journal line behind it while the timeout path emitted
+  only the generic `container_probe_timeout`; the product side of that gap is fixed in the
+  same PR, so the promise now holds as written. No check added or removed.
+
 * **6** (2026-08-20) — `image_status` gains an `unknown` member (#1939), so the three briefs
   that adjudicate that field learn to tell its two failures apart. `missing` on a running slot
   is still regression `image-status-wrong-podman-store` — a confident wrong answer. `unknown`
@@ -142,9 +149,9 @@ known-issues, or regressions, and add a line to the changelog below. A report re
   three point at the `reason=` field on the `podman_ro.image_present_unanswered` journal line
   (`grant-denied` / `podman-failed` / `podman-absent` / `invalid-argument` / `seam-error`),
   which is where the wrapper's exit-code contract now surfaces, or at
-  `slot_view.image_probe_failed` for an unknown that never reached the seam. Every `unknown`
-  has one of those two lines behind it; one with neither is a finding. No lane, tier, or phase
-  change.
+  `slot_view.image_probe_failed` (`reason=probe-error` / `probe-timeout`) for an unknown that
+  never reached the seam. Every `unknown` has one of those two lines behind it; one with
+  neither is a finding. No lane, tier, or phase change.
 
 * **5** (2026-08-20) — pre-rc.7 brief hardening from the GA-plan handoff, applied before the
   kit's first v-4-era full run. Four new checks close verification gaps for fixes that would

--- a/tests/release-validation/kit.toml
+++ b/tests/release-validation/kit.toml
@@ -4,7 +4,7 @@
 # scripts cannot read the filesystem, so when you add a lane here you must also add it to the
 # LANES table in the script. The brief itself is only ever read by the agent that runs it.
 
-kit_version = 6
+kit_version = 7
 
 [defaults]
 # Model tier per phase. Rationale in README "Phases".

--- a/tests/release-validation/lanes/readonly/api.md
+++ b/tests/release-validation/lanes/readonly/api.md
@@ -48,8 +48,9 @@ Probe the REST surface from the workstation with curl against `$API` (from `CONT
    finding**. Follow it up rather than passing it: grep the journal for
    `podman_ro.image_present_unanswered`, which carries a `reason=` naming which case fired
    (`grant-denied` / `podman-failed` / `podman-absent` / `invalid-argument` / `seam-error`),
-   or for `slot_view.image_probe_failed` (`reason=probe-error`, carrying the exception) when
-   the probe never reached the seam at all, and cross-check `hal0 doctor seams`. Every
+   or for `slot_view.image_probe_failed` (`reason=probe-error` when the probe raised before
+   reaching the seam, `reason=probe-timeout` when the whole slot probe blew its deadline
+   first), and cross-check `hal0 doctor seams`. Every
    `unknown` has exactly one of those two lines behind it; an `unknown` with neither is itself
    a finding. A whole fleet reading `unknown` is a broken install
    even though no field is lying. Conversely, `unknown` where the seam is demonstrably healthy

--- a/tests/slot_view/test_probe_concurrency.py
+++ b/tests/slot_view/test_probe_concurrency.py
@@ -129,7 +129,7 @@ async def test_one_wedged_slot_cannot_hold_the_list(
 
 
 async def test_a_wedged_profiled_slot_reports_unknown_not_not_configured(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """#1939: a slot that DOES declare an image, whose probe timed out.
 
@@ -144,10 +144,33 @@ async def test_a_wedged_profiled_slot_reports_unknown_not_not_configured(
     for cfg in configs:
         cfg["profile"] = "rocm-mtp"
 
-    out = await container_enrichment(configs, provider=provider)
+    with caplog.at_level("WARNING"):
+        out = await container_enrichment(configs, provider=provider)
 
     assert out["s1"]["image_status"] == "unknown"
     assert out["s1"]["profile"] == "rocm-mtp", "the fallback still reports the declared profile"
+    # …and it is diagnosable through the route the validation kit documents:
+    # every `unknown` carries a reason-bearing line, this one included.
+    assert "slot_view.image_probe_failed" in caplog.text
+    assert "reason=probe-timeout" in caplog.text
+    assert "slot=s1" in caplog.text
+
+
+async def test_a_wedged_profileless_slot_logs_no_image_probe_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The converse: a profileless timeout reports "not-configured", which is
+    a definitive answer, so it must NOT emit the unknown-diagnostic line — an
+    operator grepping for it would otherwise chase a seam that is fine."""
+    monkeypatch.setattr(sv_mod, "_PROBE_TIMEOUT_S", 0.4)
+    provider = SlowProvider(delay=0.01, wedged={"s1"})
+
+    with caplog.at_level("WARNING"):
+        out = await container_enrichment(_configs(3), provider=provider)
+
+    assert out["s1"]["image_status"] == "not-configured"
+    assert "slot_view.container_probe_timeout" in caplog.text
+    assert "image_probe_failed" not in caplog.text
 
 
 # ── the whole GET /api/slots path ────────────────────────────────────────────

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -236,6 +236,11 @@ const HAL0_DATA = {
       runtime: "container",
       profile: "tts",
       image: "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1",
+      // #1939 follow-up: the seed's UTILITY-tier seam-blind slot, alongside
+      // `legacy` in the headline tier. Utility slots render as MiniCard, a
+      // different component, and the indeterminate chip was missing there —
+      // so the γ-suite now exercises both card shapes.
+      image_status: "unknown",
       container_status: "running",
       container_health: true,
       model: "kokoro-v1",

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -616,6 +616,12 @@ function MiniCard({ s, ind, busy, handlers, grip, dragging, dropProps }) {
         <span className={'sdot ' + dot} title={ind.tooltip} />
         <span className="snm">{s.name}</span>
         <span className="sport">{s.port ? ':' + s.port : ''}</span>
+        {/* #1939 follow-up: the utility tier runs the same container images
+            as the headline tier, so it can hit the same unreadable image
+            store. Rendering the chip only on SlotScard made the seam failure
+            invisible for every embed / rerank / stt / tts slot — the tiers
+            differ in density, not in what they are allowed to hide. */}
+        <SlotImageUnknownChip s={s} />
       </div>
       <div className="mcard-b">
         <span className="smodel" title={s.model || ''}>

--- a/ui/tests/e2e/specs/slot-card-container-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-card-container-v3.spec.ts
@@ -342,6 +342,22 @@ test.describe('SlotCard container variant (#657)', () => {
     ).toHaveCount(0)
   })
 
+  test('the utility tier renders the chip too, not just the headline tier', async ({ page }) => {
+    // Utility slots (embed / rerank / stt / tts) render as MiniCard, a
+    // different component from SlotScard. They run the same container images
+    // and can hit the same unreadable store, so hiding the chip there made
+    // the seam failure invisible for a whole tier of slots. The seed gives
+    // `tts` image_status: 'unknown'.
+    const card = page.getByTestId('infer-slot-tts')
+    await expect(card).toBeVisible()
+    await expect(card).toHaveClass(/\bmcard\b/)
+    await expect(card.getByTestId('slot-image-unknown')).toBeVisible()
+    // A sibling mini card that is not seam-blind still carries none.
+    await expect(
+      page.getByTestId('infer-slot-embed').getByTestId('slot-image-unknown'),
+    ).toHaveCount(0)
+  })
+
   test('starting container card renders warming dot via slotIndicator', async ({ page }) => {
     // Verify warming dot for a starting container slot
     const ind = await page.evaluate((slot) => {


### PR DESCRIPTION
Two P2s landed on #1968's final commit and did not make it in before that PR was merged. Both are the same two invariants #1968 established, unmet in one place each. Neither is a regression from it — they are places the new contract simply had not reached.

## 1. The timeout path was an undiagnosable `unknown`

#1968 taught the probe-timeout fallback to report `image_status: "unknown"` for a slot that *does* declare an image (rather than the old `not-configured`, which was a claim about config from a probe that read none). But it emitted only the generic `slot_view.container_probe_timeout` line.

That made #1968's own release-validation text false: the kit tells operators every `unknown` carries a reason-bearing journal line, and that an `unknown` with none is itself a finding. A legitimate timeout therefore looked like a defect through the documented workflow. The timeout path now emits `slot_view.image_probe_failed … reason=probe-timeout` alongside the existing line.

The converse is pinned too: a **profileless** timeout still reports `not-configured` and deliberately stays silent. That is a definitive answer, and emitting the unknown-diagnostic there would send an operator hunting a seam that is fine. One test per half.

## 2. The indeterminate chip was missing from an entire tier

`SlotImageUnknownChip` was inserted into `SlotScard` only, but `InferencePane` routes embed / rerank / stt / tts slots through `utilRows` → `MiniCard`, a different component. So the seam failure was invisible for every utility slot — which run the same container images, out of the same store, and can be seam-blind in exactly the same way. The tiers differ in density, not in what they are allowed to hide.

The chip now renders in both. The forced-mock seed carries one seam-blind slot per tier (`legacy` headline, `tts` utility) so the γ-suite exercises both card shapes rather than assuming they agree — which is precisely the assumption that produced this gap.

## Kit

`kit_version` 6 → 7, per the kit's versioning policy (any change to lane briefs). `readonly/api.md` check 6 now names both `reason=` values on `slot_view.image_probe_failed`. Landing before v6's first run, so no report was produced under the incomplete wording.

## Verification

```
pytest tests/slot_view tests/providers    751 passed
pytest tests/release                      112 passed
ruff check src tests                      All checks passed!
ruff format --check src tests             1164 files already formatted
ui: npx eslint .                          clean
ui: npx tsc --noEmit                      clean
ui: npx vitest run                        14 files, 135 tests passed
ui: npm run build                         clean
ui: npx playwright test (full γ-suite)    649 passed, 16 skipped
```

Full γ-suite rather than the affected spec alone, because this touches the shared forced-mock seed (`src/dash/data.jsx`) every γ spec renders from.

Refs #1939, #1968.
