### PR TITLE
fix(install): derive seeded llama.cpp slot devices via derive_device

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2014,6 +2014,33 @@ for seed_slot in flm tts rerank utility img agent brain qwen3tts coder embed; do
     fi
 done
 
+# ── Seed device derivation (#2023) ───────────────────────────────────────
+# The loop above copies VERBATIM on purpose (curated profiles/ports must land
+# byte-for-byte), but every llama.cpp seed ships device = "gpu-rocm" — the
+# reference platform. On a box without /dev/kfd the load-time gate
+# (_gpu.require_kfd_for_gpu_slot) refuses that device by name, so a fresh
+# kfd-less install shipped ZERO loadable LLM slots and the autoload:true
+# brain anchor sat in state=error from t=0 — while the preflight above
+# printed "LLM slots will use the Vulkan lane". Route the freshly copied
+# seeds through the SAME derivation `hal0 setup --auto` uses
+# (hal0.install.profile_derive.derive_device): usable kfd keeps gpu-rocm
+# (operator ruling — ROCm stays the default where the compute node works),
+# a render-node box with a Vulkan-capable runner image derives gpu-vulkan,
+# a no-GPU box derives cpu. Non-llama seeds (flm/tts/img/qwen3tts) have
+# their own device logic and stay verbatim; slots that already existed (or
+# are tombstoned) never entered SEEDED_NEW_SLOTS and are never touched.
+# Must run BEFORE `hal0 setup --auto` below: setup treats an existing slot
+# file as operator intent and will never relabel it. Fail-soft: a failed
+# derivation keeps the shipped labels (the load-time refusal is loud and
+# names its remedy) and never fails the install.
+if (( ${#SEEDED_NEW_SLOTS[@]} > 0 )); then
+    if ! "${VENV_DIR}/bin/python" -m hal0.install.static_seeds \
+            --slots-dir "${ETC_DIR}/slots" "${SEEDED_NEW_SLOTS[@]}"; then
+        warn "seed device derivation failed — freshly seeded slots keep their shipped device labels;"
+        warn "  on a box without /dev/kfd fix per slot with: hal0 slot edit <slot> --hardware vulkan (or cpu)"
+    fi
+fi
+
 # EXPECTED, NOT A BUG: the loop above closes gaps, so upgrading a box that
 # predates a curated slot ADDS it (most often `utility`, added after the
 # original seed set). A parallel boot-time closer does the same thing —

--- a/src/hal0/install/static_seeds.py
+++ b/src/hal0/install/static_seeds.py
@@ -18,13 +18,18 @@ source here, mirroring how ``setup_command._SETUP_SLOTS`` and
 
 from __future__ import annotations
 
+import re
 import shutil
 from collections.abc import Collection
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import structlog
 
 from hal0.config import paths
+
+if TYPE_CHECKING:
+    from hal0.config.schema import HardwareInfo
 
 log = structlog.get_logger(__name__)
 
@@ -44,12 +49,141 @@ STATIC_SEED_SLOTS: tuple[str, ...] = (
     "embed",
 )
 
+#: Seed name → :func:`hal0.install.profile_derive.derive_device` capability for
+#: the llama.cpp-backed lifecycle seeds (#2023). Every one of these ships
+#: ``device = "gpu-rocm"`` in its TOML — the reference platform — but a
+#: verbatim copy on a kfd-less box hands the slot a device the load-time gate
+#: (``_gpu.require_kfd_for_gpu_slot``) can only refuse, so seeding routes them
+#: through the SAME derivation ladder ``hal0 setup --auto`` uses.
+#:
+#: ``agent``/``brain`` map to the **chat** capability: they are the chat
+#: capability's slots (ADR-0023; ``setup_command._SETUP_SLOTS`` /
+#: ``_BRAIN_SLOT``). ``derive_device``'s own ``"agent"`` capability is the
+#: NPU-only chat lane and returns ``None`` on every non-NPU box — mapping the
+#: seed name straight through would skip derivation entirely.
+#:
+#: Deliberately absent: ``flm`` (npu), ``tts`` (kokoro/cpu), ``img``
+#: (ComfyUI) and ``qwen3tts`` — non-llama runtimes with their own device
+#: logic. Their seed device ships verbatim, whatever the host.
+LLAMA_SEED_CAPABILITIES: dict[str, str] = {
+    "agent": "chat",
+    "brain": "chat",
+    "coder": "coder",
+    "embed": "embed",
+    "rerank": "rerank",
+    "utility": "utility",
+}
+
+#: The top-level ``device = "..."`` assignment in a seed TOML. The seeds keep
+#: ``device`` above the ``[model]`` table, so the first match is always the
+#: slot-level field.
+_DEVICE_LINE = re.compile(r'(?m)^(device[ \t]*=[ \t]*)"[^"]*"')
+
+
+def _resolve_hardware_info() -> HardwareInfo | None:
+    """Best-effort hardware fact for seed-device derivation, or ``None``.
+
+    Prefers the stored probe fact (``/etc/hal0/hardware.json``, written by
+    ``hal0 setup``) when it exists; otherwise runs a live light probe — the
+    fresh-install case, where install.sh's seed loop lands BEFORE ``hal0
+    setup --auto`` writes the fact. ``None`` (nothing resolvable) means the
+    caller keeps the verbatim seed devices: fail-soft, a wrong ROCm label
+    refuses loudly at load time with its remedy, and seeding must never
+    abort over a probe.
+    """
+    try:
+        if paths.hardware_json().exists():
+            from hal0.config.loader import load_hardware_info
+
+            return load_hardware_info()
+    except Exception as exc:
+        log.warning("install.seed_device_hw_fact_unreadable", error=str(exc))
+    try:
+        from hal0.hardware.probe import HardwareProbe
+
+        return HardwareProbe().probe()
+    except Exception as exc:
+        log.warning("install.seed_device_probe_failed", error=str(exc))
+        return None
+
+
+def derive_seed_device(name: str, hw: HardwareInfo) -> str | None:
+    """Host-derived device for a llama.cpp-backed seed; ``None`` = verbatim.
+
+    Same ladder as ``hal0 setup --auto`` (#1888/#1923/#1948 rulings intact):
+    usable ROCm (kfd + compute-capable / strix-halo) → ``gpu-rocm``; else a
+    Vulkan-capable GPU *and* a runner image that serves the Vulkan lane →
+    ``gpu-vulkan``; else ``cpu``. ``npu_opt_in`` is pinned False — static
+    seeding never claims the NPU (the ``flm`` seed carries that lane).
+    """
+    capability = LLAMA_SEED_CAPABILITIES.get(name)
+    if capability is None:
+        return None
+    from hal0.install.profile_derive import derive_device
+
+    return derive_device(capability, hw, npu_opt_in=False)
+
+
+def apply_derived_seed_devices(
+    names: Collection[str],
+    *,
+    slots_dir: Path | None = None,
+    hw: HardwareInfo | None = None,
+) -> dict[str, str]:
+    """Rewrite freshly seeded llama.cpp slots' ``device`` to the host-derived one.
+
+    The single derivation pass both seeding paths share (#2023):
+    :func:`seed_static_slots` calls it after its copy loop, and install.sh's
+    bash seed loop calls it via ``python -m hal0.install.static_seeds`` over
+    the slots it just copied. Only names in :data:`LLAMA_SEED_CAPABILITIES`
+    with an existing ``<name>.toml`` are considered — pass ONLY freshly seeded
+    names; an operator's existing file must never reach this function.
+
+    The hardware fact is resolved lazily (first file that actually carries a
+    ``device`` line) so converged/no-op passes cost nothing. Unresolvable
+    hardware keeps every file verbatim. Returns ``{name: device}`` for the
+    files actually rewritten.
+    """
+    dest_dir = slots_dir if slots_dir is not None else paths.slots_config_dir()
+    resolved = hw
+    rewritten: dict[str, str] = {}
+    for name in names:
+        if name not in LLAMA_SEED_CAPABILITIES:
+            continue
+        dest = dest_dir / f"{name}.toml"
+        try:
+            text = dest.read_text(encoding="utf-8")
+        except OSError:
+            # Tombstoned / pre-existing names never got a fresh copy — skip.
+            continue
+        if _DEVICE_LINE.search(text) is None:
+            continue
+        if resolved is None:
+            resolved = _resolve_hardware_info()
+            if resolved is None:
+                log.warning(
+                    "install.seed_device_derivation_skipped",
+                    detail="hardware unresolvable — seeded slots keep their shipped device",
+                )
+                return rewritten
+        device = derive_seed_device(name, resolved)
+        if device is None:
+            continue
+        new_text, n = _DEVICE_LINE.subn(rf'\g<1>"{device}"', text, count=1)
+        if n == 0 or new_text == text:
+            continue
+        dest.write_text(new_text, encoding="utf-8")
+        rewritten[name] = device
+        log.info("install.seed_device_derived", slot=name, device=device)
+    return rewritten
+
 
 def seed_static_slots(
     *,
     installer_root: Path | None = None,
     slots_dir: Path | None = None,
     existing_names: Collection[str] = (),
+    hw: HardwareInfo | None = None,
 ) -> list[str]:
     """Copy any missing static seed TOML into the slots config dir.
 
@@ -74,6 +208,13 @@ def seed_static_slots(
     import cycle at module load); ``slots_dir`` defaults to
     :func:`hal0.config.paths.slots_config_dir`. Both are injectable for
     tests.
+
+    ``hw`` (#2023): hardware fact for the seed-device derivation applied to
+    the llama.cpp-backed seeds after copying (see
+    :func:`apply_derived_seed_devices`). ``None`` resolves it lazily — and
+    only when a freshly copied seed actually carries a ``device`` line — via
+    :func:`_resolve_hardware_info`; unresolvable hardware keeps the verbatim
+    copy (fail-soft).
     """
     if installer_root is None:
         from hal0.agents.hermes_provision import REPO_ROOT_FOR_INSTALLER
@@ -103,6 +244,13 @@ def seed_static_slots(
         dest.chmod(0o644)
         seeded.append(name)
         log.info("install.static_seed_applied", slot=name, dest=str(dest))
+    if seeded:
+        # #2023: freshly copied llama.cpp seeds carry the reference platform's
+        # device = "gpu-rocm" verbatim — derive the device this host can
+        # actually load, exactly like `hal0 setup --auto` would have. Only the
+        # names copied THIS call are touched; existing/operator files above
+        # were skipped and stay untouched.
+        apply_derived_seed_devices(seeded, slots_dir=dest_dir, hw=hw)
     return seeded
 
 
@@ -173,10 +321,58 @@ def clear_seed_tombstone(name: str, *, slots_dir: Path | None = None) -> None:
             log.warning("install.seed_tombstone_clear_failed", slot=name, error=str(exc))
 
 
+def _main(argv: list[str] | None = None) -> int:
+    """``python -m hal0.install.static_seeds`` — install.sh's derivation pass.
+
+    install.sh's "Container slot seeds" bash loop copies the seed TOMLs
+    verbatim (curated profiles/ports must land byte-for-byte), then invokes
+    this over the names it just copied so the llama.cpp seeds get the same
+    host-derived device every other provisioning path uses (#2023). Exit 1
+    (hardware unresolvable — nothing rewritten) lets install.sh print its
+    fail-soft warning; unknown / non-llama names are skipped silently.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m hal0.install.static_seeds",
+        description="Derive host-appropriate devices for freshly seeded slot TOMLs.",
+    )
+    parser.add_argument(
+        "--slots-dir",
+        type=Path,
+        default=None,
+        help="Slot config dir (default: the platform slots config dir).",
+    )
+    parser.add_argument("names", nargs="+", help="Freshly seeded slot names.")
+    args = parser.parse_args(argv)
+
+    hw = _resolve_hardware_info()
+    if hw is None:
+        print(
+            "seed-device derivation: hardware unresolvable — seeded slots keep their shipped device"
+        )
+        return 1
+    rewritten = apply_derived_seed_devices(args.names, slots_dir=args.slots_dir, hw=hw)
+    for name, device in sorted(rewritten.items()):
+        print(f"seeded {name} slot: device derived -> {device}")
+    if not rewritten:
+        print("seeded slot devices already match this host — nothing rewritten")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via install.sh
+    import sys
+
+    raise SystemExit(_main(sys.argv[1:]))
+
+
 __all__ = [
+    "LLAMA_SEED_CAPABILITIES",
     "STATIC_SEED_SLOTS",
     "add_seed_tombstone",
+    "apply_derived_seed_devices",
     "clear_seed_tombstone",
+    "derive_seed_device",
     "read_seed_tombstones",
     "seed_static_slots",
 ]

--- a/tests/install/test_seed_device_derivation.py
+++ b/tests/install/test_seed_device_derivation.py
@@ -1,0 +1,220 @@
+"""#2023 — static slot seeds must go through ``derive_device``, not ship verbatim.
+
+install.sh's "Container slot seeds" loop and its Python twin
+(:func:`hal0.install.static_seeds.seed_static_slots`) copy
+``installer/etc-hal0/slots/*.toml`` byte-for-byte, and every llama.cpp-backed
+seed ships ``device = "gpu-rocm"``. On a kfd-less box the load-time gate
+(``_gpu.require_kfd_for_gpu_slot``) then refuses every one of them, so a fresh
+install has ZERO loadable LLM slots and the autoloading ``brain`` anchor sits
+in ``state=error`` from t=0.
+
+These tests pin the fix: seeding routes the llama.cpp seeds through the same
+hardware derivation the rest of the platform uses
+(:func:`hal0.install.profile_derive.derive_device`), so the seeded device can
+never contradict the host:
+
+* kfd-less render-node box → ``gpu-vulkan`` (VULKAN_CAPABLE_IMAGE_REFS-gated),
+* no-GPU box (the ct163 shape) → ``cpu``,
+* kfd-present box → still ``gpu-rocm`` (operator ruling: ROCm stays the
+  default when the compute node is there).
+
+Non-llama seeds (flm=npu, tts=kokoro, img=comfyui, qwen3tts) have their own
+device logic and must keep their shipped device verbatim.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from hal0.config.schema import GPUInfo, HardwareInfo
+from hal0.install.static_seeds import (
+    LLAMA_SEED_CAPABILITIES,
+    STATIC_SEED_SLOTS,
+    apply_derived_seed_devices,
+    seed_static_slots,
+)
+
+#: The real repo tree — the seeds a fresh install actually receives.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SEED_SRC_DIR = _REPO_ROOT / "installer" / "etc-hal0" / "slots"
+
+
+def _seeded_devices(dest: Path) -> dict[str, str | None]:
+    return {
+        p.stem: tomllib.loads(p.read_text(encoding="utf-8")).get("device")
+        for p in sorted(dest.glob("*.toml"))
+    }
+
+
+def _kfd_less_render_node_box(monkeypatch: pytest.MonkeyPatch) -> HardwareInfo:
+    """The ct151 shape: AMD render node, no /dev/kfd, Vulkan-capable runner."""
+    monkeypatch.setattr("hal0.install.profile_derive.kfd_present", lambda *a, **k: False)
+    monkeypatch.setattr(
+        "hal0.install.profile_derive.default_image_serves_vulkan_lane",
+        lambda *a, **k: True,
+    )
+    return HardwareInfo(gpus=[GPUInfo(vendor="amd", compute_capable=False, vulkan_capable=True)])
+
+
+def _kfd_present_rocm_box(monkeypatch: pytest.MonkeyPatch) -> HardwareInfo:
+    monkeypatch.setattr("hal0.install.profile_derive.kfd_present", lambda *a, **k: True)
+    monkeypatch.setattr(
+        "hal0.install.profile_derive.default_image_serves_vulkan_lane",
+        lambda *a, **k: True,
+    )
+    return HardwareInfo(gpus=[GPUInfo(vendor="amd", compute_capable=True, vulkan_capable=True)])
+
+
+def _no_gpu_box(monkeypatch: pytest.MonkeyPatch) -> HardwareInfo:
+    """The ct163 shape: privileged container, zero GPU of any kind."""
+    monkeypatch.setattr("hal0.install.profile_derive.kfd_present", lambda *a, **k: False)
+    monkeypatch.setattr(
+        "hal0.install.profile_derive.default_image_serves_vulkan_lane",
+        lambda *a, **k: True,
+    )
+    return HardwareInfo(gpus=[])
+
+
+# ── seed_static_slots (the api-lifespan gap-closer) ──────────────────────────
+
+
+def test_kfd_less_host_seeds_no_gpu_rocm_llama_slot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The #2023 pin: a fresh kfd-less box must not receive a single
+    llama.cpp slot labelled ``gpu-rocm`` — that device can only refuse."""
+    hw = _kfd_less_render_node_box(monkeypatch)
+    dest = tmp_path / "slots"
+    seeded = seed_static_slots(installer_root=_REPO_ROOT, slots_dir=dest, hw=hw)
+    assert set(seeded) == set(STATIC_SEED_SLOTS)
+    devices = _seeded_devices(dest)
+    offenders = [name for name in LLAMA_SEED_CAPABILITIES if devices.get(name) == "gpu-rocm"]
+    assert not offenders, (
+        f"llama.cpp seeds still ship the un-loadable ROCm lane on a kfd-less box: {offenders}"
+    )
+    for name in LLAMA_SEED_CAPABILITIES:
+        assert devices[name] == "gpu-vulkan", (name, devices[name])
+
+
+def test_kfd_present_host_still_derives_gpu_rocm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Operator ruling: ROCm stays the default wherever /dev/kfd is usable."""
+    hw = _kfd_present_rocm_box(monkeypatch)
+    dest = tmp_path / "slots"
+    seed_static_slots(installer_root=_REPO_ROOT, slots_dir=dest, hw=hw)
+    devices = _seeded_devices(dest)
+    for name in LLAMA_SEED_CAPABILITIES:
+        assert devices[name] == "gpu-rocm", (name, devices[name])
+
+
+def test_no_gpu_host_derives_cpu(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    hw = _no_gpu_box(monkeypatch)
+    dest = tmp_path / "slots"
+    seed_static_slots(installer_root=_REPO_ROOT, slots_dir=dest, hw=hw)
+    devices = _seeded_devices(dest)
+    for name in LLAMA_SEED_CAPABILITIES:
+        assert devices[name] == "cpu", (name, devices[name])
+
+
+def test_non_llama_seeds_keep_their_shipped_device_verbatim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """flm (npu), tts (kokoro/cpu), img (comfyui) and qwen3tts have their own
+    device logic — derivation must not touch them, whatever the host."""
+    hw = _kfd_less_render_node_box(monkeypatch)
+    dest = tmp_path / "slots"
+    seed_static_slots(installer_root=_REPO_ROOT, slots_dir=dest, hw=hw)
+    devices = _seeded_devices(dest)
+    for name in STATIC_SEED_SLOTS:
+        if name in LLAMA_SEED_CAPABILITIES:
+            continue
+        shipped = tomllib.loads((_SEED_SRC_DIR / f"{name}.toml").read_text(encoding="utf-8")).get(
+            "device"
+        )
+        assert devices[name] == shipped, (name, devices[name], shipped)
+
+
+def test_unresolvable_hardware_keeps_verbatim_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fail-soft: when no hardware fact can be resolved the copy still lands
+    (today's verbatim behaviour) rather than aborting the seed pass."""
+    monkeypatch.setattr("hal0.install.static_seeds._resolve_hardware_info", lambda: None)
+    dest = tmp_path / "slots"
+    seeded = seed_static_slots(installer_root=_REPO_ROOT, slots_dir=dest)
+    assert set(seeded) == set(STATIC_SEED_SLOTS)
+    devices = _seeded_devices(dest)
+    shipped = tomllib.loads((_SEED_SRC_DIR / "agent.toml").read_text(encoding="utf-8")).get(
+        "device"
+    )
+    assert devices["agent"] == shipped
+
+
+def test_llama_seed_capabilities_avoid_the_npu_only_lanes() -> None:
+    """``derive_device("agent", ...)`` is the NPU chat lane and returns None on
+    every non-NPU box; the seeded ``agent``/``brain`` slots are the CHAT
+    capability's slots (ADR-0023 / setup_command._SETUP_SLOTS). Pin the mapping
+    so nobody 'simplifies' it back to the seed names."""
+    assert LLAMA_SEED_CAPABILITIES["agent"] == "chat"
+    assert LLAMA_SEED_CAPABILITIES["brain"] == "chat"
+    assert set(LLAMA_SEED_CAPABILITIES) == {
+        "agent",
+        "brain",
+        "coder",
+        "embed",
+        "rerank",
+        "utility",
+    }
+
+
+# ── apply_derived_seed_devices (the install.sh bash-loop follow-up pass) ─────
+
+
+def test_apply_derived_seed_devices_rewrites_verbatim_copies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """install.sh's bash loop copies verbatim, then calls this pass over the
+    freshly seeded names — the result must match what seed_static_slots
+    derives, so both seeding paths agree."""
+    hw = _kfd_less_render_node_box(monkeypatch)
+    dest = tmp_path / "slots"
+    dest.mkdir()
+    for name in STATIC_SEED_SLOTS:
+        shutil.copyfile(_SEED_SRC_DIR / f"{name}.toml", dest / f"{name}.toml")
+    rewritten = apply_derived_seed_devices(STATIC_SEED_SLOTS, slots_dir=dest, hw=hw)
+    assert rewritten == {name: "gpu-vulkan" for name in LLAMA_SEED_CAPABILITIES}
+    devices = _seeded_devices(dest)
+    for name in LLAMA_SEED_CAPABILITIES:
+        assert devices[name] == "gpu-vulkan", (name, devices[name])
+    assert devices["flm"] == "npu"
+    assert devices["tts"] == "cpu"
+
+
+def test_apply_derived_seed_devices_noop_when_device_already_matches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hw = _kfd_present_rocm_box(monkeypatch)
+    dest = tmp_path / "slots"
+    dest.mkdir()
+    shutil.copyfile(_SEED_SRC_DIR / "agent.toml", dest / "agent.toml")
+    before = (dest / "agent.toml").read_text(encoding="utf-8")
+    rewritten = apply_derived_seed_devices(("agent",), slots_dir=dest, hw=hw)
+    assert rewritten == {}
+    assert (dest / "agent.toml").read_text(encoding="utf-8") == before
+
+
+def test_apply_derived_seed_devices_ignores_missing_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A tombstoned / already-existing slot is never copied by the bash loop,
+    so its name may reach the pass with no file present — skip, don't raise."""
+    hw = _kfd_less_render_node_box(monkeypatch)
+    dest = tmp_path / "slots"
+    dest.mkdir()
+    rewritten = apply_derived_seed_devices(("agent",), slots_dir=dest, hw=hw)
+    assert rewritten == {}

--- a/tests/installer/test_seed_order.py
+++ b/tests/installer/test_seed_order.py
@@ -38,3 +38,31 @@ def test_seed_copy_loop_runs_before_hal0_setup_auto() -> None:
         "profile, brain's brain profile, embed's 4096 context, ...) never "
         "reach a fresh box. The seed-copy loop must run first."
     )
+
+
+def test_seed_device_derivation_runs_after_copy_loop_and_before_setup() -> None:
+    """GH #2023: the copy loop is verbatim by design (curated seeds), so a
+    derivation pass over the freshly seeded slots must follow it — routed
+    through hal0.install.static_seeds so bash and the api-lifespan closer share
+    one implementation — and it must land BEFORE `hal0 setup --auto`, which
+    treats an existing file as operator intent and never touches it again."""
+    text = _INSTALL_SH.read_text(encoding="utf-8")
+
+    seed_loop_marker = (
+        "for seed_slot in flm tts rerank utility img agent brain qwen3tts coder embed; do"
+    )
+    derive_marker = "-m hal0.install.static_seeds"
+    setup_call_marker = '"${HAL0_BIN}" setup "${_setup_args[@]}"'
+
+    assert derive_marker in text, (
+        "install.sh never routes the freshly copied slot seeds through "
+        "hal0.install.static_seeds device derivation — every llama.cpp seed "
+        "ships device = gpu-rocm verbatim and a kfd-less fresh install has "
+        "zero loadable LLM slots (#2023)."
+    )
+    assert (
+        text.index(seed_loop_marker) < text.index(derive_marker) < text.index(setup_call_marker)
+    ), (
+        "the seed device derivation pass must run after the verbatim copy "
+        "loop and before hal0 setup --auto (#2023)"
+    )


### PR DESCRIPTION
Closes #2023

## What

A fresh install's slot seeding now routes every llama.cpp-backed seed (`agent`, `brain`, `coder`, `embed`, `rerank`, `utility`) through the same hardware derivation the rest of the platform uses (`hal0.install.profile_derive.derive_device`), instead of copying `device = "gpu-rocm"` verbatim onto hosts that can never load it:

* **kfd usable** (compute-capable / strix-halo + `/dev/kfd`) → `gpu-rocm` stays — operator ruling: ROCm remains the default wherever the compute node works.
* **kfd-less render-node box** (the ct151 shape) → `gpu-vulkan`, gated by the same `default_image_serves_vulkan_lane` / `VULKAN_CAPABLE_IMAGE_REFS` predicate the load gate asks (#1948), so derivation and gate can never disagree.
* **no GPU at all** (the ct163 shape) → `cpu`.

## Why there are two seeding paths — and why ct151 shows a mix

The platform has exactly two ways a slot TOML lands on a fresh box:

1. **The derivation path** — `hal0 setup --auto` → `build_auto_selections` → `apply_setup`, which calls `derive_device` per capability and writes a device the host can load. It *never touches a slot whose file already exists* (`existing_slots` guard).
2. **The verbatim path** — install.sh's "Container slot seeds" bash loop, plus its Python twin `hal0.install.static_seeds.seed_static_slots` (the api-lifespan gap-closer for upgrades). Both copy `installer/etc-hal0/slots/<name>.toml` byte-for-byte, and every llama.cpp seed hardcodes `device = "gpu-rocm"`.

Since #1475 the verbatim path deliberately runs FIRST so the curated profiles/ports (agent's `chadrock-moe`, brain's `brain` profile, embed's 4096 ctx…) win the never-overwrite race. The unintended consequence closed the loop on #2023: because the file now always exists by the time setup runs, the derivation path never reaches any slot that has a static seed — so **all** eight gpu-rocm seeds ship verbatim on every fresh box, and `_gpu.require_kfd_for_gpu_slot` refuses every one of them on a kfd-less host, leaving the autoload `brain` anchor in `state=error` from t=0.

On ct151 (read-only evidence): `agent.toml`/`coder.toml` (and `img`/`qwen3tts`/`flm`) still wear the verbatim installer copy — full seed comments, all mtimes at install time 19:27:29 — with `device = "gpu-rocm"`. `brain`/`embed`/`rerank`/`utility`/`tts` read `gpu-vulkan` only because they were **rewritten after the fact through the documented workaround** (`hal0 slot edit <slot> --hardware vulkan`): they carry the config-write serialization (comments stripped, `[model].default` bound) and mtimes 47–100 minutes after install. So nothing on ct151 was seeded correctly — the "correct" slots are the ones the operator repaired by hand, which is exactly the toil this PR removes.

## How

One shared pass, `hal0.install.static_seeds.apply_derived_seed_devices`, rewrites the top-level `device = "..."` line of **freshly copied** llama seeds to the derived device; both seeding paths call it:

* `seed_static_slots` applies it to the names it copied this call (upgrade/boot gap-closing);
* install.sh's bash loop invokes `python -m hal0.install.static_seeds --slots-dir "${ETC_DIR}/slots" <freshly-seeded names>` immediately after the copy loop — and before `hal0 setup --auto`, which treats an existing file as operator intent.

Hardware resolution is lazy and layered: stored `/etc/hal0/hardware.json` fact when present, else a live light probe (the fresh-install case — the bash loop runs before setup writes the fact). Unresolvable hardware keeps the verbatim copy: fail-soft, seeding never aborts an install or a boot, and a wrong ROCm label still refuses loudly at load time with its remedy.

## Scope decisions

* **agent/brain map to the `chat` capability.** `derive_device("agent", …)` is the NPU-only chat lane and returns `None` on non-NPU boxes; the seeded `agent`/`brain` slots are the chat capability's slots (ADR-0023, `setup_command._SETUP_SLOTS`/`_BRAIN_SLOT`). A pin test guards the mapping.
* **`npu_opt_in` pinned False** — static seeding never claims the NPU; the `flm` seed carries that lane.
* **Non-llama seeds untouched**: `flm` (npu), `tts` (kokoro/cpu), `img` (ComfyUI) and `qwen3tts` have their own device logic and keep their shipped device verbatim, per the operator's scoping. (The issue's title says "eight"; `img`/`qwen3tts` are gpu-rocm seeds but not llama.cpp-backed, so they are deliberately out of scope here.)
* **Only freshly copied files are rewritten.** Existing operator configs, tombstoned seeds, and id-keyed slots never enter the pass.
* **Not addressed (as in the issue's "worth a look" note):** on a CUDA/NVIDIA box `derive_device` itself still derives `gpu-rocm` (its `compute_capable` branch — observed live on thinmint's stored fact). That is the shared ladder's pre-existing behavior, identical to what `hal0 setup --auto` scaffolds today; changing it belongs to a follow-up on `derive_device`, not to the seeding path.

## Tests (TDD)

Red first, then green:

* `tests/install/test_seed_device_derivation.py` (new, 9 tests) — kfd-less host seeds **no** `gpu-rocm` llama slot (the #2023 pin, → `gpu-vulkan`); kfd-present host still derives `gpu-rocm` (operator ruling); no-GPU host derives `cpu`; non-llama seeds verbatim; fail-soft on unresolvable hardware; capability-mapping pin; the bash-path pass rewrites verbatim copies, no-ops when already matching, skips missing files. Runs against the real shipped seed TOMLs.
* `tests/installer/test_seed_order.py` — new ordering pin: the derivation call must sit after the copy loop and before `hal0 setup --auto` in install.sh (red: `AssertionError: install.sh never routes the freshly copied slot seeds through hal0.install.static_seeds…`).

Suites: `tests/install tests/installer tests/slots tests/config` → **2774 passed, 10 skipped**; `tests/api/test_startup_slot_seed.py` + `tests/agents/test_anchor_window.py` → 30 passed, 1 skipped (no Hermes venv, environmental). `ruff check` + `ruff format --check` clean on touched files; mypy: identical 414 pre-existing graph errors before and after with a cold cache, zero attributed to touched files (no new errors vs main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
