### PR TITLE
fix(ui): unstack the bank-row fact-type counts back onto one line

### DIFF
--- a/ui/src/dash/memory-overview-v2.jsx
+++ b/ui/src/dash/memory-overview-v2.jsx
@@ -221,10 +221,18 @@ function BankRow({ bank, onExplore, compact }) {
             table's middle column is too narrow to fit "world N ·
             experience N · observation N" on one line at 5-6-digit counts,
             so the shared .mv-legend flex-wrap produced a lopsided 2-then-1
-            wrap. Force a clean vertical stack here instead of widening the
-            shared class (which other, wider .mv-legend usages rely on for
-            a single-row layout). */}
-        <div className="mv-legend num" style={{ flexDirection: 'column', gap: 2, flexWrap: 'nowrap' }}>
+            wrap — fixed at the time by forcing a vertical stack, which
+            traded the wrap bug for 3 extra lines of card height.
+            Un-stacked (2026-08-22): keep it on one row and let
+            `justify-content: space-between` (not the shared class's
+            gap-based flow) spread the three counts across the full row
+            width, with `flexWrap: 'nowrap'` so it can never fall back to
+            wrapping — the counts just sit closer together on the
+            narrowest panel instead of breaking to a new line. */}
+        <div
+          className="mv-legend num"
+          style={{ justifyContent: 'space-between', flexWrap: 'nowrap', marginBottom: 4 }}
+        >
           <span>
             <span className="sw" style={{ background: FACT_COLORS.world }} />
             <b>{fmtN(world)}</b>


### PR DESCRIPTION
## Summary
The Memory ▸ Overview "BANKS" panel's per-bank legend (world/experience/observation counts) was forced into a vertical 3-line stack on 2026-08-21 to dodge a lopsided flex-wrap at 5-6-digit counts in the narrow panel column — but that traded the wrap bug for 3 extra lines of card height, visibly shrinking how many banks fit in the panel.

- Keep the legend on one row: `justify-content: space-between` spreads the three counts across the full row width (rather than the shared class's gap-based flow, which is what wrapped lopsided), with `flexWrap: 'nowrap'` so it can never fall back to wrapping.
- Sits directly above the composition bar, unchanged in position — just no longer stacked.

## Test plan
- [x] `npx vitest run` — 206/206
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Affected specs (memory-v2-overview, memory-v2-view, memory-bank-error-branches) — 23/23
- [x] Full e2e suite — 670 passed / 0 failed / 13 skipped
- [x] Verified live on CT105: cards are visibly shorter, more banks fit in the same panel height, no wrap at 6-digit counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)