### PR TITLE
chore(release): set version to 1.0.0-rc.9

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release — the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md §12 and §17 (maintainer-local).",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "channel": "preview",
   "toolbox_images": {
     "vulkan": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hal0-ui",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hal0-ui",
-      "version": "1.0.0-rc.8",
+      "version": "1.0.0-rc.9",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal0-ui",
   "private": true,
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "hal0ai"
-version = "1.0.0rc8"
+version = "1.0.0rc9"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Pre-cut prep for rc.9 in one PR: pyproject + manifest.json + ui package files + uv.lock (the rc.8 cut learned these must move together — #2051). update-toolbox-digests.sh ran clean. rc.9 picks up the full rc.7 GA-gate fix set (#2020–#2024 via #2036/#2035/#2034/#2053/#2054), per-tag pull (#2048), SlotSpawnFailed (#2047), typed bench caps (#1826), and ADR-0003. Next: release-check --tag v1.0.0-rc.9 --channel preview, then tag on the merge commit.