### PR TITLE
fix(brain): ground live-state answers instead of trusting the model to look

### DIFF
--- a/src/hal0/brain/chat.py
+++ b/src/hal0/brain/chat.py
@@ -227,15 +227,31 @@ Tool surfaces:
   panel — when that happens, say what you queued and why, then wait.
 
 Rules:
-- You cannot see state unless you look. Call the matching read tool first and
-  resolve exact task ids / slot names before mutating. Never guess ids.
+- GROUND EVERY CLAIM ABOUT THIS BOX IN A TOOL RESULT. You cannot see state
+  unless you look. Any question about live state — which slots exist, what is
+  loaded, which port something is on, how many models are registered, hardware
+  numbers, what is on the board — is answered by CALLING the matching read tool
+  first and reporting what it returned. Never state a port, count, name, path,
+  size or status you have not just read from a tool result in this turn. If you
+  cannot call the tool, say so plainly: an admitted gap beats a confident guess.
+- BREVITY NEVER CANCELS A TOOL CALL. "Answer in one short sentence", "quickly",
+  "just tell me" constrain the WORDING of your reply, never whether you look it
+  up. Call the tool, then answer in one sentence.
+- MATCH THE TOOL TO THE SUBJECT OF THE QUESTION. Slots, ports, what is running
+  or loaded -> list_slots / get_slot. What is installed or registered HERE ->
+  list_models. What could be downloaded from upstream -> model_catalogue (that
+  is the remote catalogue; it says nothing about this box). Hardware/VRAM ->
+  hardware_stats. Tasks and lanes -> get_board. The board is tasks ONLY: it
+  never answers a slot, model, port or hardware question.
+- Resolve exact task ids / slot names before mutating. Never guess ids.
 - Board mutations are audited and land on the live board immediately.
 - Slot load/unload/restart are DISRUPTIVE (they can evict models and drop
   in-flight requests): do them only when the operator explicitly asks, and
   state what you did.
 - For multi-step work (create a slot, set up a model, run a benchmark) lay
   out the short plan first, then execute step by step, reporting progress.
-- Prefer a clarifying question over a destructive guess. Keep replies short.
+- Prefer a clarifying question over a destructive guess. Keep replies short —
+  short AFTER you have looked, never instead of looking.
 """
 
 
@@ -321,8 +337,10 @@ def _tool_schemas() -> list[dict[str, Any]]:
     return [
         _fn(
             "get_board",
-            "Read the whole board: every task's id/title/status/assignee/"
-            "priority. Call this FIRST to resolve task ids before mutating.",
+            "Read the whole TASK board (kanban): every task's id/title/status/"
+            "assignee/priority. Tasks only — it says nothing about slots, "
+            "models, ports or hardware. Call this first to resolve task ids "
+            "before mutating a task.",
             {},
             [],
         ),
@@ -358,14 +376,17 @@ def _tool_schemas() -> list[dict[str, Any]]:
         ),
         _fn(
             "list_slots",
-            "List the inference slots: name, state (serving/ready/warming/idle/"
-            "offline/error), model, backend, throughput.",
+            "List this box's inference slots: name, state (serving/ready/"
+            "warming/idle/offline/error), model, backend, PORT and throughput. "
+            "Use for any question about what is running or loaded right now, "
+            "or which port a slot is bound to.",
             {},
             [],
         ),
         _fn(
             "get_slot",
-            "Read one inference slot in detail.",
+            "Read one of this box's inference slots in detail: state, bound "
+            "model, backend, port, context length.",
             {"name": {"type": "string"}},
             ["name"],
         ),
@@ -391,7 +412,10 @@ def _tool_schemas() -> list[dict[str, Any]]:
         ),
         _fn(
             "list_models",
-            "List the model library (installed + known models).",
+            "List the models REGISTERED ON THIS BOX (the local model library: "
+            "installed artefacts plus registry entries). Use for 'how many "
+            "models do I have', 'which models are registered/installed here'. "
+            "This is NOT the remote downloadable catalogue (model_catalogue).",
             {},
             [],
         ),
@@ -1356,6 +1380,105 @@ def _tool_intent_artefact(response: dict[str, Any], known_tool_names: frozenset[
     return matches[0] if matches else None
 
 
+# ── live-state grounding (#2022) ────────────────────────────────────────────
+#
+# `_tool_intent_artefact` above only catches a round where the small brain model
+# TRIED to call a tool and produced garbage. rc.7 validation found the other
+# half of the same defect: on the shipped ~1.1B `hal0-brain-sft` anchor the
+# model frequently does not try AT ALL — it answers "what port is the brain slot
+# running on?" with a confident, invented port and ZERO tool frames. Measured
+# 2/2 both directions: appending "Answer in one short sentence." to an otherwise
+# correctly-tool-grounded question is enough to suppress the tool round, because
+# a 1B reads a brevity instruction as permission to skip the lookup (and the
+# steward system prompt's own "Keep replies short" agreed with it).
+#
+# Nothing downstream can tell an invented port from a real one, so grounding
+# cannot be left to the model's discretion on this model class. The question
+# itself is the signal available BEFORE the answer exists: when the operator
+# asks about live box state and the chat round comes back with no tool call and
+# no artefact, that round is treated exactly like a garbled one — discarded and
+# re-run on `tool_model`, the same capable model an artefact reroutes to. It
+# costs one extra completion only on a turn that asked about live state and got
+# an ungrounded answer, and it is a no-op wherever there is nothing to reroute
+# to (`tool_model` off, or equal to the chat model) — those turns keep their
+# existing behaviour, backed by the `_tools_unavailable_notice` honesty layer
+# and the system prompt's grounding rules.
+
+#: Subjects only the live box can answer for. Broad on purpose — the cost of a
+#: false positive is one extra completion on the tool-capable model, while the
+#: cost of a false negative is a fabricated port number presented as fact.
+_LIVE_STATE_SUBJECT_RE = re.compile(
+    r"\b("
+    r"slots?|ports?|models?|gguf|runners?|backends?|"
+    r"vram|gtt|ram|gpu|npu|hardware|utili[sz]ation|temperature|"
+    r"benchmarks?|agents?|profiles?|stacks?|approvals?|"
+    r"board|tasks?|lanes?|queue|dispatcher|orchestration|"
+    r"logs?|uptime|disk|storage|settings?|version|install"
+    r")\b",
+    re.IGNORECASE,
+)
+
+#: Interrogative / imperative shapes. A statement that merely mentions a slot is
+#: not a live-state question.
+_LIVE_STATE_ASK_RE = re.compile(
+    r"\?|\b("
+    r"list|show|check|tell me|give me|what|which|where|when|who|how many|how much|"
+    r"do i|are there|is there|any|status|state|right now|currently|"
+    r"running|loaded|bound|registered|installed|enabled|available|serving"
+    r")\b",
+    re.IGNORECASE,
+)
+
+#: Conceptual / how-to phrasings that ask about hal0 as a SYSTEM rather than
+#: about this box's current state. ``what is a slot`` is documentation; ``what
+#: is the port of the brain slot`` is live state — hence the indefinite article.
+_CONCEPTUAL_RE = re.compile(
+    r"\bwhat(?:'s| is| are)\s+(?:a|an)\b|\bwhat does\b.*\bmean\b|"
+    r"\bhow do(?:es)? (?:i|you|it|they)\b|\bexplain\b|\bdifference between\b|"
+    r"\bshould i\b|\bwhy (?:do|does|is|are)\b",
+    re.IGNORECASE,
+)
+
+
+def _message_text(message: Any) -> str:
+    """The text of one chat message, flattening the OpenAI content-parts shape."""
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            p["text"] for p in content if isinstance(p, dict) and isinstance(p.get("text"), str)
+        )
+    return ""
+
+
+def _last_user_text(messages: list[dict[str, Any]]) -> str:
+    """The most recent user turn's text (the question this turn must answer)."""
+    for message in reversed(messages):
+        if isinstance(message, dict) and message.get("role") == "user":
+            return _message_text(message)
+    return ""
+
+
+def _asks_for_live_state(text: str) -> bool:
+    """Whether ``text`` asks something only a tool call can answer truthfully.
+
+    Deliberately a QUESTION-side check, not an answer-side one: by the time the
+    reply exists, an invented port and a real one are the same string. Requires
+    a live-state subject AND an interrogative/imperative shape, and excludes
+    conceptual "what is a slot" / "how do I ..." phrasings that the steward's
+    own system prompt can answer without looking anything up.
+    """
+    probe = (text or "").strip()
+    if not probe:
+        return False
+    if _CONCEPTUAL_RE.search(probe):
+        return False
+    return bool(_LIVE_STATE_SUBJECT_RE.search(probe)) and bool(_LIVE_STATE_ASK_RE.search(probe))
+
+
 def _tool_reroute_unavailable_message(tool_model: str, error: str) -> str:
     """What the steward SAYS when the reroute target has no model behind it.
 
@@ -1539,6 +1662,7 @@ def _tool_routing_llm(
     known_tool_names: frozenset[str],
     chat_model_native_tools: bool = True,
     chat_model_image: str | None = None,
+    grounding_required: bool = False,
 ) -> LlmFn:
     """Wrap ``llm`` so TOOL rounds run on ``tool_model`` and chat stays on the brain.
 
@@ -1570,6 +1694,14 @@ def _tool_routing_llm(
     the turn and (b) remember the image for every later turn (#1789 — the gate
     is capability-based now, so "assume capable" needs a runtime correction
     path). ``None`` keeps the old behaviour: no learning, no retry.
+
+    ``grounding_required`` (#2022, see :func:`_asks_for_live_state`) says the
+    operator asked about LIVE box state on this turn. A chat round that answers
+    such a question with neither a tool call nor a tool-call artefact is an
+    UNGROUNDED answer — on the shipped 1.1B anchor, reliably a fabricated one —
+    so it is discarded and re-run on ``tool_model`` exactly as a garbled round
+    is. It can fire at most once per turn (the reroute puts the turn in a tool
+    chain), and never on the no-reroute path, which has nowhere to send it.
 
     See the module comment above this function for the full routing semantics
     and why the tool-capable model — not the 1B — finishes a tool chain.
@@ -1662,18 +1794,30 @@ def _tool_routing_llm(
             return response
 
         wanted = _tool_intent_artefact(response, known_tool_names)
-        if wanted is None:
+        if wanted is None and not grounding_required:
             return response  # plain chat — the steward's own reply stands.
 
-        # The brain tried and produced garbage. Discard it and re-run THIS
-        # round on the tool-capable model. This is one extra completion inside
-        # one engine round, so `[brain_chat] max_rounds` still bounds the turn.
-        log.info(
-            "hal0.brain_chat.tool_round_rerouted",
-            tool=wanted,
-            chat_model=chat_model,
-            tool_model=tool_model,
-        )
+        if wanted is None:
+            # #2022: a live-state question answered with no tool call at all.
+            # The 1B did not garble a call, it skipped one — which on this
+            # model class means the answer is invented. Same remedy: discard
+            # and hand the round to the tool-capable model.
+            log.info(
+                "hal0.brain_chat.ungrounded_round_rerouted",
+                chat_model=chat_model,
+                tool_model=tool_model,
+            )
+        else:
+            # The brain tried and produced garbage. Discard it and re-run THIS
+            # round on the tool-capable model. This is one extra completion
+            # inside one engine round, so `[brain_chat] max_rounds` still
+            # bounds the turn.
+            log.info(
+                "hal0.brain_chat.tool_round_rerouted",
+                tool=wanted,
+                chat_model=chat_model,
+                tool_model=tool_model,
+            )
         in_tool_chain = True
         body["model"] = tool_model
         return await _degrade(await llm(body))
@@ -1939,6 +2083,12 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
     # answered False for every CPU-only/CUDA box and muted tools there.)
     chat_model_image = await _resolved_slot_image(request, model)
     chat_model_native_tools = _image_native_tools(chat_model_image)
+    # GROUNDING (#2022). Did the operator ask about live box state? If so, a
+    # chat round that comes back with no tool call is an answer the brain
+    # cannot have known — reroute it to the tool model rather than stream a
+    # fabricated port/count to the operator. Question-side, because after the
+    # fact an invented value is indistinguishable from a read one.
+    grounding_required = bool(tools) and _asks_for_live_state(_last_user_text(messages))
     llm = _tool_routing_llm(
         llm,
         chat_model=model,
@@ -1946,6 +2096,7 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
         known_tool_names=known_tool_names,
         chat_model_native_tools=chat_model_native_tools,
         chat_model_image=chat_model_image,
+        grounding_required=grounding_required,
     )
 
     # HONESTY (#1789). Tools surfaced in the prompt but no round can actually
@@ -2148,6 +2299,7 @@ __all__ = [
     "PRIMARY_SLOT_MODEL",
     "_admin_tool_names",
     "_admin_tool_schemas",
+    "_asks_for_live_state",
     "_assistant_message",
     "_assistant_text",
     "_assistant_thinking",
@@ -2165,6 +2317,7 @@ __all__ = [
     "_frame_messages",
     "_is_admin_tool_excluded",
     "_is_read_tool",
+    "_last_user_text",
     "_parse_text_tool_calls",
     "_resolve_platform_tool",
     "_resolve_tool",

--- a/src/hal0/brain/chat.py
+++ b/src/hal0/brain/chat.py
@@ -1413,7 +1413,7 @@ _LIVE_STATE_SUBJECT_RE = re.compile(
     r"vram|gtt|ram|gpu|npu|hardware|utili[sz]ation|temperature|"
     r"benchmarks?|agents?|profiles?|stacks?|approvals?|"
     r"board|tasks?|lanes?|queue|dispatcher|orchestration|"
-    r"logs?|uptime|disk|storage|settings?|version|install"
+    r"logs?|uptime|disk|storage|settings?|version|install(?:er|ation)?s?"
     r")\b",
     re.IGNORECASE,
 )

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -2537,7 +2537,11 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
     "model_list": "Aggregate models from local registry + upstreams.",
     "model_show": "Show a single model's full metadata (registry + upstream).",
     "model_scan_preview": "Preview what a model scan would register (dry run).",
-    "model_catalogue": "List the curated catalogue of blessed models.",
+    "model_catalogue": (
+        "List the curated REMOTE catalogue of blessed models available to "
+        "download. This is what COULD be pulled, not what is installed or "
+        "registered on this box — use model_list for that."
+    ),
     "model_update_check": "Check which HF-backed models have updates available.",
     "model_pulls_list": "List all pull jobs (in-flight + terminal).",
     "model_pull_status": "Get one model's pull-job progress (state, %, speed, ETA).",

--- a/tests/brain/test_brain_live_state_grounding.py
+++ b/tests/brain/test_brain_live_state_grounding.py
@@ -1,0 +1,340 @@
+"""Live-state grounding — the steward may not answer about this box from memory (#2022).
+
+rc.7 fleet validation, on the SHIPPED installer-seeded brain anchor
+(``hal0-brain-sft-q8-rocmfpx``, ~1.1B):
+
+  * ``"What port is the brain slot running on? Answer in one short sentence."``
+    came back with a confidently INVENTED port and ZERO tool frames;
+  * dropping ONLY the brevity clause flipped the same question to a correct,
+    tool-grounded answer (2/2 both directions).
+
+So the brevity instruction — reinforced by the steward prompt's own "Keep
+replies short" — was enough to suppress the tool round on that model class,
+and the existing reroute could not catch it: :func:`_tool_intent_artefact`
+fires on a GARBLED tool call, and here the model never attempted one.
+
+The fix is question-side. After the fact an invented port and a read one are
+the same string, so the only usable signal is that the operator ASKED about
+live state: such a turn is marked ``grounding_required``, and a chat round
+that answers it with no tool call is discarded and re-run on ``tool_model``,
+exactly as a garbled round is.
+
+Scripted stub LLM, no network.
+
+Run targeted:
+    uv run pytest tests/brain/test_brain_live_state_grounding.py -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hal0.api.routes import board_chat as bc
+from hal0.config.schema import BrainChatConfig, Hal0Config
+from hal0.mcp.approval_queue import ApprovalQueue
+
+#: The fabrication the rc.7 run actually got back (shape, not the exact string).
+FABRICATED = "The brain slot is running on port 8081."
+
+
+class _StubLLM:
+    """Pops a canned response per call, recording the model of EACH call."""
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    @property
+    def models(self) -> list[str]:
+        return [c["model"] for c in self.calls]
+
+    async def __call__(self, body: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(json.loads(json.dumps(body, default=str)))
+        return self._responses.pop(0) if self._responses else _final("done")
+
+
+def _final(text: str) -> dict[str, Any]:
+    return {"choices": [{"message": {"role": "assistant", "content": text}}]}
+
+
+def _tool_call(name: str, args: dict[str, Any], call_id: str) -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {"name": name, "arguments": json.dumps(args)},
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+
+class _FakeKanban:
+    async def request_json(self, method: str, path: str, **kw: Any) -> Any:
+        return {"columns": []} if path == "/board" else {"ok": True}
+
+
+def _fake_request(stub: _StubLLM, **brain_chat: Any) -> Any:
+    cfg = BrainChatConfig(read_only=False, **brain_chat)
+    state = SimpleNamespace(
+        board_chat_llm=stub,
+        hermes_kanban=_FakeKanban(),
+        approval_queue=ApprovalQueue(),
+        self_api_base_url="http://testserver",
+        brain_persona_root=Path("/nonexistent-personas-root"),
+        memory_dispatcher=None,
+        hal0_config=Hal0Config(brain_chat=cfg),
+        audit=None,
+    )
+    return SimpleNamespace(app=SimpleNamespace(state=state), headers={})
+
+
+async def _collect(request: Any, prompt: str) -> list[dict[str, Any]]:
+    out = []
+    async for frame in bc._chat_stream(
+        request, {"messages": [{"role": "user", "content": prompt}]}
+    ):
+        assert frame.startswith("data: ")
+        out.append(json.loads(frame[len("data: ") :].strip()))
+    return out
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _tokens(events: list[dict[str, Any]]) -> str:
+    return "\n".join(e["text"] for e in events if e["type"] == "token")
+
+
+# ── the reported defect ─────────────────────────────────────────────────────
+
+
+def test_brevity_clause_cannot_suppress_the_tool_round() -> None:
+    """THE #2022 repro: brevity clause -> confident invented port, zero tool frames.
+
+    The brain's ungrounded answer must be discarded and the round re-run on the
+    tool-capable model, which looks the value up.
+    """
+    stub = _StubLLM(
+        [
+            _final(FABRICATED),  # round 0, brain: fabricated, no tool call
+            _tool_call("list_slots", {}, "c1"),  # round 0 re-run, tool model
+            _final("The brain slot is on port 18102."),  # round 1, tool model
+        ]
+    )
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(
+        _collect(
+            request,
+            "What port is the brain slot running on? Answer in one short sentence.",
+        )
+    )
+
+    assert stub.models == ["hal0/brain", "hal0/agent", "hal0/agent"]
+    call = next(e for e in events if e["type"] == "tool_call")
+    assert call["name"] == "list_slots"
+    assert FABRICATED not in _tokens(events)
+    assert _tokens(events) == "The brain slot is on port 18102."
+
+
+def test_plain_live_state_question_is_grounded_too() -> None:
+    """The brevity clause is a trigger, not the disease — the plain form counts."""
+    stub = _StubLLM(
+        [
+            _final("There are 12 models registered."),
+            _tool_call("list_models", {}, "c1"),
+            _final("Three models are registered."),
+        ]
+    )
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(_collect(request, "How many models are registered on this hal0 install?"))
+
+    assert stub.models == ["hal0/brain", "hal0/agent", "hal0/agent"]
+    assert _tokens(events) == "Three models are registered."
+
+
+def test_a_grounded_brain_round_is_not_re_run() -> None:
+    """The control direction: the 1B DID call a tool -> no second completion."""
+    stub = _StubLLM([_tool_call("list_slots", {}, "c1"), _final("Port 18102.")])
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(_collect(request, "What port is the brain slot running on?"))
+
+    # Round 0 on the brain (its own call is kept), continuation on the tool model.
+    assert stub.models == ["hal0/brain", "hal0/agent"]
+    assert _tokens(events) == "Port 18102."
+
+
+def test_small_talk_never_wakes_the_tool_model() -> None:
+    """Grounding must not cost a second completion on chat that needs no lookup."""
+    for prompt in ("hi", "thanks, that helped", "you're doing great"):
+        stub = _StubLLM([_final("Happy to help.")])
+        request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+        events = _run(_collect(request, prompt))
+
+        assert stub.models == ["hal0/brain"], prompt
+        assert _tokens(events) == "Happy to help.", prompt
+
+
+def test_a_conceptual_question_stays_on_the_brain() -> None:
+    """ "What is a slot?" is documentation the system prompt already carries."""
+    stub = _StubLLM([_final("A slot is a named inference unit.")])
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(_collect(request, "What is a slot in hal0?"))
+
+    assert stub.models == ["hal0/brain"]
+    assert _tokens(events) == "A slot is a named inference unit."
+
+
+def test_grounding_is_a_no_op_with_nowhere_to_reroute() -> None:
+    """`tool_model` off -> the turn keeps its documented single-completion shape.
+
+    There is no second model to ask, so re-running the same one would only cost
+    a round; the honesty layer (`_tools_unavailable_notice`) and the system
+    prompt's grounding rules own this path.
+    """
+    stub = _StubLLM([_final(FABRICATED)])
+    request = _fake_request(stub, model="hal0/brain", tool_model="off")
+
+    events = _run(_collect(request, "What port is the brain slot running on?"))
+
+    assert stub.models == ["hal0/brain"]
+    assert events[-1] == {"type": "done"}
+
+
+def test_grounding_fires_at_most_once_per_turn() -> None:
+    """The reroute enters the tool chain — it cannot loop the turn on itself."""
+    stub = _StubLLM(
+        [
+            _final(FABRICATED),  # brain, ungrounded
+            _final("I could not read the slot table."),  # tool model, also no call
+        ]
+    )
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(_collect(request, "Which port is the brain slot bound to?"))
+
+    assert stub.models == ["hal0/brain", "hal0/agent"]
+    assert _tokens(events) == "I could not read the slot table."
+
+
+# ── the detector itself ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "What port is the brain slot running on? Answer in one short sentence.",
+        "Which port is the brain slot bound to?",
+        "How many models are registered on this hal0 install right now?",
+        "list my slots",
+        "show me the board",
+        "is the npu slot loaded",
+        "what's on the board",
+        "how much VRAM is free",
+        "which agents are installed",
+    ],
+)
+def test_live_state_questions_are_detected(prompt: str) -> None:
+    assert bc._asks_for_live_state(prompt) is True
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "hi",
+        "thanks, that helped",
+        "What is a slot?",
+        "what is an inference backend",
+        "Explain how the dispatcher decides what to run",
+        "How do I create a new profile?",
+        "Why does the board have a triage lane",
+        "",
+        "   ",
+    ],
+)
+def test_non_live_state_prompts_are_not_detected(prompt: str) -> None:
+    assert bc._asks_for_live_state(prompt) is False
+
+
+def test_last_user_text_reads_the_latest_turn_and_content_parts() -> None:
+    messages = [
+        {"role": "system", "content": "steward"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": [{"type": "text", "text": "list my slots"}]},
+    ]
+    assert bc._last_user_text(messages) == "list my slots"
+    assert bc._last_user_text([{"role": "system", "content": "x"}]) == ""
+
+
+# ── the wrong-tool half of the report ───────────────────────────────────────
+
+
+def _description(name: str) -> str:
+    for schema in bc._tool_schemas():
+        if schema["function"]["name"] == name:
+            return schema["function"]["description"]
+    raise AssertionError(f"{name} is not a surfaced local tool")
+
+
+def test_local_registry_and_remote_catalogue_are_distinguishable() -> None:
+    """`list_models` is THIS box; `model_catalogue` is what could be pulled.
+
+    rc.7 saw "how many models are registered?" answered from the HuggingFace
+    catalogue. Both descriptions now name their scope and point at each other.
+    """
+    from hal0.mcp.admin import TOOL_DESCRIPTIONS
+
+    local = _description("list_models").lower()
+    assert "this box" in local
+    assert "not the remote" in local
+
+    remote = TOOL_DESCRIPTIONS["model_catalogue"].lower()
+    assert "remote" in remote
+    assert "not what is installed" in remote
+
+
+def test_the_board_tool_does_not_advertise_itself_for_every_question() -> None:
+    """rc.7 saw `get_board` answer a SLOT question.
+
+    Its old description carried a bare "Call this FIRST", which a small model
+    reads as a global instruction; it is scoped to task ids now, and the tool
+    says out loud that it knows nothing about slots.
+    """
+    board = _description("get_board").lower()
+    assert "task ids before mutating a task" in board
+    assert "slots" in board  # the explicit "not slots/models/ports/hardware" disclaimer
+
+
+def test_slot_tools_advertise_the_port() -> None:
+    """A port question has to have an obvious tool to land on."""
+    assert "port" in _description("list_slots").lower()
+    assert "port" in _description("get_slot").lower()
+
+
+def test_the_system_prompt_forbids_trading_grounding_for_brevity() -> None:
+    """The prompt half of the fix — the model must not read "short" as "guess"."""
+    prompt = bc._SYSTEM_PROMPT
+    assert "BREVITY NEVER CANCELS A TOOL CALL" in prompt
+    assert "GROUND EVERY CLAIM ABOUT THIS BOX IN A TOOL RESULT" in prompt
+    assert "short AFTER you have looked" in prompt

--- a/tests/brain/test_brain_live_state_grounding.py
+++ b/tests/brain/test_brain_live_state_grounding.py
@@ -252,6 +252,8 @@ def test_grounding_fires_at_most_once_per_turn() -> None:
         "what's on the board",
         "how much VRAM is free",
         "which agents are installed",
+        "is the installer running?",
+        "did the last installation finish?",
     ],
 )
 def test_live_state_questions_are_detected(prompt: str) -> None:

--- a/tests/brain/test_brain_tool_reroute.py
+++ b/tests/brain/test_brain_tool_reroute.py
@@ -248,21 +248,29 @@ def test_a_reply_that_merely_mentions_a_tool_is_not_rerouted() -> None:
     Names a surfaced tool, in call form, in the reasoning — but `content` is
     non-empty, so the turn produced an actual answer and there is nothing to
     recover.
+
+    The prompt is deliberately a CONCEPTUAL one. A live-state question answered
+    with prose and no tool call is a different failure (#2022) with a different
+    remedy — it reroutes on the grounding rule, see
+    tests/brain/test_brain_live_state_grounding.py — and would confound what
+    this test is about.
     """
     stub = _StubLLM(
         [
             _leaked(
-                "You can see them on the Slots page.",
-                reasoning="I could call list_slots() but the operator only asked where.",
+                "A slot is a named inference unit; you can see yours on the Slots page.",
+                reasoning="I could call list_slots() but the operator only asked what one is.",
             )
         ]
     )
     request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
 
-    events = _run(_collect(request))
+    events = _run(_collect(request, {"messages": [{"role": "user", "content": "What is a slot?"}]}))
 
     assert stub.models == ["hal0/brain"]
-    assert _tokens(events) == "You can see them on the Slots page."
+    assert (
+        _tokens(events) == "A slot is a named inference unit; you can see yours on the Slots page."
+    )
 
 
 def test_a_usable_brain_tool_call_is_not_re_run() -> None:
@@ -868,7 +876,11 @@ def test_a_tool_format_reject_is_learned_and_the_round_is_salvaged() -> None:
     """The runtime half of the gate. "Assume capable" is only safe because a
     runner that turns out NOT to be teaches the gate on its first failure:
     THIS round retries tools-less (no 500 reaches the operator) and every
-    later turn on that image goes out tools-less from the start."""
+    later turn on that image goes out tools-less from the start.
+
+    Plain-chat prompt on purpose: a live-state question would additionally
+    reroute the salvaged round on the #2022 grounding rule, which is asserted
+    in tests/brain/test_brain_live_state_grounding.py, not here."""
     _clear_learned()
     try:
         stub = _StubLLM([{"error": _PEG_FORMAT_ERROR}, _final("Plain answer.")])
@@ -878,7 +890,7 @@ def test_a_tool_format_reject_is_learned_and_the_round_is_salvaged() -> None:
             model="hal0/brain",
         )
 
-        events = _run(_collect(request))
+        events = _run(_collect(request, {"messages": [{"role": "user", "content": "say hello"}]}))
 
         assert stub.calls[0].get("tools"), "first attempt should try the native fast path"
         assert not stub.calls[1].get("tools"), "the retry must drop tools"


### PR DESCRIPTION
## What

The brain steward no longer answers a question about this box from imagination.

**Root cause.** Grounding was entirely at the model's discretion. The reroute machinery added for the 1.1B anchor (`_tool_intent_artefact`) only recovers a round where the small model *tried* to emit a tool call and garbled it. A round where it skips the call and answers confidently is, downstream, indistinguishable from a good reply — an invented port and a read one are the same string. rc.7 measured that appending `Answer in one short sentence.` to an otherwise correctly-grounded question reliably triggers that skip on `hal0-brain-sft-q8-rocmfpx` (2/2 both directions), and the steward system prompt's own "Keep replies short" was agreeing with the user.

So the check moved to the **question side**, the only place a signal exists before the answer does:

- `_asks_for_live_state()` marks a turn whose last user message asks about live box state (slots, ports, models, hardware, board, settings, …) while excluding conceptual `what is a slot` / `how do I …` / `explain …` phrasings.
- On such a turn, a chat round returning **neither a tool call nor an artefact** is discarded and re-run on `[brain_chat] tool_model` — the same remedy, and the same code path, a garbled round already takes. It fires at most once per turn (the reroute enters the tool chain) and is a **no-op** where there is nowhere to reroute (`tool_model` off, or equal to the chat model), so those paths keep their documented single-completion shape and stay owned by the existing `_tools_unavailable_notice` honesty layer.
- The system prompt gains explicit rules: ground every claim about this box in a tool result; **brevity never cancels a tool call** (it constrains the wording, not the lookup); and a subject → tool mapping.

**The second reported failure mode** — plain questions hitting the *wrong* tool (`model_catalogue` for "how many models are registered", `get_board` for a slot question) — is fixed at its cause rather than papered over: `get_board`'s bare "Call this FIRST" (which a small model reads as a global instruction) is scoped to task ids and now says out loud that it knows nothing about slots/models/ports/hardware; `list_models` and `model_catalogue` each name their scope (this box vs remote pullable) and point at each other; `list_slots`/`get_slot` advertise the port they return.

## Why not just the prompt

A prompt rule is advice to a 1.1B that has already been observed ignoring the same class of instruction. The reroute is the enforcement; the prompt is the cheap first line.

## Verification

- New `tests/brain/test_brain_live_state_grounding.py` (30 tests) — the issue's exact repro (brevity-suffixed port question → fabricated answer, zero tool frames) reroutes, dispatches `list_slots` and the fabrication never reaches the stream; the plain form too; a brain round that *did* call a tool is not re-run; small talk and conceptual questions never wake the tool model; the no-reroute path is unchanged; the reroute fires at most once; detector table; tool-description disambiguation. **26 of 30 fail on `main`.**
- `uv run pytest tests/brain tests/board -q` → 422 passed.
- `ruff check src tests` → clean; `ruff format --check src tests` → clean.
- Two pre-existing tests in `test_brain_tool_reroute.py` used the live-state prompt `"list my slots"` incidentally while asserting something else (artefact-detector-must-not-fire-on-prose; tool-format-reject salvage). Both were re-pointed at prompts that don't ask for live state, with a comment saying why — their assertions are untouched.

## Out of scope

- The no-reroute configuration (`tool_model = off`) still cannot ground anything; that turn relies on the prompt rules and the existing `tools_unavailable` notice. Forcing a same-model retry there would double latency for every live-state turn on boxes that deliberately disabled the second model.
- No CHANGELOG hunk (#1545 — one consolidated CHANGELOG PR lands at the end of the wave).

Closes #2022