### PR TITLE
ci(ui): give the γ-suite headroom over its own globalTimeout

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,7 +10,7 @@ on:
     branches: [main]
   pull_request:
 
-# Cancel superseded PR runs (the ~8 min γ-suite is the priciest PR check);
+# Cancel superseded PR runs (the 8-12 min γ-suite is the priciest PR check);
 # never cancel a push to main — it's a required check + nightly gate input.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -46,7 +46,13 @@ export default defineConfig({
   // file here is a `.spec.ts`, so pin that explicitly (#1399).
   testMatch: '**/*.spec.ts',
   timeout: LIVE ? 180_000 : 30_000,
-  globalTimeout: LIVE ? 30 * 60_000 : 12 * 60_000,
+  // 12 minutes was set when the suite was ~8 min and 400-odd specs. At 686 specs
+  // it runs 8-12 min on the CI runners, i.e. up to 100% of its own budget, and a
+  // run that lands on the wrong side finishes with every executed spec passing,
+  // a double-digit "did not run" count and a red check that says nothing about
+  // the diff (#2032). 20 minutes restores headroom without hiding a real hang —
+  // the per-test `timeout` above is what catches those.
+  globalTimeout: LIVE ? 30 * 60_000 : 20 * 60_000,
   expect: { timeout: 5_000 },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,


### PR DESCRIPTION
## What

Raise the chromium γ-suite's non-live `globalTimeout` from 12 to 20 minutes, and correct the stale "~8 min" note in the workflow's concurrency comment.

## Why

`ui/playwright.config.ts` has carried a 12-minute budget since the suite was roughly half its current size. At 686 specs it now runs 8–12 minutes on the CI runners, i.e. up to **100% of its own budget**:

| Run | Branch | Result |
|---|---|---|
| 32579195317 | main | `671 passed (8.0m)` |
| 32577624937 | main | `672 passed (11.9m)` |
| 32600421679 | #2031 (markdown/YAML-only diff) | `647 passed (12.0m)` → **red**, 22 did not run |
| 32600421679 (re-run) | #2031 | `654 passed (12.0m)` → **red**, 14 did not run |

Zero assertion failures in either red run. The check goes red purely on wall clock, the set of dropped specs shifts between runs, and the trailing `browserContext.close: Test ended.` / `page.goto: Test ended.` noise is the global timeout tearing down in-flight workers.

A check that reds out on runner speed rather than on correctness trains everyone to re-run it — which is the habit that lets a real failure through.

## Why this is safe

`globalTimeout` bounds the suite as a whole; it is not the hang detector. The per-test `timeout` (30 s non-live) is what catches a genuinely stuck spec, and it is unchanged. Live mode (`HAL0_E2E_LIVE=1`) keeps its 30-minute budget.

## Verification

The change is a single numeric literal in an existing expression plus comments; the meaningful verification is the γ-suite run on this PR itself — it should finish with a non-zero margin and no "did not run" count. Flagging for review rather than arming automerge, since this touches CI configuration.

Closes #2032

🤖 Generated with [Claude Code](https://claude.com/claude-code)