### PR TITLE
ci(cosign-pin): pin cosign-installer to v4.1.2 — upstream ships no floating v4 alias

### DIFF
--- a/.github/workflows/cosign-pin.yml
+++ b/.github/workflows/cosign-pin.yml
@@ -82,7 +82,7 @@ jobs:
         # from the in-tree pin (its documented fallback, and what an operator
         # gets locally); installing the current release here means the
         # verifier is not itself the artifact under review.
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Check the pin against the signed sigstore checksums
         id: check


### PR DESCRIPTION
The weekly "Cosign pin drift" job (run 32734596414, 2026-08-24) fails at job setup: `Unable to resolve action sigstore/cosign-installer@v4`. Upstream publishes only full-version tags (`v4.0.0`, `v4.1.0`, `v4.1.1`, `v4.1.2`) and never created a `v4` major alias, so the job dies before its drift check ever runs. Pin the exact current release. `release.yml`'s `@v3` sites are untouched — that alias exists upstream and resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)