### PR TITLE
fix(slots): wrap spawn CalledProcessError into SlotSpawnFailed (#1424)

### DIFF
--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -95,6 +95,7 @@ from hal0.slots.naming import (
     slot_quadlet_name,
     slot_unit_name,
 )
+from hal0.slots.state import SlotSpawnFailed
 from hal0.system.seam import SystemCtlSeam, is_hal0_service_user
 
 # ``ContainerSpec`` is the back-compat alias for ``RuntimeLaunchPlan``; some
@@ -2360,7 +2361,32 @@ class ContainerProvider(Provider):
         # path every load/restart/swap goes through, before the start. No-op
         # for a healthy unit.
         self.reset_failed(slot_name)
-        self._run("systemctl", "restart", self._unit_name(slot_name))
+        unit = self._unit_name(slot_name)
+        try:
+            self._run("systemctl", "restart", unit)
+        except subprocess.CalledProcessError as exc:
+            # #1424 facet 2: raw, this is not a Hal0Error — it falls through
+            # SlotManager.load()'s re-raise into the API's generic Exception
+            # handler as 500 ``system.internal``, and ``str(exc)`` (the full
+            # sudo seam argv) is what gets stamped into the slot's
+            # user-visible ``metadata.message``. Wrap it typed: the envelope
+            # is ``slot.spawn_failed`` and the message is systemd's failure
+            # reason (the #1791 probe), never the argv. The raw error stays
+            # on the cause chain for logs.
+            reason = self.unit_failure_reason(slot_name)
+            if not reason:
+                # Probe read nothing terminal (seam denied the verb, race
+                # with systemd, …) — still name the unit and the next step,
+                # not the command line.
+                reason = (
+                    f"systemctl restart {unit} failed (exit {exc.returncode}) "
+                    f"— see `journalctl -u {unit}`"
+                )
+            log.error(
+                "container.unit_start_failed",
+                extra={"slot": slot_name, "unit": unit, "reason": reason},
+            )
+            raise SlotSpawnFailed(reason, details={"slot": slot_name}) from exc
         log.info(
             "container.unit_started",
             extra={"slot": slot_name, "unit": self._unit_name(slot_name)},

--- a/tests/providers/test_container_unit_failure.py
+++ b/tests/providers/test_container_unit_failure.py
@@ -19,6 +19,7 @@ from typing import Any
 import pytest
 
 from hal0.providers.container import ContainerProvider
+from hal0.slots.state import SlotSpawnFailed
 
 
 def _completed(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess[str]:
@@ -200,3 +201,85 @@ def test_the_start_path_clears_a_start_limited_unit_before_restarting(
     assert verbs == ["daemon-reload", "reset-failed", "restart"], (
         "reset-failed must sit between the generator reload and the start"
     )
+
+
+# ── #1424 facet 2 — a failed start surfaces typed, reason-first ─────────────
+
+
+def test_a_failed_restart_raises_slot_spawn_failed_with_the_systemd_reason(
+    provider: ContainerProvider, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1424 facet 2 — the spawn seam's ``CalledProcessError`` must not escape raw.
+
+    Raw, it is not a ``Hal0Error``: it falls through the API's generic
+    ``Exception`` handler as ``500 system.internal``, and ``str(exc)`` — the
+    full sudo seam argv — is what gets stamped into the slot's user-visible
+    ``metadata.message``. Typed, the envelope is ``slot.spawn_failed`` and the
+    message is systemd's failure reason (#1791 probe), not the argv.
+    """
+    unit = provider._unit_name("chat")
+    seam_argv = ["sudo", "-n", "hal0-systemctl", "restart", unit]
+
+    def _run(self: Any, *args: str, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ("systemctl", "restart"):
+            raise subprocess.CalledProcessError(1, seam_argv, stderr="Job failed.")
+        if args[:2] == ("systemctl", "show"):
+            return _completed(
+                "LoadState=loaded\nActiveState=failed\nResult=exit-code\nNRestarts=1\n"
+            )
+        return _completed("")
+
+    monkeypatch.setattr(ContainerProvider, "_run", _run)
+    monkeypatch.setattr(
+        "hal0.providers.container._SYSTEMCTL_SEAM.write_quadlet",
+        lambda path, text: None,
+    )
+
+    with pytest.raises(SlotSpawnFailed) as excinfo:
+        provider._write_and_start_unit("chat", "[Container]\n")
+
+    err = excinfo.value
+    assert err.code == "slot.spawn_failed"
+    # The message is systemd's reason, written for an operator…
+    assert "result=exit-code" in err.message
+    assert "journalctl" in err.message
+    # …never the seam argv (the original report leaked the full sudo command).
+    assert "sudo" not in err.message
+    assert "hal0-systemctl" not in err.message
+    # The raw error stays on the cause chain for logs, not for users.
+    assert isinstance(err.__cause__, subprocess.CalledProcessError)
+
+
+def test_a_failed_restart_is_typed_even_when_the_probe_has_no_reason(
+    provider: ContainerProvider, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ``unit_failure_reason`` reads nothing terminal (seam denied the
+    verb, race with systemd, …) the error must STILL be ``slot.spawn_failed``
+    with an operator-facing fallback that names the unit — never the argv."""
+    unit = provider._unit_name("chat")
+    seam_argv = ["sudo", "-n", "hal0-systemctl", "restart", unit]
+
+    def _run(self: Any, *args: str, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ("systemctl", "restart"):
+            raise subprocess.CalledProcessError(64, seam_argv)
+        if args[:2] == ("systemctl", "show"):
+            # Healthy-looking props → the #1791 probe returns "".
+            return _completed("LoadState=loaded\nActiveState=inactive\nResult=success\n")
+        return _completed("")
+
+    monkeypatch.setattr(ContainerProvider, "_run", _run)
+    monkeypatch.setattr(
+        "hal0.providers.container._SYSTEMCTL_SEAM.write_quadlet",
+        lambda path, text: None,
+    )
+
+    with pytest.raises(SlotSpawnFailed) as excinfo:
+        provider._write_and_start_unit("chat", "[Container]\n")
+
+    err = excinfo.value
+    assert err.code == "slot.spawn_failed"
+    assert unit in err.message
+    assert "exit 64" in err.message
+    assert "journalctl" in err.message
+    assert "sudo" not in err.message
+    assert "hal0-systemctl" not in err.message


### PR DESCRIPTION
## Why

#1424 facet 2 (the last open facet after the 2026-08-24 re-triage): when `systemctl restart` fails on the slot spawn path, `ContainerProvider._run(..., check=True)` raises a raw `subprocess.CalledProcessError`. That is not a `Hal0Error`, so it falls through `SlotManager.load()`'s re-raise into the generic `Exception` handler in `src/hal0/api/middleware/error_codes.py` and surfaces as `500 {"code":"system.internal"}` — and `str(exc)` (the full `sudo -n hal0-systemctl ...` argv) is stamped into the slot's user-visible `metadata.message`, exactly as originally reported.

## What

`_write_and_start_unit` now catches the seam's `CalledProcessError` on the `systemctl restart` and raises the existing typed `SlotSpawnFailed` (`slot.spawn_failed`) instead:

- the message is systemd's failure reason from the #1791 `unit_failure_reason` probe (crash-loop / start-limit-hit / exit-code, with the `journalctl` pointer);
- when the probe reads nothing terminal (seam denied the verb, race with systemd), an operator-facing fallback names the unit and exit code — never the argv;
- the raw `CalledProcessError` stays on the cause chain for logs.

Facets 1 and 3 were verified fixed in the re-triage comment on the issue; per that comment's fix shape this closes the issue.

## Tests

TDD red-first: two new tests in `tests/providers/test_container_unit_failure.py` (typed envelope + reason-not-argv; typed fallback when the probe has no reason) — both watched failing with the escaping raw `CalledProcessError` before the fix.

- `.venv/bin/pytest tests/providers tests/slots -q` → 1688 passed
- `ruff check` + `ruff format --check` on both touched files → clean
- `mypy src/hal0/providers/container.py` → same 2 pre-existing errors as main (zero new)

Closes #1424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
