### PR TITLE
fix/docs sync codex round2

### DIFF
--- a/scripts/docs_discourse_sync/discourse_client.py
+++ b/scripts/docs_discourse_sync/discourse_client.py
@@ -2,13 +2,20 @@
 
 Endpoints mirror discourse/discourse-developer-docs' own ``sync_docs``
 script (``lib/api.rb``): ``POST /posts.json`` to create a topic with an
-``external_id``, ``PUT /posts/{id}.json`` to edit its first post
-(title/category ride along as top-level params, same as upstream), and
-``POST /uploads.json`` (multipart) for image uploads. Where this diverges
-from upstream is topic lookup: upstream resolves every doc's topic in one
-batch via a Data Explorer query (``fetch_current_state``); this project's
-own task spec calls for the plain, documented per-doc endpoint instead —
-``GET /t/external_id/{id}.json`` — which needs no Data Explorer plugin
+``external_id``, ``PUT /posts/{id}.json`` to edit its first post, and
+``POST /uploads.json`` (multipart) for image uploads. This project's
+own param shapes were verified against Discourse's actual
+``PostsController`` source rather than assumed from upstream by
+analogy — ``create``'s ``category`` is a top-level param,
+``update``'s category change has to be ``post.category_id`` (a
+different field, nested), and ``skip_validations`` only bypasses topic
+validations (title length among them) on create, not on this update
+endpoint — see :meth:`DiscourseClient.update_topic`'s docstring. Where
+this diverges from upstream more deliberately is topic lookup: upstream
+resolves every doc's topic in one batch via a Data Explorer query
+(``fetch_current_state``); this project's own task spec calls for the
+plain, documented per-doc endpoint instead — ``GET
+/t/external_id/{id}.json`` — which needs no Data Explorer plugin
 installed and is simpler to reason about at hal0's ~50-doc scale.
 
 Every mutating call is skipped under ``dry_run`` and returns a synthesized
@@ -176,7 +183,22 @@ class DiscourseClient:
         response = self._request(
             "POST",
             "/posts.json",
-            json={"title": title, "raw": raw, "category": category_id, "external_id": external_id},
+            json={
+                "title": title,
+                "raw": raw,
+                "category": category_id,
+                "external_id": external_id,
+                # Verified against Discourse's PostsController#create_params:
+                # `is_api?` (true for an Api-Key/Api-Username request, which is
+                # all this client ever makes) permits `skip_validations`, and
+                # PostCreator skips TopicCreator's validate_child entirely when
+                # it's set — including topic_title_length. Without it, any doc
+                # whose title is under the site's min_topic_title_length
+                # (Discourse's own out-of-box default is 15; hal0's docs/
+                # corpus has 14 titles under that, e.g. "Slots", "Memory")
+                # 422s on its very first sync.
+                "skip_validations": True,
+            },
         )
         if response.status_code not in (200, 201):
             raise DiscourseAPIError("POST", "/posts.json", response)
@@ -193,7 +215,29 @@ class DiscourseClient:
         )
 
     def update_topic(self, *, post_id: int, title: str, raw: str, category_id: int) -> None:
-        """``PUT /posts/{id}.json``. Skipped under dry_run."""
+        """``PUT /posts/{id}.json``. Skipped under dry_run.
+
+        ``title`` is a top-level param (``PostsController#update`` reads
+        ``params[:title]`` directly) but the category change has to be
+        ``post.category_id``, not a top-level ``category`` — that field
+        doesn't exist on this endpoint at all and was silently ignored
+        (verified against ``PostsController#update``, which reads
+        ``params[:post][:category_id]``). A category-drift correction
+        used to report success while leaving the topic in its old
+        category, so the next sync would detect "changed" and try again,
+        forever.
+
+        ``skip_validations`` is included for parity with create, but
+        verified NOT to reliably bypass Discourse's title-length check
+        here the way it does on create: ``PostsController#update`` never
+        wires a client-supplied ``skip_validations`` through to
+        ``PostRevisor`` (only auto-sets it for staff-edited small_action
+        posts), and ``Topic``'s title validator re-runs whenever
+        ``category_id_changed?`` — not just when the title itself
+        changes — so a short-titled doc *would* still 422 on exactly the
+        category-correction update this method exists to make. See
+        ``discovery.py``'s title padding for the actual fix to that gap.
+        """
         if self.dry_run:
             return
         path = f"/posts/{post_id}.json"
@@ -201,9 +245,13 @@ class DiscourseClient:
             "PUT",
             path,
             json={
-                "post": {"raw": raw, "edit_reason": "Synced from Hal0ai/hal0 docs/"},
+                "post": {
+                    "raw": raw,
+                    "edit_reason": "Synced from Hal0ai/hal0 docs/",
+                    "category_id": category_id,
+                    "skip_validations": True,
+                },
                 "title": title,
-                "category": category_id,
             },
         )
         if response.status_code != 200:

--- a/scripts/docs_discourse_sync/discovery.py
+++ b/scripts/docs_discourse_sync/discovery.py
@@ -42,6 +42,25 @@ SECTION_TITLES: dict[str, str] = {
 _EXTERNAL_ID_SEP = "--"
 _EXTERNAL_ID_MAX_LENGTH = 50
 
+# Discourse's out-of-box SiteSetting default for min_topic_title_length.
+# discourse_client.create_topic sends skip_validations=true, which — verified
+# against PostsController#create_params — bypasses this on creation. It does
+# NOT reliably bypass it on a later update: Topic's title validator re-runs
+# whenever category_id changes (not just when the title itself does), and
+# PostsController#update never wires a client skip_validations through to
+# PostRevisor. A category-drift correction (sync.py) on a short-titled doc
+# would still 422 on that specific update without this floor. 14 of the 44
+# current docs — "Slots", "Agents", "Memory", "Stacks", "Services", ... —
+# are under it, so this isn't a hypothetical edge case.
+_DISCOURSE_MIN_TITLE_LENGTH = 15
+_TITLE_PAD_SUFFIX = " (hal0 docs)"
+
+
+def _discourse_safe_title(title: str) -> str:
+    if len(title) >= _DISCOURSE_MIN_TITLE_LENGTH:
+        return title
+    return f"{title}{_TITLE_PAD_SUFFIX}"
+
 
 class DiscoveryError(ValueError):
     """Something under docs/<section> isn't a syncable doc."""
@@ -129,7 +148,11 @@ def _load_doc(docs_dir: Path, path: Path) -> Doc:
         section=section,
         subsection=subsection,
         slug=slug,
-        title=frontmatter.title,
+        # Padded for Discourse's title-length floor if needed (see
+        # _discourse_safe_title above) — short_title, used for index-topic
+        # bullet display rather than sent as a Discourse topic title
+        # itself, deliberately stays the clean, unpadded value.
+        title=_discourse_safe_title(frontmatter.title),
         short_title=short_title,
         external_id=external_id,
         rel_key=rel_key,

--- a/scripts/docs_discourse_sync/links.py
+++ b/scripts/docs_discourse_sync/links.py
@@ -14,10 +14,21 @@ so it has no forum topic to point at. Left as a root-relative path it
 would resolve against forum.hal0.dev and 404; these are rewritten to a
 GitHub blob URL at the source instead.
 
+A fourth: a root-relative link that's missing its ``/docs`` prefix
+(``docs/reference/env-vars.mdx`` has exactly one — a real typo,
+``/guides/run-agents/...`` instead of ``/docs/guides/run-agents/...``).
+Starlight's own dev server would have 404'd on this too, so it's
+recognised and resolved the same as the correct form rather than shipped
+as a second, forum-side 404.
+
 This runs strictly after :mod:`transform` on already-transformed
 Discourse markdown, once pass 1 has produced a full external_id -> topic
 URL map — a link to a doc that doesn't exist yet at transform time (the
-whole reason this is a *second* pass) resolves fine here.
+whole reason this is a *second* pass) resolves fine here. Fenced code
+blocks and inline code spans are masked out before rewriting for the same
+reason :mod:`transform` protects them: a documentation example that
+*shows* markdown link syntax (``[Install](/docs/getting-started/install)``
+as literal text, not a real link) must not get rewritten.
 """
 
 from __future__ import annotations
@@ -26,13 +37,17 @@ import re
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 
-from .discovery import source_key_for_site_path
+from . import transform
+from .discovery import SECTIONS, source_key_for_site_path
 
 # [text](url "optional title") — the standard inline markdown link form,
 # which is the only one the transform ever emits.
 _LINK_RE = re.compile(r"(?P<full>!?\[(?P<text>[^\]]*)\]\((?P<url>[^()\s]+)(?:\s+\"[^\"]*\")?\))")
 
 _DEFAULT_GITHUB_BLOB_BASE = "https://github.com/Hal0ai/hal0/blob/main"
+_ROOT_RELATIVE_SECTION_RE = re.compile(
+    "^/(?:" + "|".join(re.escape(s) for s in SECTIONS) + r")(?:/|$)"
+)
 
 
 @dataclass(slots=True)
@@ -58,6 +73,13 @@ def _resolve(url: str, *, current_dir: str) -> tuple[str, str, str] | None:
         return None
 
     path, _, anchor = url.partition("#")
+
+    # A root-relative link that's missing its /docs prefix (a source-doc
+    # typo, but a real one — see docs/reference/env-vars.mdx) — treat it
+    # the same as if it had been written correctly, rather than leaving a
+    # link that was already broken on hal0.dev broken on the forum too.
+    if _ROOT_RELATIVE_SECTION_RE.match(path):
+        path = f"/docs{path}"
 
     if path.startswith("/docs/"):
         key = source_key_for_site_path(path)
@@ -92,9 +114,12 @@ def _resolve(url: str, *, current_dir: str) -> tuple[str, str, str] | None:
 def find_internal_link_keys(body_md: str, *, current_dir: str) -> set[str]:
     """The set of synced doc rel_keys *body_md* links to internally
     (excludes ``"blob"``-kind links, which don't participate in the
-    sync's URL map)."""
+    sync's URL map, and any link inside a fenced/inline code span)."""
+    protected = transform.protected_ranges(body_md)
     keys: set[str] = set()
     for m in _LINK_RE.finditer(body_md):
+        if transform.is_protected(m.start(), protected):
+            continue
         resolved = _resolve(m.group("url"), current_dir=current_dir)
         if resolved and resolved[0] == "topic":
             keys.add(resolved[1])
@@ -115,13 +140,19 @@ def rewrite_internal_links(
     A ``"topic"`` link whose target isn't in *url_map* (a doc that
     doesn't exist, or was skipped) is left as-is and reported in
     ``unresolved`` — pass 2 logs these rather than failing the whole sync
-    over one stale link.
+    over one stale link. A link inside a fenced code block or inline code
+    span is left untouched entirely, matching :mod:`transform`'s own
+    "code is opaque" rule — a doc example that *shows* markdown link
+    syntax as literal text isn't a real cross-link.
     """
     changed = 0
     unresolved: list[str] = []
+    protected = transform.protected_ranges(body_md)
 
     def _sub(m: re.Match[str]) -> str:
         nonlocal changed
+        if transform.is_protected(m.start(), protected):
+            return m.group("full")
         resolved = _resolve(m.group("url"), current_dir=current_dir)
         if not resolved:
             return m.group("full")

--- a/scripts/docs_discourse_sync/transform.py
+++ b/scripts/docs_discourse_sync/transform.py
@@ -57,7 +57,14 @@ _BACKTICK_RUN_RE = re.compile(r"`+")
 _BLANK_LINE_RE = re.compile(r"\n[ \t]*\n")
 _JSX_COMMENT_RE = re.compile(r"\{\s*/\*.*?\*/\s*\}", re.DOTALL)
 _TAG_RE = re.compile(r"<(/?)([A-Za-z][\w.]*)\b")
-_ATTR_RE = re.compile(r'([\w-]+)="([^"]*)"')
+# Both quote styles are valid JSX attribute syntax (`title="x"` and
+# `title='x'`) — matching only double quotes let a single-quoted attribute
+# silently vanish instead of being read: <LinkCard title='Slots' href='...' />
+# became "- []()" (empty title/href, no error), and <Aside type='danger'
+# title='Stop'> rendered as an untitled Note — exactly the silent-corruption
+# class this whole transform exists to avoid for genuinely *unknown*
+# components; a quote-style gap on a *known* one shouldn't get a pass either.
+_ATTR_RE = re.compile(r"""([\w-]+)=(?:"([^"]*)"|'([^']*)')""")
 
 _IMPORT_LINE_RE = re.compile(r"^import\s+.+?\s+from\s+['\"][^'\"]+['\"];?\s*$")
 _EXPORT_LINE_RE = re.compile(r"^export\s+.+?;?\s*$")
@@ -160,9 +167,12 @@ def _find_inline_code_spans(text: str) -> list[tuple[int, int]]:
     return spans
 
 
-def _protected_ranges(text: str) -> list[tuple[int, int]]:
+def protected_ranges(text: str) -> list[tuple[int, int]]:
     """Byte ranges of *text* that must never be substituted into: fenced
-    code blocks and inline code spans."""
+    code blocks and inline code spans. Public — :mod:`links` reuses this
+    to keep its own link-rewrite pass from touching a documentation
+    example that *shows* markdown link syntax as literal code, the same
+    "code is opaque" rule this module enforces on itself."""
     fence_ranges = [m.span() for m in _CODE_FENCE_RE.finditer(text)]
     masked = _mask_ranges(text, fence_ranges)
     ranges = list(fence_ranges)
@@ -171,7 +181,7 @@ def _protected_ranges(text: str) -> list[tuple[int, int]]:
     return ranges
 
 
-def _is_protected(pos: int, ranges: list[tuple[int, int]]) -> bool:
+def is_protected(pos: int, ranges: list[tuple[int, int]]) -> bool:
     return any(start <= pos < end for start, end in ranges)
 
 
@@ -207,7 +217,7 @@ def _validate(body: str, *, source: str, line_offset: int) -> None:
     """Raise :class:`TransformError` on anything the transform can't render,
     computing line numbers against the untouched original body."""
     header_lines, header_end = _leading_header_span(body)
-    protected = _protected_ranges(body)
+    protected = protected_ranges(body)
     protected.append((0, header_end))
     protected.sort()
     comment_ranges = [m.span() for m in _JSX_COMMENT_RE.finditer(body)]
@@ -222,7 +232,7 @@ def _validate(body: str, *, source: str, line_offset: int) -> None:
     # is not MDX/JS and must pass through untouched.
     pos = header_end
     for lineno, text in enumerate(body.split("\n")[header_lines:], start=header_lines):
-        if _LEADING_IMPORT_OR_EXPORT_RE.match(text) and not _is_protected(pos, protected):
+        if _LEADING_IMPORT_OR_EXPORT_RE.match(text) and not is_protected(pos, protected):
             raise TransformError(
                 source,
                 lineno + line_offset,
@@ -238,7 +248,7 @@ def _validate(body: str, *, source: str, line_offset: int) -> None:
     depth: dict[str, int] = {}
     for m in _TAG_RE.finditer(body):
         pos = m.start()
-        if _is_protected(pos, protected):
+        if is_protected(pos, protected):
             continue
         closing, name = m.group(1), m.group(2)
         if name not in _KNOWN_COMPONENTS:
@@ -280,7 +290,7 @@ def _validate(body: str, *, source: str, line_offset: int) -> None:
         if pos == -1:
             break
         i = pos + 1
-        if _is_protected(pos, protected) or _in_comment(pos):
+        if is_protected(pos, protected) or _in_comment(pos):
             continue
         raise TransformError(
             source,
@@ -297,7 +307,9 @@ def _strip_leading_esm_header(body: str) -> str:
 
 
 def _parse_attrs(raw: str) -> dict[str, str]:
-    return dict(_ATTR_RE.findall(raw))
+    # findall returns (name, double_quoted, single_quoted) per match, with
+    # whichever quote style *wasn't* used left as "" — pick the one that was.
+    return {name: dq or sq for name, dq, sq in _ATTR_RE.findall(raw)}
 
 
 def _render_aside(atype: str, title: str | None, body: str) -> str:
@@ -431,6 +443,13 @@ def transform_body(body: str, *, source: str, line_offset: int = 1) -> Transform
         kind, idx = m.group(1), int(m.group(2))
         return (fences if kind == "FENCE" else codespans)[idx]
 
-    working = _PLACEHOLDER_RE.sub(_restore, working)
+    # Tidy blank-line runs *before* restoring fences/code spans, not
+    # after: a placeholder token is a single opaque line with no embedded
+    # newline, so collapsing "\n{3,}" here can never reach inside a fence
+    # — restoring first would let a real fenced example's own internal
+    # blank lines (module docstring's stated invariant: fences are never
+    # touched) get globally collapsed right along with the surrounding
+    # prose's.
     working = _tidy_blank_lines(working)
+    working = _PLACEHOLDER_RE.sub(_restore, working)
     return TransformResult(body_md=working, warnings=warnings)

--- a/tests/scripts/docs_discourse_sync/test_discourse_client.py
+++ b/tests/scripts/docs_discourse_sync/test_discourse_client.py
@@ -122,6 +122,7 @@ def test_create_topic_posts_expected_payload() -> None:
         "raw": "body md",
         "category": 7,
         "external_id": "hal0-docs--getting-started--install",
+        "skip_validations": True,
     }
     assert topic == Topic(
         topic_id=34,
@@ -157,7 +158,12 @@ def test_update_topic_puts_expected_payload() -> None:
     assert captured["path"] == "/posts/999.json"
     assert captured["body"]["post"]["raw"] == "new body"
     assert captured["body"]["title"] == "Install hal0"
-    assert captured["body"]["category"] == 7
+    # category_id belongs nested under "post" (verified against
+    # PostsController#update, which reads params[:post][:category_id]) —
+    # a top-level "category" (create's field name) is silently ignored here.
+    assert "category" not in captured["body"]
+    assert captured["body"]["post"]["category_id"] == 7
+    assert captured["body"]["post"]["skip_validations"] is True
 
 
 def test_update_topic_dry_run_makes_no_request() -> None:

--- a/tests/scripts/docs_discourse_sync/test_discovery.py
+++ b/tests/scripts/docs_discourse_sync/test_discovery.py
@@ -131,10 +131,37 @@ def test_source_key_for_site_path_round_trips() -> None:
 
 
 def test_sort_order_by_sidebar_order_then_title(tmp_path: Path) -> None:
-    _write(tmp_path / "guides" / "b.mdx", "Bravo", 20)
-    _write(tmp_path / "guides" / "a.mdx", "Alpha", 10)
+    # Titles long enough to not trigger the min-title-length padding below
+    # — keeps this test about sort order alone.
+    _write(tmp_path / "guides" / "b.mdx", "Bravo Guide Doc", 20)
+    _write(tmp_path / "guides" / "a.mdx", "Alpha Guide Doc", 10)
     docs = sorted(discovery.discover_docs(tmp_path), key=lambda d: (d.sidebar_order, d.title))
-    assert [d.title for d in docs] == ["Alpha", "Bravo"]
+    assert [d.title for d in docs] == ["Alpha Guide Doc", "Bravo Guide Doc"]
+
+
+# ── Discourse minimum title length ────────────────────────────────────────
+
+
+def test_short_title_is_padded_for_discourse(tmp_path: Path) -> None:
+    _write(tmp_path / "concepts" / "slots.mdx", "Slots", 10)
+    doc = discovery.discover_docs(tmp_path)[0]
+    assert doc.title == "Slots (hal0 docs)"
+    assert len(doc.title) >= 15
+
+
+def test_title_at_or_over_min_length_is_untouched(tmp_path: Path) -> None:
+    title = "Architecture Overview"  # 22 chars, over the 15-char floor
+    _write(tmp_path / "concepts" / "architecture.mdx", title, 10)
+    doc = discovery.discover_docs(tmp_path)[0]
+    assert doc.title == title
+
+
+def test_short_title_padding_does_not_affect_short_title_field(tmp_path: Path) -> None:
+    """short_title (index-topic bullet display) stays the clean, unpadded
+    value — only the Discourse-bound title gets the length floor."""
+    _write(tmp_path / "concepts" / "slots.mdx", "Slots", 10)
+    doc = discovery.discover_docs(tmp_path)[0]
+    assert doc.short_title == "Slots"
 
 
 # ── make_external_id: Discourse's own validation rule ────────────────────

--- a/tests/scripts/docs_discourse_sync/test_links.py
+++ b/tests/scripts/docs_discourse_sync/test_links.py
@@ -139,3 +139,59 @@ def test_out_of_scope_docs_path_with_anchor_preserved() -> None:
     assert result.body_md == (
         "[ADR](https://github.com/Hal0ai/hal0/blob/main/docs/adr/0001-foo.md#some-heading)"
     )
+
+
+# ── Root-relative link missing its /docs prefix (a real source-doc typo) ──
+
+
+def test_root_relative_link_missing_docs_prefix_resolves() -> None:
+    """Regression: docs/reference/env-vars.mdx links to
+    /guides/run-agents/... (missing /docs) — a real typo that would have
+    404'd on hal0.dev's own dev server too. Recognised and resolved the
+    same as the correctly-prefixed form rather than left root-relative
+    (which would 404 against forum.hal0.dev instead)."""
+    body = "See [Run agents](/guides/run-agents/#hermes-terminal-tool-off-by-default)."
+    url_map = {"guides/run-agents": "https://forum.hal0.dev/t/run-agents/9"}
+    result = links.rewrite_internal_links(body, current_dir="x", url_map=url_map)
+    assert result.body_md == (
+        "See [Run agents](https://forum.hal0.dev/t/run-agents/9#hermes-terminal-tool-off-by-default)."
+    )
+    assert result.unresolved == []
+
+
+def test_root_relative_link_to_non_section_path_is_untouched() -> None:
+    """A root-relative path whose first segment isn't a published section
+    name isn't a "missing /docs prefix" typo — leave it alone rather than
+    guessing."""
+    body = "[Blog](/blog/some-post)"
+    result = links.rewrite_internal_links(body, current_dir="x", url_map=URL_MAP)
+    assert result.body_md == body
+    assert result.changed == 0
+
+
+# ── Code examples are never touched by link rewriting ─────────────────────
+
+
+def test_link_syntax_inside_fenced_code_block_is_untouched() -> None:
+    body = (
+        "Example:\n\n```md\n[Install](/docs/getting-started/install)\n```\n\n"
+        "Real link: [Install](/docs/getting-started/install)."
+    )
+    result = links.rewrite_internal_links(body, current_dir="x", url_map=URL_MAP)
+    # The fenced example keeps its literal, unrewritten markdown...
+    assert "```md\n[Install](/docs/getting-started/install)\n```" in result.body_md
+    # ...while the real link right after it still gets rewritten.
+    assert "Real link: [Install](https://forum.hal0.dev/t/install/2)." in result.body_md
+    assert result.changed == 1
+
+
+def test_link_syntax_inside_inline_code_span_is_untouched() -> None:
+    body = "Links look like `[text](/docs/getting-started/install)` in markdown."
+    result = links.rewrite_internal_links(body, current_dir="x", url_map=URL_MAP)
+    assert result.body_md == body
+    assert result.changed == 0
+
+
+def test_find_internal_link_keys_excludes_code_examples() -> None:
+    body = "```md\n[Install](/docs/getting-started/install)\n```"
+    assert links.find_internal_link_keys(body, current_dir="x") == set()

--- a/tests/scripts/docs_discourse_sync/test_sync.py
+++ b/tests/scripts/docs_discourse_sync/test_sync.py
@@ -101,7 +101,10 @@ class FakeForum:
                 if topic["post_id"] == post_id:
                     topic["raw"] = payload["post"]["raw"]
                     topic["title"] = payload["title"]
-                    topic["category_id"] = payload["category"]
+                    # category_id is nested under "post" on the real
+                    # PostsController#update — a top-level "category" (the
+                    # create-only field name) is silently ignored there.
+                    topic["category_id"] = payload["post"]["category_id"]
                     return httpx.Response(200, json={})
             return httpx.Response(404, json={"error_type": "not_found"})
 

--- a/tests/scripts/docs_discourse_sync/test_transform.py
+++ b/tests/scripts/docs_discourse_sync/test_transform.py
@@ -135,6 +135,36 @@ def test_fenced_code_block_passes_through_untouched() -> None:
     assert "```python\nimport os\nvalue = {1, 2, 3}\n```" in result.body_md
 
 
+def test_fenced_code_blank_lines_are_not_collapsed() -> None:
+    """Regression: blank-line tidying used to run *after* fence
+    restoration, so a fenced example with two consecutive blank lines
+    (three-plus newlines) got globally collapsed right along with
+    surrounding prose — violating the module's own "fences are never
+    touched" invariant."""
+    body = "Text.\n\n```python\ndef a():\n    pass\n\n\ndef b():\n    pass\n```\n\nMore.\n"
+    result = transform.transform_body(body, source="x.mdx")
+    assert "def a():\n    pass\n\n\ndef b():\n    pass" in result.body_md
+
+
+def test_single_quoted_jsx_attributes_parsed_like_double_quoted() -> None:
+    body = "<LinkCard title='Slots' href='/docs/concepts/slots' description='The lifecycle.' />\n"
+    result = transform.transform_body(body, source="x.mdx")
+    assert result.body_md.strip() == "- [Slots](/docs/concepts/slots): The lifecycle."
+
+
+def test_single_quoted_aside_attributes_parsed_like_double_quoted() -> None:
+    body = "<Aside type='danger' title='Stop'>\nRead this first.\n</Aside>\n"
+    result = transform.transform_body(body, source="x.mdx")
+    assert '[details="Danger: Stop"]' in result.body_md
+    assert "Read this first." in result.body_md
+
+
+def test_mixed_quote_styles_on_the_same_tag_both_parse() -> None:
+    body = "<LinkCard title='Slots' href=\"/docs/concepts/slots\" />\n"
+    result = transform.transform_body(body, source="x.mdx")
+    assert result.body_md.strip() == "- [Slots](/docs/concepts/slots)"
+
+
 def test_double_backtick_span_wrapping_a_literal_backtick_is_protected() -> None:
     """CommonMark: a code span's delimiter is a run of N backticks, closed
     by the *next run of exactly N backticks* — not just "the next


### PR DESCRIPTION
## Summary

Fix-forward on 7 codex review findings against PR #2000's (merged) fix
commits. Each verified against Discourse's actual source or the real
docs corpus before fixing — see the two commits' messages for the
per-finding evidence.

- **P1 title-length** (14/44 docs have Discourse-topic titles under the
  default 15-char minimum): `skip_validations` on create (confirmed
  effective by reading `PostsController#create_params`), plus title
  padding at generation time as the actually-guaranteed fix for the one
  path `skip_validations` doesn't reliably cover (a category-drift
  update, since `skip_validations` isn't wired through
  `PostsController#update` and Discourse's title validator re-checks
  on category change, not just title change).
- **P2 category_id on update**: was sent as a top-level `category` field
  — the create-only param name, silently ignored by
  `PostsController#update` (which reads `params[:post][:category_id]`).
  The previous round's category-drift fix would report success while
  never actually changing the category. Fixed, and verified end-to-end
  that a category-id change now actually flips.
- **P2 root-relative link missing /docs**: one real typo in
  `docs/reference/env-vars.mdx`, confirmed by grep. Normalized before
  resolution instead of left broken.
- **P2 link rewriting inside code examples**: link rewrite now masks
  fenced/inline code the same way `transform.py` does (0 occurrences in
  the corpus today, but a real gap in the "code is opaque" invariant).
- **P2 blank-line tidy before fence restore**: reordered so it can never
  reach inside a fence (harmless today — no fence has 2+ blank lines —
  but no longer coincidental).
- **P2 single-quoted JSX attributes**: `<LinkCard title='Slots' .../>`
  used to silently render as `- []()` instead of erroring or parsing —
  now parses either quote style.
- **P2 orphan-topic reconciliation**: not built, per review direction —
  filed https://github.com/Hal0ai/hal0/issues/2003 (moderation-policy
  decision, not mechanical).

## Test plan

- [x] `HAL0_HOME=$(mktemp -d) uv run pytest tests/scripts/docs_discourse_sync -q` — **111 passed** (was 99), 0 live HTTP
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] Full mocked sync over all 44 real docs with a mock that asserts the *exact* new payload shapes (`skip_validations` on create, nested `category_id` on update) — idempotent across two rounds, 0 unresolved links, the specific env-vars.mdx link fix confirmed present in the synced raw
- [x] A third mocked round with a changed `category_id` (7→42) confirmed every topic's category actually updates — proving the previous round's category fix, which looked right but wasn't wired to a real Discourse param, now genuinely works

Not merged — no live-forum credentials in this environment either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)