### PR TITLE
feat(runner-images): tag-tracked catalogue, default_images override, honest row enrichment

### DIFF
--- a/src/hal0/api/routes/runner_images.py
+++ b/src/hal0/api/routes/runner_images.py
@@ -11,6 +11,8 @@ converter rather than a plain string segment.
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping
 from typing import Any
 
 from fastapi import APIRouter, Request
@@ -22,6 +24,8 @@ from hal0.registry.runner_image import RunnerImage
 from hal0.registry.runner_image_sync import sync_runner_images
 from hal0.registry.runner_pull import RunnerPullJob
 
+log = logging.getLogger(__name__)
+
 router = APIRouter()
 
 
@@ -29,11 +33,156 @@ def _image_to_dict(image: RunnerImage) -> dict[str, Any]:
     return image.model_dump()
 
 
+# ── row enrichment (runner-image-catalogue v2) ───────────────────────────────
+#
+# The frozen cross-task contract (spec
+# docs/superpowers/specs/2026-08-24-runner-image-catalogue-v2-design.md):
+# list/sync rows gain ``available_tags`` (stored on the model),
+# ``is_default`` and ``in_use_by`` (derived here, response-side only).
+
+
+def _repo_of(ref: str) -> str:
+    """``ghcr.io/x/y:tag`` / ``...@sha256:...`` -> ``ghcr.io/x/y``."""
+    ref = ref.split("@", 1)[0]
+    head, sep, tail = ref.rpartition(":")
+    if sep and "/" not in tail:
+        return head
+    return ref
+
+
+def enrich_row(
+    image: RunnerImage,
+    *,
+    defaults: Mapping[str, tuple[str, str]],
+    slot_usage: Mapping[str, str],
+) -> dict[str, Any]:
+    """One catalogue row + the derived catalogue-v2 contract fields. Pure.
+
+    ``defaults`` maps runner-family key -> ``(effective image ref, source)``
+    where source is ``"override"`` ([slots].default_images) or ``"release"``
+    (the baked RUNNER_IMAGES constant); ``slot_usage`` maps slot name -> the
+    image ref that slot's rendered unit / resolved config launches.
+
+    ``is_default`` matches on the default ref's REPO against ``image.image``
+    (contract: "any tag"), first matching family in ``defaults`` order wins
+    (RUNNER_IMAGES insertion order — deterministic for the rocmfpx/vulkanfpx
+    shared-image pair). ``in_use_by`` matches the exact ``image:tag`` ref.
+    """
+    row = _image_to_dict(image)
+    is_default: dict[str, str] | None = None
+    for family, (ref, source) in defaults.items():
+        if _repo_of(ref) == image.image:
+            is_default = {"family": family, "source": source}
+            break
+    row["is_default"] = is_default
+    row_ref = f"{image.image}:{image.tag}"
+    row["in_use_by"] = sorted(name for name, ref in slot_usage.items() if ref == row_ref)
+    return row
+
+
+def _effective_defaults() -> dict[str, tuple[str, str]]:
+    """Family key -> ``(effective default ref, source)`` for every runner family.
+
+    The override map is read fresh from hal0.toml (same live-read idiom as
+    ``hal0.providers.container._slot_default_images`` — a Settings save lands
+    on the next request); the release tier is the baked
+    :data:`hal0.runners.RUNNER_IMAGES` constant, deliberately NOT the
+    env/manifest-resolved ref: the contract's ``"release"`` source badge
+    means "shipped default", and the env/manifest escape hatches stay out of
+    the honesty story. Fail-soft: an unreadable config degrades to
+    release-only defaults, never a 500.
+    """
+    from hal0.runners import RUNNER_IMAGES
+
+    overrides: Mapping[str, str] = {}
+    try:
+        from hal0.config.loader import load_hal0_config
+
+        raw = load_hal0_config().slots.default_images
+        if isinstance(raw, Mapping):
+            overrides = raw
+    except Exception:
+        log.warning("runner_images.default_images_load_failed", exc_info=True)
+    out: dict[str, tuple[str, str]] = {}
+    for key, runner in RUNNER_IMAGES.items():
+        ref = overrides.get(key)
+        if isinstance(ref, str) and ref:
+            out[key] = (ref, "override")
+        else:
+            out[key] = (runner.image, "release")
+    return out
+
+
+def _slot_rendered_or_resolved_image(slot_cfg: Mapping[str, Any]) -> str:
+    """The image ref one slot launches: rendered unit first, else resolved.
+
+    Contract tier 1 — the ``/etc/containers/systemd`` Quadlet snapshot: the
+    ground truth on an installed box (survives config edits that haven't
+    been applied yet). Attempted only when this process is literally the
+    ``hal0`` service account — the same gate
+    ``hal0.providers.podman_introspect`` puts on its rootful seam, and what
+    keeps a dev shell / CI runner / unit test from reading the HOST box's
+    real units into a hermetic test. Everything else (and any read failure)
+    → tier 2, the resolved config via the provider's own
+    ``_resolve_image_ref`` chain, which is what the NEXT (re)start launches.
+    """
+    try:
+        from hal0.providers.container import _QUADLET_DIR
+        from hal0.slots.naming import slot_instance_token, slot_quadlet_name
+        from hal0.system.seam import is_hal0_service_user
+
+        if is_hal0_service_user():
+            token = slot_instance_token(slot_cfg)
+            if token:
+                text = (_QUADLET_DIR / slot_quadlet_name(token)).read_text(encoding="utf-8")
+                for line in text.splitlines():
+                    if line.startswith("Image="):
+                        return line[len("Image=") :].strip()
+    except OSError:
+        pass
+    from hal0.providers.container import _resolve_image_ref
+
+    return _resolve_image_ref(slot_cfg, None)
+
+
+def _slot_image_usage() -> dict[str, str]:
+    """Slot name -> launched image ref, for every configured slot.
+
+    Contract: ``in_use_by`` is ``[]`` when unknown — every failure here
+    degrades to skipping the slot (or the whole map), never a 500 on the
+    catalogue routes.
+    """
+    usage: dict[str, str] = {}
+    try:
+        from hal0.config.loader import list_slots, load_slot_config
+
+        stems = list_slots()
+    except Exception:
+        log.warning("runner_images.slot_usage_enumeration_failed", exc_info=True)
+        return usage
+    for stem in stems:
+        try:
+            cfg = load_slot_config(stem)
+            slot_map = cfg.model_dump(mode="python")
+            name = str(slot_map.get("name") or stem)
+            usage[name] = _slot_rendered_or_resolved_image(slot_map)
+        except Exception:
+            log.warning("runner_images.slot_usage_failed slot=%s", stem, exc_info=True)
+            continue
+    return usage
+
+
+def _enriched(images: list[RunnerImage]) -> list[dict[str, Any]]:
+    defaults = _effective_defaults()
+    slot_usage = _slot_image_usage()
+    return [enrich_row(i, defaults=defaults, slot_usage=slot_usage) for i in images]
+
+
 @router.get("")
 async def list_runner_images(request: Request) -> dict[str, Any]:
-    """Return every catalogued runner image."""
+    """Return every catalogued runner image (catalogue-v2 enriched rows)."""
     store = request.app.state.runner_image_registry
-    return {"images": [_image_to_dict(i) for i in store.list()]}
+    return {"images": _enriched(store.list())}
 
 
 @router.get("/downloaded")
@@ -74,7 +223,7 @@ async def sync_runner_images_route(request: Request) -> dict[str, Any]:
     store = request.app.state.runner_image_registry
     result = await sync_runner_images(store)
     return {
-        "images": [_image_to_dict(i) for i in result.images],
+        "images": _enriched(result.images),
         "images_json_ok": result.images_json_ok,
         "images_json_error": result.images_json_error,
         "probe_errors": result.probe_errors,
@@ -123,7 +272,7 @@ async def get_runner_image(image_id: str, request: Request) -> dict[str, Any]:
             details={"image_id": image_id},
             code="runner_image.not_found",
         )
-    return _image_to_dict(image)
+    return _enriched([image])[0]
 
 
-__all__ = ["router"]
+__all__ = ["enrich_row", "router"]

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2161,6 +2161,61 @@ class SlotsConfig(BaseModel):
         ),
     )
 
+    default_images: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Per-runner-family operator default-image overrides "
+            "(runner-image-catalogue v2). Keys are hal0.runners.RUNNER_IMAGES "
+            "family keys (rocmfpx, vulkanfpx, cuda, cpu, flm, kokoro, "
+            "moonshine, qwen3tts, comfyui); values are full image refs "
+            "(e.g. 'ghcr.io/hal0ai/hal0-combined:0824'). A family listed "
+            "here launches that ref instead of the release-baked default "
+            "wherever no per-slot image_pin applies "
+            "(hal0.providers.container._resolve_image_ref). CLEAR SEMANTICS: "
+            "the settings PUT deep-merge has no key-delete idiom, so sending "
+            "an explicit null value for a family removes the override (the "
+            "validator drops null-valued keys); an empty string is rejected. "
+            "Applies on the next slot (re)start."
+        ),
+    )
+
+    @field_validator("default_images", mode="before")
+    @classmethod
+    def _default_images_known_families(cls, v: Any) -> Any:
+        """Validate the override map — and implement its clear idiom.
+
+        A ``None`` VALUE is the documented way to clear one family's
+        override (the settings PUT deep-merge replaces scalars and has no
+        delete idiom, so ``{"rocmfpx": null}`` must mean "remove the key"
+        rather than fail validation). Unknown family keys and empty/
+        non-string refs are rejected with the offending key named — the
+        family vocabulary is ``hal0.runners.RUNNER_IMAGES`` (imported
+        lazily: hal0.runners imports THIS module at import time, so a
+        module-level import here would be a cycle).
+        """
+        if v is None:
+            return {}
+        if not isinstance(v, dict):
+            return v  # let pydantic's dict[str, str] coercion produce the error
+        from hal0.runners import RUNNER_IMAGES
+
+        cleaned: dict[str, Any] = {}
+        for key, ref in v.items():
+            if ref is None:
+                continue  # explicit null = clear this family's override
+            if key not in RUNNER_IMAGES:
+                raise ValueError(
+                    f"[slots].default_images key {key!r} is not a known runner "
+                    f"family (valid: {', '.join(sorted(RUNNER_IMAGES))})"
+                )
+            if not isinstance(ref, str) or not ref.strip():
+                raise ValueError(
+                    f"[slots].default_images[{key!r}] must be a non-empty image "
+                    "ref (send null to clear the override)"
+                )
+            cleaned[key] = ref.strip()
+        return cleaned
+
     @field_validator("publish_host")
     @classmethod
     def _publish_host_sane(cls, v: str) -> str:

--- a/src/hal0/db/migrations/007_runner_image_tags.sql
+++ b/src/hal0/db/migrations/007_runner_image_tags.sql
@@ -1,0 +1,11 @@
+-- 007_runner_image_tags.sql  (schema version 7)
+--
+-- Runner-image catalogue v2 tag tracking (spec
+-- docs/superpowers/specs/2026-08-24-runner-image-catalogue-v2-design.md):
+-- every sync now stores the FULL tags/list result per row, newest first
+-- (hal0.registry.runner_image_sync.sort_tags_newest_first), so the UI can
+-- offer a per-row tag picker and surface freshly pushed tags without an
+-- images.json edit. NULL/absent means "probe failed or not yet run" and
+-- reads back as [] — the headline tag column keeps its own semantics.
+
+ALTER TABLE runner_image ADD COLUMN available_tags_json TEXT;

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -293,7 +293,9 @@ def _resolve_image_ref(
     Resolution (spec-hw-slot-ownership §3 — collapses the prior §7.1b chain)::
 
         image_default = RUNNER_IMAGES[slot.BINARY]     (code registry)
-        effective     = slot.image_pin or image_default
+        effective     = slot.image_pin
+                        or [slots].default_images[family]
+                        or image_default
 
       1. ``slot_cfg["image_pin"]`` — the single canonical escape hatch (debug
          build / A-B / rollback-to-last-known-good). A non-empty string is
@@ -301,7 +303,14 @@ def _resolve_image_ref(
          ``_resolve_image_ref`` tiers 1-2 (``slot.image`` / ``[slot].image``)
          to a first-class typed field; those old nestings are folded into
          ``image_pin`` by the migration lane, not read here.
-      2. ``image_default`` — :func:`hal0.runners.resolve_runner_image` of the
+      2. ``[slots].default_images[<family>]`` — the per-family operator
+         override (runner-image-catalogue v2), keyed by the effective
+         runner's :data:`~hal0.runners.RUNNER_IMAGES` key and read live via
+         :func:`_slot_default_images`. Sits ABOVE the whole
+         :func:`hal0.runners.resolve_runner_image` chain (env var / manifest
+         pin / baked default): a default the operator set in the UI is
+         box-wide intent, only the per-slot ``image_pin`` outranks it.
+      3. ``image_default`` — :func:`hal0.runners.resolve_runner_image` of the
          :func:`_effective_runner` (the slot's ``binary`` when set, else the
          HW-gated default via :func:`hal0.runners.runner_for_backend`). Same
          runner :func:`_resolve_llama_scalars` uses to gate mtp/jinja, so the
@@ -326,7 +335,11 @@ def _resolve_image_ref(
     # image_default = RUNNER_IMAGES[slot.BINARY] (or the HW-gated default).
     from hal0.runners import resolve_runner_image
 
-    return resolve_runner_image(_effective_runner(slot_cfg, profile))
+    runner = _effective_runner(slot_cfg, profile)
+    override = _slot_default_images().get(runner.key)
+    if isinstance(override, str) and override:
+        return override  # [slots].default_images — operator family default
+    return resolve_runner_image(runner)
 
 
 def _profile_image_and_flags(
@@ -527,6 +540,27 @@ def _slot_publish_host() -> str:
     except Exception:
         log.warning("container.publish_host_load_failed", exc_info=True)
         return "127.0.0.1"
+
+
+def _slot_default_images() -> Mapping[str, str]:
+    """Live ``[slots].default_images`` — per-family operator image overrides.
+
+    Runner-image-catalogue v2: an operator can point a runner family (a
+    ``hal0.runners.RUNNER_IMAGES`` key) at a specific image ref from the
+    runner-images page; :func:`_resolve_image_ref` honors it for every slot
+    of that family that carries no ``image_pin``. Read fresh each resolve —
+    same idiom as :func:`_slot_publish_host` — so a Settings change lands on
+    the next slot (re)start without an api process bounce. Fail-soft to ``{}``:
+    a malformed/unreadable hal0.toml must never wedge a slot launch.
+    """
+    try:
+        from hal0.config.loader import load_hal0_config
+
+        overrides = load_hal0_config().slots.default_images
+        return overrides if isinstance(overrides, Mapping) else {}
+    except Exception:
+        log.warning("container.default_images_load_failed", exc_info=True)
+        return {}
 
 
 def _slot_network_mode() -> str:

--- a/src/hal0/registry/runner_image.py
+++ b/src/hal0/registry/runner_image.py
@@ -31,6 +31,11 @@ class RunnerImage(BaseModel):
     tag: str = "latest"
     digest: str | None = None
     size_bytes: int | None = None
+    #: Every tag the GHCR ``tags/list`` probe saw, newest first (see
+    #: ``hal0.registry.runner_image_sync.sort_tags_newest_first``). ``[]``
+    #: when the probe failed or hasn't run — the headline ``tag`` above
+    #: keeps its own semantics (images.json pin, else newest, else latest).
+    available_tags: list[str] = Field(default_factory=list)
 
     # images.json (hal0.runner-images.v1) fields — None when unmatched.
     manifest_key: str | None = None

--- a/src/hal0/registry/runner_image_store.py
+++ b/src/hal0/registry/runner_image_store.py
@@ -51,10 +51,12 @@ _SCALAR_FIELDS = (
 def _row_to_runner_image(row: sqlite3.Row) -> RunnerImage:
     build_raw = row["build_json"]
     extra_raw = row["extra"]
+    tags_raw = row["available_tags_json"]
     return RunnerImage(
         **{k: row[k] for k in _SCALAR_FIELDS},
         build=json.loads(build_raw) if build_raw else None,
         extra=json.loads(extra_raw) if extra_raw else {},
+        available_tags=json.loads(tags_raw) if tags_raw else [],
     )
 
 
@@ -65,6 +67,7 @@ def _runner_image_to_row(image: RunnerImage, *, discovered_at: str | None = None
     row["updated_at"] = now
     row["build_json"] = json.dumps(image.build) if image.build is not None else None
     row["extra"] = json.dumps(image.extra) if image.extra else None
+    row["available_tags_json"] = json.dumps(image.available_tags) if image.available_tags else None
     return row
 
 

--- a/src/hal0/registry/runner_image_sync.py
+++ b/src/hal0/registry/runner_image_sync.py
@@ -32,6 +32,7 @@ whole sync run.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -81,6 +82,40 @@ def _strip_registry_host(image_ref: str) -> str:
     if sep and host == "ghcr.io":
         return rest
     return ref
+
+
+#: ``v?1.2.3``-shaped tags — the "semver" bucket of :func:`sort_tags_newest_first`.
+_SEMVER_TAG_RE = re.compile(r"^v?\d+(\.\d+)+$")
+
+
+def sort_tags_newest_first(tags: list[str]) -> list[str]:
+    """Order GHCR ``tags/list`` output newest-first (catalogue-v2 contract).
+
+    Three buckets, concatenated in this order:
+
+    1. all-digit tags (the CI date/short-SHA-free shape, e.g. ``0824``) —
+       numeric descending, so the freshest date-tag leads;
+    2. semver-shaped tags (``v1.10.0`` / ``1.2.3``) — version-tuple
+       descending (NOT lexicographic: ``v1.10.0`` beats ``v1.2.0``);
+    3. everything else (``latest``, branch names, bare SHAs) — original
+       registry order, untouched, as the stable last resort.
+
+    Pure and exported: the sync path uses it for ``available_tags`` and the
+    unpinned headline tag, and tests/UI helpers can call it directly.
+    """
+    numeric: list[str] = []
+    semver: list[str] = []
+    rest: list[str] = []
+    for tag in tags:
+        if tag.isdigit():
+            numeric.append(tag)
+        elif _SEMVER_TAG_RE.match(tag):
+            semver.append(tag)
+        else:
+            rest.append(tag)
+    numeric.sort(key=int, reverse=True)
+    semver.sort(key=lambda t: tuple(int(p) for p in t.lstrip("v").split(".")), reverse=True)
+    return numeric + semver + rest
 
 
 async def fetch_images_json(client: httpx.AsyncClient) -> tuple[list[dict[str, Any]], str | None]:
@@ -231,19 +266,25 @@ async def probe_ghcr_package(
     tag: str | None = None,
     image_id: str | None = None,
 ) -> RunnerImage:
-    """Anonymously resolve one GHCR package's latest tag + digest + size.
+    """Anonymously resolve one GHCR package's tags + digest + size.
 
-    ``tag`` pins a specific tag (from an ``images.json`` entry); when
-    omitted, the newest-looking tag from ``tags/list`` is used, falling
-    back to ``latest``. ``image_id`` sets the catalogue row id (the
+    ``tag`` pins the headline tag (from an ``images.json`` entry); when
+    omitted, the newest tag per :func:`sort_tags_newest_first` is used,
+    falling back to ``latest``. Either way ``tags/list`` is always probed
+    so the row carries the full ``available_tags`` list (catalogue v2 tag
+    tracking); a failing ``tags/list`` degrades to ``available_tags=[]``
+    without failing the row. ``image_id`` sets the catalogue row id (the
     ``images.json`` short name, e.g. ``cpu``); defaults to the repo path
     for rows with no manifest entry.
     """
     token = await _ghcr_anon_token(repo, client=client)
-    resolved_tag = tag
-    if resolved_tag is None:
+    try:
         tags = await _ghcr_list_tags(repo, token=token, client=client)
-        resolved_tag = "latest" if "latest" in tags else (tags[-1] if tags else "latest")
+    except (httpx.HTTPError, ValueError) as exc:
+        log.warning("runner_images.tags_list_failed repo=%s error=%s", repo, exc)
+        tags = []
+    available = sort_tags_newest_first(tags)
+    resolved_tag = tag if tag is not None else (available[0] if available else "latest")
     digest, size = await _ghcr_manifest_info(repo, resolved_tag, token=token, client=client)
     return RunnerImage(
         id=image_id or repo,
@@ -251,6 +292,7 @@ async def probe_ghcr_package(
         tag=resolved_tag,
         digest=digest,
         size_bytes=size,
+        available_tags=available,
     )
 
 
@@ -343,5 +385,6 @@ __all__ = [
     "SyncResult",
     "fetch_images_json",
     "probe_ghcr_package",
+    "sort_tags_newest_first",
     "sync_runner_images",
 ]

--- a/tests/api/test_runner_images_routes.py
+++ b/tests/api/test_runner_images_routes.py
@@ -154,3 +154,156 @@ def test_downloaded_list_empty_by_default(client: TestClient) -> None:
     resp = client.get("/api/runner-images/downloaded")
     assert resp.status_code == 200
     assert resp.json() == {"images": []}
+
+
+# ── row enrichment: is_default / in_use_by (runner-image-catalogue v2) ──────
+
+
+def _row(image: str, tag: str, image_id: str = "row"):
+    from hal0.registry.runner_image import RunnerImage
+
+    return RunnerImage(id=image_id, image=image, tag=tag)
+
+
+class TestEnrichRow:
+    """Pure-function contract for the catalogue v2 row enrichment."""
+
+    def test_release_default_match_any_tag(self) -> None:
+        from hal0.api.routes.runner_images import enrich_row
+
+        row = enrich_row(
+            _row("ghcr.io/hal0ai/hal0-combined", "0777"),
+            defaults={"rocmfpx": ("ghcr.io/hal0ai/hal0-combined:0824", "release")},
+            slot_usage={},
+        )
+        # "any tag": the family default's REPO matching row.image is enough.
+        assert row["is_default"] == {"family": "rocmfpx", "source": "release"}
+
+    def test_override_source_reported(self) -> None:
+        from hal0.api.routes.runner_images import enrich_row
+
+        row = enrich_row(
+            _row("ghcr.io/hal0ai/hal0-other", "1"),
+            defaults={"rocmfpx": ("ghcr.io/hal0ai/hal0-other:1", "override")},
+            slot_usage={},
+        )
+        assert row["is_default"] == {"family": "rocmfpx", "source": "override"}
+
+    def test_no_family_match_is_null(self) -> None:
+        from hal0.api.routes.runner_images import enrich_row
+
+        row = enrich_row(
+            _row("ghcr.io/hal0ai/hal0-unrelated", "1"),
+            defaults={"rocmfpx": ("ghcr.io/hal0ai/hal0-combined:0824", "release")},
+            slot_usage={},
+        )
+        assert row["is_default"] is None
+
+    def test_in_use_by_matches_exact_image_tag(self) -> None:
+        from hal0.api.routes.runner_images import enrich_row
+
+        row = enrich_row(
+            _row("ghcr.io/hal0ai/hal0-combined", "0824"),
+            defaults={},
+            slot_usage={
+                "agent": "ghcr.io/hal0ai/hal0-combined:0824",
+                "utility": "ghcr.io/hal0ai/hal0-combined:0824",
+                "npu": "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44",
+                "old": "ghcr.io/hal0ai/hal0-combined:0822",  # other tag: no match
+            },
+        )
+        assert row["in_use_by"] == ["agent", "utility"]
+        assert row["is_default"] is None
+
+
+@pytest.fixture
+def isolated_client(tmp_hal0_home: str):
+    """TestClient built AFTER HAL0_HOME isolation (settings writes land in tmp).
+
+    Same idiom as tests/api/test_settings_routes.py — the shared ``client``
+    fixture builds the app before the per-test HAL0_HOME monkeypatch.
+    """
+    from fastapi import FastAPI
+
+    from hal0.api import create_app
+
+    app: FastAPI = create_app()
+    with TestClient(app) as c:
+        yield c
+
+
+class TestRunnerImageRouteEnrichment:
+    """GET /api/runner-images rows carry the frozen catalogue-v2 contract."""
+
+    def _seed_combined(self, client: TestClient):
+        from hal0.registry.runner_image import RunnerImage
+
+        return client.app.state.runner_image_registry.upsert(
+            RunnerImage(
+                id="rocmfpx-combined",
+                image="ghcr.io/hal0ai/hal0-combined",
+                tag="0824",
+                available_tags=["0824", "0822"],
+            )
+        )
+
+    def test_release_default_and_contract_fields(self, isolated_client: TestClient) -> None:
+        """The baked rocmfpx default is hal0-combined:0824 (#2041), so the
+        combined row reports source=release with no override configured."""
+        self._seed_combined(isolated_client)
+        rows = isolated_client.get("/api/runner-images").json()["images"]
+        row = next(r for r in rows if r["id"] == "rocmfpx-combined")
+        assert row["available_tags"] == ["0824", "0822"]
+        assert row["is_default"] == {"family": "rocmfpx", "source": "release"}
+        assert row["in_use_by"] == []
+
+    def test_override_set_and_null_clear_via_settings_put(
+        self, isolated_client: TestClient
+    ) -> None:
+        """[slots].default_images written/cleared through PUT /api/settings:
+        set → source=override; explicit null value → override removed."""
+        from hal0.registry.runner_image import RunnerImage
+
+        isolated_client.app.state.runner_image_registry.upsert(
+            RunnerImage(id="other", image="ghcr.io/hal0ai/hal0-other", tag="1")
+        )
+
+        r = isolated_client.put(
+            "/api/settings",
+            json={"slots": {"default_images": {"cpu": "ghcr.io/hal0ai/hal0-other:1"}}},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["slots"]["default_images"] == {"cpu": "ghcr.io/hal0ai/hal0-other:1"}
+
+        rows = isolated_client.get("/api/runner-images").json()["images"]
+        row = next(r for r in rows if r["id"] == "other")
+        assert row["is_default"] == {"family": "cpu", "source": "override"}
+
+        # CLEAR: explicit null value removes the key (deep-merge has no
+        # delete idiom; the SlotsConfig validator drops null-valued keys).
+        r = isolated_client.put("/api/settings", json={"slots": {"default_images": {"cpu": None}}})
+        assert r.status_code == 200, r.text
+        assert r.json()["slots"]["default_images"] == {}
+
+        rows = isolated_client.get("/api/runner-images").json()["images"]
+        row = next(r for r in rows if r["id"] == "other")
+        assert row["is_default"] is None
+
+    def test_in_use_by_lists_slots_resolving_to_the_row(
+        self, isolated_client: TestClient, tmp_hal0_home: str
+    ) -> None:
+        """A slot whose resolved config references image:tag shows up in the
+        row's in_use_by (resolved-config path — no rendered units in tests)."""
+        from pathlib import Path
+
+        self._seed_combined(isolated_client)
+        slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+        slots_dir.mkdir(parents=True, exist_ok=True)
+        (slots_dir / "agent.toml").write_text(
+            'name = "agent"\nport = 8081\nimage_pin = "ghcr.io/hal0ai/hal0-combined:0824"\n',
+            encoding="utf-8",
+        )
+
+        rows = isolated_client.get("/api/runner-images").json()["images"]
+        row = next(r for r in rows if r["id"] == "rocmfpx-combined")
+        assert row["in_use_by"] == ["agent"]

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -483,6 +483,34 @@ class TestHal0Config:
             SlotsConfig(network_mode="bridge")
         assert "network_mode" in str(ei.value)
 
+    # ── [slots] default_images (runner-image-catalogue v2) ────────────────
+
+    def test_slots_default_images_defaults_empty(self) -> None:
+        assert SlotsConfig().default_images == {}
+
+    def test_slots_default_images_accepts_known_family(self) -> None:
+        cfg = SlotsConfig(default_images={"rocmfpx": "ghcr.io/hal0ai/hal0-combined:0824"})
+        assert cfg.default_images == {"rocmfpx": "ghcr.io/hal0ai/hal0-combined:0824"}
+
+    def test_slots_default_images_rejects_unknown_family(self) -> None:
+        with pytest.raises(ValidationError) as ei:
+            SlotsConfig(default_images={"warpdrive": "ghcr.io/x/y:z"})
+        msg = str(ei.value)
+        assert "warpdrive" in msg
+        assert "not a known runner family" in msg
+        assert "rocmfpx" in msg  # the error names the valid keys
+
+    def test_slots_default_images_rejects_empty_ref(self) -> None:
+        with pytest.raises(ValidationError) as ei:
+            SlotsConfig(default_images={"rocmfpx": ""})
+        assert "non-empty image ref" in str(ei.value)
+
+    def test_slots_default_images_null_value_clears_the_key(self) -> None:
+        """The settings PUT deep-merge has no delete idiom, so an explicit
+        null value IS the documented clear: the validator drops the key."""
+        cfg = SlotsConfig(default_images={"rocmfpx": None})
+        assert cfg.default_images == {}
+
     def test_extra_allow_keeps_unknown_keys(self) -> None:
         c = Hal0Config.model_validate({"future_section": {"foo": 1}})
         # extra='allow' keeps the unknown table.

--- a/tests/providers/test_gpu_vulkan_lane_gate.py
+++ b/tests/providers/test_gpu_vulkan_lane_gate.py
@@ -605,6 +605,64 @@ class TestLoadSyncThreadsTheResolvedImage:
         )
         assert written == ["utility"]
 
+    @staticmethod
+    def _override(monkeypatch, family: str, ref: str) -> None:
+        """Install a [slots].default_images override the REAL chain will read.
+
+        Patches ``hal0.config.loader.load_hal0_config`` (what
+        ``container._slot_default_images`` calls fresh on every resolve) —
+        NOT the resolution tier itself — so the test exercises the whole
+        override→resolve→preflight path, not a stub of it.
+        """
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(
+            "hal0.config.loader.load_hal0_config",
+            lambda: SimpleNamespace(slots=SimpleNamespace(default_images={family: ref})),
+        )
+
+    def test_a_broken_family_override_is_refused_through_load_sync(self, monkeypatch) -> None:
+        """Spec §1 Safety (runner-image-catalogue v2): "the Vulkan-lane gate
+        (VULKAN_CAPABLE_IMAGE_REFS) still applies at slot-load preflight — an
+        override cannot silently re-arm #1888."
+
+        A ``gpu-vulkan`` slot with NO pin resolves through the new
+        ``[slots].default_images`` tier; when the operator points the
+        ``vulkanfpx`` family at the ade07ba lineage, ``load_sync``'s
+        preflight must see THAT ref (it passes the raw ``_resolve_image_ref``
+        result to ``require_kfd_for_gpu_slot``) and refuse with the typed
+        error — never launch-and-emit-garbage. Verified red by reverting the
+        override tier: the preflight then sees the capable baked default and
+        admits the slot.
+        """
+        from hal0.providers import container as container_mod
+
+        self._amd_box_without_kfd(monkeypatch)
+        self._stub_unit_write(monkeypatch)
+        self._override(monkeypatch, "vulkanfpx", ADE07BA_REF)
+
+        with pytest.raises(GpuPreflightError) as exc:
+            container_mod.ContainerProvider().load_sync(
+                {"name": "utility", "device": "gpu-vulkan", "port": 8082},
+                {},
+            )
+        assert "1888" in str(exc.value)
+        assert ADE07BA_REF in str(exc.value)  # the refusal names the OVERRIDE ref
+
+    def test_a_capable_family_override_loads_on_a_kfd_less_box(self, monkeypatch) -> None:
+        """The positive twin: a validated override passes the same gate."""
+        from hal0.providers import container as container_mod
+
+        self._amd_box_without_kfd(monkeypatch)
+        written = self._stub_unit_write(monkeypatch)
+        self._override(monkeypatch, "vulkanfpx", VULKAN_FIXED_IMAGE)
+
+        container_mod.ContainerProvider().load_sync(
+            {"name": "utility", "device": "gpu-vulkan", "port": 8082},
+            {},
+        )
+        assert written == ["utility"]
+
 
 class TestPreflightDoesNotDisplaceTheSanityGate:
     """#1922 composition. Preflight is a *cheap, static* admission check; it

--- a/tests/providers/test_image_resolution.py
+++ b/tests/providers/test_image_resolution.py
@@ -105,6 +105,67 @@ def test_image_gen_dict_does_not_break_resolution() -> None:
     assert _resolve_image_ref(slot_cfg, _profile()) == FALLBACK_VULKAN_IMAGE
 
 
+# --- [slots] default_images override (runner-image-catalogue v2) ------------ #
+
+
+def _fake_config(default_images: dict[str, str]):
+    """A Hal0Config stand-in exposing just what the override tier reads."""
+    return SimpleNamespace(slots=SimpleNamespace(default_images=default_images))
+
+
+def test_default_images_override_beats_baked_default(monkeypatch) -> None:
+    """No pin + [slots].default_images entry for the effective family → the
+    operator override wins over the baked registry default."""
+    monkeypatch.setattr(
+        "hal0.config.loader.load_hal0_config",
+        lambda: _fake_config({"cpu": "ghcr.io/hal0ai/hal0-combined:0824"}),
+    )
+    slot_cfg = {"binary": "cpu"}
+    assert _resolve_image_ref(slot_cfg, _profile()) == "ghcr.io/hal0ai/hal0-combined:0824"
+
+
+def test_image_pin_still_beats_default_images_override(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "hal0.config.loader.load_hal0_config",
+        lambda: _fake_config({"cpu": "ghcr.io/hal0ai/hal0-combined:0824"}),
+    )
+    slot_cfg = {"image_pin": "ghcr.io/foo/debug:bar", "binary": "cpu"}
+    assert _resolve_image_ref(slot_cfg, _profile()) == "ghcr.io/foo/debug:bar"
+
+
+def test_default_images_override_applies_to_hw_gated_family(monkeypatch) -> None:
+    """No binary: the override keys on the HW-gated runner (rocmfpx here).
+
+    The override ref is deliberately NOT the baked default (which is
+    hal0-combined:0824 as of #2041) so this can only pass via the tier.
+    """
+    monkeypatch.setattr(
+        "hal0.config.loader.load_hal0_config",
+        lambda: _fake_config({"rocmfpx": "ghcr.io/hal0ai/hal0-combined:0999"}),
+    )
+    profile = SimpleNamespace(image=None, backend="rocm", device_class="gpu")
+    assert _resolve_image_ref(None, profile) == "ghcr.io/hal0ai/hal0-combined:0999"
+
+
+def test_default_images_absent_family_keeps_baked_default(monkeypatch) -> None:
+    """An override for a DIFFERENT family never leaks across families."""
+    monkeypatch.setattr(
+        "hal0.config.loader.load_hal0_config",
+        lambda: _fake_config({"rocmfpx": "ghcr.io/hal0ai/hal0-combined:0824"}),
+    )
+    assert _resolve_image_ref({"binary": "cpu"}, _profile()) == FALLBACK_VULKAN_IMAGE
+
+
+def test_default_images_config_load_failure_fails_soft(monkeypatch) -> None:
+    """A broken hal0.toml must not wedge a slot launch — baked default wins."""
+
+    def _boom() -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr("hal0.config.loader.load_hal0_config", _boom)
+    assert _resolve_image_ref({"binary": "cpu"}, _profile()) == FALLBACK_VULKAN_IMAGE
+
+
 # --- _profile_image_and_flags integration ---------------------------------- #
 
 

--- a/tests/registry/test_runner_image_sync.py
+++ b/tests/registry/test_runner_image_sync.py
@@ -59,14 +59,21 @@ def _route_handler(
     ghcr_fail: set[str] | None = None,
     manifest_body: dict | None = None,
     child_manifests: dict[str, dict] | None = None,
+    tags: list[str] | None = None,
+    tags_fail: set[str] | None = None,
 ):
     """MockTransport handler for raw.githubusercontent.com + ghcr.io.
 
     ``manifest_body`` overrides the manifest returned for tag refs;
     ``child_manifests`` maps digest refs to bodies (multi-arch children).
+    ``tags`` overrides the ``tags/list`` payload (default ``["latest"]``);
+    ``tags_fail`` names repos whose ``tags/list`` call 500s (the manifest
+    probe still succeeds — exercises the degrade-to-empty path).
     """
     ghcr_fail = ghcr_fail or set()
     child_manifests = child_manifests or {}
+    tags = tags if tags is not None else ["latest"]
+    tags_fail = tags_fail or set()
 
     def handler(request: httpx.Request) -> httpx.Response:
         url = str(request.url)
@@ -92,7 +99,10 @@ def _route_handler(
                 json=manifest_body if manifest_body is not None else _MANIFEST_BODY,
             )
         if "/tags/list" in url:
-            return httpx.Response(200, json={"tags": ["latest"]})
+            repo = url.split("https://ghcr.io/v2/")[1].split("/tags/list")[0]
+            if repo in tags_fail:
+                return httpx.Response(500, content=b"nope")
+            return httpx.Response(200, json={"tags": tags})
         return httpx.Response(404, content=b"unrouted: " + url.encode())
 
     return handler
@@ -289,6 +299,95 @@ async def test_sync_prunes_stale_rows_but_keeps_downloaded(tmp_path: Path) -> No
 
     ids = {i.id for i in store.list()}
     assert ids == {"cpu", "hal0ai/hal0-toolbox-flm", "hal0ai/old-downloaded"}
+
+
+# ── tag tracking (runner-image-catalogue v2) ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pinned_entry_keeps_tag_but_gains_available_tags(tmp_path: Path) -> None:
+    """A pinned images.json entry keeps its pin as the headline ``tag`` but
+    still stores the full newest-first ``available_tags`` list."""
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    handler = _route_handler(images_json=_IMAGES_JSON, tags=["0822", "latest", "0824"])
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.probe_errors == {}
+    cpu = store.get("cpu")
+    assert cpu is not None
+    assert cpu.tag == "latest"  # the images.json pin stays the headline
+    assert cpu.available_tags == ["0824", "0822", "latest"]
+
+
+@pytest.mark.asyncio
+async def test_unpinned_entry_headline_is_newest_tag(tmp_path: Path) -> None:
+    """No ``tag`` pin → the headline is the newest sorted tag, not ``latest``."""
+    images_json = {
+        "schema": "hal0.runner-images.v1",
+        "images": [
+            {"id": "combined", "image": "ghcr.io/hal0ai/hal0-combined"},
+        ],
+    }
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    handler = _route_handler(images_json=images_json, tags=["0822", "latest", "0824"])
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.probe_errors == {}
+    row = store.get("combined")
+    assert row is not None
+    assert row.tag == "0824"
+    assert row.available_tags == ["0824", "0822", "latest"]
+
+
+@pytest.mark.asyncio
+async def test_tags_list_failure_degrades_to_empty_available_tags(tmp_path: Path) -> None:
+    """A failing ``tags/list`` must not fail the row: the pinned headline
+    still resolves and ``available_tags`` degrades to ``[]``."""
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    handler = _route_handler(images_json=_IMAGES_JSON, tags_fail={"hal0ai/hal0-toolbox-cpu"})
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert "cpu" not in result.probe_errors
+    cpu = store.get("cpu")
+    assert cpu is not None
+    assert cpu.tag == "latest"
+    assert cpu.available_tags == []
+
+
+@pytest.mark.asyncio
+async def test_unpinned_entry_tags_list_failure_falls_back_to_latest(tmp_path: Path) -> None:
+    """No pin AND no tag list → the headline falls back to ``latest``."""
+    images_json = {
+        "schema": "hal0.runner-images.v1",
+        "images": [
+            {"id": "combined", "image": "ghcr.io/hal0ai/hal0-combined"},
+        ],
+    }
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    handler = _route_handler(images_json=images_json, tags_fail={"hal0ai/hal0-combined"})
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.probe_errors == {}
+    row = store.get("combined")
+    assert row is not None
+    assert row.tag == "latest"
+    assert row.available_tags == []
 
 
 @pytest.mark.asyncio

--- a/tests/registry/test_tag_sort.py
+++ b/tests/registry/test_tag_sort.py
@@ -1,0 +1,35 @@
+"""Tests for hal0.registry.runner_image_sync.sort_tags_newest_first.
+
+The tag-tracking headline (runner-image-catalogue v2, spec
+2026-08-24-runner-image-catalogue-v2-design.md) needs one deterministic
+"newest first" ordering for GHCR ``tags/list`` output: date-shaped numeric
+tags (``0824``) beat everything and sort descending, semver-shaped tags
+sort descending after them, and anything else keeps registry order as the
+stable last resort.
+"""
+
+from __future__ import annotations
+
+from hal0.registry.runner_image_sync import sort_tags_newest_first
+
+
+def test_date_shaped_numerics_beat_everything_and_sort_desc() -> None:
+    assert sort_tags_newest_first(["0822", "latest", "0824", "v1"])[:2] == ["0824", "0822"]
+
+
+def test_semver_sorts_desc_after_numerics() -> None:
+    out = sort_tags_newest_first(["v1.2.0", "v1.10.0", "latest"])
+    assert out[:2] == ["v1.10.0", "v1.2.0"]
+
+
+def test_registry_order_is_last_resort_and_stable() -> None:
+    assert sort_tags_newest_first(["alpha", "beta"]) == ["alpha", "beta"]
+
+
+def test_empty_ok() -> None:
+    assert sort_tags_newest_first([]) == []
+
+
+def test_buckets_concatenate_numeric_then_semver_then_rest() -> None:
+    out = sort_tags_newest_first(["latest", "v1.2.0", "0824", "alpha", "1.10.0", "0822"])
+    assert out == ["0824", "0822", "1.10.0", "v1.2.0", "latest", "alpha"]


### PR DESCRIPTION
Backend lane (PR 3 of 4) of the runner-image-catalogue v2 wave. Spec: `docs/superpowers/specs/2026-08-24-runner-image-catalogue-v2-design.md` (committed on `feat/runner-catalogue-v2`).

## Why

The runner-images page has never worked as designed. The spec's live diagnosis (ct105, rc7) names three root causes; this PR fixes the two backend ones and builds the transport for the third:

1. **Flagship runner missing from the catalogue** — `sync_runner_images` sources rows exclusively from `images.json`, which deliberately excluded `hal0-combined`, while the stale `rocmfpx` row still advertised the retired, #1888-broken `hal0-rocmfpx:ade07ba`. (Fixed data-side in the sibling hal0-runner-images PR; this code works with or without that entry.)
2. **Rows frozen to pinned tags** — sync probed exactly the `tag` named in each `images.json` entry, so new pushes stayed invisible until that file was hand-edited, and the unpinned "newest" heuristic (`tags[-1]`, registry order) was unreliable.
3. **"Assign as default" never built** — the page was browse/pull only; the fleet default was the baked `DEFAULT_ROCMFPX_IMAGE` constant with per-slot `image_pin` as the only override.

## What

- **Tag tracking (root cause 2):** every sync now fetches `tags/list` per entry and persists `available_tags` on the row, sorted by the new exported pure helper `hal0.registry.runner_image_sync.sort_tags_newest_first` (date-shaped numeric desc → semver desc → registry order). Pinned entries keep their pin as the headline `tag` but still carry the list; the unpinned headline is now the newest sorted tag (falling back to `latest`); a failing `tags/list` degrades to `available_tags=[]` without failing the row. DB migration `007_runner_image_tags.sql` adds the backing column.
- **Operator default overrides (root cause 3, backend half):** new `[slots] default_images` table on `SlotsConfig`, keyed by the `hal0.runners.RUNNER_IMAGES` family keys and validated against them (unknown key and empty-string refs rejected with the offending key named). `hal0.providers.container._resolve_image_ref` gains the override tier: `image_pin` → `[slots].default_images[<family>]` → `resolve_runner_image` (env/manifest/baked). The map is read live and fail-soft, same idiom as `publish_host`/`network_mode`, so a Settings save lands on the next slot (re)start and a broken hal0.toml never wedges a launch. The Vulkan-lane gate at slot-load preflight is untouched, so an override cannot silently re-arm #1888.
- **Row enrichment:** `GET /api/runner-images`, `POST /api/runner-images/sync`, and the detail route return rows enriched by the pure `enrich_row` helper with `is_default` and `in_use_by` per the frozen contract below.

## Settings write/clear semantics (verified)

Overrides are written through the existing `PUT /api/settings` deep-merge: `{"slots": {"default_images": {"rocmfpx": "<ref>"}}}`. The deep-merge replaces scalars and has **no key-delete idiom**, so an explicit `null` value is the documented clear: the `SlotsConfig` validator drops null-valued keys before validation, i.e. `{"slots": {"default_images": {"rocmfpx": null}}}` removes the override. Empty string is rejected (with a hint to send null). This is pinned by schema tests and an end-to-end settings-PUT route test.

## Frozen cross-task contract (the UI lane builds against this)

> `GET /api/runner-images` / `POST /api/runner-images/sync` rows gain:
>
> ```json
> {
>   "available_tags": ["0824", "0822"],
>   "is_default": {"family": "rocmfpx", "source": "override"},
>   "in_use_by": ["agent", "utility"]
> }
> ```
>
> - `available_tags`: newest-first (sort: date-shaped numeric desc → semver desc → registry order); always present, may be `[]` on probe failure; headline `tag` unchanged semantics.
> - `is_default`: `null` when no family default resolves to this row's `image` (any tag); `source` is `"override"` (from `[slots.default_images]`) or `"release"` (baked constant).
> - `in_use_by`: slot names whose *rendered unit* (`/etc/containers/systemd` snapshot via existing provider introspection, or resolved config on non-installed dev boxes) references `image:tag`; `[]` when unknown.

Implementation notes against that contract: `is_default` matches on the default ref's repo vs the row's `image` (first matching family in `RUNNER_IMAGES` order — deterministic for the rocmfpx/vulkanfpx shared-image pair); the `"release"` source is the baked `RUNNER_IMAGES` constant, deliberately not the env/manifest-resolved ref. The rendered-unit tier of `in_use_by` is gated on `is_hal0_service_user()` — the same gate `podman_introspect` puts on its rootful seam — so installed boxes read the Quadlet `Image=` snapshot while dev boxes/tests/CI use the resolved config; every failure degrades to `[]`, never a 500.

## Testing

Red-first throughout (each test watched failing before implementation): `tests/registry/test_tag_sort.py` (new), tag-tracking sync tests on the existing `httpx.MockTransport` GHCR harness, `SlotsConfig.default_images` schema tests incl. the null-clear idiom, resolution-override tests (pin still wins, no cross-family leak, fail-soft), and pure `enrich_row` + route-level enrichment tests incl. the settings-PUT set/clear round-trip. Full `tests/registry tests/providers tests/config tests/api` suites green; ruff check/format clean on touched files; mypy adds zero new errors vs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
