### PR TITLE
feat(runner-images): per-tag pull — route and job accept a catalogued tag

### DIFF
--- a/src/hal0/api/routes/runner_images.py
+++ b/src/hal0/api/routes/runner_images.py
@@ -231,16 +231,32 @@ async def sync_runner_images_route(request: Request) -> dict[str, Any]:
 
 
 @router.post("/{image_id:path}/pull", status_code=202)
-async def pull_runner_image(image_id: str, request: Request) -> dict[str, object]:
-    """Start a background ``podman pull`` for a catalogued runner image."""
-    return await _pull_jobs.enqueue(request, image_id=image_id)
+async def pull_runner_image(
+    image_id: str, request: Request, tag: str | None = None
+) -> dict[str, object]:
+    """Start a background ``podman pull`` for a catalogued runner image.
+
+    ``?tag=`` pulls that catalogued tag (headline or ``available_tags``
+    member — anything else is 404 ``runner_image.tag_not_available``);
+    omitted, the row's headline tag is pulled, exactly as before. One pull
+    slot per image: a different tag already in flight answers 409
+    ``runner_image.pull_conflict``.
+    """
+    return await _pull_jobs.enqueue(request, image_id=image_id, tag=tag)
 
 
 @router.get("/{image_id:path}/pull/status")
-async def pull_runner_image_status(image_id: str, request: Request) -> dict[str, object]:
-    """Current pull job for ``image_id``, with on-disk fallback."""
+async def pull_runner_image_status(
+    image_id: str, request: Request, tag: str | None = None
+) -> dict[str, object]:
+    """Current pull job for ``image_id``, with on-disk fallback.
+
+    ``?tag=`` answers only when the recorded job is for that tag (job
+    records carry ``tag``); a mismatch is 404, so a per-tag poller can't
+    be fooled by another tag's job in the single per-image slot.
+    """
     jobs: dict[str, RunnerPullJob] = request.app.state.runner_image_pull_jobs
-    return _pull_jobs.status(image_id, jobs)
+    return _pull_jobs.status(image_id, jobs, tag=tag)
 
 
 @router.get("/{image_id:path}/pull/stream")

--- a/src/hal0/api/routes/runner_images.py
+++ b/src/hal0/api/routes/runner_images.py
@@ -251,9 +251,10 @@ async def pull_runner_image_status(
 ) -> dict[str, object]:
     """Current pull job for ``image_id``, with on-disk fallback.
 
-    ``?tag=`` answers only when the recorded job is for that tag (job
-    records carry ``tag``); a mismatch is 404, so a per-tag poller can't
-    be fooled by another tag's job in the single per-image slot.
+    ``?tag=`` answers only with a job for that tag: the in-memory slot
+    when it matches, else that tag's persisted snapshot (snapshots are
+    per-tag files, so a newer pull can't orphan an older tag's result),
+    else 404 — a per-tag poller can't be fooled by another tag's job.
     """
     jobs: dict[str, RunnerPullJob] = request.app.state.runner_image_pull_jobs
     return _pull_jobs.status(image_id, jobs, tag=tag)

--- a/src/hal0/registry/runner_pull.py
+++ b/src/hal0/registry/runner_pull.py
@@ -159,13 +159,36 @@ def _pull_jobs_dir() -> Path:
     return paths.var_lib() / "runner-image-pull-jobs"
 
 
-def pull_job_file(image_id: str) -> Path:
-    return _pull_jobs_dir() / f"{_sanitise_id(image_id)}.json"
+def pull_job_file(image_id: str, *, tag: str | None = None) -> Path:
+    """Snapshot path for one image's pull job — per-tag when the job has one.
+
+    Tagged jobs land at ``<id>@<tag>.json`` so a new tag's pull can't
+    overwrite the previous tag's terminal record (``@`` never survives
+    ``_sanitise_id``, so the separator is unambiguous); legacy/untagged
+    jobs keep the bare ``<id>.json`` name.
+    """
+    stem = _sanitise_id(image_id)
+    if tag:
+        stem = f"{stem}@{_sanitise_id(tag)}"
+    return _pull_jobs_dir() / f"{stem}.json"
+
+
+def persisted_job_files(image_id: str) -> list[Path]:
+    """Every snapshot file for ``image_id``: the legacy untagged name plus
+    any per-tag ``<id>@<tag>.json`` siblings (name order, no ranking —
+    callers pick by snapshot content, e.g. ``started_at``)."""
+    jobs_dir = _pull_jobs_dir()
+    if not jobs_dir.is_dir():
+        return []
+    stem = _sanitise_id(image_id)
+    out = [p for p in (jobs_dir / f"{stem}.json",) if p.is_file()]
+    out.extend(sorted(jobs_dir.glob(f"{stem}@*.json")))
+    return out
 
 
 def persist_pull_job(job: RunnerPullJob) -> None:
     """Atomically mirror a job snapshot to disk (best-effort, fail-soft)."""
-    path = pull_job_file(job.image_id)
+    path = pull_job_file(job.image_id, tag=job.tag)
     try:
         ensure_shared_dir(path.parent)  # 2775, umask-proof (#1896)
         fd, tmp_str = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
@@ -342,6 +365,7 @@ __all__ = [
     "local_marker_path",
     "make_job",
     "persist_pull_job",
+    "persisted_job_files",
     "pull_job_file",
     "run_runner_pull",
     "sweep_pull_jobs",

--- a/src/hal0/registry/runner_pull.py
+++ b/src/hal0/registry/runner_pull.py
@@ -103,8 +103,8 @@ class RunnerPullJob:
     image_id: str
     image_ref: str
     #: The catalogue tag this job pulls (``image_ref``'s tag half). ``None``
-    #: only on legacy in-memory records; persisted pre-per-tag snapshots
-    #: simply lack the key.
+    #: only on in-memory records made without a tag; persisted pre-per-tag
+    #: snapshots simply lack the key.
     tag: str | None = None
     state: str = "queued"  # queued → running → {completed,failed,cancelled}
     layers_done: int = 0
@@ -164,8 +164,8 @@ def pull_job_file(image_id: str, *, tag: str | None = None) -> Path:
 
     Tagged jobs land at ``<id>@<tag>.json`` so a new tag's pull can't
     overwrite the previous tag's terminal record (``@`` never survives
-    ``_sanitise_id``, so the separator is unambiguous); legacy/untagged
-    jobs keep the bare ``<id>.json`` name.
+    ``_sanitise_id``, so the separator is unambiguous); untagged jobs
+    keep the bare ``<id>.json`` name.
     """
     stem = _sanitise_id(image_id)
     if tag:
@@ -174,13 +174,16 @@ def pull_job_file(image_id: str, *, tag: str | None = None) -> Path:
 
 
 def persisted_job_files(image_id: str) -> list[Path]:
-    """Every snapshot file for ``image_id``: the legacy untagged name plus
+    """Every snapshot file for ``image_id``: the bare untagged name plus
     any per-tag ``<id>@<tag>.json`` siblings (name order, no ranking —
     callers pick by snapshot content, e.g. ``started_at``)."""
     jobs_dir = _pull_jobs_dir()
     if not jobs_dir.is_dir():
         return []
     stem = _sanitise_id(image_id)
+    # HAL0-SUNSET: v1.1 — the bare <id>.json lookup reads snapshots written
+    # before per-tag files (#2048); drop it once those have aged out of the
+    # 14-day sweep_pull_jobs window.
     out = [p for p in (jobs_dir / f"{stem}.json",) if p.is_file()]
     out.extend(sorted(jobs_dir.glob(f"{stem}@*.json")))
     return out

--- a/src/hal0/registry/runner_pull.py
+++ b/src/hal0/registry/runner_pull.py
@@ -62,6 +62,20 @@ class RunnerImageNotCatalogued(RunnerPullError):
     status = 404
 
 
+class RunnerImageTagInvalid(RunnerPullError):
+    """The tag fails OCI tag syntax — refused before it touches any path.
+
+    Tags feed the per-tag snapshot filename (``<id>@<tag>.json``), so they
+    are allowlist-validated (:data:`_TAG_RE`, the OCI distribution-spec tag
+    grammar) rather than sanitised: a lossy transform would let distinct
+    tags collide on one file (``a/b`` vs ``a-b``), and traversal shapes
+    (``../``) must be a typed 400, never a filesystem probe.
+    """
+
+    code = "runner_image.tag_invalid"
+    status = 400
+
+
 class RunnerImageTagNotAvailable(RunnerPullError):
     """The requested tag isn't in the row's catalogued ``available_tags``.
 
@@ -90,6 +104,26 @@ class RunnerPullConflict(RunnerPullError):
 
 def _sanitise_id(image_id: str) -> str:
     return _SANITISE_RE.sub("-", image_id).strip("-.") or "runner-image"
+
+
+#: OCI distribution-spec tag grammar. Every character it admits is filename-
+#: safe (no ``/``, no ``@``, no leading ``.``), so a validated tag is used
+#: verbatim in paths.
+_TAG_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$")
+
+
+def validate_pull_tag(tag: str) -> str:
+    """Allowlist-validate ``tag`` before it reaches any filesystem path.
+
+    Raises :class:`RunnerImageTagInvalid` (400) on anything outside the OCI
+    tag grammar. Returns the tag unchanged so call sites can validate and
+    use in one expression.
+    """
+    if not _TAG_RE.fullmatch(tag):
+        raise RunnerImageTagInvalid(
+            f"invalid runner-image tag {tag!r} — not an OCI tag", details={"tag": tag}
+        )
+    return tag
 
 
 @dataclass
@@ -163,13 +197,15 @@ def pull_job_file(image_id: str, *, tag: str | None = None) -> Path:
     """Snapshot path for one image's pull job — per-tag when the job has one.
 
     Tagged jobs land at ``<id>@<tag>.json`` so a new tag's pull can't
-    overwrite the previous tag's terminal record (``@`` never survives
-    ``_sanitise_id``, so the separator is unambiguous); untagged jobs
-    keep the bare ``<id>.json`` name.
+    overwrite the previous tag's terminal record; untagged jobs keep the
+    bare ``<id>.json`` name. The tag half is allowlist-validated and used
+    verbatim — ``@`` survives neither ``_sanitise_id`` nor the tag
+    grammar, so the separator is unambiguous, and validating (rather than
+    sanitising) means distinct tags can never collide on one file.
     """
     stem = _sanitise_id(image_id)
     if tag:
-        stem = f"{stem}@{_sanitise_id(tag)}"
+        stem = f"{stem}@{validate_pull_tag(tag)}"
     return _pull_jobs_dir() / f"{stem}.json"
 
 
@@ -359,6 +395,7 @@ async def run_runner_pull(
 
 __all__ = [
     "RunnerImageNotCatalogued",
+    "RunnerImageTagInvalid",
     "RunnerImageTagNotAvailable",
     "RunnerPullConflict",
     "RunnerPullError",
@@ -372,5 +409,6 @@ __all__ = [
     "pull_job_file",
     "run_runner_pull",
     "sweep_pull_jobs",
+    "validate_pull_tag",
     "write_local_marker",
 ]

--- a/src/hal0/registry/runner_pull.py
+++ b/src/hal0/registry/runner_pull.py
@@ -76,6 +76,19 @@ class RunnerImageTagInvalid(RunnerPullError):
     status = 400
 
 
+class RunnerPullPathEscape(RunnerPullError):
+    """A jobs-dir path candidate resolved outside the pull-jobs directory.
+
+    Unreachable through the public surface — ids are sanitised and tags
+    allowlist-validated before a filename is composed — but the containment
+    check is the canonical last-line barrier at the single point where
+    request-derived data becomes a filesystem path.
+    """
+
+    code = "runner_image.path_not_contained"
+    status = 400
+
+
 class RunnerImageTagNotAvailable(RunnerPullError):
     """The requested tag isn't in the row's catalogued ``available_tags``.
 
@@ -193,6 +206,22 @@ def _pull_jobs_dir() -> Path:
     return paths.var_lib() / "runner-image-pull-jobs"
 
 
+def _contained_jobs_path(filename: str) -> Path:
+    """Resolve ``filename`` inside the pull-jobs dir, refusing escapees.
+
+    The id/tag halves are sanitised/allowlist-validated before a filename
+    exists, so escape is unreachable; this containment check is the
+    belt-and-braces barrier where request-derived data becomes a path.
+    """
+    base = _pull_jobs_dir().resolve()
+    candidate = (base / filename).resolve()
+    if not candidate.is_relative_to(base):
+        raise RunnerPullPathEscape(
+            "snapshot path escapes the pull-jobs directory", details={"filename": filename}
+        )
+    return candidate
+
+
 def pull_job_file(image_id: str, *, tag: str | None = None) -> Path:
     """Snapshot path for one image's pull job — per-tag when the job has one.
 
@@ -206,7 +235,7 @@ def pull_job_file(image_id: str, *, tag: str | None = None) -> Path:
     stem = _sanitise_id(image_id)
     if tag:
         stem = f"{stem}@{validate_pull_tag(tag)}"
-    return _pull_jobs_dir() / f"{stem}.json"
+    return _contained_jobs_path(f"{stem}.json")
 
 
 def persisted_job_files(image_id: str) -> list[Path]:
@@ -220,7 +249,7 @@ def persisted_job_files(image_id: str) -> list[Path]:
     # HAL0-SUNSET: v1.1 — the bare <id>.json lookup reads snapshots written
     # before per-tag files (#2048); drop it once those have aged out of the
     # 14-day sweep_pull_jobs window.
-    out = [p for p in (jobs_dir / f"{stem}.json",) if p.is_file()]
+    out = [p for p in (_contained_jobs_path(f"{stem}.json"),) if p.is_file()]
     out.extend(sorted(jobs_dir.glob(f"{stem}@*.json")))
     return out
 
@@ -401,6 +430,7 @@ __all__ = [
     "RunnerPullError",
     "RunnerPullJob",
     "RunnerPullJobNotFound",
+    "RunnerPullPathEscape",
     "list_persisted_jobs",
     "local_marker_path",
     "make_job",

--- a/src/hal0/registry/runner_pull.py
+++ b/src/hal0/registry/runner_pull.py
@@ -62,6 +62,32 @@ class RunnerImageNotCatalogued(RunnerPullError):
     status = 404
 
 
+class RunnerImageTagNotAvailable(RunnerPullError):
+    """The requested tag isn't in the row's catalogued ``available_tags``.
+
+    Per-tag pulls (catalogue-v2 follow-up to #2043) are restricted to tags
+    the sync probe has actually seen — the headline ``tag`` is always
+    allowed (``available_tags`` may be ``[]`` on probe failure), anything
+    else must appear in the list. Free-text refs stay out on purpose: the
+    catalogue is the honesty boundary.
+    """
+
+    code = "runner_image.tag_not_available"
+    status = 404
+
+
+class RunnerPullConflict(RunnerPullError):
+    """A pull for a *different* tag of this image is already in flight.
+
+    Job state is keyed one-per-image (jobs dict, snapshot file, marker) —
+    honest answer to a second tag while one is downloading is 409, not a
+    silent "resumed" handle to the wrong tag.
+    """
+
+    code = "runner_image.pull_conflict"
+    status = 409
+
+
 def _sanitise_id(image_id: str) -> str:
     return _SANITISE_RE.sub("-", image_id).strip("-.") or "runner-image"
 
@@ -76,6 +102,10 @@ class RunnerPullJob:
     job_id: str
     image_id: str
     image_ref: str
+    #: The catalogue tag this job pulls (``image_ref``'s tag half). ``None``
+    #: only on legacy in-memory records; persisted pre-per-tag snapshots
+    #: simply lack the key.
+    tag: str | None = None
     state: str = "queued"  # queued → running → {completed,failed,cancelled}
     layers_done: int = 0
     layers_total: int = 0
@@ -93,6 +123,7 @@ class RunnerPullJob:
             "id": self.job_id,
             "image_id": self.image_id,
             "image_ref": self.image_ref,
+            "tag": self.tag,
             "state": self.state,
             "layers_done": self.layers_done,
             "layers_total": self.layers_total,
@@ -109,12 +140,13 @@ class RunnerPullJob:
         self.progress_event = asyncio.Event()
 
 
-def make_job(image_id: str, image_ref: str) -> RunnerPullJob:
-    """Create a fresh job record for ``image_id``."""
+def make_job(image_id: str, image_ref: str, *, tag: str | None = None) -> RunnerPullJob:
+    """Create a fresh job record for ``image_id`` (``tag`` = the ref's tag half)."""
     return RunnerPullJob(
         job_id=secrets.token_hex(8),
         image_id=image_id,
         image_ref=image_ref,
+        tag=tag,
         state="queued",
         started_at=time.time(),
     )
@@ -301,6 +333,8 @@ async def run_runner_pull(
 
 __all__ = [
     "RunnerImageNotCatalogued",
+    "RunnerImageTagNotAvailable",
+    "RunnerPullConflict",
     "RunnerPullError",
     "RunnerPullJob",
     "RunnerPullJobNotFound",

--- a/src/hal0/registry/runner_pull_jobs.py
+++ b/src/hal0/registry/runner_pull_jobs.py
@@ -15,7 +15,8 @@ Interface contract:
         ``available_tags`` member); None keeps the headline behaviour.
     status(image_id, jobs, tag=None) -> dict
         GET /{id}/pull/status — disk-fallback included; ``tag`` filters to
-        the job for that tag (404 when the recorded job is another tag's).
+        the job for that tag (in-memory slot, else that tag's persisted
+        snapshot; 404 only when neither exists).
     cancel(image_id, jobs) -> dict
         POST /{id}/pull/cancel — idempotent.
     list_all(jobs) -> list[dict]
@@ -44,6 +45,7 @@ from hal0.registry.runner_pull import (
     list_persisted_jobs,
     make_job,
     persist_pull_job,
+    persisted_job_files,
     pull_job_file,
     run_runner_pull,
 )
@@ -191,9 +193,7 @@ async def _emit_terminal(event_bus: Any, job: RunnerPullJob) -> None:
         )
 
 
-def load_persisted(image_id: str) -> dict[str, Any] | None:
-    """Read a persisted job snapshot from disk (reconciled), or None."""
-    path = pull_job_file(image_id)
+def _read_snapshot(path: Any) -> dict[str, Any] | None:
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError:
@@ -202,9 +202,30 @@ def load_persisted(image_id: str) -> dict[str, Any] | None:
         loaded = json.loads(raw)
     except ValueError:
         return None
-    if not isinstance(loaded, dict):
-        return None
-    return reconcile_persisted(loaded)
+    return loaded if isinstance(loaded, dict) else None
+
+
+def load_persisted(image_id: str, tag: str | None = None) -> dict[str, Any] | None:
+    """Read a persisted job snapshot from disk (reconciled), or None.
+
+    Snapshots are per-(image, tag) files. With ``tag``, only that tag's
+    snapshot answers (pre-per-tag snapshots carry no ``tag`` key and never
+    match). Without, the most recent pull wins — highest ``started_at``
+    across the untagged legacy file and every per-tag sibling.
+    """
+    if tag is not None:
+        data = _read_snapshot(pull_job_file(image_id, tag=tag))
+        if data is None or data.get("tag") != tag:
+            return None
+        return reconcile_persisted(data)
+    best: dict[str, Any] | None = None
+    for path in persisted_job_files(image_id):
+        data = _read_snapshot(path)
+        if data is None:
+            continue
+        if best is None or (data.get("started_at") or 0) > (best.get("started_at") or 0):
+            best = data
+    return reconcile_persisted(best) if best is not None else None
 
 
 def reconcile_persisted(persisted: dict[str, Any]) -> dict[str, Any]:
@@ -222,30 +243,26 @@ def status(
 ) -> dict[str, object]:
     """Current job record for ``image_id`` (disk fallback included).
 
-    With ``tag``, only a job for that exact tag answers — the one job slot
-    per image may hold another tag's pull, and handing that back for a
-    per-tag status poll would lie. Pre-per-tag persisted snapshots carry no
-    ``tag`` key and therefore never match a tag-filtered read.
+    With ``tag``, only a job for that exact tag answers — the in-memory
+    slot may hold another tag's pull, in which case the read falls through
+    to the requested tag's persisted snapshot (a newer pull must not
+    orphan the previous tag's terminal result). Pre-per-tag persisted
+    snapshots carry no ``tag`` key and never match a tag-filtered read.
     """
     job = jobs.get(image_id)
-    if job is None:
-        persisted = load_persisted(image_id)
-        if persisted is not None:
-            if tag is not None and persisted.get("tag") != tag:
-                raise RunnerPullJobNotFound(
-                    f"no pull job for runner image {image_id!r} tag {tag!r}",
-                    details={"image_id": image_id, "tag": tag},
-                )
-            return persisted
-        raise RunnerPullJobNotFound(
-            f"no pull job for runner image {image_id!r}", details={"image_id": image_id}
-        )
-    if tag is not None and job.tag != tag:
+    if job is not None and (tag is None or job.tag == tag):
+        return job.as_dict()
+    persisted = load_persisted(image_id, tag)
+    if persisted is not None:
+        return persisted
+    if tag is not None:
         raise RunnerPullJobNotFound(
             f"no pull job for runner image {image_id!r} tag {tag!r}",
-            details={"image_id": image_id, "tag": tag, "in_flight_tag": job.tag},
+            details={"image_id": image_id, "tag": tag},
         )
-    return job.as_dict()
+    raise RunnerPullJobNotFound(
+        f"no pull job for runner image {image_id!r}", details={"image_id": image_id}
+    )
 
 
 def cancel(image_id: str, jobs: dict[str, RunnerPullJob]) -> dict[str, object]:
@@ -260,14 +277,22 @@ def cancel(image_id: str, jobs: dict[str, RunnerPullJob]) -> dict[str, object]:
 
 
 def list_all(jobs: dict[str, RunnerPullJob]) -> list[dict[str, Any]]:
-    """All pull jobs — active in-memory + persisted terminal, deduped (in-memory wins)."""
+    """All pull jobs — active in-memory + persisted terminal, deduped per image.
+
+    In-memory wins; among one image's persisted snapshots (per-tag files),
+    the most recently started wins — one row per image, matching the
+    single in-memory pull slot.
+    """
     persisted = list_persisted_jobs()
     by_id: dict[str, dict[str, Any]] = {}
     for p in persisted:
         if p.get("state") not in ("completed", "failed", "cancelled"):
             continue
         iid = p.get("image_id")
-        if isinstance(iid, str) and iid:
+        if not (isinstance(iid, str) and iid):
+            continue
+        prev = by_id.get(iid)
+        if prev is None or (p.get("started_at") or 0) >= (prev.get("started_at") or 0):
             by_id[iid] = p
     for iid, job in jobs.items():
         by_id[iid] = job.as_dict()

--- a/src/hal0/registry/runner_pull_jobs.py
+++ b/src/hal0/registry/runner_pull_jobs.py
@@ -211,7 +211,7 @@ def load_persisted(image_id: str, tag: str | None = None) -> dict[str, Any] | No
     Snapshots are per-(image, tag) files. With ``tag``, only that tag's
     snapshot answers (pre-per-tag snapshots carry no ``tag`` key and never
     match). Without, the most recent pull wins — highest ``started_at``
-    across the untagged legacy file and every per-tag sibling.
+    across the bare untagged file and every per-tag sibling.
     """
     if tag is not None:
         data = _read_snapshot(pull_job_file(image_id, tag=tag))

--- a/src/hal0/registry/runner_pull_jobs.py
+++ b/src/hal0/registry/runner_pull_jobs.py
@@ -48,6 +48,7 @@ from hal0.registry.runner_pull import (
     persisted_job_files,
     pull_job_file,
     run_runner_pull,
+    validate_pull_tag,
 )
 
 
@@ -100,6 +101,8 @@ async def enqueue(request: Request, *, image_id: str, tag: str | None = None) ->
     a *different* tag while one is downloading is an honest 409, not a
     "resumed" handle to the wrong ref.
     """
+    if tag is not None:
+        validate_pull_tag(tag)  # typed 400 before any lookup or path build
     jobs: dict[str, RunnerPullJob] = request.app.state.runner_image_pull_jobs
     existing = jobs.get(image_id)
     if existing is not None and existing.state in ("queued", "running"):
@@ -249,6 +252,8 @@ def status(
     orphan the previous tag's terminal result). Pre-per-tag persisted
     snapshots carry no ``tag`` key and never match a tag-filtered read.
     """
+    if tag is not None:
+        validate_pull_tag(tag)  # typed 400 before any lookup or path build
     job = jobs.get(image_id)
     if job is not None and (tag is None or job.tag == tag):
         return job.as_dict()

--- a/src/hal0/registry/runner_pull_jobs.py
+++ b/src/hal0/registry/runner_pull_jobs.py
@@ -9,10 +9,13 @@ disk-fallback status/stream read path, and cancel.
 
 Interface contract:
 
-    enqueue(request, *, image_id) -> dict
+    enqueue(request, *, image_id, tag=None) -> dict
         POST /{id}/pull — starts a background pull, in-flight dedup.
-    status(image_id, jobs) -> dict
-        GET /{id}/pull/status — disk-fallback included.
+        ``tag`` restricts the pulled ref to a catalogued tag (headline or
+        ``available_tags`` member); None keeps the headline behaviour.
+    status(image_id, jobs, tag=None) -> dict
+        GET /{id}/pull/status — disk-fallback included; ``tag`` filters to
+        the job for that tag (404 when the recorded job is another tag's).
     cancel(image_id, jobs) -> dict
         POST /{id}/pull/cancel — idempotent.
     list_all(jobs) -> list[dict]
@@ -34,6 +37,8 @@ from fastapi.responses import StreamingResponse
 
 from hal0.registry.runner_pull import (
     RunnerImageNotCatalogued,
+    RunnerImageTagNotAvailable,
+    RunnerPullConflict,
     RunnerPullJob,
     RunnerPullJobNotFound,
     list_persisted_jobs,
@@ -79,18 +84,33 @@ def _default_provider_factory() -> Any:
 provider_factory: Any = _default_provider_factory
 
 
-async def enqueue(request: Request, *, image_id: str) -> dict[str, object]:
+async def enqueue(request: Request, *, image_id: str, tag: str | None = None) -> dict[str, object]:
     """Start a background pull for ``image_id`` and return a job handle.
 
+    ``tag`` selects which catalogued tag to pull; ``None`` means the row's
+    headline ``tag`` (exactly the pre-per-tag behaviour). An explicit tag
+    must be the headline or a member of the row's ``available_tags`` —
+    the catalogue stays the honesty boundary, no free-text refs.
+
     Idempotent-ish: an in-flight (``queued``/``running``) job is returned
-    rather than duplicated.
+    rather than duplicated — but only when it's for the same tag (or no
+    tag was requested). Job state is keyed one-per-image, so a request for
+    a *different* tag while one is downloading is an honest 409, not a
+    "resumed" handle to the wrong ref.
     """
     jobs: dict[str, RunnerPullJob] = request.app.state.runner_image_pull_jobs
     existing = jobs.get(image_id)
     if existing is not None and existing.state in ("queued", "running"):
+        if tag is not None and existing.tag != tag:
+            raise RunnerPullConflict(
+                f"a pull for {existing.image_ref!r} is already in flight — "
+                f"wait for it (or cancel) before pulling tag {tag!r}",
+                details={"image_id": image_id, "tag": tag, "in_flight_tag": existing.tag},
+            )
         return {
             "id": existing.job_id,
             "image_id": image_id,
+            "tag": existing.tag,
             "state": existing.state,
             "resumed": True,
         }
@@ -102,9 +122,15 @@ async def enqueue(request: Request, *, image_id: str) -> dict[str, object]:
             f"runner image {image_id!r} not in catalogue — sync first",
             details={"image_id": image_id},
         )
-    image_ref = f"{entry.image}:{entry.tag}"
+    if tag is not None and tag != entry.tag and tag not in entry.available_tags:
+        raise RunnerImageTagNotAvailable(
+            f"tag {tag!r} is not a catalogued tag of runner image {image_id!r} — sync first",
+            details={"image_id": image_id, "tag": tag, "available_tags": entry.available_tags},
+        )
+    pull_tag = tag if tag is not None else entry.tag
+    image_ref = f"{entry.image}:{pull_tag}"
 
-    job = make_job(image_id, image_ref)
+    job = make_job(image_id, image_ref, tag=pull_tag)
     jobs[image_id] = job
     persist_pull_job(job)
 
@@ -129,7 +155,13 @@ async def enqueue(request: Request, *, image_id: str) -> dict[str, object]:
                 await _emit_terminal(event_bus, job)
 
     schedule_pull_task(request.app.state, image_id, _run())
-    return {"id": job.job_id, "image_id": image_id, "state": job.state, "image_ref": image_ref}
+    return {
+        "id": job.job_id,
+        "image_id": image_id,
+        "tag": pull_tag,
+        "state": job.state,
+        "image_ref": image_ref,
+    }
 
 
 async def _emit_terminal(event_bus: Any, job: RunnerPullJob) -> None:
@@ -185,14 +217,33 @@ def reconcile_persisted(persisted: dict[str, Any]) -> dict[str, Any]:
     return persisted
 
 
-def status(image_id: str, jobs: dict[str, RunnerPullJob]) -> dict[str, object]:
+def status(
+    image_id: str, jobs: dict[str, RunnerPullJob], *, tag: str | None = None
+) -> dict[str, object]:
+    """Current job record for ``image_id`` (disk fallback included).
+
+    With ``tag``, only a job for that exact tag answers — the one job slot
+    per image may hold another tag's pull, and handing that back for a
+    per-tag status poll would lie. Pre-per-tag persisted snapshots carry no
+    ``tag`` key and therefore never match a tag-filtered read.
+    """
     job = jobs.get(image_id)
     if job is None:
         persisted = load_persisted(image_id)
         if persisted is not None:
+            if tag is not None and persisted.get("tag") != tag:
+                raise RunnerPullJobNotFound(
+                    f"no pull job for runner image {image_id!r} tag {tag!r}",
+                    details={"image_id": image_id, "tag": tag},
+                )
             return persisted
         raise RunnerPullJobNotFound(
             f"no pull job for runner image {image_id!r}", details={"image_id": image_id}
+        )
+    if tag is not None and job.tag != tag:
+        raise RunnerPullJobNotFound(
+            f"no pull job for runner image {image_id!r} tag {tag!r}",
+            details={"image_id": image_id, "tag": tag, "in_flight_tag": job.tag},
         )
     return job.as_dict()
 

--- a/tests/api/test_runner_images_routes.py
+++ b/tests/api/test_runner_images_routes.py
@@ -216,6 +216,152 @@ class TestEnrichRow:
         assert row["is_default"] is None
 
 
+# ── per-tag pull (catalogue v2 follow-up to #2043/#2044) ────────────────────
+
+
+class TestPerTagPull:
+    """POST /{id}/pull?tag=… pulls that catalogued tag, not just the headline.
+
+    #2043 scoped the UI per-tag Pull out because ``runner_pull_jobs.enqueue``
+    resolved ``image:tag`` exclusively from the row's headline tag. The route
+    now accepts an optional ``tag`` restricted to the row's ``available_tags``
+    (headline always allowed); omitting it keeps today's headline behaviour.
+    """
+
+    IMAGE_ID = "hal0ai/hal0-combined"
+
+    def _seed(self, client: TestClient) -> None:
+        from hal0.registry.runner_image import RunnerImage
+
+        client.app.state.runner_image_registry.upsert(
+            RunnerImage(
+                id=self.IMAGE_ID,
+                image="ghcr.io/hal0ai/hal0-combined",
+                tag="0824",
+                available_tags=["0824", "0822"],
+            )
+        )
+
+    def _stub_provider(self, pulled: list[str]) -> None:
+        class _RecordingProvider:
+            async def pull_image_stream(self, image: str):
+                pulled.append(image)
+                yield {"state": "completed", "layer": 1, "total_layers": 1}
+
+        runner_pull_jobs.provider_factory = lambda: _RecordingProvider()
+
+    def _wait_terminal(self, client: TestClient, params: dict[str, str] | None = None) -> dict:
+        import time
+
+        for _ in range(200):
+            resp = client.get(f"/api/runner-images/{self.IMAGE_ID}/pull/status", params=params)
+            if resp.status_code == 200 and resp.json()["state"] in (
+                "completed",
+                "failed",
+                "cancelled",
+            ):
+                return resp.json()
+            time.sleep(0.01)
+        raise AssertionError("pull job never reached a terminal state")
+
+    def test_explicit_tag_pulls_that_ref(self, client: TestClient) -> None:
+        self._seed(client)
+        pulled: list[str] = []
+        self._stub_provider(pulled)
+
+        resp = client.post(f"/api/runner-images/{self.IMAGE_ID}/pull", params={"tag": "0822"})
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["tag"] == "0822"
+        assert body["image_ref"] == "ghcr.io/hal0ai/hal0-combined:0822"
+        assert body["id"]
+
+        status = self._wait_terminal(client)
+        assert status["state"] == "completed"
+        assert status["tag"] == "0822"
+        assert status["image_ref"] == "ghcr.io/hal0ai/hal0-combined:0822"
+        assert pulled == ["ghcr.io/hal0ai/hal0-combined:0822"]
+
+    def test_no_tag_keeps_headline_behaviour(self, client: TestClient) -> None:
+        self._seed(client)
+        pulled: list[str] = []
+        self._stub_provider(pulled)
+
+        resp = client.post(f"/api/runner-images/{self.IMAGE_ID}/pull")
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["tag"] == "0824"
+        assert body["image_ref"] == "ghcr.io/hal0ai/hal0-combined:0824"
+        self._wait_terminal(client)
+        assert pulled == ["ghcr.io/hal0ai/hal0-combined:0824"]
+
+    def test_unknown_tag_404s_with_available_tags(self, client: TestClient) -> None:
+        self._seed(client)
+        resp = client.post(f"/api/runner-images/{self.IMAGE_ID}/pull", params={"tag": "9999"})
+        assert resp.status_code == 404
+        err = resp.json()["error"]
+        assert err["code"] == "runner_image.tag_not_available"
+        assert err["details"]["tag"] == "9999"
+        assert err["details"]["available_tags"] == ["0824", "0822"]
+
+    def test_headline_tag_allowed_even_when_probe_failed(self, client: TestClient) -> None:
+        """available_tags may be [] on probe failure — the headline stays pullable."""
+        from hal0.registry.runner_image import RunnerImage
+
+        client.app.state.runner_image_registry.upsert(
+            RunnerImage(
+                id=self.IMAGE_ID,
+                image="ghcr.io/hal0ai/hal0-combined",
+                tag="0824",
+                available_tags=[],
+            )
+        )
+        pulled: list[str] = []
+        self._stub_provider(pulled)
+        resp = client.post(f"/api/runner-images/{self.IMAGE_ID}/pull", params={"tag": "0824"})
+        assert resp.status_code == 202
+        assert resp.json()["tag"] == "0824"
+
+    def test_inflight_other_tag_conflicts_409(self, client: TestClient) -> None:
+        from hal0.registry.runner_pull import make_job
+
+        self._seed(client)
+        job = make_job(self.IMAGE_ID, "ghcr.io/hal0ai/hal0-combined:0824", tag="0824")
+        client.app.state.runner_image_pull_jobs[self.IMAGE_ID] = job
+
+        resp = client.post(f"/api/runner-images/{self.IMAGE_ID}/pull", params={"tag": "0822"})
+        assert resp.status_code == 409
+        err = resp.json()["error"]
+        assert err["code"] == "runner_image.pull_conflict"
+        assert err["details"]["in_flight_tag"] == "0824"
+
+    def test_inflight_same_tag_resumes(self, client: TestClient) -> None:
+        from hal0.registry.runner_pull import make_job
+
+        self._seed(client)
+        job = make_job(self.IMAGE_ID, "ghcr.io/hal0ai/hal0-combined:0824", tag="0824")
+        client.app.state.runner_image_pull_jobs[self.IMAGE_ID] = job
+
+        resp = client.post(f"/api/runner-images/{self.IMAGE_ID}/pull", params={"tag": "0824"})
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["resumed"] is True
+        assert body["tag"] == "0824"
+        assert body["id"] == job.job_id
+
+    def test_status_tag_filter(self, client: TestClient) -> None:
+        self._seed(client)
+        pulled: list[str] = []
+        self._stub_provider(pulled)
+        client.post(f"/api/runner-images/{self.IMAGE_ID}/pull", params={"tag": "0822"})
+        status = self._wait_terminal(client, params={"tag": "0822"})
+        assert status["tag"] == "0822"
+
+        miss = client.get(f"/api/runner-images/{self.IMAGE_ID}/pull/status", params={"tag": "0824"})
+        assert miss.status_code == 404
+        assert miss.json()["error"]["code"] == "runner_image.pull_job_not_found"
+
+
 @pytest.fixture
 def isolated_client(tmp_hal0_home: str):
     """TestClient built AFTER HAL0_HOME isolation (settings writes land in tmp).

--- a/tests/api/test_runner_images_routes.py
+++ b/tests/api/test_runner_images_routes.py
@@ -372,6 +372,33 @@ class TestPerTagPull:
         assert body["state"] == "completed"
         assert body["image_ref"] == "ghcr.io/hal0ai/hal0-combined:0822"
 
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "../../etc/passwd",
+            "a/b",
+            "..",
+            ".hidden",
+            "-leading",
+            "we@ird",
+            "a" * 129,
+        ],
+    )
+    def test_malformed_tag_refused_before_any_path_use(self, client: TestClient, bad: str) -> None:
+        """Tags feed the snapshot filename (<id>@<tag>.json) — anything
+        outside strict OCI tag syntax is a typed 400 on both the pull and
+        status routes, before any filesystem path is built (CodeQL
+        py/path-injection on #2048)."""
+        self._seed(client)
+
+        pull = client.post(f"/api/runner-images/{self.IMAGE_ID}/pull", params={"tag": bad})
+        assert pull.status_code == 400
+        assert pull.json()["error"]["code"] == "runner_image.tag_invalid"
+
+        status = client.get(f"/api/runner-images/{self.IMAGE_ID}/pull/status", params={"tag": bad})
+        assert status.status_code == 400
+        assert status.json()["error"]["code"] == "runner_image.tag_invalid"
+
     def test_status_tag_filter(self, client: TestClient) -> None:
         self._seed(client)
         pulled: list[str] = []

--- a/tests/api/test_runner_images_routes.py
+++ b/tests/api/test_runner_images_routes.py
@@ -349,6 +349,29 @@ class TestPerTagPull:
         assert body["tag"] == "0824"
         assert body["id"] == job.job_id
 
+    def test_status_for_previous_tag_survives_new_pull(self, client: TestClient) -> None:
+        """A terminal tag-A job stays reachable via ?tag=A after tag B's pull
+        claims the single in-memory slot — snapshots persist per (image, tag),
+        so starting a new tag's pull can't orphan the old tag's result."""
+        self._seed(client)
+        pulled: list[str] = []
+        self._stub_provider(pulled)
+
+        first = client.post(f"/api/runner-images/{self.IMAGE_ID}/pull", params={"tag": "0822"})
+        assert first.status_code == 202
+        done = self._wait_terminal(client, params={"tag": "0822"})
+        assert done["state"] == "completed"
+
+        second = client.post(f"/api/runner-images/{self.IMAGE_ID}/pull", params={"tag": "0824"})
+        assert second.status_code == 202
+
+        old = client.get(f"/api/runner-images/{self.IMAGE_ID}/pull/status", params={"tag": "0822"})
+        assert old.status_code == 200
+        body = old.json()
+        assert body["tag"] == "0822"
+        assert body["state"] == "completed"
+        assert body["image_ref"] == "ghcr.io/hal0ai/hal0-combined:0822"
+
     def test_status_tag_filter(self, client: TestClient) -> None:
         self._seed(client)
         pulled: list[str] = []

--- a/tests/registry/test_runner_pull.py
+++ b/tests/registry/test_runner_pull.py
@@ -174,6 +174,28 @@ class TestJobTag:
         assert job.as_dict()["tag"] is None
 
 
+class TestTagPathSafety:
+    """The tag half of a snapshot filename is allowlist-validated, never
+    sanitised: a lossy transform would let distinct tags collide on one
+    file (``a/b`` vs ``a-b``, ``a-`` vs ``a``)."""
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["../../etc/passwd", "a/b", "..", ".hidden", "-leading", "we@ird", "a" * 129],
+    )
+    def test_pull_job_file_rejects_non_oci_tags(self, bad: str) -> None:
+        from hal0.registry.runner_pull import RunnerImageTagInvalid
+
+        with pytest.raises(RunnerImageTagInvalid):
+            pull_job_file("hal0ai/hal0-toolbox-cpu", tag=bad)
+
+    def test_valid_tag_lands_verbatim_inside_jobs_dir(self) -> None:
+        tagged = pull_job_file("hal0ai/hal0-toolbox-cpu", tag="0824")
+        untagged = pull_job_file("hal0ai/hal0-toolbox-cpu")
+        assert tagged.parent == untagged.parent
+        assert tagged.name == "hal0ai-hal0-toolbox-cpu@0824.json"
+
+
 class TestPersistence:
     def test_tagged_jobs_persist_side_by_side(self, store: RunnerImageStore) -> None:
         """Per-tag snapshot files: a new tag's pull must not overwrite the

--- a/tests/registry/test_runner_pull.py
+++ b/tests/registry/test_runner_pull.py
@@ -160,6 +160,20 @@ class TestCancel:
         assert entry.downloaded is False
 
 
+class TestJobTag:
+    def test_make_job_carries_tag_into_as_dict(self) -> None:
+        job = make_job(
+            "hal0ai/hal0-toolbox-cpu", "ghcr.io/hal0ai/hal0-toolbox-cpu:0822", tag="0822"
+        )
+        assert job.tag == "0822"
+        assert job.as_dict()["tag"] == "0822"
+
+    def test_make_job_tag_defaults_to_none(self) -> None:
+        job = _job()
+        assert job.tag is None
+        assert job.as_dict()["tag"] is None
+
+
 class TestPersistence:
     def test_persist_and_reload_snapshot(self, store: RunnerImageStore) -> None:
         job = _job()

--- a/tests/registry/test_runner_pull.py
+++ b/tests/registry/test_runner_pull.py
@@ -189,6 +189,20 @@ class TestTagPathSafety:
         with pytest.raises(RunnerImageTagInvalid):
             pull_job_file("hal0ai/hal0-toolbox-cpu", tag=bad)
 
+    def test_containment_guard_refuses_escaping_filenames(self) -> None:
+        """Belt-and-braces below the sanitise/allowlist layers: the single
+        choke point building jobs-dir paths resolves the candidate and
+        refuses anything outside the directory."""
+        from hal0.registry.runner_pull import RunnerPullPathEscape, _contained_jobs_path
+
+        with pytest.raises(RunnerPullPathEscape):
+            _contained_jobs_path("../../../etc/passwd.json")
+        with pytest.raises(RunnerPullPathEscape):
+            _contained_jobs_path("a/../../b.json")
+        ok = _contained_jobs_path("ok.json")
+        assert ok.name == "ok.json"
+        assert ok.parent == _contained_jobs_path("ok2.json").parent
+
     def test_valid_tag_lands_verbatim_inside_jobs_dir(self) -> None:
         tagged = pull_job_file("hal0ai/hal0-toolbox-cpu", tag="0824")
         untagged = pull_job_file("hal0ai/hal0-toolbox-cpu")

--- a/tests/registry/test_runner_pull.py
+++ b/tests/registry/test_runner_pull.py
@@ -175,6 +175,20 @@ class TestJobTag:
 
 
 class TestPersistence:
+    def test_tagged_jobs_persist_side_by_side(self, store: RunnerImageStore) -> None:
+        """Per-tag snapshot files: a new tag's pull must not overwrite the
+        previous tag's terminal record (review of #2048)."""
+        a = make_job("hal0ai/hal0-toolbox-cpu", "ghcr.io/hal0ai/hal0-toolbox-cpu:0822", tag="0822")
+        a.state = "completed"
+        persist_pull_job(a)
+        b = make_job("hal0ai/hal0-toolbox-cpu", "ghcr.io/hal0ai/hal0-toolbox-cpu:0824", tag="0824")
+        persist_pull_job(b)
+
+        assert pull_job_file(a.image_id, tag="0822").exists()
+        assert pull_job_file(b.image_id, tag="0824").exists()
+        tags = {s.get("tag") for s in list_persisted_jobs() if s.get("image_id") == a.image_id}
+        assert tags == {"0822", "0824"}
+
     def test_persist_and_reload_snapshot(self, store: RunnerImageStore) -> None:
         job = _job()
         job.state = "completed"


### PR DESCRIPTION
## What

Backend half of per-tag Pull — the follow-up #2043's body explicitly scoped out (spec: `docs/superpowers/specs/2026-08-24-runner-image-catalogue-v2-design.md`, plan Task C/D neighbourhood). Until now `runner_pull_jobs.enqueue` resolved `image:tag` exclusively from the row's catalogued headline tag, so the UI's tag picker could browse `available_tags` (#2044) but never pull one.

## Changes

- **`POST /api/runner-images/{id}/pull?tag=…`** — optional `tag` query param. Omitted → exactly the old headline behaviour (no caller changes needed). Explicit tag must be the row's headline `tag` or a member of its `available_tags`; anything else is 404 `runner_image.tag_not_available` (details carry `available_tags`). The catalogue stays the honesty boundary — no free-text refs. The headline is always allowed even when `available_tags == []` (probe failure).
- **Job records carry `tag`** — `RunnerPullJob.tag` + `make_job(..., tag=)`, included in `as_dict()` so the status/stream/list payloads and the persisted snapshot all say which tag a job pulled. Pre-existing snapshots simply lack the key.
- **`GET …/pull/status?tag=…`** — optional filter: answers with the in-memory job when it matches the tag, otherwise falls through to **that tag's persisted snapshot**, and 404s (`runner_image.pull_job_not_found`) only when neither exists. A per-tag poller can't be fooled by another tag's job in the single in-memory slot.
- **Per-(image, tag) snapshot files** (review finding on the first revision): tagged jobs persist to `<id>@<tag>.json` (`@` can't survive id/tag sanitisation, so the separator is unambiguous); untagged/legacy jobs keep `<id>.json`. Starting tag B's pull therefore no longer overwrites tag A's terminal record on disk — `status?tag=A` still answers after B begins (test pins this). `sweep_pull_jobs` and `list_persisted_jobs` glob `*.json` and handle both layouts unchanged; `pulls/list` stays one row per image, most-recent `started_at` winning among a row's snapshots.
- **Honest conflict, not fake dedup** — the in-flight slot is one-per-image (jobs dict, local marker). A pull request for a *different* tag while one is in flight returns 409 `runner_image.pull_conflict` (details name the in-flight tag) instead of silently handing back a "resumed" handle to the wrong ref. Same-tag (or tag-less) re-requests still resume the in-flight job, now with `tag` in the response.

## Compatibility

- **Response envelopes gain `tag` unconditionally (deliberate, additive):** `POST …/pull` (including the `resumed` shape), `…/pull/status`, `…/pull/stream` events, and `…/pulls/list` rows now always carry `tag` — even when the query param is omitted (`tag` is then the headline tag; `null` only on pre-existing in-memory/persisted records). No field was removed or retyped; the UI hook tolerates unknown fields.
- **Snapshot layout:** new files are `<id>@<tag>.json`; pre-existing `<id>.json` snapshots remain readable (status/list/stream fallback) and sweepable. They carry no `tag` key, so they never satisfy a tag-filtered status read — documented, honest behaviour.
- `status` without `tag` keeps its meaning: in-memory job first, else the most recent persisted pull (highest `started_at` across an image's snapshots).

## Scope honesty

- **UI is deliberately untouched.** #2043 ships the Pull button disabled for non-headline tags with an explanatory tooltip; wiring the picker to `?tag=`, reworking that disable logic, and per-tag status display is a UI follow-up, not a "tiny wiring change" — doing it half-way here would leave the page lying about job state. Follow-up PR will consume this contract.
- **Local download state stays image-keyed** (one marker/`local_path` per image; last pull wins, marker records the actual ref pulled). A per-tag downloaded-state model is out of scope.
- Cancel/stream routes gain no tag filter — one job per image means the existing routes stay accurate; status is the per-tag poll surface.

## Verification (red-first TDD)

- 11 new tests written first and watched fail (8 route tests in `tests/api/test_runner_images_routes.py::TestPerTagPull`, 2 job-record tests in `tests/registry/test_runner_pull.py::TestJobTag`, 1 persistence test in `::TestPersistence`), then green.
- `.venv/bin/pytest tests/api tests/registry -q` — **2270 passed, 1 skipped** (journalctl-present skip; run before the review fix). Post-fix: `.venv/bin/pytest tests/api/test_runner_images_routes.py tests/registry/test_runner_pull.py -q` — **32 passed**.
- `.venv/bin/ruff check` + `ruff format --check` on all five touched files — clean.
- `mypy src` — zero errors in the touched modules; repo-wide count unchanged vs main (pre-existing errors only, none in `runner_pull*`/`runner_images`); targeted `mypy` on the three src files: `Success: no issues found`.
- Known local `tests/mcp/` failure (root-owned `/etc/hal0/hal0.toml`) — environmental, not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
