### PR TITLE
chore(release): set version to 1.0.0-rc.8

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release — the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md §12 and §17 (maintainer-local).",
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "channel": "preview",
   "toolbox_images": {
     "vulkan": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hal0-ui",
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hal0-ui",
-      "version": "1.0.0-rc.7",
+      "version": "1.0.0-rc.8",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal0-ui",
   "private": true,
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Pre-cut version bump for the rc8 release: pyproject, manifest.json, ui package files. scripts/update-toolbox-digests.sh ran clean — all 7 toolbox digests already current, zero null. Next: release-check --tag v1.0.0-rc.8, then tag on the merge commit.