### PR TITLE
fix(normalize): do not inject enable_thinking:false into grammar-constrained chat bodies

### DIFF
--- a/src/hal0/normalize/thinking.py
+++ b/src/hal0/normalize/thinking.py
@@ -20,7 +20,21 @@ Policy:
   - Caller set a top-level boolean ``enable_thinking`` / ``thinking`` → translated
     into ``chat_template_kwargs.enable_thinking`` (the lever that actually works)
     and the ineffective top-level field is dropped.
-  - Otherwise → default to suppression (``enable_thinking: false``).
+  - Otherwise → default to suppression (``enable_thinking: false``), EXCEPT for
+    a request that engages a constrained-decoding grammar (``response_format``
+    json_object / json_schema, llama.cpp ``grammar`` / ``json_schema``), which
+    is left alone — see below.
+
+Why structured output is exempt (#2020): a Qwen3-family template renders the
+``enable_thinking is false`` branch as a literal ``<think>\\n\\n</think>`` block
+in the prompt (the installer-seeded ``hal0-brain-sft.jinja`` does exactly this).
+Combined with a JSON grammar, llama-server's sampler-chain construction throws
+``Failed to initialize samplers: std::exception`` and the request hard-400s.
+Since a suppression the caller never asked for is our own invention, we simply
+do not invent it when a grammar is in play: no kwarg is added and the template
+default applies. An *explicit* caller preference — either lever — is still
+honoured verbatim, and a default of ``true`` is still applied (thinking ON is
+grammar-compatible; only the empty-think-block branch collides).
 
 Idempotent and non-mutating.
 """
@@ -30,6 +44,23 @@ from __future__ import annotations
 from typing import Any
 
 _TOP_LEVEL_KEYS = ("enable_thinking", "thinking")
+
+# ``response_format.type`` values that engage a constrained-decoding grammar.
+_GRAMMAR_RESPONSE_FORMATS = frozenset({"json_object", "json_schema"})
+# llama.cpp's native top-level grammar levers, accepted on /v1/chat/completions.
+_GRAMMAR_KEYS = ("grammar", "json_schema")
+
+
+def _wants_structured_output(body: dict[str, Any]) -> bool:
+    """True when the request constrains decoding with a grammar.
+
+    Covers the OpenAI ``response_format`` (json_object / json_schema) and
+    llama.cpp's native top-level ``grammar`` / ``json_schema``.
+    """
+    fmt = body.get("response_format")
+    if isinstance(fmt, dict) and fmt.get("type") in _GRAMMAR_RESPONSE_FORMATS:
+        return True
+    return any(body.get(key) not in (None, "", {}) for key in _GRAMMAR_KEYS)
 
 
 def _explicit_kwarg_set(body: dict[str, Any]) -> bool:
@@ -67,6 +98,11 @@ def apply_thinking_policy(
 
     intent = _caller_intent(body)
     want = default_thinking if intent is None else intent
+
+    # #2020: never *invent* a suppression for a grammar-constrained request —
+    # the rendered empty think-block collides with sampler init and hard-400s.
+    if intent is None and not want and _wants_structured_output(body):
+        return body
 
     ctk = {**(body.get("chat_template_kwargs") or {}), "enable_thinking": want}
     # Drop the ineffective top-level booleans; keep everything else.

--- a/tests/api/test_chat_normalization.py
+++ b/tests/api/test_chat_normalization.py
@@ -120,6 +120,28 @@ async def test_model_default_overridden_by_request():
 
 
 @pytest.mark.asyncio
+async def test_json_mode_request_leaves_route_without_injected_suppression():
+    """#2020: a json_object body must reach the dispatcher WITHOUT an
+    unrequested ``enable_thinking: false`` — that kwarg plus a JSON grammar
+    hard-400s ("Failed to initialize samplers") on Qwen3-templated models."""
+    import json
+
+    req = _make_request(cfgs=_PRIMARY, loaded={"big"})
+    out = await v1._normalize_chat_body(
+        req,
+        {
+            "model": "hal0/agent",
+            "messages": [{"role": "user", "content": "json please"}],
+            "response_format": {"type": "json_object"},
+        },
+    )
+    assert out["model"] == "big"
+    assert "chat_template_kwargs" not in out
+    # the body the dispatcher re-reads must be clean too
+    assert "chat_template_kwargs" not in json.loads(req._body)
+
+
+@pytest.mark.asyncio
 async def test_request_body_rewritten_for_downstream_consumers():
     import json
 

--- a/tests/normalize/test_thinking.py
+++ b/tests/normalize/test_thinking.py
@@ -94,3 +94,79 @@ def test_does_not_mutate_input():
     src2 = {"enable_thinking": False}
     apply_thinking_policy(src2)
     assert src2 == {"enable_thinking": False}
+
+
+# --- #2020: structured output must not get an unrequested suppression kwarg ---
+#
+# The seeded hal0-brain-sft template emits a literal `<think>\n\n</think>` block
+# when `enable_thinking is false`; combined with a json_object/json_schema
+# grammar llama-server b109 throws "Failed to initialize samplers" and hard-400s.
+# A caller that never asked for reasoning suppression must not be given it.
+
+
+def test_json_object_response_format_skips_default_suppression():
+    body = {"model": "m", "messages": [], "response_format": {"type": "json_object"}}
+    out = apply_thinking_policy(body)
+    assert "chat_template_kwargs" not in out
+    assert out == body
+
+
+def test_json_schema_response_format_skips_default_suppression():
+    body = {
+        "model": "m",
+        "response_format": {"type": "json_schema", "json_schema": {"name": "x", "schema": {}}},
+    }
+    out = apply_thinking_policy(body)
+    assert "chat_template_kwargs" not in out
+
+
+def test_llamacpp_grammar_skips_default_suppression():
+    out = apply_thinking_policy({"model": "m", "grammar": 'root ::= "a"'})
+    assert "chat_template_kwargs" not in out
+
+
+def test_llamacpp_top_level_json_schema_skips_default_suppression():
+    out = apply_thinking_policy({"model": "m", "json_schema": {"type": "object"}})
+    assert "chat_template_kwargs" not in out
+
+
+def test_text_response_format_still_suppressed():
+    # `{"type": "text"}` engages no grammar — the normal default still applies.
+    out = apply_thinking_policy({"model": "m", "response_format": {"type": "text"}})
+    assert out["chat_template_kwargs"]["enable_thinking"] is False
+
+
+def test_structured_output_respects_explicit_caller_suppression():
+    # An explicit caller request is honoured verbatim, json mode or not — the
+    # policy only declines to *invent* a suppression the caller never asked for.
+    body = {
+        "model": "m",
+        "response_format": {"type": "json_object"},
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    assert apply_thinking_policy(body) == body
+
+    out = apply_thinking_policy(
+        {"model": "m", "response_format": {"type": "json_object"}, "enable_thinking": False}
+    )
+    assert out["chat_template_kwargs"]["enable_thinking"] is False
+
+
+def test_structured_output_still_honours_thinking_default_true():
+    # enable_thinking=true is grammar-compatible (verified live on the seeded
+    # model), so a slot/model default of ON is still applied under json mode.
+    out = apply_thinking_policy(
+        {"model": "m", "response_format": {"type": "json_object"}}, default_thinking=True
+    )
+    assert out["chat_template_kwargs"]["enable_thinking"] is True
+
+
+def test_structured_output_policy_is_idempotent():
+    once = apply_thinking_policy({"model": "m", "response_format": {"type": "json_object"}})
+    assert apply_thinking_policy(once) == once
+
+
+def test_malformed_response_format_falls_back_to_default():
+    # Junk in response_format must not crash the normaliser.
+    out = apply_thinking_policy({"model": "m", "response_format": "json_object"})
+    assert out["chat_template_kwargs"]["enable_thinking"] is False


### PR DESCRIPTION
## What changed

`hal0.normalize.thinking.apply_thinking_policy` no longer injects a default
`chat_template_kwargs: {"enable_thinking": false}` into a chat body that engages a
constrained-decoding grammar:

- OpenAI `response_format` with `type` in `{json_object, json_schema}`
- llama.cpp's native top-level `grammar` / `json_schema`

For those bodies the kwarg is simply not added, so the chat template's own default applies.

## Why

The default suppression is hal0's own invention — the caller never sent it. On a Qwen3-family
template the `enable_thinking is false` branch renders a literal `<think>\n\n</think>` block into
the prompt (the installer-seeded `src/hal0/templates/chat/hal0-brain-sft.jinja:172-176` does
exactly this). Combined with a JSON grammar, llama-server b109 throws in sampler-chain
construction and returns HTTP 400 `Failed to initialize samplers: std::exception`.

Since `hal0-api` adds the kwarg on the way through `/v1/chat/completions`, every JSON-mode client
400s against such a model even though the byte-identical body succeeds sent direct to the slot
(the decisive A/B in #2020). Blast radius on a fresh install is total: hindsight's
`retain_extract_facts` retries forever, and the seeded brain-sft template is the only one a fresh
install ships. Root cause confirmed to be this single site — `grep` shows no other request-path
writer of `enable_thinking` (`api/routes/chat_templates.py:48` is a render-lint fixture;
`models_service.py:1266` is an error-message example), so the fix is at the cause, not the symptom.

Deliberately narrow:

- An **explicit** caller preference still wins verbatim, JSON mode or not — either
  `chat_template_kwargs.enable_thinking` or the translated top-level boolean. If a client asks for
  suppression under a grammar, that is its call.
- A **model/slot default of `true`** is still applied under JSON mode. The issue's direct-to-slot
  isolation showed `enable_thinking=true` → 200 and kwarg-absent → 200; only the empty-think-block
  branch collides.
- `response_format: {"type": "text"}` engages no grammar and keeps the normal default.
- Malformed `response_format` (e.g. a bare string) falls back to the normal default rather than
  raising.

## How it was verified

Regression tests written first, confirmed red on `main`'s behaviour, green after:

- `tests/normalize/test_thinking.py` — 9 new unit tests: json_object / json_schema / `grammar` /
  top-level `json_schema` skip the default; `text` format does not; explicit caller suppression
  and a `default_thinking=True` slot default are still honoured; idempotence; malformed input.
- `tests/api/test_chat_normalization.py::test_json_mode_request_leaves_route_without_injected_suppression`
  — route-level: a `response_format` body leaves `_normalize_chat_body` (and the rewritten
  `request._body` the dispatcher re-reads) with no `chat_template_kwargs`. Pure unit level, no
  hermes and no live slot, so it is CI-safe.

```
$ HAL0_HOME=$(mktemp -d) uv run --extra dev pytest -q -x -p no:randomly
11413 passed, 18 skipped, 1 xfailed in 1488.99s
$ uv run --extra dev ruff check <changed files>   # All checks passed!
$ uv run --extra dev ruff format --check <changed files>   # 3 files already formatted
```

Red-before evidence (pre-fix run of the new tests): 5 failed, 41 passed — the four grammar cases
plus the route assertion.

## Out of scope

- The upstream llama.cpp sampler-init crash itself (an empty think-block prefix plus a JSON grammar
  should not throw) — not ours to fix; this removes hal0's contribution to it.
- Changing `hal0-brain-sft.jinja`. Editing the seeded template would perturb a shipped model's
  prompt format for a bug that is really an unrequested-kwarg problem.
- The hal0 CLI `/think off` path passes its toggle as `default_thinking`, so under a grammar it
  would also decline to suppress. The REPL never sends `response_format`, so there is no behaviour
  change in practice; making the REPL toggle a true explicit intent is a separate cleanup.
- No CHANGELOG hunk (per #1545, the wave lands one consolidated CHANGELOG PR).

Closes #2020