### PR TITLE
feat(ui): runner images under Slots, profiles under Models, defaults strip + tag picker

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -26,6 +26,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "eslint": "^9.39.5",
         "globals": "^15.15.0",
+        "happy-dom": "^20.11.6",
         "tailwindcss": "^4.2.2",
         "typescript": "^5.6.3",
         "vite": "^6.0.3",
@@ -1915,6 +1916,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1941,6 +1952,23 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2215,6 +2243,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2424,6 +2465,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2819,6 +2873,25 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.6.tgz",
+      "integrity": "sha512-Hldbg8AdAa5a5oDcZpjqnGitp7JB0hqWmfv/8qr+kft4vzSD8BHsbdRfzYvL/0QcbKcURC/yyoygbeDQarPvYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3880,6 +3953,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -4086,6 +4166,16 @@
         }
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4127,6 +4217,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -33,6 +33,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.39.5",
     "globals": "^15.15.0",
+    "happy-dom": "^20.11.6",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.6.3",
     "vite": "^6.0.3",

--- a/ui/src/api/hooks/useRunnerImages.ts
+++ b/ui/src/api/hooks/useRunnerImages.ts
@@ -12,8 +12,16 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { apiGet, apiPost, Hal0Error } from '../client'
+import { apiGet, apiPost, apiPut, Hal0Error } from '../client'
 import { ENDPOINTS } from '../endpoints'
+
+// Which family default (if any) resolves to this row's image, and where that
+// default comes from: the baked release constant or the operator's
+// [slots].default_images override (runner-catalogue-v2 contract).
+export interface RunnerImageDefault {
+  family: string
+  source: 'override' | 'release'
+}
 
 export interface RunnerImage {
   id: string
@@ -31,6 +39,12 @@ export interface RunnerImage {
   discovered_at: string | null
   updated_at: string | null
   extra: Record<string, unknown>
+  // runner-catalogue-v2 enrichment (backend PR feat/runner-catalogue-backend).
+  // Optional so rows from a pre-contract backend still type-check; the view
+  // helpers degrade gracefully when they're absent.
+  available_tags?: string[]
+  is_default?: RunnerImageDefault | null
+  in_use_by?: string[]
 }
 
 const RUNNER_IMAGES_POLL_MS = 30_000
@@ -76,6 +90,25 @@ export function useRunnerImageSync() {
   return useMutation<RunnerImageSyncResult, Hal0Error, void>({
     mutationFn: () => apiPost<RunnerImageSyncResult>(ENDPOINTS.runnerImagesSync),
     onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['runner-images'] })
+    },
+  })
+}
+
+// ─── useSetDefaultImage ──────────────────────────────────────────────
+// Writes (or clears) a per-family operator default via the existing
+// PUT /api/settings deep-merge: {"slots": {"default_images": {family: ref}}}.
+// Clearing sends `ref: null` — the settings route treats an explicit null as
+// key removal (Task C's verified deep-merge semantics). Invalidate both the
+// settings cache and the runner-image rows: `is_default` is computed
+// server-side from the effective default map.
+export function useSetDefaultImage() {
+  const qc = useQueryClient()
+  return useMutation<unknown, Hal0Error, { family: string; ref: string | null }>({
+    mutationFn: ({ family, ref }) =>
+      apiPut(ENDPOINTS.settings, { slots: { default_images: { [family]: ref } } }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['settings'] })
       qc.invalidateQueries({ queryKey: ['runner-images'] })
     },
   })

--- a/ui/src/api/mockFixtures.ts
+++ b/ui/src/api/mockFixtures.ts
@@ -1436,30 +1436,37 @@ function buildMemoryGraphStatus() {
   }
 }
 
-// ─── Runner Images (Models → Runner Images tab) ───────────────────────────
+// ─── Runner Images (Slots → Runner Images tab) ────────────────────────────
 // Shape mirrors /api/runner-images (registry rows synced from
-// hal0-runner-images images.json + GHCR). One row is enough for the
-// catalog list + card to render; the pulls list must be an ARRAY — the
-// downloads pane calls `.filter` on it directly.
+// hal0-runner-images images.json + GHCR), including the runner-catalogue-v2
+// contract enrichment (available_tags newest-first, is_default, in_use_by).
+// One row is enough for the catalog list + card + Defaults strip to render;
+// the pulls list must be an ARRAY — the downloads pane calls `.filter` on it
+// directly.
 function buildRunnerImages() {
   return {
     images: [
       {
-        id: 'rocmfpx',
-        image: 'ghcr.io/hal0ai/hal0-rocmfpx',
-        tag: 'ade07ba',
+        id: 'rocmfpx-combined',
+        image: 'ghcr.io/hal0ai/hal0-combined',
+        tag: '0822',
         digest: 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
         size_bytes: 7_340_032_000,
         manifest_key: null,
-        ownership: 'referenced',
-        publish: 'manual',
-        notes: 'ROCmFPX runner — HIP+Vulkan single build (mock fixture).',
+        ownership: 'owned',
+        publish: 'external',
+        notes: 'Canonical ROCmFPX+Vulkan combined runner (mock fixture).',
         build: null,
         local_path: null,
         downloaded_at: null,
         discovered_at: '2026-08-08T00:00:00Z',
         updated_at: '2026-08-08T00:00:00Z',
         extra: {},
+        // Headline deliberately trails available_tags[0] so the "newer tag"
+        // chip surface renders in mock mode.
+        available_tags: ['0824', '0822'],
+        is_default: { family: 'rocmfpx', source: 'release' },
+        in_use_by: ['agent', 'utility'],
       },
     ],
   }

--- a/ui/src/dash/__tests__/runner-images-confirm-flow.test.tsx
+++ b/ui/src/dash/__tests__/runner-images-confirm-flow.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+//
+// Runner Images — set-as-family-default confirm flow (runner-catalogue-v2,
+// PR #2043 review follow-up).
+//
+// A REAL render + click test, not a pure-helper test: reviewer found that
+// runner-images.jsx referenced ConfirmDialog without an import, relying on
+// the legacy primitives.jsx window-global. The pure-helper suite never
+// rendered the component tree, so an unresolved identifier could pass the
+// suite and only crash in the browser. This test mounts RunnerImagesView
+// with real ReactDOM against happy-dom and drives the flow — Set-as-default
+// click → confirm dialog (naming the in_use_by slots) → confirm fires the
+// PUT /api/settings mutation — so any identifier that resolves neither via
+// import nor test-installed global fails the run at render time.
+//
+// The data hooks are mocked at the module boundary (contract-shaped rows);
+// primitives.jsx's ConfirmDialog/Modal render for real.
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+;(globalThis as unknown as { React: typeof React }).React = React
+// Icon glyphs come from chrome.jsx's window global — irrelevant here.
+;(globalThis as unknown as { Icons: unknown }).Icons = new Proxy({}, { get: () => null })
+
+// vi.mock factories are hoisted above imports, so the spy + fixture rows they
+// close over must be hoisted too. The "spy" is a plain call log — enough to
+// assert exact mutation payloads without pulling vi.fn through the hoist.
+const { mutateSpy, ROWS } = vi.hoisted(() => ({
+  mutateSpy: [] as unknown[],
+  ROWS: [
+    {
+      id: 'rocmfpx-combined',
+      image: 'ghcr.io/hal0ai/hal0-combined',
+      tag: '0822',
+      digest: null,
+      size_bytes: 7_340_032_000,
+      manifest_key: null,
+      ownership: 'owned',
+      publish: 'external',
+      notes: null,
+      build: null,
+      local_path: null,
+      downloaded_at: null,
+      discovered_at: null,
+      updated_at: null,
+      extra: {},
+      available_tags: ['0824', '0822'],
+      is_default: { family: 'rocmfpx', source: 'release' },
+      in_use_by: ['agent', 'utility'],
+    },
+  ],
+}))
+
+vi.mock('@/api/hooks/useRunnerImages', () => ({
+  useRunnerImages: () => ({ data: ROWS, isPending: false, isError: false, error: null }),
+  useRunnerImageSync: () => ({ isPending: false, mutateAsync: async () => ({ images: ROWS }) }),
+  useRunnerImagePullJob: () => ({
+    imageId: null, jobId: null, state: 'idle', layersDone: 0, layersTotal: 0,
+    line: null, error: null, pct: null, inFlight: false, terminal: false,
+    start: async () => ({}), cancel: async () => {}, reset: () => {}, reattach: async () => {},
+  }),
+  useRunnerImagePullsList: () => ({ data: [] }),
+  useDownloadedRunnerImages: () => ({ data: [] }),
+  useRunnerImage: () => ({ data: null }),
+  useSetDefaultImage: () => ({
+    isPending: false,
+    mutate: (vars: unknown) => { (mutateSpy as unknown[]).push(vars) },
+  }),
+}))
+
+const { RunnerImagesView } = await import('../runner-images.jsx')
+
+function textButtons(root: HTMLElement): HTMLButtonElement[] {
+  return Array.from(root.querySelectorAll('button'))
+}
+
+describe('RunnerImagesView set-as-default confirm flow', () => {
+  afterEach(() => {
+    ;(mutateSpy as unknown[]).length = 0
+    document.body.innerHTML = ''
+  })
+
+  it('renders, opens the confirm naming in_use_by slots, and confirm fires the settings mutation', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    act(() => {
+      root.render(React.createElement(RunnerImagesView))
+    })
+
+    // Contract surfaces are up: defaults strip row + set-default CTA.
+    expect(host.querySelector('[data-testid="ri-defaults"]')).toBeTruthy()
+    const setBtn = host.querySelector('[data-testid="ri-set-default"]') as HTMLButtonElement
+    expect(setBtn).toBeTruthy()
+    // The headline tag already IS the rocmfpx default, so re-pinning it is a
+    // no-op — the CTA gates until a different tag is picked.
+    expect(setBtn.disabled).toBe(true)
+    // No dialog yet.
+    expect(host.querySelector('.modal-backdrop')).toBeNull()
+
+    // Pick the newer tag from the tag <select> → CTA arms.
+    const pick = host.querySelector('[data-testid="ri-tag-pick"]') as HTMLSelectElement
+    expect(pick).toBeTruthy()
+    act(() => {
+      pick.value = '0824'
+      pick.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(setBtn.disabled).toBe(false)
+
+    // Click Set-as-default → the confirm dialog opens and names the slots
+    // that will drift to the new default.
+    act(() => { setBtn.click() })
+    expect(host.querySelector('.modal-backdrop')).toBeTruthy()
+    expect(host.textContent).toContain('Set rocmfpx default')
+    expect(host.textContent).toContain('ghcr.io/hal0ai/hal0-combined:0824')
+    expect(host.textContent).toContain('agent, utility')
+
+    // Confirm → exactly one PUT /api/settings mutation with the family +
+    // selected ref; the dialog closes.
+    const confirmBtn = textButtons(host).find(b => b.textContent === 'Set default')
+    expect(confirmBtn).toBeTruthy()
+    act(() => { confirmBtn!.click() })
+    expect(mutateSpy).toEqual([{ family: 'rocmfpx', ref: 'ghcr.io/hal0ai/hal0-combined:0824' }])
+    expect(host.querySelector('.modal-backdrop')).toBeNull()
+
+    act(() => { root.unmount() })
+  })
+
+  it('cancel closes the dialog without firing the mutation', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    act(() => {
+      root.render(React.createElement(RunnerImagesView))
+    })
+    const pick = host.querySelector('[data-testid="ri-tag-pick"]') as HTMLSelectElement
+    act(() => {
+      pick.value = '0824'
+      pick.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    act(() => { (host.querySelector('[data-testid="ri-set-default"]') as HTMLButtonElement).click() })
+    const cancelBtn = textButtons(host).find(b => b.textContent === 'Cancel')
+    expect(cancelBtn).toBeTruthy()
+    act(() => { cancelBtn!.click() })
+    expect(host.querySelector('.modal-backdrop')).toBeNull()
+    expect(mutateSpy).toEqual([])
+    act(() => { root.unmount() })
+  })
+})

--- a/ui/src/dash/__tests__/runner-images-view.test.tsx
+++ b/ui/src/dash/__tests__/runner-images-view.test.tsx
@@ -1,0 +1,89 @@
+// Runner Images page pure helpers (runner-catalogue-v2, Task D).
+//
+// Fixtures are shaped to the frozen Task-C contract: /api/runner-images rows
+// carry `available_tags` (newest-first), `is_default` ({family, source} |
+// null) and `in_use_by` (slot names). The helpers under test drive the
+// Defaults strip and the per-row "newer tag" chip; they must stay defensive
+// against rows from a pre-contract backend (fields missing) rather than
+// assuming Task C has merged.
+//
+// runner-images.jsx is a window-globals dash module (`const {...} = React`
+// at module top), so the globals are installed before the dynamic import —
+// same pattern as memoryOverviewV2.smoke.test.tsx.
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+;(globalThis as unknown as { window: typeof globalThis }).window = globalThis
+;(globalThis as unknown as { React: typeof React }).React = React
+
+const { defaultsStripRows, newerTagAvailable } = await import('../runner-images.jsx')
+
+// Minimal contract-shaped row; overrides per case.
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'rocmfpx-combined',
+    image: 'ghcr.io/hal0ai/hal0-combined',
+    tag: '0824',
+    available_tags: ['0824', '0822'],
+    is_default: { family: 'rocmfpx', source: 'release' },
+    in_use_by: ['agent', 'utility'],
+    ...overrides,
+  }
+}
+
+describe('defaultsStripRows', () => {
+  it('emits one {family, ref, source} row per family default, sorted by family', () => {
+    const images = [
+      row(),
+      row({
+        id: 'kokoro',
+        image: 'ghcr.io/hal0ai/hal0-kokoro',
+        tag: 'v1.2',
+        available_tags: ['v1.2'],
+        is_default: { family: 'kokoro', source: 'override' },
+        in_use_by: [],
+      }),
+    ]
+    expect(defaultsStripRows(images)).toEqual([
+      { family: 'kokoro', ref: 'ghcr.io/hal0ai/hal0-kokoro:v1.2', source: 'override' },
+      { family: 'rocmfpx', ref: 'ghcr.io/hal0ai/hal0-combined:0824', source: 'release' },
+    ])
+  })
+
+  it('skips rows that are no family default (is_default null or missing)', () => {
+    const images = [row({ is_default: null }), row({ id: 'x', is_default: undefined })]
+    expect(defaultsStripRows(images)).toEqual([])
+  })
+
+  it('keeps the first row per family when several rows carry the same family', () => {
+    const images = [
+      row(),
+      row({ id: 'rocmfpx-hy3', image: 'ghcr.io/hal0ai/hal0-rocmfpx-hy3', tag: 'hy3' }),
+    ]
+    const rows = defaultsStripRows(images)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].ref).toBe('ghcr.io/hal0ai/hal0-combined:0824')
+  })
+
+  it('tolerates empty/absent input', () => {
+    expect(defaultsStripRows([])).toEqual([])
+    expect(defaultsStripRows(undefined)).toEqual([])
+  })
+})
+
+describe('newerTagAvailable', () => {
+  it('is true when the newest available tag differs from the headline tag', () => {
+    expect(newerTagAvailable(row({ tag: '0822', available_tags: ['0824', '0822'] }))).toBe(true)
+  })
+
+  it('is false when the headline already is the newest tag', () => {
+    expect(newerTagAvailable(row())).toBe(false)
+  })
+
+  it('is false on probe failure (available_tags empty) or missing fields', () => {
+    expect(newerTagAvailable(row({ available_tags: [] }))).toBe(false)
+    expect(newerTagAvailable(row({ available_tags: undefined }))).toBe(false)
+    expect(newerTagAvailable(row({ tag: null }))).toBe(false)
+    expect(newerTagAvailable(undefined)).toBe(false)
+  })
+})

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -409,7 +409,9 @@ function TopBar({ route, onCmdK, onBoard, onAgentChat, onMenu, menuOpen = false 
     agent:     ["Tools",  "Agent"],
     settings:  ["Configure", "Settings"],
     connections: ["Network", "Connections"],
-    profiles:  ["iGPU Slots", "Profiles"],
+    // (runner-catalogue-v2: the legacy top-level "profiles" route is gone —
+    // #profiles now redirects to the Models ▸ Profiles tab in main.jsx, so
+    // the Models labels apply.)
     board:     ["Orchestration", "Board"],
     benchmarks: ["Performance", "Benchmarks"],
     services:  ["Companions", "Services"],
@@ -489,13 +491,19 @@ function useNavItems() {
   return [
     { id: "dashboard", label: "Overview", icon: Icons.dashboard },
     // v0.5 nav: Slots hosts Endpoints (local OpenAI endpoints, from the old
-    // Connections page) and Profiles (container-slot templates, #658) as tabs.
+    // Connections page) as a tab; runner-catalogue-v2 adds Runner Images (the
+    // container images slots run on — a lifecycle concern, so it lives here,
+    // not under the model catalog) and moves Profiles under Models.
     { id: "slots", label: "Slots", icon: Icons.slots, cnt: slotCount, children: [
-      { id: "slots/endpoints", label: "Endpoints" },
-      { id: "slots/profiles",  label: "Profiles" },
-      { id: "slots/stacks",    label: "Stacks" },
+      { id: "slots/endpoints",     label: "Endpoints" },
+      { id: "slots/runner-images", label: "Runner Images" },
+      { id: "slots/stacks",        label: "Stacks" },
     ] },
-    { id: "models", label: "Models", icon: Icons.models, cnt: modelCount },
+    // Profiles (container-slot templates, #658) template what a slot SERVES —
+    // model-catalog territory — so runner-catalogue-v2 files them under Models.
+    { id: "models", label: "Models", icon: Icons.models, cnt: modelCount, children: [
+      { id: "models/profiles", label: "Profiles" },
+    ] },
     // The Operator Board (#board) is no longer a top-level nav row — it lives
     // in the sidebar Services zone (ServiceLinks) as the "Kanban" option, and
     // stays reachable via ⌘B.

--- a/ui/src/dash/command-palette.jsx
+++ b/ui/src/dash/command-palette.jsx
@@ -233,7 +233,11 @@ function buildCommandItems(slots, models, activePull, owuiUrl = "") {
   const routes = [
     { id: "r-dashboard", route: "dashboard", label: "Dashboard",  icon: Icons.dashboard, sub: "chat + snapshot + health", keywords: "home chat overview" },
     { id: "r-slots",     route: "slots",     label: "Slots",      icon: Icons.slots,     sub: "inventory + capability rollups", keywords: "lifecycle" },
+    // runner-catalogue-v2 IA: Runner Images is a Slots sub-page (nav id
+    // slots/runner-images); Profiles moved beneath Models (models/profiles).
+    { id: "r-runner-images", route: "slots/runner-images", label: "Runner Images", icon: Icons.slots, sub: "container image catalogue · tags, defaults, pulls", keywords: "runner images ghcr containers pull tag default" },
     { id: "r-models",    route: "models",    label: "Models",     icon: Icons.models,    sub: "catalog + downloads", keywords: "catalog hugging face" },
+    { id: "r-profiles",  route: "models/profiles", label: "Profiles", icon: Icons.models, sub: "container-slot templates", keywords: "profiles templates igpu slot" },
     { id: "r-board",     route: "board",     label: "Operator Board", icon: Icons.board, sub: "kanban · tasks, agents, orchestration", keywords: "kanban tasks board lanes orchestrator dispatch" },
     { id: "r-benchmarks", route: "benchmarks", label: "Benchmarks", icon: Icons.bench, sub: "roster board · runs · evals · run queue", keywords: "perf speed throughput decode prefill bench" },
     { id: "r-hardware",  route: "hardware",  label: "Hardware",   icon: Icons.hardware,  sub: "cpu, gpu, npu, memory" },

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -53,7 +53,10 @@ const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
 // We also accept "agents/mcp" as an alias so the canonical URL path stays
 // readable (`/agents/mcp` from the spec). Any unknown head falls back to
 // the dashboard.
-const ROUTES = ["dashboard", "slots", "profiles", "models", "logs", "agent", "memory", "settings", "mcp", "connections", "board", "services", "benchmarks"];
+// runner-catalogue-v2: "profiles" is no longer a route of its own — the
+// redirects below rewrite legacy #profiles / #slots/profiles deep-links to
+// the Models ▸ Profiles tab before the ROUTES lookup runs.
+const ROUTES = ["dashboard", "slots", "models", "logs", "agent", "memory", "settings", "mcp", "connections", "board", "services", "benchmarks"];
 function parseRoute() {
   const raw = (window.location.hash || "#dashboard").replace(/^#/, "");
   const [path, qs] = raw.split("?");
@@ -75,12 +78,15 @@ function parseRoute() {
     head = "slots";
     rest = ["endpoints"];
   }
-  // v0.5 nav: Profiles moved into a Slots tab. Redirect old #profiles links.
-  if (head === "profiles") {
-    if (typeof window !== "undefined" && window.location.hash !== "#slots/profiles") {
-      window.location.hash = "#slots/profiles";
+  // runner-catalogue-v2 nav: Profiles now lives under Models (it templates
+  // model-serving containers, not slot lifecycle). Redirect both legacy
+  // shapes — the v0.4 top-level #profiles and the v0.5 #slots/profiles tab —
+  // to the Models ▸ Profiles tab.
+  if (head === "profiles" || (head === "slots" && rest[0] === "profiles")) {
+    if (typeof window !== "undefined" && window.location.hash !== "#models/profiles") {
+      window.location.hash = "#models/profiles";
     }
-    head = "slots";
+    head = "models";
     rest = ["profiles"];
   }
   // v0.3 PR-8: legacy #peers route redirects to the Peer memory
@@ -330,7 +336,9 @@ function App() {
             onGo={go}
           />
         );
-      case "models":   return <ModelsView />;
+      // modelParam drives the Models tabs the same way slotParam drives the
+      // Slots tabs — #models/profiles deep-links the Profiles tab.
+      case "models":   return <ModelsView modelParam={param} />;
       case "logs":     return <LogsView />;
       // v0.5 nav: Agent is a tabbed shell hosting Memory + MCP. #memory and
       // #mcp are kept as routes that resolve to their tab inside AgentView (so

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -14,7 +14,6 @@ import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
 import { useMetaEnums } from '@/api/hooks/useMeta'
 import { isUpstreamModel } from '@/lib/normalizeApiModel'
 import { MODEL_SORT_FIELDS, sortModels, fmtAdded, isMtpModel, isMoeModel } from '@/dash/model-sort.js'
-import { RunnerImagesView, RunnerImagesSyncButton } from '@/dash/runner-images.jsx'
 
 const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
 
@@ -57,7 +56,9 @@ function usePageReset(deps) {
 }
 
 // ── ModelsView ─────────────────────────────────────────────────────────
-function ModelsView() {
+// `modelParam` mirrors SlotsView's slotParam: #models/profiles deep-links
+// the Profiles tab (runner-catalogue-v2 — Profiles moved here from Slots).
+function ModelsView({ modelParam = null }) {
   const [selId, setSelId] = useStateM(null);
   // Simplified multi-select OR filters
   const [filterSel, setFilterSel] = useStateM([]);
@@ -65,8 +66,14 @@ function ModelsView() {
   const [sortField, setSortField] = useStateM("name");
   const [sortDir, setSortDir] = useStateM("asc");
   const [q, setQ] = useStateM("");
-  // Tabs: "inference" (default), "image", "upstream", "runner-images"
-  const [tab, setTab] = useStateM("inference");
+  // Tabs: "inference" (default), "image", "upstream", "profiles"
+  const [tab, setTab] = useStateM(modelParam === "profiles" ? "profiles" : "inference");
+  // Sidebar sub-link #models/profiles selects the tab; navigating back to
+  // bare #models drops out of the Profiles tab (same idiom as SlotsView).
+  useEffectM(() => {
+    if (modelParam === "profiles") setTab("profiles");
+    else setTab((t) => (t === "profiles" ? "inference" : t));
+  }, [modelParam]);
   // Pagination
   const [page, setPage] = useStateM(1);
   const [perPage, setPerPage] = useStateM(25);
@@ -243,12 +250,13 @@ function ModelsView() {
       <div className="vh">
         <span className="vh-eye mono">Catalog</span>
         {/* One heading for the whole catalog — the active tab names it. The
-            Runner Images tab swaps the title and header actions in place
-            rather than stacking a second vh below the tab bar. */}
-        <h1>{tab === "runner-images" ? "Runner Images" : "Models"}</h1>
+            Profiles tab swaps the title in place (and drops the model CTAs —
+            ProfilesView carries its own actions) rather than stacking a
+            second vh below the tab bar. */}
+        <h1>{tab === "profiles" ? "Profiles" : "Models"}</h1>
         <span className="vh-spacer" />
-        {tab === "runner-images" ? (
-          <RunnerImagesSyncButton />
+        {tab === "profiles" ? (
+          null
         ) : (
           <>
             {updatable.length > 0 ? (
@@ -285,7 +293,7 @@ function ModelsView() {
           role="tab"
           aria-selected={tab === "inference"}
           className={"slot-tab" + (tab === "inference" ? " on" : "")}
-          onClick={() => setTab("inference")}
+          onClick={() => { setTab("inference"); if (modelParam) window.location.hash = "#models"; }}
         >
           <span>Inference Models</span>
           <span className="slot-tab-ct num">{inferenceRows.length}</span>
@@ -294,7 +302,7 @@ function ModelsView() {
           role="tab"
           aria-selected={tab === "image"}
           className={"slot-tab comfy" + (tab === "image" ? " on" : "")}
-          onClick={() => setTab("image")}
+          onClick={() => { setTab("image"); if (modelParam) window.location.hash = "#models"; }}
         >
           <span>Image / ComfyUI</span>
           <span className="slot-tab-ct num">{comfyTotal}</span>
@@ -303,23 +311,23 @@ function ModelsView() {
           role="tab"
           aria-selected={tab === "upstream"}
           className={"slot-tab" + (tab === "upstream" ? " on" : "")}
-          onClick={() => setTab("upstream")}
+          onClick={() => { setTab("upstream"); if (modelParam) window.location.hash = "#models"; }}
         >
           <span>Upstream Models</span>
           <span className="slot-tab-ct num">{upstreamTotal}</span>
         </button>
         <button
           role="tab"
-          aria-selected={tab === "runner-images"}
-          className={"slot-tab" + (tab === "runner-images" ? " on" : "")}
-          onClick={() => setTab("runner-images")}
+          aria-selected={tab === "profiles"}
+          className={"slot-tab" + (tab === "profiles" ? " on" : "")}
+          onClick={() => { window.location.hash = "#models/profiles"; }}
         >
-          <span>Runner Images</span>
+          <span>Profiles</span>
         </button>
       </div>
 
-      {tab === "runner-images" ? (
-        <RunnerImagesView />
+      {tab === "profiles" ? (
+        window.ProfilesView ? <window.ProfilesView /> : null
       ) : (
       <div className="models-layout" style={{marginTop: 18}}>
         {/* ── List (toolbar + rows) ── */}

--- a/ui/src/dash/runner-images.jsx
+++ b/ui/src/dash/runner-images.jsx
@@ -1,16 +1,23 @@
-// hal0 dashboard — Runner Images (subpage of Models, feat/runner-image-catalogue)
+// hal0 dashboard — Runner Images (Slots ▸ Runner Images, runner-catalogue-v2)
 //
 // Mirrors models.jsx's ModelsView/ModelRow/ModelDetail/DownloadRow/DownloadsPane
 // shapes: RunnerImagesView / RunnerImageRow / RunnerCard / RunnerDownloadRow /
 // RunnerDownloadsPane. Backed by useRunnerImages.ts (list/sync/pull-job/pulls-list),
 // mirroring useModels.ts's usePullJob() SSE pattern — progress here is
 // layers_done/layers_total (a whole OCI image pull via podman) instead of bytes.
+//
+// runner-catalogue-v2 additions: a Defaults strip (per-family effective image
+// ref + release/override badge + clear), a per-row tag picker over the
+// contract's `available_tags`, a "newer tag" chip when the headline lags the
+// registry, and Set-as-family-default (PUT /api/settings override map) with a
+// confirm dialog naming the `in_use_by` slots that will drift.
 
 import {
   useRunnerImages,
   useRunnerImageSync,
   useRunnerImagePullJob,
   useRunnerImagePullsList,
+  useSetDefaultImage,
 } from '@/api/hooks/useRunnerImages'
 
 const { useState: useStateRI, useEffect: useEffectRI } = React;
@@ -23,10 +30,50 @@ function fmtBytesRI(b) {
   return `${(b / 1024 ** 3).toFixed(2)} GB`;
 }
 
+// ── Pure helpers (unit-tested in __tests__/runner-images-view.test.tsx) ──
+
+// Defaults-strip rows from the enriched /api/runner-images list: one
+// {family, ref, source} per family whose default resolves to a catalogued
+// row (`is_default` carries the family + whether it's the baked release
+// default or a [slots].default_images override). First row per family wins;
+// sorted by family for a stable strip order. Defensive against rows from a
+// pre-contract backend (no is_default field) — they're simply skipped.
+export function defaultsStripRows(images) {
+  const rows = [];
+  const seen = new Set();
+  for (const img of images || []) {
+    const d = img && img.is_default;
+    if (!d || !d.family || seen.has(d.family)) continue;
+    seen.add(d.family);
+    rows.push({ family: d.family, ref: `${img.image}:${img.tag}`, source: d.source });
+  }
+  rows.sort((a, b) => (a.family < b.family ? -1 : a.family > b.family ? 1 : 0));
+  return rows;
+}
+
+// True when the registry knows a newer tag than the row's headline `tag` —
+// `available_tags` is newest-first per the sync contract, so this is just a
+// head comparison. False on probe failure (empty list) or missing fields.
+export function newerTagAvailable(image) {
+  if (!image || !image.tag) return false;
+  const tags = image.available_tags;
+  if (!Array.isArray(tags) || tags.length === 0) return false;
+  return tags[0] !== image.tag;
+}
+
+// Tag choices for the card's tag <select>: the contract's newest-first
+// `available_tags` with the headline tag guaranteed present (prepended when
+// the probe failed or predates the contract).
+function tagChoices(image) {
+  const tags = Array.isArray(image?.available_tags) ? image.available_tags : [];
+  if (image?.tag && !tags.includes(image.tag)) return [image.tag, ...tags];
+  return tags.length ? tags : (image?.tag ? [image.tag] : []);
+}
+
 // ── RunnerImagesSyncButton ──────────────────────────────────────────────
-// Rendered by models.jsx inside the Models page header (vh) when the
-// Runner Images tab is active — the view below carries no header of its
-// own, so the page keeps a single "Catalog / Runner Images" heading.
+// Rendered inside RunnerImagesView's toolbar — the Slots page (which hosts
+// this view as its Runner Images tab) keeps its own "Lifecycle / Slots"
+// header, so the sync CTA lives with the catalogue surface it refreshes.
 export function RunnerImagesSyncButton() {
   const sync = useRunnerImageSync();
 
@@ -72,6 +119,7 @@ export function RunnerImagesView() {
   return (
     <div className="models-layout" style={{marginTop: 18}}>
         <div className="mdl-list">
+          <DefaultsStrip images={images} />
           <div className="mdl-toolbar">
             <input
               className="input mono mdl-search"
@@ -79,6 +127,9 @@ export function RunnerImagesView() {
               value={q}
               onChange={(e) => setQ(e.target.value)}
             />
+            <div className="mdl-toolbar-grp" style={{marginLeft: "auto"}}>
+              <RunnerImagesSyncButton />
+            </div>
           </div>
 
           <div className="mdl-list-h">
@@ -115,6 +166,77 @@ export function RunnerImagesView() {
   );
 }
 
+// ── DefaultsStrip ───────────────────────────────────────────────────────
+// Per-family effective default images (from the rows' server-computed
+// `is_default` enrichment): family → effective ref + a release-default /
+// override badge. An override gets a clear button — clearing writes
+// `{family: null}` through the settings override map and falls back to the
+// baked release default, so the confirm names the slots that will drift.
+function DefaultsStrip({ images }) {
+  const rows = defaultsStripRows(images);
+  const setDefault = useSetDefaultImage();
+  const [clearFamily, setClearFamily] = useStateRI(null);
+  if (rows.length === 0) return null;
+
+  const clearRow = rows.find(r => r.family === clearFamily) || null;
+  // Slots pinned to the override'd default — they fall back on clear.
+  const clearImg = clearRow
+    ? (images || []).find(i => i.is_default && i.is_default.family === clearRow.family)
+    : null;
+  const drifters = (clearImg?.in_use_by || []);
+
+  const onClear = () => {
+    const fam = clearFamily;
+    setClearFamily(null);
+    setDefault.mutate({ family: fam, ref: null }, {
+      onSuccess: () => window.__hal0Toast && window.__hal0Toast(`${fam}: override cleared — release default applies`, "info"),
+      onError: (e) => window.__hal0Toast && window.__hal0Toast(`Clear failed — ${e?.message || "see logs"}`, "err"),
+    });
+  };
+
+  return (
+    <div className="ri-defaults" data-testid="ri-defaults" style={{padding: "10px 16px", borderBottom: "1px solid var(--line-soft)"}}>
+      <div className="mono" style={{fontSize: 10, color: "var(--fg-4)", textTransform: "uppercase", letterSpacing: ".08em", marginBottom: 6}}>
+        Family defaults
+      </div>
+      {rows.map(r => (
+        <div key={r.family} data-testid={`ri-default-${r.family}`} style={{display: "flex", alignItems: "center", gap: 8, padding: "3px 0", fontSize: 12}}>
+          <span className="mono" style={{color: "var(--fg-2)", minWidth: 88}}>{r.family}</span>
+          <span className="mono" style={{color: "var(--fg-3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap"}}>{r.ref}</span>
+          {r.source === "override"
+            ? <span className="chip" style={{color: "var(--accent)", borderColor: "var(--accent-line)"}}>override</span>
+            : <span className="chip">release default</span>}
+          {r.source === "override" && (
+            <button
+              className="btn ghost sm"
+              data-testid={`ri-clear-default-${r.family}`}
+              disabled={setDefault.isPending}
+              onClick={() => setClearFamily(r.family)}
+              title="Remove the operator override — the release default applies again"
+            >clear</button>
+          )}
+        </div>
+      ))}
+      <ConfirmDialog
+        open={!!clearRow}
+        onCancel={() => setClearFamily(null)}
+        onConfirm={onClear}
+        title={`Clear ${clearRow?.family || ""} override`}
+        message={
+          clearRow
+            ? `Remove the ${clearRow.family} override (${clearRow.ref}) and fall back to the release default.` +
+              (drifters.length
+                ? ` Slots using it now: ${drifters.join(", ")} — they pick up the release image on their next restart.`
+                : " No slot currently references it.")
+            : ""
+        }
+        confirmLabel="Clear override"
+        footerNote="Applies on the next slot restart."
+      />
+    </div>
+  );
+}
+
 // ── RunnerImageRow ──────────────────────────────────────────────────────
 function RunnerImageRow({ image, selected, onSelect }) {
   return (
@@ -129,6 +251,16 @@ function RunnerImageRow({ image, selected, onSelect }) {
         <span className="sub">{image.image}:{image.tag}</span>
       </span>
       <span className="mdl-row-tags">
+        {image.is_default && (
+          <span className="chip" style={{color: "var(--ok)", borderColor: "var(--ok)"}}>
+            {image.is_default.family} default{image.is_default.source === "override" ? " · override" : ""}
+          </span>
+        )}
+        {newerTagAvailable(image) && (
+          <span className="chip" data-testid="ri-newer-tag" style={{color: "var(--accent)", borderColor: "var(--accent-line)"}}>
+            newer: {image.available_tags[0]}
+          </span>
+        )}
         {image.ownership && <span className="chip">{image.ownership}</span>}
         {image.publish && <span className="chip">{image.publish}</span>}
         {(image.extra?.features || []).map(f => (
@@ -146,6 +278,13 @@ function RunnerImageRow({ image, selected, onSelect }) {
 // ── RunnerCard (detail view) ────────────────────────────────────────────
 function RunnerCard({ image }) {
   const pull = useRunnerImagePullJob();
+  const setDefault = useSetDefaultImage();
+  // Tag picker over the contract's available_tags (headline preselected).
+  // null = "follow the headline"; reset whenever the selected row changes.
+  const [pickedTag, setPickedTag] = useStateRI(null);
+  const imageId = image?.id;
+  useEffectRI(() => { setPickedTag(null); }, [imageId]);
+  const [confirmDefault, setConfirmDefault] = useStateRI(false);
 
   if (!image) {
     return (
@@ -155,6 +294,16 @@ function RunnerCard({ image }) {
     );
   }
 
+  const tags = tagChoices(image);
+  const selTag = pickedTag ?? image.tag;
+  // The pull job is id-keyed: POST /{id}/pull resolves the catalogued row's
+  // headline tag server-side (registry/runner_pull_jobs.enqueue) and takes no
+  // tag parameter. Pulling a non-headline tag therefore isn't wired yet — the
+  // button gates honestly instead of pretending, and setting a tag as the
+  // family default rolls the headline on the next sync, after which it IS the
+  // pullable tag. (Called out in the PR body; per-tag pull needs a backend
+  // pull-route change.)
+  const pullTagMismatch = selTag !== image.tag;
   const inFlight = pull.imageId === image.id && pull.inFlight;
   const onPull = async () => {
     try {
@@ -163,6 +312,21 @@ function RunnerCard({ image }) {
     } catch (e) {
       window.__hal0Toast && window.__hal0Toast(`Pull failed to start — ${e?.message || "see logs"}`, "err");
     }
+  };
+
+  // Set-as-family-default: only offered when the backend already associates
+  // this row's image with a family (`is_default.family`) — for any other row
+  // there is no family key to write the override under.
+  const family = image.is_default?.family || null;
+  const defaultRef = `${image.image}:${selTag}`;
+  const alreadyDefault = !!(image.is_default && selTag === image.tag && image.is_default.source);
+  const inUseBy = Array.isArray(image.in_use_by) ? image.in_use_by : [];
+  const onSetDefault = () => {
+    setConfirmDefault(false);
+    setDefault.mutate({ family, ref: defaultRef }, {
+      onSuccess: () => window.__hal0Toast && window.__hal0Toast(`${family} default → ${defaultRef}`, "info"),
+      onError: (e) => window.__hal0Toast && window.__hal0Toast(`Set default failed — ${e?.message || "see logs"}`, "err"),
+    });
   };
 
   // Feature tags: the tag/pill component the Models page uses for capability
@@ -191,6 +355,7 @@ function RunnerCard({ image }) {
         <div><div className="k">ownership</div><div className="v">{image.ownership || "—"}</div></div>
         <div><div className="k">publish</div><div className="v">{image.publish || "—"}</div></div>
         <div><div className="k">manifest key</div><div className="v">{image.manifest_key || "—"}</div></div>
+        <div><div className="k">in use by</div><div className="v mono">{inUseBy.length ? inUseBy.join(", ") : "—"}</div></div>
       </div>
 
       {image.notes && (
@@ -211,6 +376,27 @@ function RunnerCard({ image }) {
       )}
 
       <div style={{padding: "0 16px 16px"}}>
+        {tags.length > 1 && (
+          <div style={{display: "flex", alignItems: "center", gap: 8, marginBottom: 10}}>
+            <span className="mono" style={{fontSize: 11, color: "var(--fg-4)"}}>tag</span>
+            <select
+              className="input mono"
+              data-testid="ri-tag-pick"
+              value={selTag}
+              onChange={(e) => setPickedTag(e.target.value)}
+              style={{fontSize: 11, padding: "3px 6px"}}
+            >
+              {tags.map(t => (
+                <option key={t} value={t}>{t}{t === image.tag ? " · headline" : ""}</option>
+              ))}
+            </select>
+            {newerTagAvailable(image) && (
+              <span className="chip" style={{color: "var(--accent)", borderColor: "var(--accent-line)"}}>
+                newer: {image.available_tags[0]}
+              </span>
+            )}
+          </div>
+        )}
 
         {inFlight ? (
           <div>
@@ -221,14 +407,50 @@ function RunnerCard({ image }) {
             <button className="btn ghost sm" onClick={pull.cancel} style={{marginTop: 6}}>Cancel</button>
           </div>
         ) : (
-          <button className="btn" data-testid="ri-pull" onClick={onPull}>
-            {Icons.download} {image.local_path ? "Re-pull" : "Pull"}
-          </button>
+          <div style={{display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap"}}>
+            <button
+              className="btn"
+              data-testid="ri-pull"
+              disabled={pullTagMismatch}
+              title={pullTagMismatch
+                ? `Pull is keyed to the headline tag (${image.tag}) — set ${selTag} as the ${family || "family"} default first; the catalogue rolls to it on sync`
+                : undefined}
+              onClick={onPull}
+            >
+              {Icons.download} {image.local_path ? "Re-pull" : "Pull"} <span className="mono" style={{fontSize: 10, opacity: .7}}>:{image.tag}</span>
+            </button>
+            {family && (
+              <button
+                className="btn ghost"
+                data-testid="ri-set-default"
+                disabled={setDefault.isPending || alreadyDefault}
+                title={alreadyDefault
+                  ? `${defaultRef} already is the ${family} default`
+                  : `Pin ${defaultRef} as the ${family} family default via a settings override`}
+                onClick={() => setConfirmDefault(true)}
+              >Set as {family} default</button>
+            )}
+          </div>
         )}
         {pull.imageId === image.id && pull.error && (
           <div className="mono" style={{fontSize: 11, color: "var(--err)", marginTop: 6}}>{pull.error.message}</div>
         )}
       </div>
+
+      <ConfirmDialog
+        open={confirmDefault}
+        onCancel={() => setConfirmDefault(false)}
+        onConfirm={onSetDefault}
+        title={`Set ${family || ""} default`}
+        message={
+          `Pin ${defaultRef} as the ${family || ""} family default ([slots].default_images override).` +
+          (inUseBy.length
+            ? ` Slots on this family's image now: ${inUseBy.join(", ")} — they move to the new tag on their next restart.`
+            : " No slot currently references this image.")
+        }
+        confirmLabel="Set default"
+        footerNote="Applies on the next slot restart."
+      />
     </div>
   );
 }

--- a/ui/src/dash/runner-images.jsx
+++ b/ui/src/dash/runner-images.jsx
@@ -19,6 +19,11 @@ import {
   useRunnerImagePullsList,
   useSetDefaultImage,
 } from '@/api/hooks/useRunnerImages'
+// Explicit import rather than the legacy window-global (primitives.jsx also
+// publishes ConfirmDialog on window) — the settings pages' idiom. Keeps this
+// module renderable without chrome wiring, e.g. under vitest
+// (__tests__/runner-images-confirm-flow.test.tsx renders the confirm flow).
+import { ConfirmDialog } from '@/dash/primitives.jsx'
 
 const { useState: useStateRI, useEffect: useEffectRI } = React;
 

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -17,6 +17,7 @@ import {
 } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
 import { useComfyui } from '@/api/hooks/useComfyui'
+import { RunnerImagesView } from '@/dash/runner-images.jsx'
 import { ActivityLog } from './activity-log.jsx'
 import { ComfyuiPane } from './comfyui-pane.jsx'
 import { NpuOccupancyCard } from './npu-pane.jsx'
@@ -620,7 +621,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
   // slots, and is mutually exclusive with the LLM stack — so it gets its own
   // tab instead of a SlotCard in the Image group.
   const [tab, setTab] = useStateS(
-    slotParam === "endpoints" || slotParam === "profiles" || slotParam === "stacks" || slotParam === "image"
+    slotParam === "endpoints" || slotParam === "runner-images" || slotParam === "stacks" || slotParam === "image"
       ? slotParam
       : "inference",
   );
@@ -671,13 +672,15 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
     }
   }, [slotParam, slots]);
 
-  // v0.5 nav: sidebar sub-links #slots/endpoints and #slots/profiles select the
-  // matching tab; #slots/image deep-links the ComfyUI pane (AI Capabilities →
-  // Image generation links here); navigating back to bare #slots (or a
-  // slot-name param) drops out of a sub-tab back to Inference.
+  // v0.5 nav: sidebar sub-links #slots/endpoints and #slots/runner-images
+  // select the matching tab (runner-catalogue-v2: Profiles moved to Models ▸
+  // Profiles — main.jsx redirects the legacy #slots/profiles deep-links);
+  // #slots/image deep-links the ComfyUI pane (AI Capabilities → Image
+  // generation links here); navigating back to bare #slots (or a slot-name
+  // param) drops out of a sub-tab back to Inference.
   React.useEffect(() => {
-    if (slotParam === "endpoints" || slotParam === "profiles" || slotParam === "stacks" || slotParam === "image") setTab(slotParam);
-    else setTab((t) => (t === "endpoints" || t === "profiles" || t === "stacks" ? "inference" : t));
+    if (slotParam === "endpoints" || slotParam === "runner-images" || slotParam === "stacks" || slotParam === "image") setTab(slotParam);
+    else setTab((t) => (t === "endpoints" || t === "runner-images" || t === "stacks" ? "inference" : t));
   }, [slotParam]);
 
   // Listen for the N hotkey via global event (wired by main.jsx)
@@ -856,12 +859,13 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
     );
   }
 
-  // Sub-tabs (Endpoints / Profiles / Stacks) are slot-independent surfaces —
-  // they must stay reachable even while /api/slots is loading or has resolved
-  // empty (a fresh box with no slots is exactly when you want to apply a Stack
-  // or pick a Profile). Only the slot-centric Inference/Image tabs fall through
-  // to the loading skeleton / empty state below.
-  const onSubTab = tab === "endpoints" || tab === "profiles" || tab === "stacks";
+  // Sub-tabs (Endpoints / Runner Images / Stacks) are slot-independent
+  // surfaces — they must stay reachable even while /api/slots is loading or
+  // has resolved empty (a fresh box with no slots is exactly when you want to
+  // apply a Stack or pull a runner image). Only the slot-centric
+  // Inference/Image tabs fall through to the loading skeleton / empty state
+  // below.
+  const onSubTab = tab === "endpoints" || tab === "runner-images" || tab === "stacks";
 
   // Loading skeleton — shown while /api/slots is still resolving so no
   // fake/stub slot cards flash before real data arrives.
@@ -1024,11 +1028,11 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
         </button>
         <button
           role="tab"
-          aria-selected={tab === "profiles"}
-          className={"slot-tab" + (tab === "profiles" ? " on" : "")}
-          onClick={() => { window.location.hash = "#slots/profiles"; }}
+          aria-selected={tab === "runner-images"}
+          className={"slot-tab" + (tab === "runner-images" ? " on" : "")}
+          onClick={() => { window.location.hash = "#slots/runner-images"; }}
         >
-          <span>Profiles</span>
+          <span>Runner Images</span>
         </button>
         <button
           role="tab"
@@ -1045,8 +1049,8 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
           {window.LocalEndpointsPanel ? <window.LocalEndpointsPanel /> : null}
           {window.UpstreamProvidersPanel ? <window.UpstreamProvidersPanel /> : null}
         </div>
-      ) : tab === "profiles" ? (
-        window.ProfilesView ? <window.ProfilesView /> : null
+      ) : tab === "runner-images" ? (
+        <RunnerImagesView />
       ) : tab === "stacks" ? (
         window.StacksView ? <window.StacksView /> : null
       ) : (

--- a/ui/tests/e2e/specs/mobile-nav-v3.spec.ts
+++ b/ui/tests/e2e/specs/mobile-nav-v3.spec.ts
@@ -41,11 +41,15 @@ test.describe('Mobile nav drawer (≤720px)', () => {
     }
     // v0.5 sub-link rows now carry data-testids (the drawer rows had none before).
     // Accordion: they're collapsed until the parent is expanded, so open the
-    // Slots + Agents sections via their carets first.
+    // Slots + Models + Agents sections via their carets first.
+    // runner-catalogue-v2 IA: Runner Images is a Slots sub-link; Profiles
+    // moved beneath Models.
     await drawer.locator('[data-testid="nav-drawer-slots-toggle"]').click()
+    await drawer.locator('[data-testid="nav-drawer-models-toggle"]').click()
     await drawer.locator('[data-testid="nav-drawer-agent-toggle"]').click()
     await expect(drawer.locator('[data-testid="nav-drawer-slots-endpoints"]')).toBeVisible()
-    await expect(drawer.locator('[data-testid="nav-drawer-slots-profiles"]')).toBeVisible()
+    await expect(drawer.locator('[data-testid="nav-drawer-slots-runner-images"]')).toBeVisible()
+    await expect(drawer.locator('[data-testid="nav-drawer-models-profiles"]')).toBeVisible()
     await expect(drawer.locator('[data-testid="nav-drawer-memory"]')).toBeVisible()
     await expect(drawer.locator('[data-testid="nav-drawer-mcp"]')).toBeVisible()
     // the removed top-level items are gone from the drawer too.

--- a/ui/tests/e2e/specs/models-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-v3.spec.ts
@@ -1,7 +1,9 @@
 /**
  * models-v3 — `#models` route renders the 4-tab catalog (Inference / Image / Upstream /
- * Runner Images) with simplified OR filter chips, pagination, and download-icon
- * installed indicators.
+ * Profiles) with simplified OR filter chips, pagination, and download-icon
+ * installed indicators. (runner-catalogue-v2 IA: the Runner Images tab moved
+ * to Slots ▸ Runner Images — see runner-images-slots-v3.spec.ts — and
+ * Profiles moved here from Slots.)
  *
  * Wireup (#220 brief): the catalog drives off `useModels()` and the
  * AddByHF modal calls `POST /api/models/inspect` → `usePullJob().start()`.
@@ -21,14 +23,16 @@ test.describe('Models v3 (/models)', () => {
     await expect(page.locator('.mdl-list')).toBeVisible()
   })
 
-  test('four tabs: Inference, Image/ComfyUI, Upstream, Runner Images', async ({ page }) => {
+  test('four tabs: Inference, Image/ComfyUI, Upstream, Profiles', async ({ page }) => {
     await page.goto('/#models')
     await expect(page.locator('.slot-tab[role="tab"]')).toHaveCount(4)
     await expect(page.locator('.slot-tab:has-text("Inference Models")')).toBeVisible()
     await expect(page.locator('.slot-tab:has-text("Image / ComfyUI")')).toBeVisible()
     await expect(page.locator('.slot-tab:has-text("Upstream Models")')).toBeVisible()
-    // Runner Images (feat/runner-image-catalogue) — subpage of Models, not top-level nav.
-    await expect(page.locator('.slot-tab:has-text("Runner Images")')).toBeVisible()
+    // Profiles (runner-catalogue-v2 IA) — moved here from Slots; Runner
+    // Images left for Slots ▸ Runner Images.
+    await expect(page.locator('.slot-tab:has-text("Profiles")')).toBeVisible()
+    await expect(page.locator('.slot-tab:has-text("Runner Images")')).toHaveCount(0)
     // Default tab is Inference
     await expect(page.locator('.slot-tab.on:has-text("Inference Models")')).toBeVisible()
   })
@@ -39,19 +43,28 @@ test.describe('Models v3 (/models)', () => {
     await expect(page.locator('.view .vh button:has-text("Search HF")')).toBeVisible()
   })
 
-  test('Runner Images tab swaps the page heading in place — no second vh', async ({ page }) => {
+  test('Profiles tab swaps the page heading in place — no second vh', async ({ page }) => {
     await page.goto('/#models')
-    await page.locator('.slot-tab:has-text("Runner Images")').click()
+    await page.locator('.slot-tab:has-text("Profiles")').click()
+    // The tab routes through the hash so the sidebar sub-link stays in sync.
+    await expect(page).toHaveURL(/#models\/profiles/)
     // The single catalog heading renames; the view must not stack a second one.
     await expect(page.locator('.view .vh h1')).toHaveCount(1)
-    await expect(page.locator('.view .vh h1')).toHaveText('Runner Images')
-    // Header actions swap to the sync CTA; the Models CTAs leave.
-    await expect(page.getByTestId('ri-sync')).toBeVisible()
+    await expect(page.locator('.view .vh h1')).toHaveText('Profiles')
+    // The Models CTAs leave — ProfilesView carries its own actions.
     await expect(page.locator('.view .vh button:has-text("Add by HF coords")')).toHaveCount(0)
     // Switching back restores the Models heading + CTAs.
     await page.locator('.slot-tab:has-text("Inference Models")').click()
     await expect(page.locator('.view .vh h1')).toHaveText('Models')
     await expect(page.locator('.view .vh button:has-text("Add by HF coords")')).toBeVisible()
+  })
+
+  test('legacy #slots/profiles and #profiles deep-links land on Models ▸ Profiles', async ({ page }) => {
+    await page.goto('/#slots/profiles')
+    await expect(page).toHaveURL(/#models\/profiles/)
+    await expect(page.locator('.slot-tab.on:has-text("Profiles")')).toBeVisible()
+    await page.goto('/#profiles')
+    await expect(page).toHaveURL(/#models\/profiles/)
   })
 
   test('simplified filter chips toggle OR semantics', async ({ page }) => {

--- a/ui/tests/e2e/specs/profiles-crud-v3.spec.ts
+++ b/ui/tests/e2e/specs/profiles-crud-v3.spec.ts
@@ -40,9 +40,11 @@ const CUSTOM_PROFILE = {
 
 const PROFILES_WITH_CUSTOM = [...MOCK_DATA.profiles, CUSTOM_PROFILE]
 
-// Helper: navigate to profiles page and wait for it to be ready.
+// Helper: navigate to the profiles page and wait for it to be ready.
+// runner-catalogue-v2 IA: Profiles is the Models ▸ Profiles tab now (legacy
+// #profiles / #slots/profiles redirect here — models-v3.spec.ts covers it).
 async function gotoProfiles(page: any) {
-  await page.goto('/#profiles')
+  await page.goto('/#models/profiles')
   await page.waitForFunction(
     () => typeof (window as any).ProfilesView === 'function',
   )

--- a/ui/tests/e2e/specs/profiles-page-v3.spec.ts
+++ b/ui/tests/e2e/specs/profiles-page-v3.spec.ts
@@ -79,7 +79,9 @@ test.describe('Profiles page (#658)', () => {
     await page.route('**/api/profiles', (route) =>
       json(route, MOCK_DATA.profiles),
     )
-    await page.goto('/#profiles')
+    // runner-catalogue-v2 IA: Profiles is the Models ▸ Profiles tab now
+    // (legacy #profiles / #slots/profiles redirect here — models-v3 covers it).
+    await page.goto('/#models/profiles')
     await page.waitForFunction(
       () => typeof (window as any).ProfilesView === 'function',
     )

--- a/ui/tests/e2e/specs/runner-images-slots-v3.spec.ts
+++ b/ui/tests/e2e/specs/runner-images-slots-v3.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * runner-images-slots-v3 — Slots ▸ Runner Images tab (runner-catalogue-v2).
+ *
+ * The Runner Images catalogue moved from Models ▸ Runner Images to a Slots
+ * sub-page (nav id slots/runner-images) — runner images are what slots RUN,
+ * a lifecycle concern. The listing is served by the FORCED VITE_MOCK_HAL0
+ * path (mockFixtures.ts buildRunnerImages, contract-shaped rows carrying
+ * available_tags / is_default / in_use_by), same as models-v3.spec.ts.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+test.describe('Runner Images under Slots (/slots/runner-images)', () => {
+  test('#slots/runner-images deep-links the tab; page keeps the Slots heading', async ({ page }) => {
+    await page.goto('/#slots/runner-images')
+    await expect(page.locator('.slot-tab.on:has-text("Runner Images")')).toBeVisible()
+    // Like Endpoints/Stacks, the sub-tab keeps the single Slots page heading.
+    await expect(page.locator('.view .vh h1')).toHaveText('Slots')
+    await expect(page.locator('.models-layout')).toBeVisible()
+    // Sync CTA lives with the catalogue surface now (not the page header).
+    await expect(page.getByTestId('ri-sync')).toBeVisible()
+  })
+
+  test('sidebar sub-link navigates to the tab', async ({ page }) => {
+    await page.goto('/#slots')
+    const sb = page.locator('.sidebar')
+    await sb.locator('[data-testid="nav-slots-runner-images"]').click()
+    await expect(page).toHaveURL(/#slots\/runner-images/)
+    await expect(page.locator('.slot-tab.on:has-text("Runner Images")')).toBeVisible()
+  })
+
+  test('defaults strip + per-row enrichment chips render from contract rows', async ({ page }) => {
+    await page.goto('/#slots/runner-images')
+    // Defaults strip: family → effective ref + source badge.
+    const strip = page.getByTestId('ri-defaults')
+    await expect(strip).toBeVisible()
+    await expect(strip.getByTestId('ri-default-rocmfpx')).toContainText('rocmfpx')
+    // Row card: pull CTA present; tag picker renders when several tags exist.
+    await expect(page.getByTestId('ri-pull')).toBeVisible()
+    await expect(page.getByTestId('ri-tag-pick')).toBeVisible()
+    await expect(page.getByTestId('ri-set-default')).toBeVisible()
+  })
+
+  test('Models page no longer hosts the Runner Images tab', async ({ page }) => {
+    await page.goto('/#models')
+    await expect(page.locator('.slot-tabs')).toBeVisible()
+    await expect(page.locator('.slot-tab:has-text("Runner Images")')).toHaveCount(0)
+  })
+})

--- a/ui/tests/e2e/specs/sidebar-accordion-v3.spec.ts
+++ b/ui/tests/e2e/specs/sidebar-accordion-v3.spec.ts
@@ -3,11 +3,13 @@
  *
  * Two behaviours pinned here:
  *
- *  1. Accordion — parent rows with sub-links (Slots ▸ Endpoints/Profiles,
- *     Agents ▸ Memory/MCP) start COLLAPSED. The sub-links don't render until
- *     the parent is opened (via its caret), and the section you navigate into
- *     auto-expands. This is the "endpoints/profiles don't show until Slots is
- *     clicked" contract.
+ *  1. Accordion — parent rows with sub-links (Slots ▸ Endpoints/Runner
+ *     Images/Stacks, Models ▸ Profiles, Agents ▸ Memory/MCP;
+ *     runner-catalogue-v2 moved Runner Images under Slots and Profiles under
+ *     Models) start COLLAPSED. The sub-links don't render until the parent is
+ *     opened (via its caret), and the section you navigate into auto-expands.
+ *     This is the "sub-links don't show until their parent is clicked"
+ *     contract.
  *
  *  2. Services zone — a separate group pinned to the sidebar bottom, fenced off
  *     from the app/config nav above. Holds Kanban (internal #board) plus the
@@ -42,13 +44,13 @@ test.describe('sidebar accordion', () => {
 
     // Collapsed by default on an unrelated route — sub-links absent.
     await expect(sb.locator('[data-testid="nav-slots-endpoints"]')).toHaveCount(0)
-    await expect(sb.locator('[data-testid="nav-slots-profiles"]')).toHaveCount(0)
+    await expect(sb.locator('[data-testid="nav-slots-runner-images"]')).toHaveCount(0)
     await expect(sb.locator('[data-testid="nav-mcp"]')).toHaveCount(0)
 
     // Expand Slots via its caret → its sub-links appear; Agents stays closed.
     await sb.locator('[data-testid="nav-slots-toggle"]').click()
     await expect(sb.locator('[data-testid="nav-slots-endpoints"]')).toBeVisible()
-    await expect(sb.locator('[data-testid="nav-slots-profiles"]')).toBeVisible()
+    await expect(sb.locator('[data-testid="nav-slots-runner-images"]')).toBeVisible()
     await expect(sb.locator('[data-testid="nav-mcp"]')).toHaveCount(0)
 
     // Collapse again — sub-links go away.
@@ -62,7 +64,14 @@ test.describe('sidebar accordion', () => {
     await page.goto('/#slots/endpoints')
     const sb = page.locator('.sidebar')
     await expect(sb.locator('[data-testid="nav-slots-endpoints"]')).toBeVisible({ timeout: FIVE_S })
-    await expect(sb.locator('[data-testid="nav-slots-profiles"]')).toBeVisible()
+    await expect(sb.locator('[data-testid="nav-slots-runner-images"]')).toBeVisible()
+  })
+
+  test('Models hosts the Profiles sub-link (runner-catalogue-v2 IA)', async ({ page }) => {
+    await page.goto('/#models/profiles')
+    const sb = page.locator('.sidebar')
+    // Auto-expanded because the route is inside the Models section.
+    await expect(sb.locator('[data-testid="nav-models-profiles"]')).toBeVisible({ timeout: FIVE_S })
   })
 })
 


### PR DESCRIPTION
## What

UI half of runner-catalogue-v2 (Task D of the plan; spec: `docs/superpowers/specs/2026-08-24-runner-image-catalogue-v2-design.md`). Two IA moves plus the catalogue page features, built against the frozen Task-C API contract using contract-shaped mock fixtures — the unit suite is green independently of the backend.

**Merge order: this PR merges AFTER the backend PR `feat/runner-catalogue-backend`** — the gamma suite against a real backend needs the enriched `/api/runner-images` rows (`available_tags`, `is_default`, `in_use_by`) and the `[slots].default_images` settings override to exist. Unit tests here are mock-based and green regardless.

## Nav-id changes (reviewers, please note)

- `slots/runner-images` (new) — Runner Images is now a Slots sub-page. Runner images are what slots *run*; filing them under the model catalog buried them.
- `models/profiles` (new) — Profiles moved beneath Models. Profiles template what a slot *serves*, which is catalog territory. The `slots/profiles` nav id is gone.
- Legacy deep-links redirect in `main.jsx`: `#profiles` and `#slots/profiles` → `#models/profiles` (covered by a gamma test). The top-level `profiles` route is removed from `ROUTES`.
- All three nav registries updated together: `chrome.jsx` (TopBar title map + `useNavItems`, which feeds both the desktop sidebar and the mobile drawer) and both command-palette lists (Routes gained Runner Images + Profiles entries; the Settings deep-link list was checked and its `set-hardware` blurb still accurately describes the settings page, so it stands).
- Gamma specs asserting the old locations are updated in this PR: `models-v3`, `sidebar-accordion-v3`, `mobile-nav-v3`, `profiles-page-v3`, `profiles-crud-v3`, plus a new `runner-images-slots-v3` spec for the moved page.

## Page features

- **Defaults strip** — per-family effective image ref from the rows server-computed `is_default`, with a `release default` / `override` badge; overrides get a clear button whose confirm dialog names the `in_use_by` slots that fall back on their next restart. Clearing writes `{"slots": {"default_images": {family: null}}}` through the existing PUT /api/settings deep-merge (null = key removal per Task C).
- **Tag picker + newer-tag chip** — per-row select over the contract newest-first `available_tags` (headline preselected); a chip flags when the registry knows a newer tag than the headline.
- **Set-as-family-default** — per row/tag, via a `useSetDefaultImage` mutation (PUT /api/settings override map), confirm dialog names the `in_use_by` slots that will drift.
- Pure helpers `defaultsStripRows` / `newerTagAvailable` are exported and unit-tested red-first (`ui/src/dash/__tests__/runner-images-view.test.tsx`, 7 tests).

## Scope decision: per-tag Pull

Pull jobs are **id-keyed to the headline tag**: `registry/runner_pull_jobs.enqueue` resolves `image:tag` from the catalogued row server-side and the pull route takes no tag parameter. Rather than fake a per-tag pull, the Pull button pulls the headline tag and is disabled when a non-headline tag is selected, with a tooltip explaining that setting the tag as the family default rolls the headline (on sync), after which it is the pullable tag. True per-tag pulls need a backend pull-route change and are deliberately out of scope here.

## Verification

- `npm run typecheck` — clean
- `npm run test:unit` — 25 files / 220 tests passed (includes the 7 new helper tests, watched fail first)
- `npx eslint` on all touched dash files — clean
- Gamma suite runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
