### PR TITLE
fix(ui): add a Device select to the slot edit drawer for rocm/vulkan switching

### DIFF
--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -266,9 +266,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// in npu-pane.jsx, so react-query serves it from cache here.
 	const slotsQuery = useSlots();
 	// HW grid (spec-hw-slot-ownership §2): BINARY options + fit-check metadata
-	// from system-info (RUNNER_IMAGES). The device ENUM is no longer read here —
-	// device rides the model at creation and is not editable post-create, so the
-	// drawer only ever *displays* the slot's persisted device.
+	// from system-info (RUNNER_IMAGES). Device is seeded from the model at
+	// creation and editable here post-create (the HW grid's Device select) —
+	// it is the UI's only rocm↔vulkan switch, since BINARY is metadata-gated
+	// to the same image and profiles carry backend only as an inert fit hint.
 	const systemInfoQuery = useSystemInfo();
 
 	// Seed from the PERSISTED context window (slot.ctx_max, from
@@ -627,8 +628,21 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		// would strand the currently-bound model — block Save until the
 		// operator swaps to a compatible model or reverts the profile pick.
 		if (strandsBoundModel) {
-			errs.profile =
-				"This profile switches the slot to a device that can't run the bound model — swap to a compatible model first, or pick a same-backend profile.";
+			const msg =
+				"This switches the slot to a device that can't run the bound model — swap to a compatible model first, or keep the current backend.";
+			if (changes.device) errs.device = msg;
+			else errs.profile = msg;
+		}
+		// Device and profile edited to CONFLICTING backends in one Save — the
+		// server hard-rejects that pair (_reconcile_device_profile's operator
+		// error). Surface it inline instead of as a failed submit.
+		if (changes.device && changes.profile && profileSel) {
+			const selProf = (
+				Array.isArray(profilesQuery.data) ? profilesQuery.data : []
+			).find((p) => p.name === profileSel);
+			if (selProf?.backend && selProf.backend !== deviceBackend(device)) {
+				errs.profile = `Profile "${profileSel}" declares backend "${selProf.backend}" but Device is set to "${device}" — pick a matching pair.`;
+			}
 		}
 		if (Object.keys(errs).length > 0) {
 			setFieldErrs(errs);
@@ -767,21 +781,36 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// "is this actually pending" from an equality check on every read.
 	const pendingCrossDevice =
 		pendingDevice !== device ? pendingDevice : null;
-	// Codex P1: a Save that switches the slot to `pendingCrossDevice` also
-	// re-derives its device server-side (_reconcile_device_profile) — but the
-	// currently BOUND model rides along untouched. If that model doesn't fit
-	// the new backend (e.g. a rocmfp4 model on a ROCm→Vulkan switch), Save
-	// would strand it: a live container restarts onto a runner that can't
-	// load its own bound model. Block Save in that case (see onSaveClick)
-	// rather than let the restart fail after the fact.
-	const boundModelId = slot.model_id || slot.model || "";
+	// A live edit of the HW grid's Device select itself (the direct
+	// rocm↔vulkan switch): `device` state has already moved, so
+	// `pendingDevice` equals it — compare against the PERSISTED device to
+	// know a switch is pending. Same Save-time consequences as a
+	// cross-backend profile pick, different control.
+	// Compared against the FROZEN baseline (#1398), not the live-polled slot
+	// prop, so background drift can never read as an operator edit.
+	const deviceIsLiveEdit = baseline ? device !== baseline.device : false;
+	// The device this slot will actually launch on after Save, when that
+	// differs from the persisted one — from either switching control.
+	const pendingTargetDevice =
+		pendingCrossDevice || (deviceIsLiveEdit ? device : null);
+	// Codex P1: a Save that switches the slot's device — via a cross-backend
+	// profile (server-side _reconcile_device_profile) or the Device select
+	// directly — leaves the currently BOUND model riding along untouched. If
+	// that model doesn't fit the new backend (e.g. a rocmfp4 model on a
+	// ROCm→Vulkan switch), Save would strand it: a live container restarts
+	// onto a runner that can't load its own bound model. Block Save in that
+	// case (see onSaveClick) rather than let the restart fail after the fact.
+	// Judge the RESOLVED bound-model row (curModelRow), not the bare bound id:
+	// an id that doesn't resolve against /api/models (catalog still loading,
+	// legacy alias, HAL0_DATA seed) gives no honest compatibility answer, and
+	// blocking on "not found" would veto every switch in that window.
 	const strandsBoundModel =
-		!!pendingCrossDevice &&
-		!!boundModelId &&
+		!!pendingTargetDevice &&
+		!!curModelRow &&
 		!compatibleModels(modelsQuery.data, {
 			type: slot.type,
-			backend: deviceBackend(pendingCrossDevice),
-		}).some((m) => m.id === boundModelId);
+			backend: deviceBackend(pendingTargetDevice),
+		}).some((m) => m.id === curModelRow.id);
 
 	// Instant-apply pin/unpin for the drawer header toggle (§21.10, #1367).
 	// Fires the PUT, toasts the result, and lets the slots poll re-render from
@@ -1467,13 +1496,70 @@ function EditSlotDrawer({ open, slot, onClose }) {
 							!supported.includes(devBackend)
 								? `Device backend "${devBackend}" is not in ${binary}'s supported backends (${supported.join(", ")}). The slot may fall back or fail at spawn.`
 								: null;
+						// GPU device options: the rocm↔vulkan pair every GPU box can
+						// host (one Vulkan-portable image serves both), plus the
+						// slot's persisted value when it sits outside that pair
+						// (gpu-cuda, hand-edited TOML) so opening the drawer never
+						// silently rewrites it. Non-GPU devices (npu/cpu/img) route
+						// to different runtime families — switching those is a
+						// re-create, not an edit, so they keep no control.
+						const gpuDeviceOptions = ["gpu-rocm", "gpu-vulkan"];
+						const persistedDevice = slot.device || "gpu-rocm";
+						if (
+							deviceClassOf(persistedDevice) === "gpu" &&
+							!gpuDeviceOptions.includes(persistedDevice)
+						)
+							gpuDeviceOptions.unshift(persistedDevice);
 						return (
 							<>
-								{/* Device has no control here on purpose: it rides the model
-								    at creation (see the create modal's device-redirect note);
-								    the per-slot Profile select above picks this slot's
-								    runtime (runner family + image), not its flag tune. The
-								    drawer still READS slot.device for the fit filters below. */}
+								{/* Device — the slot's typed backend fact (gpu-rocm /
+								    gpu-vulkan). Seeded from the model at creation, editable
+								    here post-create: this select is the ONLY UI path that
+								    switches a slot between the ROCm and Vulkan backends
+								    (the Runner Binary below is metadata-gated to the SAME
+								    image and never flips the backend; profiles carry
+								    backend only as an inert fit hint). Save persists it
+								    via PUT /config { device } and cold-restarts. */}
+								{deviceClassOf(persistedDevice) === "gpu" && (
+									<div className="form-row">
+										<div className="form-lbl">
+											<span>Device</span>
+											<FieldInfoIcon description="⟳ GPU backend this slot launches on. Switching
+												rocm↔vulkan restarts the slot onto the other
+												llama-server backend (same runner image). The bound
+												model must be runnable on the target backend —
+												Save blocks otherwise." />
+										</div>
+										<div className="form-ctl">
+											<select
+												className={
+													"input mono" + (fieldErrs.device ? " input-err" : "")
+												}
+												data-testid="slot-hw-device"
+												value={device}
+												onChange={(e) => {
+													setDevice(e.target.value);
+													setFieldErrs((p) => ({ ...p, device: undefined }));
+												}}
+											>
+												{gpuDeviceOptions.map((d) => (
+													<option key={d} value={d}>
+														{d} · {deviceBackend(d)}
+													</option>
+												))}
+											</select>
+											{fieldErrs.device && (
+												<div
+													className="hint"
+													data-testid="slot-hw-device-err"
+													style={{ color: "var(--err)" }}
+												>
+													{fieldErrs.device}
+												</div>
+											)}
+										</div>
+									</div>
+								)}
 								<div className="form-row">
 									<div className="form-lbl">
 										<span>Runner Image</span>

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -187,16 +187,50 @@ test.describe('Slot edit controls (/slots)', () => {
     expect(puts[0]).toHaveProperty('n_gpu_layers', -1)
   })
 
-  test('HW grid — the typed fields + Runner Image render; Device does not (§2)', async ({ page }) => {
+  test('HW grid — the typed fields + Runner Image + Device render (§2)', async ({ page }) => {
     await seedSlots(page, [PRIMARY, EMBED])
     await page.goto('/#slots/primary')
-    // Device is create-time only now: it rides the model and is fixed for the
-    // slot's lifetime, so the drawer displays it but offers no control.
-    await expect(page.getByTestId('slot-hw-device')).toHaveCount(0)
+    // Device is editable post-create for GPU slots (fix-gpu-slot-switch):
+    // it is the UI's only rocm↔vulkan switch — BINARY never flips the
+    // backend (metadata, not a selector) and seed profiles declare none.
+    await expect(page.getByTestId('slot-hw-device')).toBeVisible()
+    await expect(page.getByTestId('slot-hw-device')).toHaveValue('gpu-rocm')
     await expect(page.getByTestId('slot-hw-ngl')).toBeVisible()
     await expect(page.getByTestId('slot-hw-threads')).toBeVisible()
     await expect(page.getByTestId('slot-hw-binary')).toBeVisible()
     await expect(page.getByTestId('slot-hw-image-pin')).toBeVisible()
+  })
+
+  test('HW grid — switching Device rocm→vulkan Save PUTs /config { device } and restarts', async ({ page }) => {
+    const puts: any[] = []
+    const restarts: string[] = []
+    await page.route('**/api/slots/primary/config', async (route) => {
+      if (route.request().method() === 'PUT') puts.push(JSON.parse(route.request().postData() || '{}'))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.route('**/api/slots/primary/defaults', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+    await page.route('**/api/slots/primary/restart', async (route) => {
+      restarts.push(route.request().method())
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await seedSlots(page, [PRIMARY, EMBED])
+    await page.goto('/#slots/primary')
+    await page.getByTestId('slot-hw-device').selectOption('gpu-vulkan')
+    await page.locator('.drawer button:has-text("Save")').click()
+    await expect.poll(() => puts.length).toBeGreaterThan(0)
+    expect(puts[0]).toMatchObject({ device: 'gpu-vulkan' })
+    // A device flip is a hardware change — the cold restart fires in the
+    // background after the config write lands.
+    await expect.poll(() => restarts.length).toBeGreaterThan(0)
+  })
+
+  test('HW grid — Device select is absent on a non-GPU slot', async ({ page }) => {
+    await seedSlots(page, [{ ...PRIMARY, name: 'cpuish', device: 'cpu' }, EMBED])
+    await page.goto('/#slots/cpuish')
+    await expect(page.locator('.drawer')).toBeVisible()
+    await expect(page.getByTestId('slot-hw-device')).toHaveCount(0)
   })
 
   test('HW grid — all editable fields persist their wire keys', async ({ page }) => {


### PR DESCRIPTION
## What

Adds a **Device** select (`gpu-rocm` / `gpu-vulkan`) to the slot edit drawer's Hardware group, for GPU-class slots only, restoring a working UI path to switch a slot between the ROCm and Vulkan backends.

## Why

There was **no working path** to switch a GPU slot's backend from the UI:

- The **Runner Binary** select shows `rocmfpx · rocm` / `vulkanfpx · vulkan`, but it is explicitly metadata, not a selector — both keys resolve to the same Vulkan-portable image, and the concrete backend is chosen by the slot's typed `device` (`runners/__init__.py`, `supported_backends` docstring).
- The **cross-backend Profile** path (#1636) only works for a profile that *declares* a backend — none of the seed profiles do (verified on CT105: every `/api/profiles` row has `backend: null`).
- The two owning specs drifted: the model drawer says the model is device-agnostic and "device lives on the slot's HW grid now" (spec-hw-slot-ownership §1/§8), while the slot drawer said "device rides the model at creation and is not editable post-create" (§2). Net result: `device` was editable **nowhere**.

So the operator selects either pseudo-switch, Save succeeds, and the slot card — which derives its backend chip from the untouched `device` — shows no change. Reported on LXC105 (rc.6, latest code confirmed deployed).

All the plumbing already existed end-to-end (drawer `device` state, frozen-baseline dirty predicate, `PUT /config { device }` save body, cold-restart trigger, server-side `_reconcile_device_profile`); only the control was missing.

## Also fixed along the way

- Extended the Codex-P1 strand guard to a direct device edit: Save blocks when the bound model can't run on the target backend.
- That guard now judges the **resolved** bound-model row instead of the bare bound id — an id that doesn't resolve against `/api/models` (catalog loading, legacy alias) was vetoing every switch.
- Device + profile edited to conflicting backends in one Save now surfaces inline instead of as the server's failed-submit `SlotConfigError`.

## Verification

- `npm run lint`, `npm run typecheck`, `npm run test:unit` (174 passed) green.
- Full Playwright e2e suite: 650 passed, 1 unrelated flake (`board-chat-error-surfacing-v3` — passes in isolation, untouched by this diff).
- Updated `slot-edit-controls-v3.spec.ts`: the old "Device does not render (§2)" assertion is reversed; new tests cover the render, the `PUT /config { device: "gpu-vulkan" }` wire write + background restart, and absence of the control on non-GPU slots.

## Out of scope

- Seed profiles still declare no `backend`, so the #1636 cross-backend profile path remains dead code on real installs — left as-is now that the Device select covers the operator need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)