### PR TITLE
chore(runner): roll the default runner pin to hal0-combined:0824 (#2037 fail-fast)

### DIFF
--- a/packaging/runner/rocmfpx/manifest.toml
+++ b/packaging/runner/rocmfpx/manifest.toml
@@ -11,7 +11,7 @@
 
 [image]
 #: The tag this recipe produces. Keep in lockstep with DEFAULT_ROCMFPX_IMAGE.
-tag = "ghcr.io/hal0ai/hal0-combined:0822"
+tag = "ghcr.io/hal0ai/hal0-combined:0824"
 
 [base]
 #: Runtime layer. A Kyuz0 amd-strix-halo-toolboxes derivative; the ROCm

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1010,7 +1010,13 @@ MTP_FLAG_BUNDLE = build_mtp_flag_bundle("rocm")
 #: (debug builds, A/B tests, etc.).  See #__hal0_image_control__ for the
 #: phasing: 0.9.5 wires slot.image + DEFAULT_ROCMFPX_IMAGE; 0.9.6 will
 #: drop ``image`` from SEED_PROFILES entirely.
-DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-combined:0822"
+#: 0824 lineage (2026-08-24): byte-for-byte the 0822 recipe — same pinned
+#: ROCmFPX source ref, same three patches, same base digest — rebuilt via
+#: packaging/runner/rocmfpx/build.sh for exactly one delta: the #2037
+#: fail-fast entrypoint (supervises llama-server, translates a non-signal
+#: death before /health ever answered 200 into exit 64 so the template's
+#: RestartPreventExitStatus=64 can park a doomed model immediately).
+DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-combined:0824"
 
 #: Historical DEFAULT_ROCMFPX_IMAGE values (and their pre-consolidation
 #: equivalents). A slot-level ``image`` pin equal to one of these is a STALE
@@ -1040,6 +1046,10 @@ DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-combined:0822"
 #: control-token pieces are stripped before the parser sees them).
 STALE_ROCMFPX_IMAGE_REFS = frozenset(
     {
+        # Former default (rc.7). Same recipe lineage as the current 0824 pin
+        # but with the pre-#2037 exec-only entrypoint, so a slot still pinned
+        # here never fail-fasts a doomed model — creation-time debris, retag.
+        "ghcr.io/hal0ai/hal0-combined:0822",
         # Former default (rc.6). Its Vulkan backend emits invalid tokens for
         # every model (#1888) — a slot still pinned here is debris from an
         # older release, not an opt-out, and must be retagged.
@@ -1069,7 +1079,14 @@ STALE_ROCMFPX_IMAGE_REFS = frozenset(
 #: plain non-FPX ggufs, a ≥256-token generation with a clean tail, native
 #: ``tool_calls`` on the shipped brain, and a readable diagnostic instead of
 #: a SIGSEGV with zero devices mapped (#1936).
-VULKAN_FIXED_IMAGE = "ghcr.io/hal0ai/hal0-combined:0822"
+#:
+#: ``:0824`` re-earned membership per the rule below rather than inheriting
+#: it: same pinned source/patches/base as ``:0822`` (only the #2037 entrypoint
+#: differs), but the builder stage's dnf toolchain is unpinned, so "same
+#: recipe" does not prove same binaries. Probed 2026-08-24 on ct105
+#: (kfd present) and ct151 (kfd ABSENT): temp-0 Paris probe on the Vulkan
+#: lane, ≥256-token clean tail, and the #1936 device-less diagnostic.
+VULKAN_FIXED_IMAGE = "ghcr.io/hal0ai/hal0-combined:0824"
 
 #: Runner images allowed to serve the ``gpu-vulkan`` llama.cpp lane on an AMD
 #: host. Consulted by :func:`hal0.providers._gpu.image_serves_vulkan_lane`,


### PR DESCRIPTION
Completes the deploy chain for #2037 (PR #2039): the entrypoint change is baked into the image at build time, so until now `RestartPreventExitStatus=64` was inert — units carried the directive but nothing ever exited 64.

## The image

`ghcr.io/hal0ai/hal0-combined:0824` (digest `sha256:b31d43d7b5e82181afcab5fd72abf437a2d05b1d66a3668ebbf966acbc1d8cda`), built with `packaging/runner/rocmfpx/build.sh` from a clean checkout of merged main (`19bab635`) on the dedicated build host. Byte-for-byte the `:0822` recipe — same pinned ROCmFPX source (`0a59add8`), same three patches, same base digest — with exactly one delta: the #2037 fail-fast entrypoint.

## The pin changes

- `DEFAULT_ROCMFPX_IMAGE` / `VULKAN_FIXED_IMAGE` → `:0824`; `packaging/runner/rocmfpx/manifest.toml` tag kept in lockstep (pinned by `test_the_manifest_tag_matches_the_shipped_pin`).
- `:0822` joins `STALE_ROCMFPX_IMAGE_REFS` — a slot still pinned there is creation-time debris; the updater retags it to the new default. Explicit operator pins to anything else stay untouched.
- `VULKAN_CAPABLE_IMAGE_REFS` follows `VULKAN_FIXED_IMAGE` per its evidence rule (see below).

## Validation (2026-08-24, per the §3-C membership rule)

Membership was re-earned rather than inherited — the builder stage's dnf toolchain is unpinned, so "same recipe" does not prove same binaries. Throwaway containers only, no slot machinery:

| Probe | ct105 (kfd present) | ct151 (kfd ABSENT, unprivileged LXC) |
|---|---|---|
| temp-0 "capital of France" + 256-token clean tail, Vulkan lane | Paris ✓ | Paris ✓ |
| same, ROCm lane | Paris ✓ | n/a (no kfd) |
| #1936 device-less GPU request | exit 78 + readable diagnostic ✓ | ✓ |
| **#2037 fail-fast: doomed model, devices present** | **exit 64** + "llama-server exited (rc=1) before /health ever answered — died during model load" ✓ | ✓ |

The last row is the end-to-end proof this chain exists for: on the shipped image a corrupt/missing model now dies once with a distinct exit status instead of burning the whole restart ramp.

## Tests

`tests/packaging`, `tests/config`, image-resolution / vulkan-lane-gate / GPU-preflight / brain-model / bench-harness / tool-reroute suites: 1004 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)