### PR TITLE
fix(installer): break hal0-api/hindsight-api systemd ordering cycle

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1358,12 +1358,17 @@ cat > "${API_UNIT}" <<EOF
 [Unit]
 Description=hal0 API daemon
 Documentation=https://github.com/hal0ai/hal0
-# hindsight-api ordering (#1613): a cold engine start outlasts hal0-api's
-# boot probe, degrading memory to the pgvector fallback. After= narrows the
-# boot-time window (the runtime self-heal re-probe covers the rest); both
-# directives are no-ops on a box without the engine unit.
-After=network-online.target hindsight-api.service
-Wants=network-online.target hindsight-api.service
+# hindsight-api ordering: deliberately NO After=/Wants= on hindsight-api.
+# The engine unit already carries a soft After=hal0-api.service (its
+# extraction LLM fronts through hal0-api), so pointing back at it from here
+# — as #1613 once did — created a bidirectional ordering cycle that systemd
+# resolved by dropping a unit from the cold-boot transaction, failing the
+# boot outright (observed on CT105, 2026-08-21). The #1613 concern (cold
+# engine start outlasting the boot probe) is covered by the runtime
+# self-heal re-probe alone; memory degrades to pgvector briefly instead of
+# the box failing to boot.
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
## What

Removes `hindsight-api.service` from the generated hal0-api unit's `After=`/`Wants=` in `installer/install.sh`. `installer/systemd/hindsight-api.service` already carries a soft `After=hal0-api.service`, so the #1613 back-edge made the ordering bidirectional.

## Why

A bidirectional ordering cycle only bites when both units cold-start in one transaction — systemd breaks the cycle by dropping a unit, which failed CT105's boot after the 2026-08-21 host reset (`timedatectl`/dbus symptoms were downstream of the dropped unit). Normal operation masks it because both services rarely cold-start together. The concern #1613 addressed (cold engine start outlasting hal0-api's boot probe) is covered by the runtime self-heal re-probe — memory degrades to pgvector briefly instead of the box failing to boot.

## How verified

- Identical change hand-applied to CT105's live unit on 2026-08-21 during recovery: box cold-boots cleanly, both services active, engine reachable (verified via `/api/memory/engine` and live UI).
- `bash -n installer/install.sh` clean.

Found during the memory-v2 build (PR #1987 live smoke / host recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)