### PR TITLE
fix(slots): fail-fast doomed model loads via entrypoint exit 64

### DIFF
--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -277,7 +277,8 @@ validate_dropin_body() {  # arg: kind (gateway|hindsight); body on stdin
 #               HealthCmd= HealthStartPeriod= HealthInterval= HealthRetries=
 #               HealthTimeout= Exec=
 #   [Service]   Restart= RestartSec= RestartSteps= RestartMaxDelaySec=
-#               SyslogIdentifier= StandardOutput= StandardError=
+#               RestartPreventExitStatus= SyslogIdentifier= StandardOutput=
+#               StandardError=
 #   [Install]   WantedBy=hal0.target        (omitted when autoload = false)
 #
 # Sections may appear at most once and only in that order; [Container] is
@@ -429,13 +430,16 @@ validate_quadlet_directive() {  # args: section, "Key=Value" line
 
     # ── [Service] ───────────────────────────────────────────────────────
     # Copied VERBATIM into the generated system unit by podman's quadlet
-    # generator — i.e. host-side root. Exactly the seven the renderer emits;
+    # generator — i.e. host-side root. Exactly the eight the renderer emits;
     # every Exec*=, User=, Group=, WorkingDirectory=, … lands in the default
-    # arm below and dies.
+    # arm below and dies. RestartPreventExitStatus= (#2037) is pinned to a
+    # single uint — the renderer emits exactly `64`; signal names, lists and
+    # ranges systemd would also accept are refused here.
     'Service|Restart')           [[ "$value" =~ $_QRE_RESTART ]] || _quadlet_die "bad Restart: $value" ;;
     'Service|RestartSec')        [[ "$value" =~ $_QRE_UINT ]]    || _quadlet_die "bad RestartSec: $value" ;;
     'Service|RestartSteps')      [[ "$value" =~ $_QRE_UINT ]]    || _quadlet_die "bad RestartSteps: $value" ;;
     'Service|RestartMaxDelaySec') [[ "$value" =~ $_QRE_UINT ]]   || _quadlet_die "bad RestartMaxDelaySec: $value" ;;
+    'Service|RestartPreventExitStatus') [[ "$value" =~ $_QRE_UINT ]] || _quadlet_die "bad RestartPreventExitStatus: $value" ;;
     'Service|SyslogIdentifier')  [[ "$value" =~ $_QRE_CTRNAME ]] || _quadlet_die "bad SyslogIdentifier: $value" ;;
     'Service|StandardOutput')    [[ "$value" == "journal" ]]     || _quadlet_die "bad StandardOutput: $value" ;;
     'Service|StandardError')     [[ "$value" == "journal" ]]     || _quadlet_die "bad StandardError: $value" ;;

--- a/packaging/runner/rocmfpx/entrypoint.sh
+++ b/packaging/runner/rocmfpx/entrypoint.sh
@@ -2,7 +2,16 @@
 # hal0 runner preflight — a device-less GPU start must be a readable diagnostic, not a SIGSEGV
 # (#1936). Gates ONLY on an explicit GPU request: llama.cpp defaults to CPU when neither -ngl
 # nor -dev is passed, so absence of those flags must never be treated as a GPU request.
+#
+# Test seams (unset in the shipped image, harmless there):
+#   HAL0_RUNNER_SERVER   — server binary (default /opt/rocmfpx/bin/llama-server)
+#   HAL0_RUNNER_DEV_ROOT — prefix for the /dev probes, so the no-GPU branch is testable
+#                          on a dev box that has real devices
+SERVER="${HAL0_RUNNER_SERVER:-/opt/rocmfpx/bin/llama-server}"
+DEV_ROOT="${HAL0_RUNNER_DEV_ROOT:-}"
+
 wants_gpu=0
+port=8080
 prev=""
 for a in "$@"; do
   case "$prev" in
@@ -14,14 +23,22 @@ for a in "$@"; do
         ROCm*|rocm*|Vulkan*|vulkan*|CUDA*|cuda*|SYCL*|sycl*) wants_gpu=1 ;;
       esac
       ;;
+    --port)
+      port="$a"
+      ;;
+  esac
+  # --port=NNNN (single-token form) — the template renders the two-token
+  # form, but operator-edited profile flags may not.
+  case "$a" in
+    --port=*) port="${a#--port=}" ;;
   esac
   prev="$a"
 done
 
 if [ "$wants_gpu" = "1" ]; then
   has_dev=0
-  [ -e /dev/kfd ] && has_dev=1
-  for r in /dev/dri/renderD*; do [ -e "$r" ] && has_dev=1; done
+  [ -e "${DEV_ROOT}/dev/kfd" ] && has_dev=1
+  for r in "${DEV_ROOT}"/dev/dri/renderD*; do [ -e "$r" ] && has_dev=1; done
   if [ "$has_dev" = "0" ]; then
     echo "hal0-runner: GPU offload was requested but no GPU devices are visible in this container." >&2
     echo "hal0-runner: expected /dev/kfd (ROCm lane) and/or /dev/dri/renderD* (Vulkan lane)." >&2
@@ -30,4 +47,39 @@ if [ "$wants_gpu" = "1" ]; then
     exit 78
   fi
 fi
-exec /opt/rocmfpx/bin/llama-server "$@"
+
+# Load-phase exit translation (#2037): llama-server exits 1 for every failure
+# class, so systemd cannot fail-fast a doomed model. Supervise the child and
+# watch /health — "loaded" means /health answered 200 at least once (during
+# load llama-server either isn't listening yet or answers 503, so a bare TCP
+# accept is not enough). A normal (non-signal) death before that point becomes
+# exit 64 for RestartPreventExitStatus=64 to act on; signal deaths (OOM kill,
+# GPU reset — possibly transient) and anything after load keep their own code
+# and the restart backoff runway.
+"$SERVER" "$@" &
+child=$!
+trap 'kill -TERM "$child" 2>/dev/null' TERM INT
+
+ready=0
+while kill -0 "$child" 2>/dev/null; do
+  if curl -sf -o /dev/null "http://127.0.0.1:${port}/health"; then
+    ready=1
+    break
+  fi
+  sleep 0.5
+done
+
+# A trap interrupting wait returns 128+sig with the child unreaped — wait again
+# until the child's own status comes back.
+while :; do
+  wait "$child"
+  rc=$?
+  kill -0 "$child" 2>/dev/null || break
+done
+
+if [ "$ready" = "0" ] && [ "$rc" -ge 1 ] && [ "$rc" -le 127 ]; then
+  echo "hal0-runner: llama-server exited (rc=$rc) before /health ever answered — died during model load." >&2
+  echo "hal0-runner: translating to exit 64 so systemd can fail-fast instead of burning the restart ramp (hal0 issue #2037)." >&2
+  exit 64
+fi
+exit "$rc"

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -860,6 +860,12 @@ def _render_quadlet_from_plan(
             "RestartSec=5",
             "RestartSteps=6",
             "RestartMaxDelaySec=300",
+            # #2037 fail-fast: the runner entrypoint translates a death
+            # before /health ever answered into exit 64 ("died during model
+            # load" — corrupt GGUF, bogus flag), which would otherwise burn
+            # the whole ramp above on a doomed model. Old images never exit
+            # 64, so this is inert against them — safe version skew.
+            "RestartPreventExitStatus=64",
             f"SyslogIdentifier={container_name}",
             "StandardOutput=journal",
             "StandardError=journal",

--- a/tests/installer/test_runner_entrypoint.py
+++ b/tests/installer/test_runner_entrypoint.py
@@ -1,0 +1,140 @@
+"""#2037 — load-phase exit-code translation in the runner entrypoint.
+
+``packaging/runner/rocmfpx/entrypoint.sh`` is PID 1 of every llama-server
+slot container. llama-server exits 1 for every failure class, so systemd
+cannot tell "doomed model, never retry" from "transient crash, retry with
+backoff". The entrypoint owns the child and can see the one signal that
+separates them — did ``/health`` ever answer 200 — and translates a
+died-during-load into exit 64 for ``RestartPreventExitStatus=64`` to act on.
+
+These tests run the real script with a fake server binary
+(``HAL0_RUNNER_SERVER`` override) — no image build, no GPU, no root. Same
+posture as the ``hal0-systemctl`` wrapper suites.
+"""
+
+from __future__ import annotations
+
+import socket
+import stat
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+ENTRYPOINT = REPO / "packaging" / "runner" / "rocmfpx" / "entrypoint.sh"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _run_with_fake_server(
+    tmp_path: Path, fake_body: str, *args: str
+) -> subprocess.CompletedProcess[str]:
+    fake = tmp_path / "fake-llama-server"
+    fake.write_text(fake_body)
+    fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+    return subprocess.run(
+        [str(ENTRYPOINT), *args],
+        env={"PATH": "/usr/bin:/bin", "HAL0_RUNNER_SERVER": str(fake)},
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+
+def test_death_before_health_translates_to_64(tmp_path: Path) -> None:
+    """A server that dies before /health ever answers (corrupt GGUF, bogus
+    flag — llama-server says exit 1 for all of them) must surface as 64."""
+    proc = _run_with_fake_server(tmp_path, "#!/bin/sh\nexit 1\n", "--port", str(_free_port()))
+    assert proc.returncode == 64, proc.stderr
+    assert "before" in proc.stderr  # a diagnostic, not a silent remap
+
+
+def test_clean_exit_is_not_translated(tmp_path: Path) -> None:
+    """Exit 0 during load (e.g. --help paths) is not a doomed model."""
+    proc = _run_with_fake_server(tmp_path, "#!/bin/sh\nexit 0\n", "--port", str(_free_port()))
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_signal_death_during_load_is_not_translated(tmp_path: Path) -> None:
+    """A SIGKILL'd load (OOM-killer, GPU reset) may be transient — keep the
+    backoff runway, propagate 128+sig untouched."""
+    proc = _run_with_fake_server(
+        tmp_path, "#!/bin/sh\nkill -KILL $$\n", "--port", str(_free_port())
+    )
+    assert proc.returncode == 137, proc.stderr
+
+
+def test_crash_after_health_propagates_real_code(tmp_path: Path) -> None:
+    """Once /health has answered 200 the model loaded fine; a later crash is
+    a serving failure and keeps its own exit code (and the restart ramp)."""
+    port = _free_port()
+    fake_body = (
+        "#!/usr/bin/env python3\n"
+        "import http.server, sys, threading, time\n"
+        "args = sys.argv[1:]\n"
+        "port = int(args[args.index('--port') + 1])\n"
+        "class H(http.server.BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        "        self.send_response(200)\n"
+        "        self.end_headers()\n"
+        "    def log_message(self, *a):\n"
+        "        pass\n"
+        "srv = http.server.HTTPServer(('127.0.0.1', port), H)\n"
+        "threading.Thread(target=srv.serve_forever, daemon=True).start()\n"
+        "time.sleep(3)\n"
+        "sys.exit(7)\n"
+    )
+    proc = _run_with_fake_server(tmp_path, fake_body, "--port", str(port))
+    assert proc.returncode == 7, proc.stderr
+
+
+def test_port_equals_form_is_parsed(tmp_path: Path) -> None:
+    """``--port=NNNN`` single-token form: the template renders the two-token
+    form, but operator-edited profile flags may not. A missed parse would
+    poll the 8080 default, never see /health, and mistranslate the post-load
+    exit below into 64."""
+    port = _free_port()
+    fake_body = (
+        "#!/usr/bin/env python3\n"
+        "import http.server, sys, threading, time\n"
+        "port = int(\n"
+        "    [a for a in sys.argv[1:] if a.startswith('--port=')][0].split('=', 1)[1]\n"
+        ")\n"
+        "class H(http.server.BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        "        self.send_response(200)\n"
+        "        self.end_headers()\n"
+        "    def log_message(self, *a):\n"
+        "        pass\n"
+        "srv = http.server.HTTPServer(('127.0.0.1', port), H)\n"
+        "threading.Thread(target=srv.serve_forever, daemon=True).start()\n"
+        "time.sleep(3)\n"
+        "sys.exit(7)\n"
+    )
+    proc = _run_with_fake_server(tmp_path, fake_body, f"--port={port}")
+    assert proc.returncode == 7, proc.stderr
+
+
+def test_gpu_preflight_still_refuses_with_78(tmp_path: Path) -> None:
+    """#1936's device-less GPU gate must survive the supervision rewrite."""
+    fake = tmp_path / "fake-llama-server"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+    proc = subprocess.run(
+        [str(ENTRYPOINT), "-ngl", "99", "--port", str(_free_port())],
+        env={
+            "PATH": "/usr/bin:/bin",
+            "HAL0_RUNNER_SERVER": str(fake),
+            # force the no-device branch even on a GPU dev box
+            "HAL0_RUNNER_DEV_ROOT": str(tmp_path),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert proc.returncode == 78, proc.stderr

--- a/tests/installer/test_systemctl_quadlet_validation.py
+++ b/tests/installer/test_systemctl_quadlet_validation.py
@@ -333,6 +333,14 @@ ESCALATIONS = {
     "service-standardoutput-file": f"{_HEAD}\n[Service]\nStandardOutput=file:/root/.ssh/authorized_keys\n",
     "service-syslogidentifier-free": f"{_HEAD}\n[Service]\nSyslogIdentifier=../evil\n",
     "service-restart-free": f"{_HEAD}\n[Service]\nRestart=/bin/sh\n",
+    # #2037: RestartPreventExitStatus= is pinned to a single uint (the renderer
+    # emits exactly `64`); signal names / lists / ranges are refused.
+    "service-restartpreventexitstatus-signal": (
+        f"{_HEAD}\n[Service]\nRestartPreventExitStatus=SIGKILL\n"
+    ),
+    "service-restartpreventexitstatus-list": (
+        f"{_HEAD}\n[Service]\nRestartPreventExitStatus=64 78\n"
+    ),
     "service-workingdirectory": f"{_HEAD}\n[Service]\nWorkingDirectory=/root\n",
     "service-environmentfile": f"{_HEAD}\n[Service]\nEnvironmentFile=/tmp/evil.env\n",
     "service-permissionsstartonly": f"{_HEAD}\n[Service]\nPermissionsStartOnly=true\n",

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -577,6 +577,18 @@ class TestRenderUnit:
         assert "StartLimitIntervalSec" not in service_section
         assert "StartLimitBurst" not in service_section
 
+    def test_restart_prevent_exit_status_lands_in_service_section(self) -> None:
+        """#2037: the runner entrypoint translates died-during-load into exit
+        64; ``RestartPreventExitStatus=64`` lets systemd fail-fast a doomed
+        model instead of burning the whole backoff ramp. Old images never emit
+        64, so the directive is inert against them — safe version skew.
+        """
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_llama("test-slot", _TEST_IMAGE, 8095, "/mnt/ai-models/model.gguf", flags)
+        service_section = unit.partition("[Service]")[2].partition("[Install]")[0]
+        assert "RestartPreventExitStatus=64" in service_section
+
     def test_numeric_group_add_present(self) -> None:
         """GroupAdd= must use numeric GIDs (toolbox images lack group names)."""
         from hal0.providers._gpu import resolve_gpu_group_ids


### PR DESCRIPTION
Closes #2037. Follow-up to #2012/#2015.

## Why

llama-server exits 1 for every failure class — corrupt GGUF and bogus CLI flag look identical to systemd — so `RestartPreventExitStatus=` was unusable and a genuinely doomed model burned the whole #2012 backoff ramp (~10 restarts over ~20 minutes) before parking.

## What

Three layers, one repo (the entrypoint source lives in `packaging/runner/rocmfpx/`, not the image repo):

1. **Entrypoint** (`packaging/runner/rocmfpx/entrypoint.sh`): now supervises llama-server instead of `exec`-ing it, polling `/health` on the slot's `--port`. "Loaded" = `/health` answered 200 at least once (during load llama-server either isn't listening or answers 503, so a bare TCP accept is not enough). A **normal (non-signal) death before that point** is translated to **exit 64**; signal deaths (OOM kill, GPU reset — possibly transient) and post-load crashes propagate untouched and keep the backoff runway. The #1936 GPU preflight (exit 78) is unchanged. Test seams: `HAL0_RUNNER_SERVER`, `HAL0_RUNNER_DEV_ROOT` (unset in the shipped image).
2. **Template** (`src/hal0/providers/container.py`): `[Service]` gains `RestartPreventExitStatus=64` next to the backoff keys.
3. **Wrapper** (`installer/wrappers/hal0-systemctl`): the `[Service]` allow-list accepts the new key, pinned to a single uint (`_QRE_UINT`) — signal names / lists / ranges systemd would accept are refused; both comment inventories updated.

## Version skew

Safe in both directions: an old image never exits 64, so the directive is inert; a new image under an old template just keeps today's backoff behaviour. The template change reaches live units on the next slot load/restart re-render.

## Tests (written red-first)

- `tests/installer/test_runner_entrypoint.py` (new): runs the real script with a fake server — death-before-health → 64 (with diagnostic), clean exit 0 not translated, SIGKILL during load → 137 untouched, crash after health → real code (7), preflight still 78.
- `tests/providers/test_container.py`: template emits `RestartPreventExitStatus=64` in `[Service]`.
- `tests/installer/test_systemctl_quadlet_validation.py`: renderer output accepted byte-for-byte (existing parametrised suite now covers the new key); `RestartPreventExitStatus=SIGKILL` and `=64 78` refused.

## Verification

- Full suite: 11081 passed, 18 skipped, 1 xfailed.
- `ruff check` / `ruff format --check` clean.
- mypy: zero new errors vs main (only a pre-existing sentry_sdk env diff and a line-number shift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)