### PR TITLE
fix(installer): persist bootstrap-verified cosign for the updater (#2052)

### DIFF
--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -231,6 +231,11 @@ $(cosign_manual_install_hint)"
 $(cosign_manual_install_hint)"
     fi
     _COSIGN_BIN="${out}"
+    # Hand the verified binary to install.sh so it can persist a cosign
+    # for the updater (#2052) — the work directory does not survive the
+    # install, and a fresh box otherwise has no cosign for its first
+    # `hal0 update`.
+    export HAL0_BOOTSTRAP_COSIGN="${out}"
     ok "pinned cosign ${_COSIGN_VERSION} sha256 OK (${actual:0:12}…)"
 }
 

--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -182,8 +182,10 @@ cosign_manual_install_hint() {
 # Resolve _COSIGN_BIN. Prefers a distro-packaged cosign (it rides the
 # distro's own update track and needs no pin from us); otherwise downloads
 # the pinned official build into the trap-guarded work dir, verifies its
-# sha256 against the constant above, and uses it from there. Nothing is
-# installed anywhere persistent.
+# sha256 against the constant above, and uses it from there. This script
+# installs nothing persistent itself, but a fetched binary is handed to
+# install.sh via HAL0_BOOTSTRAP_COSIGN so the installer can persist it for
+# the updater (#2052).
 ensure_cosign() {
     local work="$1"
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -295,6 +295,14 @@ info "system: $(uname -srm)"
 # bare "command not found" deep in the install.
 preflight_bootstrap_prereqs || die "missing base prereqs — see above (installer/bootstrap.sh's one-liner preflight requires the same tools)"
 
+# Persist bootstrap's digest-pinned cosign so the updater's signature
+# gate works on the very first `hal0 update` (#2052). Soft: warns and
+# continues when there is nothing to persist. Dev installs manage their
+# own tools.
+if [[ "${DEV_MODE}" -eq 0 ]]; then
+    persist_bootstrap_cosign
+fi
+
 # Architecture is a hard requirement in every mode — all shipped binaries
 # (FastFlowLM .deb, toolbox container images) are amd64-only.
 preflight_arch || die "hal0 requires an x86_64 host (see the message above)"

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1622,3 +1622,31 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     preflight_all
     exit $?
 fi
+
+# ── cosign persistence for the updater (#2052) ─────────────────────────────
+# bootstrap.sh verifies the release with a digest-pinned cosign fetched into
+# its throwaway work directory, but nothing used to leave a cosign on the
+# installed system — so the FIRST `hal0 update` of every fresh install
+# hard-failed its signature gate ("cosign is not installed"). The updater's
+# requirement is correct; the dependency belongs to the platform. Persist
+# the exact binary bootstrap already verified (sha256 pinned in
+# bootstrap.sh, handed over via HAL0_BOOTSTRAP_COSIGN). Never overwrite a
+# system cosign; warn honestly — never die — when there is nothing to
+# persist (e.g. a tarball-direct install), because the install itself is
+# fine and only the first update is affected.
+persist_bootstrap_cosign() {
+    local dest_dir="${1:-/usr/local/bin}"
+    if command -v cosign >/dev/null 2>&1; then
+        return 0
+    fi
+    if [[ -n "${HAL0_BOOTSTRAP_COSIGN:-}" && -x "${HAL0_BOOTSTRAP_COSIGN}" ]]; then
+        if install -m 0755 "${HAL0_BOOTSTRAP_COSIGN}" "${dest_dir}/cosign"; then
+            ok "cosign: persisted bootstrap's pinned build to ${dest_dir}/cosign (hal0 update requires it)"
+        else
+            warn "could not persist cosign to ${dest_dir}/cosign — the first 'hal0 update' will fail its signature check until cosign is installed (https://docs.sigstore.dev/cosign/installation/)"
+        fi
+        return 0
+    fi
+    warn "cosign is not installed and this run has no bootstrap-verified binary to persist — the first 'hal0 update' will fail its signature check until cosign is installed (https://docs.sigstore.dev/cosign/installation/)"
+    return 0
+}

--- a/tests/installer/test_install_cosign_persist.py
+++ b/tests/installer/test_install_cosign_persist.py
@@ -1,0 +1,141 @@
+"""Fresh installs persist a cosign for the updater — #2052.
+
+``installer/bootstrap.sh`` verifies the release with a digest-pinned cosign
+fetched into its throwaway work directory, but nothing used to leave a
+cosign on the installed system — so the FIRST ``hal0 update`` of every
+fresh install hard-failed its signature gate (``cosign is not installed``,
+journal ``updater.privileged_failed verb=stage``). The updater's
+requirement is correct; the dependency belongs to the platform.
+
+The fix has two halves:
+
+* ``ensure_cosign()`` (bootstrap.sh) exports ``HAL0_BOOTSTRAP_COSIGN``
+  pointing at the binary it fetched and sha256-checked, so the verified
+  bytes survive the ``exec`` into install.sh.
+* ``persist_bootstrap_cosign`` (installer/lib/preflight.sh, called from
+  install.sh's pre-flight step outside dev mode) installs that exact
+  binary to ``/usr/local/bin/cosign`` — never overwriting a system cosign,
+  and warning honestly (first ``hal0 update`` will fail) when there is
+  nothing to persist, e.g. a tarball-direct install.
+
+These tests exercise the shell function directly (subprocess, real bash —
+the technique ``tests/installer/test_preflight_gpu_gate.py`` uses) plus
+static-text assertions proving the bootstrap export and the install.sh
+call site exist.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PREFLIGHT = _REPO_ROOT / "installer" / "lib" / "preflight.sh"
+_BOOTSTRAP = _REPO_ROOT / "installer" / "bootstrap.sh"
+_INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
+
+# ui.sh helpers the function calls; stubbed so output is capturable and the
+# restricted environment needs no extra sourcing.
+_STUBS = """
+info() { printf 'INFO:%s\\n' "$*"; }
+ok()   { printf 'OK:%s\\n' "$*"; }
+warn() { printf 'WARN:%s\\n' "$*" >&2; }
+err()  { printf 'ERR:%s\\n' "$*" >&2; }
+"""
+
+
+def _run_persist(
+    tmp_path: Path,
+    *,
+    with_system_cosign: bool,
+    bootstrap_cosign: Path | None,
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """Drive persist_bootstrap_cosign under a controlled PATH."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    dest_dir = tmp_path / "dest"
+    dest_dir.mkdir(exist_ok=True)
+    if with_system_cosign:
+        fake = bin_dir / "cosign"
+        fake.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        fake.chmod(0o755)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:/usr/bin:/bin"
+    env.pop("HAL0_BOOTSTRAP_COSIGN", None)
+    if bootstrap_cosign is not None:
+        env["HAL0_BOOTSTRAP_COSIGN"] = str(bootstrap_cosign)
+
+    script = _STUBS + f'source "{_PREFLIGHT}"\n' + f'persist_bootstrap_cosign "{dest_dir}"\n'
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    return proc, dest_dir
+
+
+def _make_bootstrap_binary(tmp_path: Path) -> Path:
+    src = tmp_path / "work" / "cosign"
+    src.parent.mkdir(exist_ok=True)
+    src.write_text("#!/usr/bin/env bash\necho fake-cosign\n", encoding="utf-8")
+    src.chmod(0o755)
+    return src
+
+
+class TestPersistBootstrapCosign:
+    def test_persists_bootstrap_binary_when_host_has_none(self, tmp_path: Path) -> None:
+        src = _make_bootstrap_binary(tmp_path)
+        proc, dest_dir = _run_persist(tmp_path, with_system_cosign=False, bootstrap_cosign=src)
+        assert proc.returncode == 0, proc.stderr
+        installed = dest_dir / "cosign"
+        assert installed.is_file(), proc.stdout + proc.stderr
+        assert installed.read_bytes() == src.read_bytes()
+        mode = stat.S_IMODE(installed.stat().st_mode)
+        assert mode & stat.S_IXUSR, f"not executable: {oct(mode)}"
+        assert "OK:" in proc.stdout
+
+    def test_never_overwrites_a_system_cosign(self, tmp_path: Path) -> None:
+        src = _make_bootstrap_binary(tmp_path)
+        proc, dest_dir = _run_persist(tmp_path, with_system_cosign=True, bootstrap_cosign=src)
+        assert proc.returncode == 0, proc.stderr
+        assert not (dest_dir / "cosign").exists()
+
+    def test_warns_and_survives_with_nothing_to_persist(self, tmp_path: Path) -> None:
+        proc, dest_dir = _run_persist(tmp_path, with_system_cosign=False, bootstrap_cosign=None)
+        # Soft path: the install must not die, but must say what will break.
+        assert proc.returncode == 0, proc.stderr
+        assert not (dest_dir / "cosign").exists()
+        assert "WARN:" in proc.stderr
+        assert "hal0 update" in proc.stderr
+
+    def test_ignores_non_executable_bootstrap_path(self, tmp_path: Path) -> None:
+        src = tmp_path / "work" / "cosign"
+        src.parent.mkdir(exist_ok=True)
+        src.write_text("not a binary", encoding="utf-8")  # no exec bit
+        proc, dest_dir = _run_persist(tmp_path, with_system_cosign=False, bootstrap_cosign=src)
+        assert proc.returncode == 0, proc.stderr
+        assert not (dest_dir / "cosign").exists()
+        assert "WARN:" in proc.stderr
+
+
+class TestWiring:
+    def test_bootstrap_exports_verified_binary_path(self) -> None:
+        code = "\n".join(
+            line
+            for line in _BOOTSTRAP.read_text(encoding="utf-8").splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        assert "export HAL0_BOOTSTRAP_COSIGN=" in code
+
+    def test_install_sh_calls_persist_outside_dev_mode(self) -> None:
+        text = _INSTALL_SH.read_text(encoding="utf-8")
+        assert "persist_bootstrap_cosign" in text
+        # The call must come before any filesystem mutation of the install
+        # proper — i.e. in the pre-flight region, after the bootstrap-prereq
+        # parity check.
+        assert text.index("persist_bootstrap_cosign") < text.index("GPU / NPU device gate")


### PR DESCRIPTION
## Why

Every fresh install could verify its own release (bootstrap.sh fetches a digest-pinned cosign into its throwaway work dir) but shipped a system with no cosign at all — so the FIRST `hal0 update` hard-failed at the updater's signature gate: `cosign is not installed` (journal `updater.privileged_failed verb=stage`). Found on the rc.8 update lane, reproduced verbatim on a fresh rc.9 install (ct151) during 1.0-readiness validation. This is blocker 2 in the rc.9 readiness verdict: a public 1.0's first self-update must work.

## What

- `ensure_cosign()` (bootstrap.sh) now exports `HAL0_BOOTSTRAP_COSIGN` pointing at the binary it fetched and sha256-checked against the pin, so the verified bytes survive the `exec` into install.sh. When a system cosign is used, nothing is exported and nothing changes.
- New `persist_bootstrap_cosign` (installer/lib/preflight.sh), called from install.sh's pre-flight region outside dev mode: installs that exact binary to `/usr/local/bin/cosign`. Never overwrites a system cosign. When there is nothing to persist (tarball-direct install with `HAL0_INSTALL_SKIP_VERIFY=1`), it warns that the first `hal0 update` will fail and continues — the install itself is unaffected, and inventing a second digest-pin site in install.sh would duplicate the trust root bootstrap already owns.

No new trust root: the persisted binary is the same one bootstrap verified against the sha256 pinned in bootstrap.sh (maintained by scripts/update-cosign-pin.sh).

Not addressed here (still open in #2052's cosmetic half): the CLI surfacing the generic `stage (rc=1)` instead of the child's typed cosign error — that is an updater seam change, separate from provisioning.

## Tests

`tests/installer/test_install_cosign_persist.py`: drives `persist_bootstrap_cosign` in real bash under a controlled PATH (persists when host has none; never overwrites system cosign; warns-and-survives with nothing to persist; ignores a non-executable handoff path), plus wiring assertions (bootstrap export exists; install.sh call site sits in the pre-flight region). Full `tests/installer/` suite: 827 passed, 1 pre-existing skip (shellcheck absent).

Closes #2052

🤖 Generated with [Claude Code](https://claude.com/claude-code)
