### PR TITLE
fix(slots): self-heal crash-looped slots — restart backoff, half-open breaker, visible state

### DIFF
--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -276,8 +276,8 @@ validate_dropin_body() {  # arg: kind (gateway|hindsight); body on stdin
 #               AddCapability= PodmanArgs= Volume= Environment= PublishPort=
 #               HealthCmd= HealthStartPeriod= HealthInterval= HealthRetries=
 #               HealthTimeout= Exec=
-#   [Service]   Restart= RestartSec= SyslogIdentifier= StandardOutput=
-#               StandardError=
+#   [Service]   Restart= RestartSec= RestartSteps= RestartMaxDelaySec=
+#               SyslogIdentifier= StandardOutput= StandardError=
 #   [Install]   WantedBy=hal0.target        (omitted when autoload = false)
 #
 # Sections may appear at most once and only in that order; [Container] is
@@ -398,7 +398,11 @@ validate_quadlet_directive() {  # args: section, "Key=Value" line
     # Charset-pinned, not semantics-pinned — see the HONEST BOUNDARY note.
     'Container|Image')          [[ "$value" =~ $_QRE_IMAGE ]]    || _quadlet_die "bad Image: $value" ;;
     'Container|ContainerName')  [[ "$value" =~ $_QRE_CTRNAME ]]  || _quadlet_die "bad ContainerName: $value" ;;
-    'Container|LogDriver')      [[ "$value" == "none" ]]         || _quadlet_die "bad LogDriver: $value" ;;
+    # passthrough is what the renderer emits now (unit-journaled, single
+    # copy); none is accepted for the skew window where an older venv
+    # renders through a newer wrapper.
+    'Container|LogDriver')      [[ "$value" == "passthrough" || "$value" == "none" ]] \
+                                                                 || _quadlet_die "bad LogDriver: $value" ;;
     'Container|Network')        [[ "$value" =~ $_QRE_NETWORK ]]  || _quadlet_die "bad Network: $value" ;;
     'Container|AddDevice')
       [[ "$value" =~ $_QRE_DEVICE ]] || _quadlet_die "bad AddDevice: $value"
@@ -425,11 +429,13 @@ validate_quadlet_directive() {  # args: section, "Key=Value" line
 
     # ── [Service] ───────────────────────────────────────────────────────
     # Copied VERBATIM into the generated system unit by podman's quadlet
-    # generator — i.e. host-side root. Exactly the five the renderer emits;
+    # generator — i.e. host-side root. Exactly the seven the renderer emits;
     # every Exec*=, User=, Group=, WorkingDirectory=, … lands in the default
     # arm below and dies.
     'Service|Restart')           [[ "$value" =~ $_QRE_RESTART ]] || _quadlet_die "bad Restart: $value" ;;
     'Service|RestartSec')        [[ "$value" =~ $_QRE_UINT ]]    || _quadlet_die "bad RestartSec: $value" ;;
+    'Service|RestartSteps')      [[ "$value" =~ $_QRE_UINT ]]    || _quadlet_die "bad RestartSteps: $value" ;;
+    'Service|RestartMaxDelaySec') [[ "$value" =~ $_QRE_UINT ]]   || _quadlet_die "bad RestartMaxDelaySec: $value" ;;
     'Service|SyslogIdentifier')  [[ "$value" =~ $_QRE_CTRNAME ]] || _quadlet_die "bad SyslogIdentifier: $value" ;;
     'Service|StandardOutput')    [[ "$value" == "journal" ]]     || _quadlet_die "bad StandardOutput: $value" ;;
     'Service|StandardError')     [[ "$value" == "journal" ]]     || _quadlet_die "bad StandardError: $value" ;;

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -732,16 +732,30 @@ def _render_quadlet_from_plan(
         # slot's restart rate-limiting (install-validation m2, halo150,
         # 2026-07-19). Restart=/RestartSec= stay in [Service] below — those
         # ARE Service-section keys.
-        "StartLimitIntervalSec=300",
-        "StartLimitBurst=5",
+        #
+        # Window/burst are sized for the RestartSteps= ramp below: ~10
+        # attempts spread over ~20 minutes (5s → 300s geometric), so a
+        # transient cause — a neighbour hogging the GPU, a cold mount, a
+        # slow image pull — gets real time to clear before systemd gives
+        # up. The old 300s/5 pairing burned all 5 attempts in ~16s and
+        # LATCHED the unit in ``failed`` (#1424): slot 15 stayed down for
+        # hours after the actual contention had passed.
+        "StartLimitIntervalSec=1800",
+        "StartLimitBurst=10",
         "",
         "[Container]",
         f"Image={plan.image}",
         f"ContainerName={container_name}",
-        # ``LogDriver=none`` keeps conmon→journal the single sink so
-        # ``journalctl -u`` isn't double-fed (podman's own journald driver
-        # would tag a second copy — the old B3 note).
-        "LogDriver=none",
+        # ``LogDriver=passthrough`` hands the container's stdout/stderr to
+        # the unit itself, which systemd journals exactly once. The old
+        # ``LogDriver=none`` assumed conmon→journal held the streams, but
+        # the Quadlet service runs podman detached: the client exits after
+        # echoing the container id, conmon holds the real streams, and with
+        # podman's own sink disabled there was NO sink at all — every slot
+        # produced zero container output and a crashing model's actual
+        # error was invisible. (#721/B3 was a real double-logging bug; the
+        # wrong copy was removed.)
+        "LogDriver=passthrough",
     ]
     # ── ONE quadlet render for every substrate (halo150/143 O8+O11) ──────
     # DELIBERATE: no native AutoRemove=/GroupAdd=/SecurityOpt= keys and no
@@ -839,7 +853,13 @@ def _render_quadlet_from_plan(
             "",
             "[Service]",
             "Restart=always",
-            "RestartSec=3",
+            # Geometric restart ramp (systemd ≥ 254; the lxc105 reference
+            # substrate runs 255): 5s → 10 → 20 → 39 → 77 → 152 → 300,
+            # capped at RestartMaxDelaySec. Sized together with the
+            # StartLimit window in [Unit] above.
+            "RestartSec=5",
+            "RestartSteps=6",
+            "RestartMaxDelaySec=300",
             f"SyslogIdentifier={container_name}",
             "StandardOutput=journal",
             "StandardError=journal",

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -169,11 +169,37 @@ class RegistryUnavailableError(Hal0Error):
 
 # Crash-loop breaker (issue i4): a load() from ERROR is throttled with
 # exponential backoff — min(base * 2**(failures-1), max) — and after
-# _CRASH_LOOP_PARK_AFTER consecutive failures the slot is parked (refuses
-# lazy-load until an operator action resets the breaker).
+# _CRASH_LOOP_PARK_AFTER consecutive failures the slot is parked. A parked
+# breaker HALF-OPENS once its cool-down elapses: one trial load rides the
+# normal path (which clears systemd's start-limit latch before the start),
+# success closes the breaker, failure re-parks it with a doubled cool-down
+# up to _CRASH_LOOP_PARK_MAX_S. Operator actions (reset_load_failures)
+# still short-circuit all of it.
 _CRASH_LOOP_BASE_S = 5.0
 _CRASH_LOOP_MAX_S = 300.0
 _CRASH_LOOP_PARK_AFTER = 5
+_CRASH_LOOP_PARK_MAX_S = 3600.0
+
+
+def _crash_loop_remaining_s(failures: int, last_failure: float) -> float:
+    """Seconds until the breaker permits the next spawn attempt (0 = now).
+
+    Below the park threshold: the i4 backoff curve. At or past it: the
+    half-open cool-down, doubling per failed trial and capped at
+    ``_CRASH_LOOP_PARK_MAX_S``.
+    """
+    if failures <= 0:
+        return 0.0
+    interval: float
+    if failures >= _CRASH_LOOP_PARK_AFTER:
+        interval = min(
+            _CRASH_LOOP_MAX_S * (2 ** (failures - _CRASH_LOOP_PARK_AFTER)),
+            _CRASH_LOOP_PARK_MAX_S,
+        )
+    else:
+        interval = min(_CRASH_LOOP_BASE_S * (2 ** (failures - 1)), _CRASH_LOOP_MAX_S)
+    return max(0.0, last_failure + interval - time.monotonic())
+
 
 # slot.state event coalescing window: identical ERROR-edged transition
 # pairs (error→starting / starting→error) within this window fold into
@@ -1496,29 +1522,38 @@ class SlotManager:
         failures, last_failure = self._load_failures.get(self._key(slot_name), (0, 0.0))
         if failures <= 0:
             return
+        remaining = _crash_loop_remaining_s(failures, last_failure)
+        if remaining <= 0:
+            # Half-open: the cool-down has elapsed, so this ONE attempt is
+            # permitted through the normal path (which clears systemd's
+            # start-limit latch before starting the unit). The slot lock
+            # serialises it; a concurrent caller lands after either the
+            # healthy convergence (breaker cleared) or the failure stamp
+            # (fresh timestamp → gate refuses again). Without this, a
+            # parked slot stayed down until a human noticed: the breaker
+            # returned 503s forever while systemd held the unit ``failed``.
+            return
         if failures >= _CRASH_LOOP_PARK_AFTER:
             raise SlotCrashLooping(
                 f"slot {slot_name!r} is parked after {failures} consecutive load "
-                "failures — fix the cause, then load/restart it manually",
+                f"failures — next automatic trial in {remaining:.0f}s "
+                "(or fix the cause and load/restart it manually)",
                 details={
                     "slot": slot_name,
                     "failures": failures,
                     "parked": True,
-                    "retry_after_s": int(_CRASH_LOOP_MAX_S),
-                },
-            )
-        backoff_s = min(_CRASH_LOOP_BASE_S * (2 ** (failures - 1)), _CRASH_LOOP_MAX_S)
-        remaining = last_failure + backoff_s - time.monotonic()
-        if remaining > 0:
-            raise SlotCrashLooping(
-                f"slot {slot_name!r} failed {failures} consecutive load(s) — "
-                f"backing off {remaining:.0f}s before the next spawn attempt",
-                details={
-                    "slot": slot_name,
-                    "failures": failures,
                     "retry_after_s": max(1, int(remaining) + 1),
                 },
             )
+        raise SlotCrashLooping(
+            f"slot {slot_name!r} failed {failures} consecutive load(s) — "
+            f"backing off {remaining:.0f}s before the next spawn attempt",
+            details={
+                "slot": slot_name,
+                "failures": failures,
+                "retry_after_s": max(1, int(remaining) + 1),
+            },
+        )
 
     def reset_load_failures(self, slot_name: str) -> None:
         """Clear the crash-loop breaker for *slot_name* (operator intent).
@@ -1531,6 +1566,31 @@ class SlotManager:
         key = self._peek_key(self._resolve_alias(slot_name))
         if key is not None:
             self._load_failures.pop(key, None)
+
+    def _breaker_snapshot(self, slot_name: str) -> dict[str, Any] | None:
+        """Live breaker view for status surfaces, or ``None`` when closed.
+
+        The breaker used to be invisible: it refused dispatch with 503s
+        while the slot card showed a bare ERROR/OFFLINE, and nothing short
+        of ``systemctl`` told the operator why — which is how a parked slot
+        survived four hours unnoticed. ``status()`` stamps this into slot
+        metadata so the inventory carries the state and the wait.
+        """
+        failures, last_failure = self._load_failures.get(self._key(slot_name), (0, 0.0))
+        if failures <= 0:
+            return None
+        remaining = _crash_loop_remaining_s(failures, last_failure)
+        if remaining <= 0:
+            state = "half-open"
+        elif failures >= _CRASH_LOOP_PARK_AFTER:
+            state = "parked"
+        else:
+            state = "backoff"
+        return {
+            "state": state,
+            "failures": failures,
+            "retry_after_s": 0 if remaining <= 0 else max(1, int(remaining) + 1),
+        }
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 
@@ -2164,6 +2224,9 @@ class SlotManager:
         }
         if backend:
             meta["backend"] = backend
+        breaker = self._breaker_snapshot(slot_name)
+        if breaker:
+            meta["breaker"] = breaker
         if include_config_drift:
             config_drift = await self.compute_config_drift(slot_name, cfg=cfg, active=active)
             if config_drift is not None:

--- a/tests/installer/test_systemctl_start_limit_recovery.py
+++ b/tests/installer/test_systemctl_start_limit_recovery.py
@@ -2,7 +2,7 @@
 
 ``installer/wrappers/hal0-systemctl`` is the ENTIRE privileged surface for slot
 lifecycle on a hal0-service-user box. Once systemd hits ``StartLimitBurst``
-(the slot quadlet ships ``StartLimitIntervalSec=300`` / ``StartLimitBurst=5``)
+(the slot quadlet ships ``StartLimitIntervalSec=1800`` / ``StartLimitBurst=10``)
 it parks the unit in ``failed`` with ``Result=start-limit-hit`` and refuses
 EVERY subsequent ``start``/``restart`` for the rest of the interval. The slot
 was then unloadable via the API until an operator ran ``reset-failed`` by hand.

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -572,8 +572,8 @@ class TestRenderUnit:
         unit = _render_llama("test-slot", _TEST_IMAGE, 8095, "/mnt/ai-models/model.gguf", flags)
         unit_section, _, remainder = unit.partition("[Container]")
         service_section = remainder.partition("[Service]")[2].partition("[Install]")[0]
-        assert "StartLimitIntervalSec=300" in unit_section
-        assert "StartLimitBurst=5" in unit_section
+        assert "StartLimitIntervalSec=1800" in unit_section
+        assert "StartLimitBurst=10" in unit_section
         assert "StartLimitIntervalSec" not in service_section
         assert "StartLimitBurst" not in service_section
 

--- a/tests/slots/test_crash_loop_breaker.py
+++ b/tests/slots/test_crash_loop_breaker.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import pytest
 
-from hal0.slots.manager import _CRASH_LOOP_PARK_AFTER, SlotManager
+from hal0.slots.manager import _CRASH_LOOP_MAX_S, _CRASH_LOOP_PARK_AFTER, SlotManager
 from hal0.slots.state import SlotCrashLooping, SlotState
 from tests.slots.conftest import FakeContainerProvider
 
@@ -86,11 +86,14 @@ async def test_parks_after_max_consecutive_failures(
     container_stub: FakeContainerProvider,
 ) -> None:
     """After N consecutive failures the slot parks: load() short-circuits
-    with SlotCrashLooping regardless of elapsed time."""
+    with SlotCrashLooping for the whole half-open cool-down."""
     sm = SlotManager()
-    for _ in range(_CRASH_LOOP_PARK_AFTER):
+    for i in range(_CRASH_LOOP_PARK_AFTER):
         await _fail_load_once(sm, container_stub)
-        _rewind_backoff(sm)
+        if i < _CRASH_LOOP_PARK_AFTER - 1:
+            # Keep the LAST failure's timestamp fresh — the parked refusal
+            # holds only inside the cool-down (half-open opens after it).
+            _rewind_backoff(sm)
 
     key = sm._key("chat")
     rec = sm._states[key]
@@ -101,9 +104,82 @@ async def test_parks_after_max_consecutive_failures(
     with pytest.raises(SlotCrashLooping) as exc_info:
         await sm.load("chat")
     assert exc_info.value.details["parked"] is True
+    # The refusal carries the real wait, not a permanent verdict.
+    assert 1 <= exc_info.value.details["retry_after_s"] <= int(_CRASH_LOOP_MAX_S) + 1
     # Parked refusal is free — no terminate, no spawn.
     assert len(container_stub.unload_calls) == unloads_before
     assert container_stub.load_calls == []
+
+
+async def test_parked_breaker_half_opens_and_recovers(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """Once the cool-down elapses, ONE trial load rides the normal path —
+    a parked slot self-heals instead of waiting for an operator."""
+    sm = SlotManager()
+    for _ in range(_CRASH_LOOP_PARK_AFTER):
+        await _fail_load_once(sm, container_stub)
+        _rewind_backoff(sm)
+
+    container_stub.fail_load = None
+    await sm.load("chat")
+
+    key = sm._key("chat")
+    assert sm._current_state("chat") == SlotState.READY
+    assert key not in sm._load_failures
+    assert "parked" not in sm._states[key].extra
+
+
+async def test_failed_half_open_trial_reparks_with_longer_cooldown(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """A failed trial re-opens the breaker with a doubled cool-down, so a
+    genuinely broken model converges to rare, cheap probes — not a hot loop."""
+    sm = SlotManager()
+    for _ in range(_CRASH_LOOP_PARK_AFTER):
+        await _fail_load_once(sm, container_stub)
+        _rewind_backoff(sm)
+
+    # The permitted trial fails too (the model really is broken).
+    await _fail_load_once(sm, container_stub)
+
+    with pytest.raises(SlotCrashLooping) as exc_info:
+        await sm.load("chat")
+    assert exc_info.value.details["parked"] is True
+    assert exc_info.value.details["failures"] == _CRASH_LOOP_PARK_AFTER + 1
+    assert exc_info.value.details["retry_after_s"] > int(_CRASH_LOOP_MAX_S)
+
+
+async def test_status_surfaces_breaker_state(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """The inventory carries the breaker: state, failure count, and the wait —
+    the failure mode used to be invisible outside systemctl."""
+    sm = SlotManager()
+    assert "breaker" not in (await sm.status("chat")).metadata
+
+    await _fail_load_once(sm, container_stub)
+    breaker = (await sm.status("chat")).metadata["breaker"]
+    assert breaker == {"state": "backoff", "failures": 1, "retry_after_s": breaker["retry_after_s"]}
+    assert breaker["retry_after_s"] >= 1
+
+    for _ in range(_CRASH_LOOP_PARK_AFTER - 1):
+        _rewind_backoff(sm)
+        await _fail_load_once(sm, container_stub)
+    breaker = (await sm.status("chat")).metadata["breaker"]
+    assert breaker["state"] == "parked"
+    assert breaker["failures"] == _CRASH_LOOP_PARK_AFTER
+
+    _rewind_backoff(sm)
+    breaker = (await sm.status("chat")).metadata["breaker"]
+    assert breaker == {
+        "state": "half-open",
+        "failures": _CRASH_LOOP_PARK_AFTER,
+        "retry_after_s": 0,
+    }
 
 
 async def test_manual_reset_unparks_and_load_recovers(


### PR DESCRIPTION
## Problem

A slot that failed fast burned its `StartLimitBurst=5` in ~16s and latched in systemd `failed`; hal0's crash-loop breaker independently parked the slot and returned 503s forever. Neither layer consulted the other, neither was visible anywhere, and only a human could clear either — which is how slot 15 stayed down for ~4 hours after the transient GPU contention that killed it had passed. Debugging was blind on top: `LogDriver=none` under a detached Quadlet start left container output with **no sink at all**, so the real error never reached the journal.

## Fix

**1. Quadlet restart policy: geometric backoff instead of a 16-second burst** (`providers/container.py`)

```ini
[Unit]
StartLimitIntervalSec=1800     # was 300
StartLimitBurst=10             # was 5

[Service]
RestartSec=5                   # was 3
RestartSteps=6                 # new — geometric ramp (systemd ≥254; lxc105 runs 255)
RestartMaxDelaySec=300         # new — cap at 5 min
```

Retries become ~5s → 10 → 20 → 39 → 77 → 152 → 300 → …: about 10 attempts over ~20 minutes. Transient causes (GPU-hogging neighbour, cold mount, slow pull) get real time to clear; a corrupt model still stops hammering.

**2. Breaker half-open state** (`slots/manager.py`)

The parked breaker previously reset only on operator action — that's what made the outage permanent. Now, once its cool-down elapses, the gate permits **one** trial load through the normal path (which already clears systemd's start-limit latch before starting). Success closes the breaker; failure re-parks it with a doubled cool-down, capped at 1h. The slot lock serialises the trial. "Down until a human notices" becomes self-healing.

**3. Both states visible** (`slots/manager.py` `status()`)

Slot metadata now carries the live breaker view:

```json
"breaker": {"state": "backoff|parked|half-open", "failures": 6, "retry_after_s": 512}
```

Nothing before this surfaced the breaker anywhere — the failure mode was silent, which is how it survived four hours. (The latched-unit side was already surfaced by the #1791 `unit_failure_reason` probe.)

**4. `LogDriver=passthrough`** (`providers/container.py`, prerequisite)

`LogDriver=none` assumed conmon→journal held the streams, but the Quadlet service runs podman detached: the client exits after echoing the container id, and with podman's sink disabled there was no sink at all — measured 0 container-output lines across all slots over 24h. `passthrough` hands the container's stdout/stderr to the unit, journaled exactly once (the #721/B3 double-logging fix removed the wrong copy). `installer/wrappers/hal0-systemctl` allowlist updated accordingly (accepts `none` too for the version-skew window) plus the two new `[Service]` keys.

## Not done, deliberately

- `RestartPreventExitStatus=` fail-fast for doomed loads: llama-server exits 1 for everything (corrupt GGUF and bogus CLI flag both tested), so the directive can't discriminate until the container entrypoint translates load failures into a distinct exit code.
- Layering stays: systemd owns process restart, the breaker gates dispatch. The half-open trial reuses the existing reset-failed-then-restart path rather than adding a second systemctl caller.

## Tests

- `test_parks_after_max_consecutive_failures` re-baselined: parked refusal holds for the cool-down, not forever, and carries the real `retry_after_s`.
- New: `test_parked_breaker_half_opens_and_recovers`, `test_failed_half_open_trial_reparks_with_longer_cooldown`, `test_status_surfaces_breaker_state`.
- Quadlet template assertions updated; wrapper `check-quadlet` suite validates renderer output end-to-end (real bash), `bash -n` clean.
- Full suite green; no new mypy errors; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
