### PR TITLE
fix/docs sync follow redirects

### DIFF
--- a/scripts/docs_discourse_sync/discourse_client.py
+++ b/scripts/docs_discourse_sync/discourse_client.py
@@ -146,9 +146,21 @@ class DiscourseClient:
         without ever calling a mutating endpoint. Returns ``None`` on 404
         (no topic with this external_id yet), which is the expected,
         common case on a doc's first sync — not an error.
+
+        This endpoint never returns the topic JSON directly: Discourse's
+        ``TopicsController#show_by_external_id`` always
+        ``redirect_to_correct_topic``s — a 301 to the canonical
+        ``/t/<slug>/<id>.json``, found on the live pilot's second sync
+        (mocks never modeled it, since every mock returned 200 straight
+        away). The redirect target carries ``include_raw`` forward
+        (Discourse allow-lists it through the redirect), so following it
+        loses nothing — ``follow_redirects`` is scoped to just this GET,
+        not enabled client-wide, since a redirected POST/PUT changing
+        method or replaying a body is a very different, riskier thing to
+        do silently.
         """
         path = f"/t/external_id/{external_id}.json"
-        response = self._request("GET", path, params={"include_raw": "true"})
+        response = self._request("GET", path, params={"include_raw": "true"}, follow_redirects=True)
         if response.status_code == 404:
             return None
         if response.status_code != 200:

--- a/scripts/docs_discourse_sync/discovery.py
+++ b/scripts/docs_discourse_sync/discovery.py
@@ -57,9 +57,21 @@ _TITLE_PAD_SUFFIX = " (hal0 docs)"
 
 
 def _discourse_safe_title(title: str) -> str:
-    if len(title) >= _DISCOURSE_MIN_TITLE_LENGTH:
-        return title
-    return f"{title}{_TITLE_PAD_SUFFIX}"
+    """Pad *title* to the Discourse title-length floor, unconditionally.
+
+    A single ``_TITLE_PAD_SUFFIX`` appended once isn't a guarantee — it's
+    tuned for the current corpus's shortest title ("CLI", 3 chars +
+    12-char suffix = 15, exactly at the floor) but a 1-2 char title would
+    still undershoot it (codex round 3 on PR #2004: "X" + suffix = 13).
+    Reappending the same suffix until the floor is cleared is guaranteed
+    regardless of how short the original title is, at the cost of visible
+    repetition for a title that short — an acceptable tradeoff for a case
+    that doesn't exist in the docs/ corpus today (nothing under 3 chars).
+    """
+    padded = title
+    while len(padded) < _DISCOURSE_MIN_TITLE_LENGTH:
+        padded = f"{padded}{_TITLE_PAD_SUFFIX}"
+    return padded
 
 
 class DiscoveryError(ValueError):

--- a/tests/scripts/docs_discourse_sync/test_discourse_client.py
+++ b/tests/scripts/docs_discourse_sync/test_discourse_client.py
@@ -32,20 +32,35 @@ def _client(handler, **kwargs) -> DiscourseClient:
     )
 
 
+def _resolve_topic_json() -> dict:
+    return {
+        "id": 55,
+        "slug": "install-hal0",
+        "title": "Install hal0",
+        "category_id": 7,
+        "post_stream": {"posts": [{"id": 999, "raw": "content here"}]},
+    }
+
+
 def test_resolve_topic_found() -> None:
+    """Discourse's real /t/external_id/{id}.json NEVER returns the topic
+    JSON directly — TopicsController#show_by_external_id always
+    redirect_to_correct_topic (301 to the canonical /t/<slug>/<id>.json,
+    verified against the controller source). Every mock here follows
+    that same two-hop shape so the test suite doesn't diverge from the
+    live pilot's actual behavior the way it did before this was found."""
+
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == "/t/external_id/hal0-docs--getting-started--install.json"
-        assert request.url.params["include_raw"] == "true"
-        return httpx.Response(
-            200,
-            json={
-                "id": 55,
-                "slug": "install-hal0",
-                "title": "Install hal0",
-                "category_id": 7,
-                "post_stream": {"posts": [{"id": 999, "raw": "content here"}]},
-            },
-        )
+        if request.url.path == "/t/external_id/hal0-docs--getting-started--install.json":
+            assert request.url.params["include_raw"] == "true"
+            return httpx.Response(
+                301,
+                headers={"Location": "/t/install-hal0/55.json?include_raw=true"},
+            )
+        if request.url.path == "/t/install-hal0/55.json":
+            assert request.url.params["include_raw"] == "true"
+            return httpx.Response(200, json=_resolve_topic_json())
+        raise AssertionError(f"unexpected request: {request.url.path}")
 
     with _client(handler) as client:
         topic = client.resolve_topic("hal0-docs--getting-started--install")
@@ -59,6 +74,21 @@ def test_resolve_topic_found() -> None:
         category_id=7,
     )
     assert topic.url("https://forum.hal0.dev") == "https://forum.hal0.dev/t/install-hal0/55"
+
+
+def test_create_topic_does_not_follow_a_redirect() -> None:
+    """Redirect-following is scoped to resolve_topic's GET, not enabled
+    client-wide — a redirected mutating call changing method or
+    replaying a body is a very different, riskier thing to do silently.
+    A 301 from a mutating call should surface as an error, not get
+    silently followed and treated as success."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(301, headers={"Location": "/posts/999.json"})
+
+    with _client(handler) as client, pytest.raises(DiscourseAPIError) as exc_info:
+        client.create_topic(external_id="hal0-docs--x", title="X", raw="raw", category_id=7)
+    assert exc_info.value.status_code == 301
 
 
 def test_resolve_topic_lookup_path_has_exactly_one_id_segment() -> None:

--- a/tests/scripts/docs_discourse_sync/test_discovery.py
+++ b/tests/scripts/docs_discourse_sync/test_discovery.py
@@ -164,6 +164,25 @@ def test_short_title_padding_does_not_affect_short_title_field(tmp_path: Path) -
     assert doc.short_title == "Slots"
 
 
+@pytest.mark.parametrize("title", ["X", "Hi", "CLI", "1234", "A" * 14])
+def test_discourse_safe_title_always_clears_the_floor(title: str) -> None:
+    """codex round 3 on PR #2004: a single suffix append is tuned for the
+    corpus's shortest real title ("CLI", 3 chars — lands exactly on 15)
+    but undershoots for a 1-2 char title ("X" + the 12-char suffix = 13).
+    Every length up to (and including) one short of the floor must clear
+    it, not just the ones that happen to occur in docs/ today."""
+    padded = discovery._discourse_safe_title(title)
+    assert len(padded) >= discovery._DISCOURSE_MIN_TITLE_LENGTH
+    assert padded.startswith(title)
+
+
+def test_discourse_safe_title_one_char_title_is_padded_enough(tmp_path: Path) -> None:
+    _write(tmp_path / "concepts" / "x.mdx", "X", 10)
+    doc = discovery.discover_docs(tmp_path)[0]
+    assert len(doc.title) >= 15
+    assert doc.title.startswith("X")
+
+
 # ── make_external_id: Discourse's own validation rule ────────────────────
 # app/models/topic.rb: `validates :external_id, format: { with: /\A[\w-]+\z/ },
 # length: { maximum: EXTERNAL_ID_MAX_LENGTH }` where EXTERNAL_ID_MAX_LENGTH = 50.

--- a/tests/scripts/docs_discourse_sync/test_sync.py
+++ b/tests/scripts/docs_discourse_sync/test_sync.py
@@ -11,6 +11,7 @@ second blind run.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import httpx
@@ -65,6 +66,18 @@ class FakeForum:
         if request.method == "GET" and request.url.path.startswith("/t/external_id/"):
             external_id = request.url.path.removeprefix("/t/external_id/").removesuffix(".json")
             topic = self.topics.get(external_id)
+            if topic is None:
+                return httpx.Response(404, json={"error_type": "not_found"})
+            # Real Discourse never answers this lookup directly — it 301s
+            # to the canonical /t/<slug>/<id>.json (found on the live
+            # pilot's second sync; TopicsController#show_by_external_id
+            # always redirect_to_correct_topic, verified against source).
+            location = f"/t/{topic['slug']}/{topic['topic_id']}.json?include_raw=true"
+            return httpx.Response(301, headers={"Location": location})
+
+        if request.method == "GET" and re.match(r"^/t/[^/]+/\d+\.json$", request.url.path):
+            topic_id = int(request.url.path.rsplit("/", 1)[-1].removesuffix(".json"))
+            topic = next((t for t in self.topics.values() if t["topic_id"] == topic_id), None)
             if topic is None:
                 return httpx.Response(404, json={"error_type": "not_found"})
             return httpx.Response(


### PR DESCRIPTION
## Summary

Fixes a live-pilot failure found on the second (idempotency) sync run
against forum.hal0.dev, plus one edge case codex round 3 logged as
known-but-not-actioned on #2004.

- **Redirect-following on external_id lookup**: the initial 44-doc
  migration succeeded, but the very next run failed immediately with
  `DiscourseAPIError: GET /t/external_id/....json -> 301`. Verified
  against Discourse's source: `TopicsController#show_by_external_id`
  *always* 301-redirects to the canonical `/t/<slug>/<id>.json` — this
  was never a direct-200 endpoint, the mocks just never modeled it.
  `resolve_topic` now follows that one redirect (scoped there, not
  client-wide — a redirected mutating call is a different risk). Every
  mock in the suite now serves the real two-hop shape.
- **Title-padding floor guarantee**: a single suffix append clears the
  floor for the corpus's shortest real title ("CLI") but would
  undershoot for a hypothetical 1-2 char title. Now loops until the
  floor is unconditionally cleared.

## Test plan

- [x] `HAL0_HOME=$(mktemp -d) uv run pytest tests/scripts/docs_discourse_sync -q` — **118 passed** (was 111), 0 live HTTP
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] Reproduced the exact live failure in a mocked full-corpus sync: a
      second run where every one of 49 lookups (44 docs + 5 index
      topics) hits the 301 path — confirmed idempotent (all noop)
      instead of raising
- [x] `_discourse_safe_title` parametrized over 1-2 char titles, confirms
      the floor is always cleared

Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)