### PR TITLE
fix(ui): give the device/profile pill its own row on the slot card

### DIFF
--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -1228,6 +1228,23 @@
 :is(.infer-pane, .npu-pane) .sctrl.scard-model-edit {
   flex: 0 0 auto;
 }
+/* Device + profile pill's own row, directly under the model control — pulled
+   out of .scard-foot so a long custom profile name never eats into the
+   lifecycle-controls' space and forces them onto a cramped wrapped line. */
+:is(.infer-pane, .npu-pane) .scard-profile-row {
+  display: flex;
+  min-width: 0;
+}
+:is(.infer-pane, .npu-pane) .scard-profile-row .prov {
+  min-width: 0;
+  max-width: 100%;
+}
+:is(.infer-pane, .npu-pane) .scard-profile-row .profile-pill {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
 
 /* expanded-body status line — right-aligned mono */
 :is(.infer-pane, .npu-pane) .body-status {

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -495,6 +495,18 @@ export function SlotScard({
         ) : (
           modelNode
         )}
+        {/* Device + profile pill gets its OWN row, directly under the model
+            control, instead of sharing the bottom action bar. It's a long,
+            variable-length control (custom profile names can run well past
+            "vulkan"/"rocm") and packing it into .scard-foot alongside the
+            image/mem chips and the lifecycle buttons was squeezing the
+            buttons onto a cramped wrapped line on any card with a longer
+            profile name or an image-unknown chip present. Giving it a row of
+            its own means .scard-foot only ever holds short, fixed-width
+            chips + controls, so the controls stop competing for space. */}
+        <div className="scard-profile-row">
+          <DevCell s={s} onProfile={onEdit} />
+        </div>
         {full && (
           <div className="scard-meta">
             <div className="m">
@@ -514,7 +526,6 @@ export function SlotScard({
           </div>
         )}
         <div className={'scard-foot' + (full ? '' : ' bare')}>
-          <DevCell s={s} onProfile={onEdit} />
           <BackendMismatch s={s} onEdit={onEdit} />
           <SlotImageUnknownChip s={s} />
           {full && memGb != null && <span className="tag-chip">{memGb} GB</span>}

--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -71,6 +71,26 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
     await expect(pill).toContainText('rocm')
   })
 
+  test('device/profile pill has its own row, out of the bottom action bar (#squished-controls fix)', async ({ page }) => {
+    // Regression: the [ device | PROFILE ] pill used to share .scard-foot with
+    // the image/mem chips AND the lifecycle controls — a long custom profile
+    // name (or the #1939 image-unknown chip) could squeeze the Stop/Restart/
+    // Logs/Edit buttons onto a cramped wrapped line. The pill now lives in its
+    // own .scard-profile-row directly under the model control, so .scard-foot
+    // only ever holds short fixed-width chips + the controls.
+    await page.goto('/#slots')
+    const card = body(page).getByTestId('infer-slot-primary')
+    const profileRow = card.locator('.scard-profile-row')
+    await expect(profileRow).toBeVisible()
+    await expect(profileRow.locator('.prov')).toBeVisible()
+    await expect(profileRow.getByTestId('infer-profile-primary')).toBeVisible()
+    // .scard-foot must NOT contain the provider/profile pill any more.
+    await expect(card.locator('.scard-foot .prov')).toHaveCount(0)
+    await expect(card.locator('.scard-foot [data-testid="infer-profile-primary"]')).toHaveCount(0)
+    // the lifecycle controls still render, undisturbed, inside .scard-foot.
+    await expect(card.locator('.scard-foot .slot-ctrls')).toBeVisible()
+  })
+
   test('NPU/FLM slots are cordoned off to the NPU pane', async ({ page }) => {
     await page.goto('/#slots')
     await expect(pane(page)).toBeVisible()

--- a/ui/tests/e2e/specs/slot-card-reorder-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-card-reorder-v3.spec.ts
@@ -63,6 +63,32 @@ const pane = (page: Page) => page.locator('.infer-pane:not(.infer-hero-top)').fi
 const card = (page: Page, name: string) => pane(page).getByTestId(`infer-slot-${name}`)
 const grip = (page: Page, name: string) => page.getByTestId(`infer-grip-${name}`)
 
+// Native HTML5 drag-and-drop requires the browser to see the pointer cross a
+// drag THRESHOLD shortly after mousedown to actually start a drag session.
+// `locator.dragTo()` moves from source to target in one hop, which is fine
+// over a short distance but can silently fail to trigger dragstart at all
+// over a longer one (no drag session ever begins — dragenter/drop never
+// fire, and the reorder is a no-op). The full-card grid rows aren't a fixed
+// height (P2 card content varies — e.g. the profile pill's row), so the
+// vertical distance between a grip and another row's card isn't constant.
+// Stepping the mouse move — the standard Playwright workaround for native
+// DnD — keeps the drag reliable regardless of row height.
+async function dragGripTo(page: Page, source: ReturnType<typeof grip>, target: ReturnType<typeof card>) {
+  const src = (await source.boundingBox())!
+  const dst = (await target.boundingBox())!
+  const sx = src.x + src.width / 2
+  const sy = src.y + src.height / 2
+  const tx = dst.x + dst.width / 2
+  const ty = dst.y + dst.height / 2
+  await page.mouse.move(sx, sy)
+  await page.mouse.down()
+  const steps = 10
+  for (let i = 1; i <= steps; i++) {
+    await page.mouse.move(sx + (tx - sx) * (i / steps), sy + (ty - sy) * (i / steps))
+  }
+  await page.mouse.up()
+}
+
 const namesOf = (sel: string) => async (page: Page) => {
   const ids = await pane(page)
     .locator(sel)
@@ -103,11 +129,17 @@ test.describe('Slot card — drag to reorder', () => {
     expect(await chatOrder(page)).toEqual(['alpha', 'bravo', 'charlie'])
 
     // The cards sit below the telemetry header; a native drag needs both ends
-    // of the gesture inside the viewport, so bring the row up first.
-    await card(page, 'charlie').scrollIntoViewIfNeeded()
+    // of the gesture inside the viewport, so bring the row up first. Scroll
+    // to the DRAG SOURCE (alpha), not the target — "nearest" scrolling to
+    // charlie alone can leave alpha's row flush against the fixed topbar,
+    // with the grip's hit-test point actually landing on the topbar instead
+    // of the grip itself (the row content is variable-height — e.g. the
+    // profile-pill row — so how much scroll "nearest" applies isn't fixed).
+    await grip(page, 'alpha').scrollIntoViewIfNeeded()
+    await expect(card(page, 'charlie')).toBeInViewport()
 
     // Drag alpha rightwards onto charlie — it lands past charlie.
-    await grip(page, 'alpha').dragTo(card(page, 'charlie'))
+    await dragGripTo(page, grip(page, 'alpha'), card(page, 'charlie'))
     await expect.poll(() => chatOrder(page)).toEqual(['bravo', 'charlie', 'alpha'])
 
     // No Save step: the arrangement is already persisted, client-side only.


### PR DESCRIPTION
## What

The device/profile pill (`[vulkan | CHADROCK-MOE]`) shared one flex-wrap row with the image chip, mem chip, and all five lifecycle buttons; long profile names crowded the buttons onto a cramped wrapped line. The pill moves to its own row under the model dropdown; `.scard-foot` keeps only short fixed-width chips + controls. Also hardens the drag-to-reorder e2e helper: the taller card stopped Playwright's `dragTo()` from crossing Chromium's native drag-start threshold, and scroll targeting could leave the drag source under the fixed topbar — proven a test-infra issue (manual drag at identical coordinates works), fixed in the helper with a regression test locking the new row.

## Why

Operator-reported layout break on slot cards with long custom profile names (live CT105 review, 2026-08-22).

## How verified

vitest 174/174; targeted e2e inference-pane + slot-card-reorder 19/19 (1 pre-existing skip); verified live on CT105 at default and 1000px viewports — five buttons on one row, uniform width, no wrap. Cherry-picked from the memory-v2 preview branch so it lands independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)