### PR TITLE
chore(ui): drop the "Chat in terminal: hermes chat" header string

### DIFF
--- a/ui/src/dash/agents/agent-view.jsx
+++ b/ui/src/dash/agents/agent-view.jsx
@@ -77,7 +77,6 @@ function AgentView() {
         <span className="vh-eye mono">Tools</span>
         <h1>Agents</h1>
         <span className="vh-spacer" />
-        <span className="hint mono">Chat in terminal: <code>hermes chat</code></span>
       </div>
 
       <div

--- a/ui/tests/e2e/specs/agent-view-v3.spec.ts
+++ b/ui/tests/e2e/specs/agent-view-v3.spec.ts
@@ -17,7 +17,9 @@
  *   - the locked roadmap cards render behind the coming-soon mask
  *   - Overview · Memory · MCP tabs are present; the long-removed surfaces
  *     (chat / personas / skills / plugins / inbox / peers) stay ABSENT
- *   - the header carries the `hermes chat` terminal hint
+ *   - the header no longer carries the `hermes chat` terminal hint (copy-only
+ *     removal, 2026-08-22 — web chat is still replaced by the TUI; only the
+ *     visible reminder string was dropped, not the underlying behavior)
  *   - hash routes #agent/memory + legacy #peers land on the Memory tab
  */
 import { test, expect, json } from '../fixtures/apiMock'
@@ -104,12 +106,13 @@ test.describe('Agents shell v0.5 (#agent — Overview default)', () => {
     await expect(card.locator('[data-testid="agent-action-logs"]')).toHaveCount(0)
   })
 
-  test('header carries the `hermes chat` terminal hint (web chat replaced by TUI)', async ({
+  test('header no longer carries the `hermes chat` terminal hint (copy-only removal)', async ({
     page,
   }) => {
     await page.goto('/#agent')
-    await expect(page.locator('.view .vh')).toContainText('hermes chat', { timeout: FIVE_S })
     await expect(page.locator('.view .vh h1')).toHaveText('Agents')
+    await expect(page.locator('.view .vh')).not.toContainText('hermes chat')
+    await expect(page.locator('.view .vh .hint')).toHaveCount(0)
   })
 
   test('#agent/memory hash routes to the Memory tab', async ({ page }) => {


### PR DESCRIPTION
## Summary
Operator asked for the visible reminder string removed from the Agents page header (`.view .vh`) — the underlying behavior it described (web chat replaced by the TUI) is unchanged, only the copy goes.

## Test plan
- [x] `npx vitest run` — 206/206
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `agent-view-v3.spec.ts` updated to assert the hint is absent, matching test 6/6
- [x] Full e2e suite — 670 passed / 0 failed / 13 skipped
- [x] Verified live on CT105: header now reads just "Agents", no hint text

🤖 Generated with [Claude Code](https://claude.com/claude-code)