### PR TITLE
fix(hermes): ship the mcp extra and stop reporting ok over a dead MCP client

### DIFF
--- a/installer/agents/hermes/requirements.txt
+++ b/installer/agents/hermes/requirements.txt
@@ -13,4 +13,12 @@
 # unit needs: it runs `hermes serve` in web/dashboard mode (HERMES_WEB_DIST
 # + HERMES_DASHBOARD_TUI in the unit drop-in). Without it the unit
 # crash-loops on `No module named 'fastapi'`.
-hermes-agent[web] @ git+https://github.com/NousResearch/hermes-agent.git@9de9c25f620ff7f1ce0fd5457d596052d5159596
+#
+# The `mcp` extra pulls the MCP client (`mcp==...`), which upstream gates
+# behind this extra. Without it the venv has NO `mcp` package: both MCP
+# servers hal0 provisions into config.yaml (hal0-admin, hal0-memory) are
+# dead while `hermes mcp list` still prints ✓ (#2021,
+# `hermes-venv-missing-mcp-extra`). The provisioning `mcp_wire` phase now
+# hard-fails when the venv client cannot import/connect — do not drop this
+# extra.
+hermes-agent[web,mcp] @ git+https://github.com/NousResearch/hermes-agent.git@9de9c25f620ff7f1ce0fd5457d596052d5159596

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -2690,6 +2690,29 @@ def _probe_mcp_client(
     }
 
 
+#: Provisioning-side ceiling for hermes-client probes. Server entries carry
+#: their own RUNTIME timeouts (hal0-memory's 900s covers agentic
+#: memory_reflect calls; hal0-admin's is slot-lifecycle-sized) and those are
+#: the budget hermes itself renders into config.yaml — but a provisioning
+#: probe only performs ``initialize`` + ``tools/list``, and bootstrap must
+#: stay bounded: a server that cannot answer tools/list inside two minutes
+#: is not slow, it is not answering. ``min(entry timeout, this)`` keeps a
+#: slow-but-legitimate server from false-FAILing the honest gate without
+#: letting one server hang provisioning for 15 minutes (#2053 review).
+_MCP_CLIENT_PROBE_CEILING_S = 120.0
+
+
+def _mcp_client_probe_timeout(entry_timeout: Any) -> float:
+    """Bounded per-server timeout for a provisioning-time client probe."""
+    try:
+        t = float(entry_timeout)
+    except (TypeError, ValueError):
+        return 40.0
+    if t <= 0:
+        return 40.0
+    return min(t, _MCP_CLIENT_PROBE_CEILING_S)
+
+
 def _phase_mcp_wire(ctx: _StepCtx) -> PhaseResult:
     """Verify the two hal0-bundled MCP servers respond + record their tool list.
 
@@ -2779,7 +2802,11 @@ def _phase_mcp_wire(ctx: _StepCtx) -> PhaseResult:
         # config.yaml hands hermes (#2021). A failure here is client-side
         # by construction, so it fails the phase.
         client_probe = ctx.io.probe_mcp_client(
-            venv_python, entry["url"], agent_id=state.agent_id, private=entry["private"]
+            venv_python,
+            entry["url"],
+            agent_id=state.agent_id,
+            private=entry["private"],
+            timeout=_mcp_client_probe_timeout(entry.get("timeout")),
         )
         if not client_probe.get("ok"):
             failure = f"{name}: {client_probe.get('stage')}: {client_probe.get('error')}"
@@ -5670,15 +5697,21 @@ def _smoke_admin_tools_list(state: BootstrapState, io: InstallIO) -> tuple[bool,
     #2021: this smoke used to POST at the server with the bootstrap's own
     stdlib client and passed green while the hermes venv had no ``mcp``
     package at all. It now runs :func:`_probe_mcp_client` — the venv's own
-    interpreter and MCP client stack, against the exact transport URL
-    config.yaml wires — so a dead client fails the smoke the same way it
-    fails the agent.
+    interpreter and MCP client stack, against the hal0-admin entry from
+    :func:`_default_mcp_servers` (the same inventory config_write renders,
+    so the smoke cannot drift from the transport URL config.yaml actually
+    wires) — and a dead client fails the smoke the same way it fails the
+    agent.
     """
+    entry = next((e for e in _default_mcp_servers() if e["name"] == "hal0-admin"), None)
+    if entry is None:
+        return (False, "hal0-admin missing from the builtin MCP server inventory")
     probe = io.probe_mcp_client(
         _venv_python(Path(state.venv)),
-        "http://127.0.0.1:8080/mcp/admin/mcp",
+        entry["url"],
         agent_id=state.agent_id,
-        private=False,
+        private=bool(entry.get("private")),
+        timeout=_mcp_client_probe_timeout(entry.get("timeout")),
     )
     if not probe.get("ok"):
         stage = probe.get("stage") or "probe"

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -827,7 +827,10 @@ def upgrade_hermes_runtime(
     if not pip.exists():
         return False, f"hermes venv missing at {venv} — run `hal0 agent install hermes` first"
 
-    spec = f"hermes-agent[web]=={version}" if version else None
+    # ``[web,mcp]`` — an exact-version upgrade must request the same extras as
+    # requirements.txt: rebuilding the venv from ``[web]`` alone strips the MCP
+    # client out from under a working install (#2021).
+    spec = f"hermes-agent[web,mcp]=={version}" if version else None
     pip_argv = [str(pip), "-m", "pip", "install", "--upgrade"]
     pip_argv += [spec] if spec else ["-r", str(requirements)]
     try:
@@ -2565,6 +2568,128 @@ def _probe_mcp_server(
     return {"ok": True, "tools": tools, "error": None}
 
 
+#: Runs inside the HERMES venv interpreter (which has no hal0 installed —
+#: stdlib + whatever hermes-agent's extras pulled in, nothing else). Emits
+#: exactly one JSON verdict line on stdout and always exits 0; the parent
+#: (:func:`_probe_mcp_client`) owns turning "no verdict" into a failure.
+_MCP_CLIENT_PROBE_SCRIPT = """\
+import asyncio, json, os, sys
+
+
+def _emit(payload):
+    sys.stdout.write(json.dumps(payload) + "\\n")
+
+
+try:
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+except BaseException as exc:  # ImportError, but also half-broken installs
+    _emit({"ok": False, "stage": "import", "tools": [],
+           "error": f"{type(exc).__name__}: {exc}"})
+    sys.exit(0)
+
+url = os.environ.get("HAL0_MCP_PROBE_URL") or ""
+if not url:
+    _emit({"ok": True, "stage": "import", "tools": [], "error": None})
+    sys.exit(0)
+
+headers = json.loads(os.environ.get("HAL0_MCP_PROBE_HEADERS") or "{}")
+
+
+async def _probe():
+    async with streamablehttp_client(url, headers=headers) as (read, write, _sid):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            listed = await session.list_tools()
+            return [t.name for t in listed.tools]
+
+
+try:
+    tools = asyncio.run(_probe())
+except BaseException as exc:
+    _emit({"ok": False, "stage": "connect", "tools": [],
+           "error": f"{type(exc).__name__}: {exc}"})
+    sys.exit(0)
+
+_emit({"ok": True, "stage": "connected", "tools": tools, "error": None})
+"""
+
+
+def _probe_mcp_client(
+    venv_python: Path,
+    url: str | None,
+    *,
+    agent_id: str,
+    private: bool = False,
+    timeout: float = 40.0,
+) -> dict[str, Any]:
+    """Probe an MCP server THROUGH the hermes venv's own client stack.
+
+    :func:`_probe_mcp_server` answers "is the server up?" with the
+    bootstrap's stdlib HTTP client — which says nothing about whether
+    HERMES can reach it. rc.7 shipped a venv with no ``mcp`` package at all
+    and every server-side surface still read green (#2021,
+    ``hermes-venv-missing-mcp-extra``). This probe runs the venv's OWN
+    interpreter: ``import mcp`` + the streamable-HTTP transport, then a real
+    ``initialize`` → ``tools/list`` session against the exact transport URL
+    config.yaml wires — the same code path a hermes turn takes.
+
+    ``url=None`` runs the import assertion only (no server round-trip).
+
+    Returns ``{"ok": bool, "stage": str, "tools": [...], "error": str | None}``
+    where ``stage`` is where the probe got to: ``venv`` (no interpreter),
+    ``import``, ``connect``, ``connected``, or ``exec`` (probe subprocess
+    itself misbehaved). Auth mirrors :func:`_probe_mcp_server` — bearer from
+    the box service identity, resolved fresh per call.
+    """
+    from hal0.service_identity import service_key
+
+    python = Path(venv_python)
+    if not python.exists():
+        return {
+            "ok": False,
+            "stage": "venv",
+            "tools": [],
+            "error": f"venv python missing at {python}",
+        }
+    headers: dict[str, str] = {"X-hal0-Agent": agent_id}
+    bearer = service_key(prefer="admin")
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    if private:
+        headers["X-hal0-Private"] = "1"
+    env = _hal0_subprocess_env(
+        HAL0_MCP_PROBE_URL=url or "",
+        # Env, not argv: the bearer must not show up in the process list.
+        HAL0_MCP_PROBE_HEADERS=json.dumps(headers),
+    )
+    try:
+        result = subprocess.run(  # nosec B603 — fixed argv, our own venv interpreter
+            [str(python), "-c", _MCP_CLIENT_PROBE_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {"ok": False, "stage": "exec", "tools": [], "error": str(exc)}
+    for line in reversed((result.stdout or "").strip().splitlines()):
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and "ok" in payload:
+            return payload
+    stderr_tail = (result.stderr or "").strip()[-400:]
+    return {
+        "ok": False,
+        "stage": "exec",
+        "tools": [],
+        "error": f"probe emitted no verdict (rc={result.returncode}): {stderr_tail}",
+    }
+
+
 def _phase_mcp_wire(ctx: _StepCtx) -> PhaseResult:
     """Verify the two hal0-bundled MCP servers respond + record their tool list.
 
@@ -2574,8 +2699,39 @@ def _phase_mcp_wire(ctx: _StepCtx) -> PhaseResult:
     missing entry (or a missing allow-list file entirely) is a
     warning, NOT a hard fail — bootstrap continues so the operator
     can wire the missing piece by hand after install.
+
+    #2021: server-side reachability alone is NOT wiring. rc.7 shipped a
+    hermes venv with no ``mcp`` package (``hermes-agent[web]`` without the
+    ``mcp`` extra) and this phase still checkpointed ``ok`` — every probe
+    went through the bootstrap's stdlib HTTP client, never through the
+    client hermes actually uses. The phase now also asserts the HERMES
+    CLIENT works (:func:`_probe_mcp_client`): the venv must import ``mcp``
+    plus its streamable-HTTP transport, and every server the raw probe
+    proves live must be reachable through that client too. Either
+    client-side failure is a hard ``FAIL`` — a dead client is a broken
+    install, not a warm-up warning; the ADR-0013 degraded posture stays
+    reserved for servers that are themselves unreachable.
     """
     state = ctx.state
+    venv_python = _venv_python(Path(state.venv))
+    # Import assertion first: runs unconditionally (even if the allowlist
+    # skips every server) so "the venv has no MCP client" can never hide.
+    client_import = ctx.io.probe_mcp_client(venv_python, None, agent_id=state.agent_id)
+    if not client_import.get("ok"):
+        return PhaseResult(
+            status=PhaseStatus.FAIL,
+            details={
+                "mcp_client": client_import,
+                "servers": {},
+                "allowlist_present": None,
+                "warnings": [],
+                "rendered_servers": [],
+            },
+            reason=(
+                f"hermes venv has no working MCP client "
+                f"({client_import.get('stage')}): {client_import.get('error')}"
+            ),
+        )
     allowlist = _load_agent_allowlist()
     # PR-3 Phase 6: source the canonical inventory from
     # ``_default_mcp_servers()`` so the probe loop and the template loop
@@ -2584,6 +2740,7 @@ def _phase_mcp_wire(ctx: _StepCtx) -> PhaseResult:
 
     results: dict[str, Any] = {}
     warnings: list[str] = []
+    client_failures: list[str] = []
     rendered_servers: list[dict[str, Any]] = []
     for entry in servers:
         name = entry["name"]
@@ -2612,32 +2769,72 @@ def _phase_mcp_wire(ctx: _StepCtx) -> PhaseResult:
             # later turn — degraded probe is usually just "MCP server
             # warming up", not a permanent failure. The system prompt
             # already tells the agent to retry on connection errors.
+            # No client probe against a server that is provably down: the
+            # client cannot be blamed for it, and the import assertion
+            # above already vouched for the client itself.
+            rendered_servers.append(entry)
+            continue
+        # The server is provably live — now the connection that actually
+        # matters: THROUGH the hermes client, at the FULL transport URL
+        # config.yaml hands hermes (#2021). A failure here is client-side
+        # by construction, so it fails the phase.
+        client_probe = ctx.io.probe_mcp_client(
+            venv_python, entry["url"], agent_id=state.agent_id, private=entry["private"]
+        )
+        if not client_probe.get("ok"):
+            failure = f"{name}: {client_probe.get('stage')}: {client_probe.get('error')}"
+            client_failures.append(failure)
+            results[name] = {
+                "status": "client_failed",
+                "tool_count": len(probe["tools"]),
+                "tools": probe["tools"],
+                "client": {
+                    "status": "failed",
+                    "stage": client_probe.get("stage"),
+                    "error": client_probe.get("error"),
+                },
+            }
             rendered_servers.append(entry)
             continue
         results[name] = {
             "status": "ok",
             "tool_count": len(probe["tools"]),
             "tools": probe["tools"],
+            "client": {
+                "status": "ok",
+                "tool_count": len(client_probe.get("tools") or []),
+            },
         }
         rendered_servers.append(entry)
 
-    # Even with warnings we return OK — degraded MCP connectivity is
-    # surfaced for smoke_tests + self_report to display, not a fatal
-    # bootstrap blocker (per the plan §9 contract).
+    details = {
+        "mcp_client": client_import,
+        "servers": results,
+        "allowlist_present": allowlist is not None,
+        "warnings": warnings,
+        "rendered_servers": rendered_servers,
+    }
+    if client_failures:
+        # The raw probe proved the server(s) live; the hermes client still
+        # could not connect. Reporting ok here is exactly the lie #2021
+        # shipped — fail the phase, typed, with every client failure named.
+        return PhaseResult(
+            status=PhaseStatus.FAIL,
+            details=details,
+            reason="hermes MCP client cannot connect to live server(s) — "
+            + "; ".join(client_failures),
+        )
+
+    # Even with warnings we return OK — degraded MCP connectivity (the
+    # SERVER side being down/warming up) is surfaced for smoke_tests +
+    # self_report to display, not a fatal bootstrap blocker (per the plan
+    # §9 contract).
     #
     # ``rendered_servers`` is consumed by Phase 5 (config_write) on the
     # next bootstrap run — it's how Phase 6 hands the template the live
     # probe result. The list survives via the persisted ``provision.json``
     # checkpoint so re-runs use the same shape.
-    return PhaseResult(
-        status=PhaseStatus.OK,
-        details={
-            "servers": results,
-            "allowlist_present": allowlist is not None,
-            "warnings": warnings,
-            "rendered_servers": rendered_servers,
-        },
-    )
+    return PhaseResult(status=PhaseStatus.OK, details=details)
 
 
 # ── Phase H.5: persona_seed (PR-3) ──────────────────────────────────────────
@@ -5468,15 +5665,26 @@ def _smoke_anchor_context_window(state: BootstrapState, io: InstallIO) -> tuple[
 
 
 def _smoke_admin_tools_list(state: BootstrapState, io: InstallIO) -> tuple[bool, str]:
-    probe = io.probe_mcp_server(
-        "http://127.0.0.1:8080/mcp/admin",
+    """tools/list THROUGH the hermes client, not the bootstrap's HTTP probe.
+
+    #2021: this smoke used to POST at the server with the bootstrap's own
+    stdlib client and passed green while the hermes venv had no ``mcp``
+    package at all. It now runs :func:`_probe_mcp_client` — the venv's own
+    interpreter and MCP client stack, against the exact transport URL
+    config.yaml wires — so a dead client fails the smoke the same way it
+    fails the agent.
+    """
+    probe = io.probe_mcp_client(
+        _venv_python(Path(state.venv)),
+        "http://127.0.0.1:8080/mcp/admin/mcp",
         agent_id=state.agent_id,
         private=False,
     )
-    if not probe["ok"]:
-        return (False, probe["error"] or "unreachable")
-    n = len(probe["tools"])
-    return (n >= 5, f"{n} tools advertised")
+    if not probe.get("ok"):
+        stage = probe.get("stage") or "probe"
+        return (False, f"hermes mcp client {stage}: {probe.get('error') or 'unreachable'}")
+    n = len(probe.get("tools") or [])
+    return (n >= 5, f"{n} tools via hermes mcp client")
 
 
 def _smoke_hermes_md_contains_primary(state: BootstrapState, _io: InstallIO) -> tuple[bool, str]:
@@ -6100,6 +6308,7 @@ class InstallIO:
         _fetch_anchor_models
     )
     probe_mcp_server: Callable[..., dict[str, Any]] = _probe_mcp_server
+    probe_mcp_client: Callable[..., dict[str, Any]] = _probe_mcp_client
     mcp_memory_call: Callable[..., dict[str, Any]] = _mcp_memory_call
     install_venv: Callable[..., None] = _install_venv
     read_env_probe: Callable[[], dict[str, Any]] = _read_env_probe

--- a/tests/agents/_hermes_fakes.py
+++ b/tests/agents/_hermes_fakes.py
@@ -259,6 +259,14 @@ def install_io(hp, *, record: list[list[str]] | None = None, slots=None):
             "tools": ["t1", "t2", "t3", "t4", "t5"],
             "error": None,
         },
+        # The hermes-venv client probe (#2021): a healthy fake box imports
+        # and connects — mcp_wire / admin_tools_list now hard-require it.
+        probe_mcp_client=lambda _python, url, **k: {
+            "ok": True,
+            "stage": "import" if url is None else "connected",
+            "tools": [] if url is None else ["t1", "t2", "t3", "t4", "t5"],
+            "error": None,
+        },
         mcp_memory_call=_memory,
         install_venv=_install_venv,
         read_env_probe=lambda: {

--- a/tests/agents/hermes/test_contract_compatibility.py
+++ b/tests/agents/hermes/test_contract_compatibility.py
@@ -358,9 +358,23 @@ def test_installer_pins_reviewed_official_commit() -> None:
     requirements = (_REPO_ROOT / "installer/agents/hermes/requirements.txt").read_text()
 
     assert (
-        "hermes-agent[web] @ git+https://github.com/NousResearch/hermes-agent.git@"
+        "hermes-agent[web,mcp] @ git+https://github.com/NousResearch/hermes-agent.git@"
         f"{HERMES_COMMIT}" in requirements
     )
+
+
+def test_installer_requests_the_mcp_extra() -> None:
+    """Upstream gates its MCP client behind the ``mcp`` extra. Shipping
+    ``hermes-agent[web]`` alone builds a venv with NO ``mcp`` package — both
+    hal0-provisioned MCP servers dead while every self-check read green
+    (#2021, ``hermes-venv-missing-mcp-extra``). The active requirement line
+    must always request it."""
+    from hal0.agents.hermes_provision import _hermes_requirement_line
+
+    requirements = (_REPO_ROOT / "installer/agents/hermes/requirements.txt").read_text()
+    line = _hermes_requirement_line(requirements)
+    extras = line.split("[", 1)[1].split("]", 1)[0].split(",")
+    assert "mcp" in [e.strip() for e in extras], line
 
 
 def _upstream_pin() -> dict:

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1445,7 +1445,8 @@ def test_mcp_wire_phase_returns_ok_with_tools_when_servers_respond(
 ) -> None:
     state = hp.BootstrapState()
     io = hp.InstallIO(
-        probe_mcp_server=lambda url, **_kw: {"ok": True, "tools": ["t1", "t2"], "error": None}
+        probe_mcp_server=lambda url, **_kw: {"ok": True, "tools": ["t1", "t2"], "error": None},
+        probe_mcp_client=_client_probe_ok,
     )
     monkeypatch.setattr(hp, "_load_agent_allowlist", lambda *_a, **_kw: None)
     out = hp._phase_mcp_wire(hp._StepCtx(state=state, io=io))
@@ -1472,7 +1473,7 @@ def test_mcp_wire_phase_probes_mount_root_not_double_mcp_suffixed(
         return {"ok": True, "tools": ["t1"], "error": None}
 
     state = hp.BootstrapState()
-    io = hp.InstallIO(probe_mcp_server=_fake_probe)
+    io = hp.InstallIO(probe_mcp_server=_fake_probe, probe_mcp_client=_client_probe_ok)
     monkeypatch.setattr(hp, "_load_agent_allowlist", lambda *_a, **_kw: None)
     hp._phase_mcp_wire(hp._StepCtx(state=state, io=io))
 
@@ -1492,7 +1493,8 @@ def test_mcp_wire_phase_degrades_not_fails_on_unreachable_server(
             "ok": False,
             "tools": [],
             "error": "connection refused",
-        }
+        },
+        probe_mcp_client=_client_probe_ok,
     )
     monkeypatch.setattr(hp, "_load_agent_allowlist", lambda *_a, **_kw: None)
     out = hp._phase_mcp_wire(hp._StepCtx(state=state, io=io))
@@ -1500,6 +1502,166 @@ def test_mcp_wire_phase_degrades_not_fails_on_unreachable_server(
     assert out.status == hp.PhaseStatus.OK
     assert out.details["servers"]["hal0-admin"]["status"] == "degraded"
     assert "connection refused" in out.details["warnings"][0]
+
+
+# ── #2021 — mcp_wire must verify the hermes CLIENT, not just the server ──────
+#
+# rc.7 shipped a hermes venv with NO ``mcp`` package at all
+# (``hermes-agent[web]`` without the ``mcp`` extra) and mcp_wire still
+# reported ``status: ok, mcp_server_count: 2`` — every probe went through the
+# bootstrap's own stdlib HTTP client, never through the client hermes actually
+# uses. These tests pin the honest contract: a hermes venv whose MCP client
+# cannot import or cannot connect to a provably-live server is a hard phase
+# FAIL, typed in the details, never a green checkpoint.
+
+
+def _client_probe_ok(_python: object, url: object, **_kw: object) -> dict[str, object]:
+    """A hermes-venv client probe that imports and connects."""
+    if url is None:
+        return {"ok": True, "stage": "import", "tools": [], "error": None}
+    return {"ok": True, "stage": "connected", "tools": ["t1", "t2"], "error": None}
+
+
+def test_mcp_wire_phase_fails_when_hermes_client_cannot_import_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``mcp`` package in the hermes venv → FAIL, not ok (#2021)."""
+    state = hp.BootstrapState()
+    io = hp.InstallIO(
+        probe_mcp_server=lambda url, **_kw: {"ok": True, "tools": ["t1"], "error": None},
+        probe_mcp_client=lambda _python, _url, **_kw: {
+            "ok": False,
+            "stage": "import",
+            "tools": [],
+            "error": "ModuleNotFoundError: No module named 'mcp'",
+        },
+    )
+    monkeypatch.setattr(hp, "_load_agent_allowlist", lambda *_a, **_kw: None)
+    out = hp._phase_mcp_wire(hp._StepCtx(state=state, io=io))
+    assert out.status == hp.PhaseStatus.FAIL
+    client = out.details["mcp_client"]
+    assert client["ok"] is False
+    assert client["stage"] == "import"
+    assert "No module named 'mcp'" in (out.reason or "")
+
+
+def test_mcp_wire_phase_fails_when_client_cannot_connect_to_live_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server answers the raw HTTP probe but the hermes client cannot connect
+    → the client is the defect and the phase must FAIL, not warn (#2021)."""
+
+    def _client_probe(_python: object, url: object, **_kw: object) -> dict[str, object]:
+        if url is None:
+            return {"ok": True, "stage": "import", "tools": [], "error": None}
+        return {
+            "ok": False,
+            "stage": "connect",
+            "tools": [],
+            "error": "mcp.client.streamable_http is not available",
+        }
+
+    state = hp.BootstrapState()
+    io = hp.InstallIO(
+        probe_mcp_server=lambda url, **_kw: {"ok": True, "tools": ["t1"], "error": None},
+        probe_mcp_client=_client_probe,
+    )
+    monkeypatch.setattr(hp, "_load_agent_allowlist", lambda *_a, **_kw: None)
+    out = hp._phase_mcp_wire(hp._StepCtx(state=state, io=io))
+    assert out.status == hp.PhaseStatus.FAIL
+    assert out.details["servers"]["hal0-admin"]["client"]["status"] == "failed"
+    assert "streamable_http" in (out.reason or "")
+
+
+def test_mcp_wire_phase_probes_client_with_venv_python_and_transport_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The client probe runs the HERMES VENV interpreter against the FULL
+    transport URL (the exact url config.yaml hands hermes) — probing any
+    other interpreter or endpoint re-opens the #2021 blind spot."""
+    seen: list[tuple[str, object]] = []
+
+    def _client_probe(python: object, url: object, **_kw: object) -> dict[str, object]:
+        seen.append((str(python), url))
+        return _client_probe_ok(python, url)
+
+    state = hp.BootstrapState()
+    io = hp.InstallIO(
+        probe_mcp_server=lambda url, **_kw: {"ok": True, "tools": ["t1"], "error": None},
+        probe_mcp_client=_client_probe,
+    )
+    monkeypatch.setattr(hp, "_load_agent_allowlist", lambda *_a, **_kw: None)
+    out = hp._phase_mcp_wire(hp._StepCtx(state=state, io=io))
+    assert out.status == hp.PhaseStatus.OK
+    venv_python = str(hp._venv_python(Path(state.venv)))
+    assert (venv_python, None) in seen  # the standalone import assertion
+    assert (venv_python, "http://127.0.0.1:8080/mcp/admin/mcp") in seen
+    assert (venv_python, "http://127.0.0.1:8080/mcp/memory/mcp") in seen
+    assert out.details["mcp_client"]["ok"] is True
+    assert out.details["servers"]["hal0-admin"]["client"]["status"] == "ok"
+
+
+def test_mcp_wire_phase_degraded_server_stays_warning_when_client_imports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A server that fails BOTH probes is still the ADR-0013 warm-up warning —
+    the client cannot be blamed for a server that is provably down."""
+    state = hp.BootstrapState()
+    io = hp.InstallIO(
+        probe_mcp_server=lambda url, **_kw: {
+            "ok": False,
+            "tools": [],
+            "error": "connection refused",
+        },
+        probe_mcp_client=lambda _python, url, **_kw: (
+            {"ok": True, "stage": "import", "tools": [], "error": None}
+            if url is None
+            else {"ok": False, "stage": "connect", "tools": [], "error": "connection refused"}
+        ),
+    )
+    monkeypatch.setattr(hp, "_load_agent_allowlist", lambda *_a, **_kw: None)
+    out = hp._phase_mcp_wire(hp._StepCtx(state=state, io=io))
+    assert out.status == hp.PhaseStatus.OK
+    assert out.details["servers"]["hal0-admin"]["status"] == "degraded"
+
+
+def test_smoke_admin_tools_list_probes_through_hermes_client() -> None:
+    """The admin_tools_list smoke goes THROUGH the hermes venv's own MCP
+    client — probing the server with the bootstrap's stdlib HTTP client is
+    exactly the blind spot that let #2021 read green over a dead client."""
+    seen: list[tuple[str, object]] = []
+
+    def _client_probe(python: object, url: object, **_kw: object) -> dict[str, object]:
+        seen.append((str(python), url))
+        return {
+            "ok": True,
+            "stage": "connected",
+            "tools": ["a", "b", "c", "d", "e", "f"],
+            "error": None,
+        }
+
+    state = hp.BootstrapState()
+    io = hp.InstallIO(probe_mcp_client=_client_probe)
+    passed, detail = hp._smoke_admin_tools_list(state, io)
+    assert passed is True
+    assert seen == [(str(hp._venv_python(Path(state.venv))), "http://127.0.0.1:8080/mcp/admin/mcp")]
+    assert "6 tools" in detail
+
+
+def test_smoke_admin_tools_list_fails_when_hermes_client_cannot_import() -> None:
+    state = hp.BootstrapState()
+    io = hp.InstallIO(
+        probe_mcp_client=lambda _python, _url, **_kw: {
+            "ok": False,
+            "stage": "import",
+            "tools": [],
+            "error": "ModuleNotFoundError: No module named 'mcp'",
+        }
+    )
+    passed, detail = hp._smoke_admin_tools_list(state, io)
+    assert passed is False
+    assert "import" in detail
+    assert "No module named 'mcp'" in detail
 
 
 # ── #243 phase impl — namespace_register + identity card schema ─────────────
@@ -1708,7 +1870,8 @@ def test_mcp_wire_phase_skips_server_not_in_allowlist(
         lambda *_a, **_kw: {"hal0-admin": {"builtin": True}},
     )
     io = hp.InstallIO(
-        probe_mcp_server=lambda url, **_kw: {"ok": True, "tools": ["t1"], "error": None}
+        probe_mcp_server=lambda url, **_kw: {"ok": True, "tools": ["t1"], "error": None},
+        probe_mcp_client=_client_probe_ok,
     )
     out = hp._phase_mcp_wire(hp._StepCtx(state=state, io=io))
     assert out.status == hp.PhaseStatus.OK

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1664,6 +1664,117 @@ def test_smoke_admin_tools_list_fails_when_hermes_client_cannot_import() -> None
     assert "No module named 'mcp'" in detail
 
 
+def test_mcp_wire_phase_threads_entry_timeout_to_client_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each server entry carries its own RUNTIME timeout (hal0-memory: 900s
+    for agentic memory_reflect; hal0-admin: slot-lifecycle-sized). A probe
+    capped at a hardcoded 40s false-FAILs a slow-but-legitimate server —
+    but provisioning must stay bounded too, so the probe gets
+    ``min(entry timeout, _MCP_CLIENT_PROBE_CEILING_S)``."""
+    seen: dict[str, object] = {}
+
+    def _client_probe(_python: object, url: object, **kw: object) -> dict[str, object]:
+        if url is not None:
+            seen[str(url)] = kw.get("timeout")
+        return _client_probe_ok(_python, url)
+
+    state = hp.BootstrapState()
+    io = hp.InstallIO(
+        probe_mcp_server=lambda url, **_kw: {"ok": True, "tools": ["t1"], "error": None},
+        probe_mcp_client=_client_probe,
+    )
+    monkeypatch.setattr(hp, "_load_agent_allowlist", lambda *_a, **_kw: None)
+    out = hp._phase_mcp_wire(hp._StepCtx(state=state, io=io))
+    assert out.status == hp.PhaseStatus.OK
+    for entry in hp._default_mcp_servers():
+        expected = min(float(entry["timeout"]), hp._MCP_CLIENT_PROBE_CEILING_S)
+        assert seen[entry["url"]] == expected, entry["name"]
+    # hal0-memory's 900s runtime budget MUST be capped for provisioning.
+    assert seen["http://127.0.0.1:8080/mcp/memory/mcp"] == hp._MCP_CLIENT_PROBE_CEILING_S
+
+
+def test_probe_mcp_client_runs_interpreter_with_probe_script_and_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real ``_probe_mcp_client`` path, against a fake interpreter that
+    dumps its argv + env: pins the subprocess argv shape (``-c`` + the
+    embedded probe script) and the env plumbing (URL + headers travel via
+    env, never argv — the bearer must not show up in the process list)."""
+    fake = tmp_path / "fake-python"
+    fake.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "print(json.dumps({\n"
+        "    'ok': True, 'stage': 'connected', 'tools': [], 'error': None,\n"
+        "    'argv': sys.argv[1:],\n"
+        "    'url_env': os.environ.get('HAL0_MCP_PROBE_URL'),\n"
+        "    'headers_env': os.environ.get('HAL0_MCP_PROBE_HEADERS'),\n"
+        "}))\n"
+    )
+    fake.chmod(0o755)
+    import hal0.service_identity as si
+
+    monkeypatch.setattr(si, "service_key", lambda **_kw: "tok-123")
+    res = hp._probe_mcp_client(
+        fake, "http://127.0.0.1:8080/mcp/admin/mcp", agent_id="hermes-agent", private=True
+    )
+    assert res["ok"] is True
+    assert res["argv"] == ["-c", hp._MCP_CLIENT_PROBE_SCRIPT]
+    assert res["url_env"] == "http://127.0.0.1:8080/mcp/admin/mcp"
+    headers = json.loads(res["headers_env"])
+    assert headers["X-hal0-Agent"] == "hermes-agent"
+    assert headers["Authorization"] == "Bearer tok-123"
+    assert headers["X-hal0-Private"] == "1"
+
+
+def test_probe_mcp_client_script_emits_verdict_on_real_interpreter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The embedded probe script must be valid Python that always prints a
+    typed JSON verdict — the ``exec`` no-verdict fallback firing on a healthy
+    interpreter would be a probe bug misreported as a client defect."""
+    import hal0.service_identity as si
+
+    monkeypatch.setattr(si, "service_key", lambda **_kw: None)
+    res = hp._probe_mcp_client(Path(sys.executable), None, agent_id="hermes-agent")
+    # url=None is the import-only assertion; whichever way ``import mcp``
+    # resolves on THIS interpreter, the verdict must come from the script.
+    assert res["stage"] == "import"
+    assert set(res) >= {"ok", "stage", "tools", "error"}
+
+
+def test_smoke_admin_tools_list_url_follows_server_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The smoke reads the hal0-admin URL from ``_default_mcp_servers()`` —
+    the same inventory config_write renders — so it cannot drift from what
+    config.yaml actually wires."""
+    seen: list[object] = []
+
+    def _client_probe(_python: object, url: object, **_kw: object) -> dict[str, object]:
+        seen.append(url)
+        return {"ok": True, "stage": "connected", "tools": ["a", "b", "c", "d", "e"], "error": None}
+
+    monkeypatch.setattr(
+        hp,
+        "_default_mcp_servers",
+        lambda: [
+            {
+                "name": "hal0-admin",
+                "url": "http://10.9.8.7:1234/mcp/admin/mcp",
+                "private": False,
+                "timeout": 7,
+            }
+        ],
+    )
+    state = hp.BootstrapState()
+    io = hp.InstallIO(probe_mcp_client=_client_probe)
+    passed, _detail = hp._smoke_admin_tools_list(state, io)
+    assert passed is True
+    assert seen == ["http://10.9.8.7:1234/mcp/admin/mcp"]
+
+
 # ── #243 phase impl — namespace_register + identity card schema ─────────────
 
 

--- a/tests/agents/test_hermes_upgrade.py
+++ b/tests/agents/test_hermes_upgrade.py
@@ -82,7 +82,9 @@ def test_version_pin_installs_exact_spec(tmp_path: Path) -> None:
     assert ok is True
     pip = _pip_call(r.calls)
     assert pip is not None
-    assert pip[-1] == "hermes-agent[web]==0.15.2"
+    # ``[web,mcp]``: an exact-version upgrade must keep the MCP client extra —
+    # rebuilding the venv from ``[web]`` alone strips hermes' MCP client (#2021).
+    assert pip[-1] == "hermes-agent[web,mcp]==0.15.2"
     assert "-r" not in pip
 
 


### PR DESCRIPTION
## Why

GA blocker #2021 (\`hermes-venv-missing-mcp-extra\`, found by rc-validate on v1.0.0-rc.7): \`installer/agents/hermes/requirements.txt\` installed \`hermes-agent[web]\`, but upstream gates its MCP client behind the separate \`mcp\` extra. The hermes venv therefore had **no \`mcp\` package at all** — both MCP servers hal0 itself provisions into hermes config.yaml (hal0-admin, hal0-memory) were dead — while every self-check surface read green: \`hermes mcp list\` printed ✓, \`provision.json\` reported \`mcp_wire.status: ok, mcp_server_count: 2\`, and the \`admin_tools_list\` smoke passed because it probed the **server** with the bootstrap stdlib HTTP client, never through the client hermes actually uses. Net effect: the prelude promised tools, the model received none, and live-state questions were answered with confident fabrications.

Spec: \`tests/release-validation/reports/v1.0.0-rc.7.md\` (finding #2) and \`tests/release-validation/regressions.yaml\` → \`hermes-venv-missing-mcp-extra\`.

## What

All three parts the issue requires — the one-line dependency fix alone would leave the lying surfaces in place:

1. **\`hermes-agent[web,mcp]\`** in \`installer/agents/hermes/requirements.txt\`, and in the exact-version spec \`upgrade_hermes_runtime\` pip-installs — rc.7 proved an agent-upgrade rebuild (ct150) loses MCP too, not just fresh installs.
2. **\`mcp_wire\` now asserts the hermes CLIENT actually works.** New \`_probe_mcp_client\` InstallIO seam runs the hermes venv own interpreter: \`import mcp\` + the streamable-HTTP transport, then a real \`initialize\` → \`tools/list\` session at the exact transport URL config.yaml wires. A venv that cannot import, or a client that cannot connect to a server the raw probe just proved live, is a **typed hard \`FAIL\`** (stage: \`venv\`/\`import\`/\`connect\`/\`exec\` in \`details.mcp_client\` and per-server \`details.servers.<name>.client\`) — never \`ok\`. The ADR-0013 degraded-server warning posture is unchanged for servers that are themselves down/warming up.
3. **\`smoke_tests.admin_tools_list\` probes through the hermes client**, not the server, so this defect class cannot pass silently green again.

## Testing

TDD red-first: 13 failures watched (\`10 failed\` in \`tests/agents/test_hermes_provision.py\`, \`2 failed\` in \`tests/agents/hermes/test_contract_compatibility.py\`, \`1 failed\` in \`tests/agents/test_hermes_upgrade.py\`) before implementing.

- \`tests/agents/ tests/cli/\`: **1589 passed**, 1 skipped, 1 pre-existing xfail
- \`tests/installer/\`: **820 passed**, 1 skipped
- \`ruff check\` + \`ruff format --check\` clean on touched files
- mypy: zero new errors vs main (16 pre-existing module errors on both sides)

Closes #2021

🤖 Generated with [Claude Code](https://claude.com/claude-code)
