### PR TITLE
feat(ui): render the crash-loop breaker on slot cards and the slot drawer

### DIFF
--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -46,6 +46,13 @@ export interface SlotMetrics {
   res?: string
 }
 
+/** #2012 crash-loop breaker snapshot view — see Slot.metadata.breaker. */
+export interface SlotBreaker {
+  state: 'backoff' | 'parked' | 'half-open'
+  failures: number
+  retry_after_s: number
+}
+
 export interface Slot {
   name: string
   type: string
@@ -101,6 +108,16 @@ export interface Slot {
    *  used / max". Absent when the slot configures no context window —
    *  the UI shows an em-dash, never a fabricated number. */
   ctx_max?: number
+  /** Crash-loop breaker view (#2012), stamped into slot metadata by the
+   *  manager whenever the breaker is non-closed and ABSENT otherwise —
+   *  presence of `metadata.breaker` is the render signal. `retry_after_s`
+   *  is computed at snapshot time; the UI counts down from fetch. Prefer
+   *  this over the older `metadata.parked` extra, which is stamped only on
+   *  ERROR transitions and goes stale. */
+  metadata?: {
+    breaker?: SlotBreaker
+    [key: string]: unknown
+  }
   /** Wall-clock epoch (seconds) of the most recent request served by
    *  this slot. ``null``/undefined means hal0-api has not seen a request
    *  for this slot since startup. Used by the slots view to render the
@@ -340,6 +357,9 @@ function normalizeSlot(s: any): Slot {
     // profile image). Coerce the flag to a boolean.
     actual_image: s?.actual_image ?? null,
     image_mismatch: !!s?.image_mismatch,
+    // metadata rides the spread above; restated so the pass-through is a
+    // documented contract (breaker chip, #2038) rather than an accident.
+    metadata: s?.metadata,
     // container_status / container_health are set by _container_state_enrichment.
     container_status: s?.container_status ?? null,
     container_health: s?.container_health ?? null,

--- a/ui/src/dash/__tests__/breaker-chip.test.ts
+++ b/ui/src/dash/__tests__/breaker-chip.test.ts
@@ -1,0 +1,84 @@
+// #2038 — render the crash-loop breaker (metadata.breaker, #2012) on slot
+// surfaces. The breaker view is stamped into slot metadata whenever it is
+// non-closed and absent otherwise; `retry_after_s` is computed at snapshot
+// time, so the classifier takes the seconds elapsed since fetch and counts
+// down client-side. The classifier is pinned here rather than left to the
+// JSX, same as image-status-chip.test.ts.
+import { describe, expect, it } from 'vitest'
+
+import type { Slot } from '@/api/hooks/useSlots'
+
+import { breakerChip } from '../slot-status.js'
+
+const BASE: Slot = {
+  name: 'agent',
+  type: 'llm',
+  device: 'gpu-vulkan',
+  model: 'chadrock-35b',
+  state: 'error',
+  metrics: {},
+  runtime: 'container',
+}
+
+function withBreaker(breaker: unknown): Slot {
+  return { ...BASE, metadata: { breaker } } as Slot
+}
+
+describe('breakerChip', () => {
+  it('is null without a breaker view (breaker closed / pre-#2012 backend)', () => {
+    expect(breakerChip(BASE)).toBeNull()
+    expect(breakerChip(withBreaker(undefined))).toBeNull()
+    expect(breakerChip({ ...BASE, metadata: {} } as Slot)).toBeNull()
+  })
+
+  it('backoff → amber retry countdown with the failure count', () => {
+    const chip = breakerChip(
+      withBreaker({ state: 'backoff', failures: 3, retry_after_s: 40 })
+    )
+    expect(chip).not.toBeNull()
+    expect(chip!.tone).toBe('warn')
+    expect(chip!.label).toBe('retry in 40s')
+    expect(chip!.tooltip).toContain('3 failures')
+  })
+
+  it('parked → red, failures in the label, countdown in the tooltip', () => {
+    const chip = breakerChip(
+      withBreaker({ state: 'parked', failures: 7, retry_after_s: 512 })
+    )
+    expect(chip).not.toBeNull()
+    expect(chip!.tone).toBe('err')
+    expect(chip!.label).toBe('parked · 7 failures')
+    expect(chip!.tooltip).toContain('512s')
+    // the escape hatch must be named — parked is deliberate refusal, not death
+    expect(chip!.tooltip.toLowerCase()).toContain('manual')
+  })
+
+  it('half-open → neutral trial-pending hint, no countdown', () => {
+    const chip = breakerChip(
+      withBreaker({ state: 'half-open', failures: 5, retry_after_s: 0 })
+    )
+    expect(chip).not.toBeNull()
+    expect(chip!.tone).toBe('neutral')
+    expect(chip!.label).toBe('trial pending')
+    expect(chip!.tooltip.toLowerCase()).toContain('next')
+  })
+
+  it('counts down from elapsed seconds and clamps at zero', () => {
+    const slot = withBreaker({ state: 'backoff', failures: 2, retry_after_s: 30 })
+    expect(breakerChip(slot, 10)!.label).toBe('retry in 20s')
+    expect(breakerChip(slot, 90)!.label).toBe('retry in 0s')
+  })
+
+  it('singularises a single failure', () => {
+    const chip = breakerChip(
+      withBreaker({ state: 'parked', failures: 1, retry_after_s: 8 })
+    )
+    expect(chip!.label).toBe('parked · 1 failure')
+  })
+
+  it('ignores an unknown breaker state rather than guessing a colour', () => {
+    expect(
+      breakerChip(withBreaker({ state: 'closed', failures: 0, retry_after_s: 0 }))
+    ).toBeNull()
+  })
+})

--- a/ui/src/dash/breaker-chip.jsx
+++ b/ui/src/dash/breaker-chip.jsx
@@ -1,0 +1,65 @@
+// #2038 — crash-loop breaker chip, shared by the inference slot cards and the
+// slot edit drawer. The classifier (state → tone/label/tooltip) lives in
+// slot-status.js so this component and any future surface cannot drift; this
+// file owns only the client-side countdown and the colour tokens.
+import React from 'react'
+
+import { breakerChip } from './slot-status.js'
+
+const { useEffect, useRef, useState } = React
+
+// tone → the card's colour vocabulary (dashboard.css tokens). Neutral is the
+// dashed grey of SlotImageUnknownChip: half-open is "a trial will run", which
+// is neither an error nor a warning.
+const TONES = {
+  warn: {
+    color: 'var(--warn)',
+    borderColor: 'var(--warn-line)',
+    background: 'var(--warn-soft)',
+  },
+  err: {
+    color: 'var(--err)',
+    borderColor: 'var(--err-line)',
+    background: 'var(--err-soft)',
+  },
+  neutral: {
+    color: 'var(--fg-3)',
+    borderStyle: 'dashed',
+    borderColor: 'var(--fg-3)',
+  },
+}
+
+export function SlotBreakerChip({ s }) {
+  const b = s?.metadata?.breaker
+  // `retry_after_s` is computed when the backend built the snapshot; count
+  // down from the moment THIS breaker view arrived. Keyed on the view's
+  // content so a fresh poll (new retry_after_s) restarts the clock, while a
+  // pure re-render does not. The reset runs in an effect, so the first
+  // render after a fresh poll can be up to one frame stale — invisible at
+  // 1s label granularity, and it keeps the render pure.
+  const viewKey = b ? `${b.state}:${b.retry_after_s}:${b.failures}` : ''
+  const receivedAt = useRef(Date.now())
+  useEffect(() => {
+    receivedAt.current = Date.now()
+  }, [viewKey])
+  const [, setTick] = useState(0)
+  const counting = !!b && (b.state === 'backoff' || b.state === 'parked')
+  useEffect(() => {
+    if (!counting) return undefined
+    const t = setInterval(() => setTick((n) => n + 1), 1000)
+    return () => clearInterval(t)
+  }, [counting, viewKey])
+
+  const chip = breakerChip(s, (Date.now() - receivedAt.current) / 1000)
+  if (!chip) return null
+  return (
+    <span
+      className="tag-chip"
+      data-testid={`slot-breaker-${s.name}`}
+      title={chip.tooltip}
+      style={TONES[chip.tone] || TONES.neutral}
+    >
+      {chip.label}
+    </span>
+  )
+}

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -39,6 +39,7 @@ import { useModels } from '@/api/hooks/useModels'
 import { isUpstreamModel } from '@/lib/normalizeApiModel'
 import { useMemoryMapModel } from './memory-map'
 import { slotIndicatorFromPhase, isSlotLive, imageStatusChip } from './slot-status.js'
+import { SlotBreakerChip } from './breaker-chip.jsx'
 import { slotModelRow } from './slots/slot-shared.js'
 import { useCardReorder } from './slots/card-order.js'
 // devKind — one shared, meta-aware helper (src/lib/deviceMeta.ts); replaces
@@ -526,6 +527,9 @@ export function SlotScard({
           </div>
         )}
         <div className={'scard-foot' + (full ? '' : ' bare')}>
+          {/* #2038: breaker first — when the slot is deliberately refusing
+              loads, that is the most actionable thing on the card. */}
+          <SlotBreakerChip s={s} />
           <BackendMismatch s={s} onEdit={onEdit} />
           <SlotImageUnknownChip s={s} />
           {full && memGb != null && <span className="tag-chip">{memGb} GB</span>}

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -22,6 +22,7 @@ import { useSlotLogsStream } from "@/api/hooks/useLogs";
 import { ENDPOINTS } from "@/api/endpoints";
 import { normalizeApiModel, isUpstreamModel } from "@/lib/normalizeApiModel";
 import { stateChipClassForSlot, slotButtonPhase } from "./slot-status.js";
+import { SlotBreakerChip } from "./breaker-chip.jsx";
 import { npuModalityOn } from "./npu-modality.js";
 import { slotModelRow, npuAnchorSlot } from "./slots/slot-shared.js";
 
@@ -1336,10 +1337,17 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						k="state"
 						v={
 							<span
-								data-testid="slot-state-readonly"
-								className={stateChipClass(slot)}
+								style={{ display: "inline-flex", gap: 6, alignItems: "center" }}
 							>
-								{slot.state}
+								<span
+									data-testid="slot-state-readonly"
+									className={stateChipClass(slot)}
+								>
+									{slot.state}
+								</span>
+								{/* #2038: breaker view rides next to the lifecycle state so
+								    "error" + "parked · N failures" read as one story. */}
+								<SlotBreakerChip s={slot} />
 							</span>
 						}
 					/>

--- a/ui/src/dash/slot-status.js
+++ b/ui/src/dash/slot-status.js
@@ -276,6 +276,70 @@ export function imageStatusChip(slot) {
 }
 
 /**
+ * Chip for the crash-loop breaker view (#2012 → #2038), or null.
+ *
+ * The manager stamps `metadata.breaker = {state, failures, retry_after_s}`
+ * into every slot snapshot while the breaker is non-closed and omits it
+ * otherwise, so presence of the field IS the render signal. Prefer this over
+ * the older `metadata.parked` extra — that one is stamped only on ERROR
+ * transitions and goes stale; the breaker view is the live truth.
+ *
+ * `retry_after_s` is computed at snapshot time. The caller passes the seconds
+ * elapsed since it fetched the snapshot and the countdown is clamped at 0 —
+ * accurate enough between polls, and never shows a negative.
+ *
+ * Tone maps onto the card's colour rule (see header):
+ *   backoff   → warn    (amber — the slot is deliberately waiting, not dead)
+ *   parked    → err     (red — refusing loads until the trial; needs an eye)
+ *   half-open → neutral (a trial will run on the next request; nothing to fix)
+ *
+ * @param {object|null|undefined} slot
+ * @param {number} [elapsedS] - seconds since the snapshot was fetched
+ * @returns {{tone: string, label: string, tooltip: string}|null}
+ */
+export function breakerChip(slot, elapsedS = 0) {
+  const b = slot?.metadata?.breaker;
+  if (!b || typeof b !== "object") return null;
+  const failures = Number(b.failures) || 0;
+  const failTxt = failures === 1 ? "1 failure" : `${failures} failures`;
+  const remaining = Math.max(
+    0,
+    Math.round((Number(b.retry_after_s) || 0) - elapsedS),
+  );
+  switch (b.state) {
+    case "backoff":
+      return {
+        tone: "warn",
+        label: `retry in ${remaining}s`,
+        tooltip:
+          `Crash-loop breaker: the last load failed (${failTxt} in a row). ` +
+          `Next automatic retry in ${remaining}s.`,
+      };
+    case "parked":
+      return {
+        tone: "err",
+        label: `parked · ${failTxt}`,
+        tooltip:
+          `Crash-loop breaker: parked after ${failTxt} — the slot is ` +
+          `deliberately refusing loads. Next automatic trial in ${remaining}s; ` +
+          `a manual Start/Restart attempts a load immediately.`,
+      };
+    case "half-open":
+      return {
+        tone: "neutral",
+        label: "trial pending",
+        tooltip:
+          "Crash-loop breaker half-open: the next load request runs a single " +
+          "trial. Success closes the breaker; failure parks it again.",
+      };
+    default:
+      // Unknown state (schema drift): render nothing rather than guess a
+      // colour — same honesty rule as imageStatusChip above.
+      return null;
+  }
+}
+
+/**
  * Project slotPhase() → stateChipClass-compatible CSS class.
  * Used in slot-modals.jsx to color lifecycle state chips.
  */


### PR DESCRIPTION
Closes #2038. Follow-up to #2012.

## Why

The API has served `metadata.breaker = {state, failures, retry_after_s}` since #2012, but nothing rendered it. An operator looking at the dashboard saw only a red ERROR chip — no hint the slot was deliberately refusing loads, how many consecutive failures it had, or when the next automatic trial runs. Invisibility of exactly this state is how the 2026-08-22 outage went unnoticed for four hours (#2015).

## What

- `ui/src/dash/slot-status.js` — `breakerChip(slot, elapsedS)`: pure classifier (state → tone/label/tooltip), beside its siblings (`imageStatusChip`, …) so surfaces can't drift. `retry_after_s` is computed at snapshot time, so the caller passes seconds-since-fetch and the countdown clamps at 0. Unknown breaker state renders nothing rather than guessing a colour. Prefers `metadata.breaker` over the older, stale-prone `metadata.parked` extra per the issue.
- `ui/src/dash/breaker-chip.jsx` — `SlotBreakerChip`: owns only the 1s countdown tick (clock re-keyed when a fresh poll delivers a new breaker view) and the colour tokens (`--warn*` / `--err*` / dashed neutral, matching `BackendMismatch` and `SlotImageUnknownChip`).
- Rendered in two places: the inference slot card foot (first chip — most actionable thing on the card) and beside the lifecycle state chip in the slot edit drawer, so "error" + "parked · 7 failures" read as one story.
- `ui/src/api/hooks/useSlots.ts` — typed `SlotBreaker` + `Slot.metadata.breaker`.

States per the proposal: `backoff` → amber "retry in Ns" (failure count in tooltip); `parked` → red "parked · N failures" (trial countdown + manual Start/Restart escape hatch in tooltip); `half-open` → neutral dashed "trial pending".

No backend work — the field is present whenever the breaker is non-closed and absent otherwise, so presence is the render signal.

## Tests

`ui/src/dash/__tests__/breaker-chip.test.ts` (written red-first): null without a breaker view, all three states' tone/label/tooltip, countdown from elapsed seconds + clamp at zero, singularised "1 failure", unknown state → null. Full UI unit suite 213 passed; `npm run typecheck` clean; γ-suite covers the panes in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)