### PR TITLE
chore(release): refresh uv.lock for 1.0.0-rc.8

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "hal0ai"
-version = "1.0.0rc7"
+version = "1.0.0rc8"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Follow-up to #2049: the version bump left uv.lock at 1.0.0rc7, so every uv run --locked invocation (pytest gate, ruff gate in scripts/release-check.sh) fails with lockfile-out-of-date before running anything. Two-line lock refresh.