### PR TITLE
docs(rc-validate): document ct151 pristine-rollback gotchas (#2064)

### DIFF
--- a/tests/release-validation/README.md
+++ b/tests/release-validation/README.md
@@ -34,7 +34,11 @@ not content: each agent reads its own brief, `CONTEXT.md`, `known-issues.yaml`, 
 
 ```sh
 # 1. Reset and install the RC on the target boxes (operator, out of band):
-#    ct151-cpu-fresh  -> pct rollback 151 pristine, fix resolv.conf, fresh install
+#    ct151-cpu-fresh  -> pct rollback 151 pristine, then the POST-ROLLBACK CHECKLIST in
+#                        boxes.toml (rollback DELETES the dev0/dev3 passthrough entries —
+#                        re-add + confirm gid=991; `pct set 151 --nameserver`, never an
+#                        in-container resolv.conf edit; `apt install -y curl jq`), then
+#                        fresh install
 #    ct150-update     -> stage the new preview manifest, leave it on the PREVIOUS release
 #
 # 2. Then, from a Claude Code session in the hal0 repo:
@@ -130,6 +134,17 @@ known-issues, or regressions, and add a line to the changelog below. A report re
 `kit_version` it ran under, so an old report can always be read against the rules it ran with.
 
 ### Kit changelog
+
+* **10** (2026-08-25) — ct151 reset facts relearned the hard way during the rc.9 fresh lane
+  (#2064). `boxes.toml` `[boxes.ct151-cpu-fresh]`: gotcha 4 upgraded from a gid-drift check to
+  a hard re-add — `pct rollback 151 pristine` DELETES the dev0/dev3 passthrough entries from
+  the CT config outright (the pristine snapshot predates them); gotcha 1's DNS fix corrected to
+  `pct set 151 --nameserver` on the hypervisor (an in-container resolv.conf edit is regenerated
+  away by PVE on every boot); new gotcha 6 — the pristine minimal Ubuntu 26.04 image ships with
+  neither curl nor jq, so `apt install -y curl jq` precedes the bootstrap. The notes now carry
+  an explicit POST-ROLLBACK CHECKLIST (re-add passthrough + confirm gid=991, `--nameserver`,
+  curl+jq, then install) and the README reset step points at it. Pinned by
+  `tests/release/test_kit_ct151_reset_gotchas.py` so a curation pass cannot drop them.
 
 * **9** (2026-08-22) — Curation from the v1.0.0-rc.7 skeptic/verify pass (10 candidate findings
   adversarially re-checked, 10 ended up split between real-new-defect and adjudicated-by-design).

--- a/tests/release-validation/boxes.toml
+++ b/tests/release-validation/boxes.toml
@@ -28,8 +28,9 @@ api = "http://10.0.1.151:8080"
 auth_required = false
 status = "PREFERRED fresh box as of 2026-08-22 — rc.7 verified via a genuine fresh install from pristine"
 notes = """
-Fresh-install lane. Reset: `pct rollback 151 pristine` on the hypervisor, THEN run the installer
-fresh — this is now the ONLY reset point (corrected 2026-08-22: the `rc6-installed` /
+Fresh-install lane. Reset: `pct rollback 151 pristine` on the hypervisor, THEN the
+POST-ROLLBACK CHECKLIST below (re-add dev0/dev3 passthrough, `pct set --nameserver`,
+`apt install -y curl jq`), THEN run the installer fresh — this is now the ONLY reset point (corrected 2026-08-22: the `rc6-installed` /
 `rc5-installed` convenience post-install snapshots this file used to document are GONE;
 `pct listsnapshot 151` shows only `pristine` (2026-08-08) and `current`). Do not attempt
 `pct rollback 151 rc6-installed` or any named post-install snapshot — it will fail. Every prior
@@ -69,19 +70,39 @@ must be the thing that catches the resulting garbage (never a silent `ready`) �
 
 GOTCHAS, in order:
   1. The pristine snapshot has broken DNS — /etc/resolv.conf points at an unreachable
-     Tailscale 100.100.100.100. Fix it before anything else or the install fails opaquely.
+     Tailscale 100.100.100.100. Fix it on the HYPERVISOR with `pct set 151 --nameserver <ip>`
+     (corrected 2026-08-25, rc.9): editing /etc/resolv.conf inside the container does NOT
+     stick — PVE regenerates it on every boot, so an in-container edit silently reverts at the
+     next restart and the install fails opaquely again. Fix it before anything else.
   2. (stale, retired) The install no longer needs HAL0_ALLOW_CPU_ONLY=1 — GPU passthrough
      exists.
   3. No NFS mount. Test models must be rsynced to /mnt/ai-models; workstation ggufs are often
      symlinks into huggingface/hub, so use `rsync -L` — and /mnt/ai-models is NOT in hal0's
      model roots, so a staged gguf is invisible until `hal0 model add`.
-  4. (stale, retired) "/dev/dri absent in sysfs" predates the dev0/dev3 passthrough. After any
-     `pct rollback 151`, confirm dev0/dev3 keep gid=991 or the installer's GPU preflight aborts.
+  4. (upgraded from a perms check to a hard re-add, 2026-08-25, rc.9) `pct rollback 151
+     pristine` DELETES the dev0/dev3 passthrough entries from the CT config outright — the
+     pristine snapshot (2026-08-08) predates them, so this is not gid drift: the device
+     entries are GONE after every rollback. Re-add them on the hypervisor before installing
+     (`pct set 151 --dev0 /dev/dri/renderD128,gid=991 --dev3 /dev/accel/accel0,gid=991`), then
+     confirm gid=991 stuck on both, or the installer's GPU preflight aborts. The earlier
+     "/dev/dri absent in sysfs" note predates the passthrough entirely and stays retired.
   5. (stale, retired 2026-08-22 — no post-install convenience snapshot exists any more, so this
      no longer applies) After a rollback to a named post-install snapshot, services would not
      come back on their own — `systemctl start hal0.target` (hermes unit
      `hermes-gateway.service`). A genuinely fresh installer run (the only reset path now)
      starts both units itself; no manual start has been needed on the last two runs.
+  6. (added 2026-08-25, rc.9) The pristine minimal Ubuntu 26.04 image ships with NEITHER curl
+     NOR jq — `apt install -y curl jq` up front, before the bootstrap/installer fetch, or the
+     fresh-install lane dies at its very first command. A product-side bootstrap preflight is
+     tracked separately; the kit lane must not depend on it landing.
+
+POST-ROLLBACK CHECKLIST (every `pct rollback 151 pristine`, in order — gotchas 4, 1, 6):
+  1. `pct set 151 --dev0 /dev/dri/renderD128,gid=991 --dev3 /dev/accel/accel0,gid=991`, then
+     confirm gid=991 on both entries (rollback deleted them — gotcha 4).
+  2. `pct set 151 --nameserver <ip>` on the hypervisor (gotcha 1 — never edit resolv.conf
+     inside the container).
+  3. Boot the CT, `apt install -y curl jq` (gotcha 6).
+  4. Only then run the installer/bootstrap.
 """
 
 # ct152-cpu-fresh (the CPU-only fresh box, no GPU passthrough) was DESTROYED 2026-08-21. There

--- a/tests/release-validation/kit.toml
+++ b/tests/release-validation/kit.toml
@@ -4,7 +4,7 @@
 # scripts cannot read the filesystem, so when you add a lane here you must also add it to the
 # LANES table in the script. The brief itself is only ever read by the agent that runs it.
 
-kit_version = 9
+kit_version = 10
 
 [defaults]
 # Model tier per phase. Rationale in README "Phases".

--- a/tests/release/test_kit_ct151_reset_gotchas.py
+++ b/tests/release/test_kit_ct151_reset_gotchas.py
@@ -1,0 +1,56 @@
+"""ct151 post-rollback checklist stays documented in the validation kit (#2064).
+
+The rc.9 run relearned three ct151 provisioning facts the hard way: ``pct
+rollback 151 pristine`` deletes the dev0/dev3 passthrough entries outright
+(the pristine snapshot predates them), an in-container resolv.conf fix does
+not survive a boot (PVE regenerates it — the fix is ``pct set --nameserver``),
+and the pristine minimal Ubuntu 26.04 image ships with neither curl nor jq.
+These tests pin the kit docs so a future boxes.toml/README curation pass
+cannot silently drop the checklist and send the next operator through the
+same three opaque failures.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+BOXES = Path("tests/release-validation/boxes.toml")
+README = Path("tests/release-validation/README.md")
+
+
+def _ct151_notes() -> str:
+    return tomllib.loads(BOXES.read_text())["boxes"]["ct151-cpu-fresh"]["notes"]
+
+
+def test_ct151_notes_say_rollback_deletes_dev_passthrough() -> None:
+    notes = _ct151_notes()
+    assert "DELETES" in notes, (
+        "ct151 notes lost the fact that `pct rollback 151 pristine` deletes "
+        "the dev0/dev3 passthrough entries (not just gid drift)"
+    )
+    assert "pct set 151 --dev0 /dev/dri/renderD128,gid=991 --dev3 /dev/accel/accel0,gid=991" in notes, (
+        "ct151 notes lost the exact re-add command for the dev0/dev3 passthrough entries"
+    )
+
+
+def test_ct151_notes_prescribe_pct_level_nameserver_fix() -> None:
+    notes = _ct151_notes()
+    assert "pct set 151 --nameserver" in notes, (
+        "ct151 notes lost the pct-level DNS fix — an in-container resolv.conf "
+        "edit does not survive a boot (PVE regenerates it)"
+    )
+
+
+def test_ct151_notes_include_curl_jq_preinstall() -> None:
+    assert re.search(r"apt install -y curl jq", _ct151_notes()), (
+        "ct151 notes lost the `apt install -y curl jq` step — the pristine "
+        "minimal Ubuntu 26.04 image ships with neither"
+    )
+
+
+def test_readme_reset_step_carries_the_checklist() -> None:
+    readme = README.read_text()
+    for fragment in ("--nameserver", "gid=991", "curl jq"):
+        assert fragment in readme, (
+            f"README's ct151 reset step lost the post-rollback checklist item {fragment!r}"
+        )

--- a/tests/release/test_kit_ct151_reset_gotchas.py
+++ b/tests/release/test_kit_ct151_reset_gotchas.py
@@ -28,9 +28,9 @@ def test_ct151_notes_say_rollback_deletes_dev_passthrough() -> None:
         "ct151 notes lost the fact that `pct rollback 151 pristine` deletes "
         "the dev0/dev3 passthrough entries (not just gid drift)"
     )
-    assert "pct set 151 --dev0 /dev/dri/renderD128,gid=991 --dev3 /dev/accel/accel0,gid=991" in notes, (
-        "ct151 notes lost the exact re-add command for the dev0/dev3 passthrough entries"
-    )
+    assert (
+        "pct set 151 --dev0 /dev/dri/renderD128,gid=991 --dev3 /dev/accel/accel0,gid=991" in notes
+    ), "ct151 notes lost the exact re-add command for the dev0/dev3 passthrough entries"
 
 
 def test_ct151_notes_prescribe_pct_level_nameserver_fix() -> None:


### PR DESCRIPTION
## Summary

Kit-side docs fix for the three ct151 provisioning gotchas the rc.9 fresh lane hit undocumented. `tests/release-validation/boxes.toml` (ct151 notes), the kit README's reset step, and `kit.toml` (kit_version 9 -> 10, per the kit's versioning policy) are updated; a small static contract test pins the checklist. Docs-only — no product code.

## Root cause

The ct151 entry in boxes.toml understated or omitted three facts:

1. Gotcha 4 said to "confirm dev0/dev3 keep gid=991" after a rollback — but `pct rollback 151 pristine` deletes the passthrough entries outright (the pristine snapshot, 2026-08-08, predates them). It is not perms drift: the device entries are gone and must be re-added after every rollback.
2. Gotcha 1 said to "fix resolv.conf" without saying how — an in-container edit is regenerated away by PVE on every boot; the fix must be `pct set 151 --nameserver` on the hypervisor.
3. Nothing mentioned that the pristine minimal Ubuntu 26.04 image ships with neither curl nor jq, so the fresh lane dies at its first command unless `apt install -y curl jq` runs before bootstrap.

## Fix

- boxes.toml ct151: gotcha 1 corrected to the pct-level nameserver fix, gotcha 4 upgraded from a perms check to a hard re-add with the exact `pct set 151 --dev0 ... --dev3 ...` command, new gotcha 6 for curl+jq, and an explicit POST-ROLLBACK CHECKLIST (re-add passthrough + confirm gid=991, `--nameserver`, curl+jq, then install) that the reset instructions now point at.
- README: the "Running a validation" step-1 reset line now carries the checklist instead of a bare "fix resolv.conf".
- kit.toml: kit_version 10, with a matching changelog entry in the README.
- New `tests/release/test_kit_ct151_reset_gotchas.py` (written first, 4 failures against the old docs) pins the three facts so a future curation pass cannot silently drop them.

## Test evidence

`python3 -m pytest --noconftest tests/release/test_kit_ct151_reset_gotchas.py tests/release/test_rc_validate_kit_contract.py -q` -> 10 passed (macOS workstation; `--noconftest` because the root conftest needs the full dep tree, which `uv sync` cannot build on this NFS mount — CI runs the suite normally). boxes.toml re-parsed clean with tomllib after the edits.

Fixes #2064

🤖 Generated with [Claude Code](https://claude.com/claude-code)