### PR TITLE
chore(release): set version to 1.0.0-rc.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ curl -fsSL https://hal0.dev/install.sh | sudo bash
 > brain steward model, and starts the API. When it finishes, open the
 > dashboard and assign models to slots.
 
-> **Status: release candidate — `v1.0.0-rc.6`.** v1.0.0 stable is the target
+> **Status: release candidate — `v1.0.0-rc.7`.** v1.0.0 stable is the target
 > of the current cut. Every release candidate is validated on a real-hardware
 > fleet before the next cut; see [`CHANGELOG.md`](./CHANGELOG.md) for what
 > each candidate closed.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release — the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md §12 and §17 (maintainer-local).",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "channel": "preview",
   "toolbox_images": {
     "vulkan": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hal0-ui",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hal0-ui",
-      "version": "1.0.0-rc.6",
+      "version": "1.0.0-rc.7",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal0-ui",
   "private": true,
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "hal0ai"
-version = "1.0.0rc6"
+version = "1.0.0rc7"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
The release recipe's set-version step for the rc.7 cut: `scripts/set-version.py 1.0.0-rc.7` (manifest.json, pyproject.toml, ui package files, both locks) + the README status blockquote, which the script doesn't cover — the exact gap that left the public README two candidates stale before #1957. Script gap filed separately.

Lands together with changelog #1965; the tag goes on the tip containing both. Part of the operator-held rc.7 cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)