### PR TITLE
chore: apply codex style nits from PR #2008 review

### DIFF
--- a/src/hal0/api/routes/memory_admin.py
+++ b/src/hal0/api/routes/memory_admin.py
@@ -501,12 +501,12 @@ async def bank_units(request: Request, bank_id: str) -> dict[str, Any]:
         # that newest-first order among any rows tied on salience.
         scored = [r for r in kept if r["salience"] is not None]
         unscored = [r for r in kept if r["salience"] is None]
-        scored.sort(key=lambda r: _unit_ts(r), reverse=True)
+        scored.sort(key=_unit_ts, reverse=True)
         scored.sort(key=lambda r: -r["salience"])
-        unscored.sort(key=lambda r: _unit_ts(r), reverse=True)
+        unscored.sort(key=_unit_ts, reverse=True)
         kept = scored + unscored
     else:
-        kept.sort(key=lambda r: _unit_ts(r), reverse=True)
+        kept.sort(key=_unit_ts, reverse=True)
     page = kept[offset : offset + limit]
     nxt = offset + limit if offset + limit < len(kept) else None
     return {

--- a/ui/src/dash/memory.jsx
+++ b/ui/src/dash/memory.jsx
@@ -765,7 +765,7 @@ function MemoryView({ param } = {}) {
     const qIdx = hash.indexOf('?');
     const qs = qIdx >= 0 ? hash.slice(qIdx) : '';
     window.location.hash = memHashPrefix() + '/bank' + qs;
-  }, [param])
+  }, [param]);
 
   const useMemoryEngine = window.__hal0UseMemoryEngine;
   const useMemoryBanks = window.__hal0UseMemoryBanks;


### PR DESCRIPTION
Explicit semicolon on the redirect effect; pass _unit_ts directly as the
sort key instead of a wrapper lambda (all three sites).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
