### PR TITLE
fix(ui): size the Slots-page CPU·Memory gauge against the shared pool total

### DIFF
--- a/ui/src/dash/telemetry-header.jsx
+++ b/ui/src/dash/telemetry-header.jsx
@@ -234,9 +234,22 @@ function ThCellCpuMem() {
   const stats = useStatsHardware()
   const power = useStatsPower()
   const s = stats.data
+  // #1978 unified the dashboard's "unified memory" figures against the
+  // shared memory-map pool total (useMemoryMapModel) so the Slots-page map,
+  // the dashboard hero card, and the dashboard health strip could no
+  // longer diverge — but this cell lives in telemetry-header.jsx (a
+  // different file than that fix touched) and was missed: it still sized
+  // itself off ram_total_mb, showing the host's raw ~96 GB RAM total right
+  // next to ThRuler's memory-map band on this SAME page showing the
+  // GTT-aware ~116 GB pool total for what reads as "the same number".
+  // Same fix, same fallback order: prefer the live pool total on a
+  // GPU/unified box, fall back to RAM total everywhere else (non-UMA boxes,
+  // and test mocks with no memory-map model wired up).
+  const mm = useMemoryMapModel()
+  const poolTotalGb = mm.pool.kind === 'unified' ? mm.pool.totalGb || 0 : 0
 
   const usedGb = s?.ram_used_mb != null ? s.ram_used_mb / 1024 : null
-  const totalGb = s?.ram_total_mb != null ? s.ram_total_mb / 1024 : hw.data?.ram?.total || null
+  const totalGb = poolTotalGb || (s?.ram_total_mb != null ? s.ram_total_mb / 1024 : hw.data?.ram?.total || null)
   const ramPct = usedGb != null && totalGb ? (usedGb / totalGb) * 100 : null
   const cpuUtil = typeof s?.cpu_util === 'number' ? s.cpu_util : null
   const cpuTemp = power.data?.cpu_temp_c ?? null

--- a/ui/tests/e2e/specs/memory-map-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-map-v3.spec.ts
@@ -142,4 +142,26 @@ test.describe('Unified memory hero (dashboard)', () => {
     await expect(cell.locator('.rd-health-v')).toContainText('39.1')
     await expect(cell.locator('.rd-health-v')).toContainText('/128 GB')
   })
+
+  // Live screenshot feedback (2026-08-22): the operator spotted the
+  // Slots-page header's own "CPU · Memory" gauge cell (telemetry-
+  // header.jsx's ThCellCpuMem, a DIFFERENT file than #1978 touched)
+  // still reading the raw ram_total_mb (~94 GB) right next to ThRuler's
+  // memory-map band on the SAME page correctly showing the ~128 GB pool
+  // total — the exact class of divergence #1978 fixed for the dashboard's
+  // three other "memory" figures, just missed here.
+  test('Slots-page "CPU · Memory" gauge also reads the shared pool total, not raw ram_total_mb', async ({
+    page,
+  }) => {
+    await mockStatsHardware(page, { configured: false, detected: false })
+    await page.goto('/#slots')
+    const hero = page.getByTestId('telemetry-header')
+    const cell = hero.locator('.th-cell', { hasText: 'CPU · Memory' })
+    await expect(cell).toBeVisible()
+    // Same 40000 MB used / unified_memory_mb 131072 probe mock as the
+    // health-strip test above — same pool, same expected reading.
+    await expect(cell).toContainText('39.1')
+    await expect(cell).toContainText('/ 128 GB')
+    await expect(cell).not.toContainText('/ 94 GB')
+  })
 })


### PR DESCRIPTION
## What

The telemetry header's CPU·Memory gauge still sized itself off raw `ram_total_mb` (~96 GB host RAM) while the memory-map ruler directly below it — fixed by #1978 — reads the shared pool total (116 GB on unified-memory boxes). Same fix pattern as #1978's three sites: prefer the live pool total on GPU/unified boxes, fall back to RAM total elsewhere; the used figure remains genuine RAM usage.

## Why

Fourth figure #1978 missed (different file): the same Slots page showed "/ 96 GB" and "/ 116 GB" for the same memory concept, one gauge above the other.

## How verified

- Regression test added mirroring the existing health-strip test (memory-map-v3 spec now 6/6).
- vitest 174/174 on this branch; verified live on CT105: gauge reads 24.3 / 116 GB, matching the ruler.

Found during memory-v2 live review; cherry-picked from the preview branch so it lands independently of PR #1987.

🤖 Generated with [Claude Code](https://claude.com/claude-code)