### PR TITLE
fix(hermes): root hermes runs resolve the hal0 service home, and say so (#2063)

### DIFF
--- a/docs/guides/run-agents.mdx
+++ b/docs/guides/run-agents.mdx
@@ -185,6 +185,22 @@ Default uninstall tears down the agent's private memory namespace too;
 </TabItem>
 </Tabs>
 
+## Running `hermes` as root
+
+Upstream `hermes` resolves its state from `~/.hermes`, so a bare root
+invocation would read `/root/.hermes` — an empty tree the agent never
+uses — and commands like `hermes mcp list` would falsely report
+"No MCP servers configured" on a healthy install. hal0's `hermes`
+wrapper prevents that: run as root, it re-executes as the `hal0`
+service user (via the run-as-hal0 guard), so you see the same config
+the running agent uses. If the guard can't drop privileges, the
+wrapper points `HOME` at the service home instead and prints which
+`~/.hermes` tree it resolved on stderr. `HAL0_ALLOW_ROOT=1` opts out
+for deliberate root debugging — the wrapper then leaves root's
+environment alone but still names the tree it is reading. The
+euid-aware fix inside the hermes CLI itself is an upstream
+(NousResearch/hermes-agent) matter; the wrapper is hal0's seam.
+
 ## Personas
 
 A persona is a TOML file pairing a system prompt with tool gating:

--- a/installer/wrappers/hermes
+++ b/installer/wrappers/hermes
@@ -67,6 +67,44 @@ case "${1:-}" in
     --hal0-ready) exit 0 ;;
 esac
 
+# root-home fallback (#2063): reaching this point as root means the guard
+# above could NOT drop privileges — the guard lib is missing/unreadable
+# (partial or dev install) or the hal0 user is absent — or the operator
+# forced root via HAL0_ALLOW_ROOT. Upstream hermes resolves its state dir
+# from $HOME (`~/.hermes`; the CLI-side euid-aware fix belongs upstream),
+# so an unguarded root run silently reads /root/.hermes — a tree the hal0
+# service never writes — and `hermes mcp list` falsely reports "No MCP
+# servers configured" on a healthy install. Point HOME at the hal0 service
+# home instead (and strip any inherited HERMES_HOME, matching the guard's
+# `env -u` posture), and ALWAYS name the tree this invocation resolves so
+# an empty result is diagnosable rather than a false "broken install".
+# HAL0_SERVICE_HOME bypasses the getent lookup (tests / nonstandard
+# service accounts; set-but-empty means "no service user resolvable").
+# HAL0_RUNAS_TEST_UID is the guard's documented test-only euid seam.
+_hal0_euid="${HAL0_RUNAS_TEST_UID:-$(id -u 2>/dev/null || echo 0)}"
+if [ "$_hal0_euid" = "0" ]; then
+    case "${HAL0_ALLOW_ROOT:-}" in
+        1 | true | yes | TRUE | YES)
+            # Deliberate root debug: env left alone, resolved path named.
+            printf 'hermes: HAL0_ALLOW_ROOT set — reading %s/.hermes (root debug; NOT the hal0 service home)\n' \
+                "${HOME:-/root}" >&2
+            ;;
+        *)
+            _hal0_svc_home="${HAL0_SERVICE_HOME-$(getent passwd hal0 2>/dev/null | cut -d: -f6)}"
+            if [ -n "$_hal0_svc_home" ]; then
+                HOME="$_hal0_svc_home"
+                export HOME
+                unset HERMES_HOME
+                printf 'hermes: running as root without the run-as-hal0 guard — reading %s/.hermes (hal0 service home)\n' \
+                    "$_hal0_svc_home" >&2
+            else
+                printf 'hermes: running as root and no hal0 service user found — reading %s/.hermes\n' \
+                    "${HOME:-/root}" >&2
+            fi
+            ;;
+    esac
+fi
+
 if [ ! -x "$HAL0_HERMES_BIN" ]; then
     printf 'hermes: venv binary missing at %s\n' "$HAL0_HERMES_BIN" >&2
     printf '  Run `hal0 agent bootstrap hermes` to provision.\n' >&2

--- a/tests/agents/test_hermes_wrapper.py
+++ b/tests/agents/test_hermes_wrapper.py
@@ -648,6 +648,136 @@ def test_hal0_hermes_wrapper_defaults_home_when_unset(tmp_path: Path) -> None:
     assert "HERMES_HOME=/var/lib/hal0/agents/hermes" not in out.stdout
 
 
+# ── #2063 — root runs must resolve the hal0 service home, and say so ─────────
+#
+# `hermes mcp list`/`test` as root used to silently read /root/.hermes and
+# report "No MCP servers configured" on a healthy install. The run-as-hal0
+# guard already fixes the normal installed-box case by dropping to the hal0
+# user, but when the guard lib is absent (partial/dev install) the wrapper
+# proceeded as root unguarded. These tests drive the wrapper's fallback:
+# still-root after the guard block → point HOME at the service home (or at
+# minimum print WHICH ~/.hermes tree this invocation resolves).
+#
+# Seams (test-only, mirroring tests/agents/test_run_as_hal0_guard.py):
+#   HAL0_RUNAS_TEST_UID  — fake the euid (we can't become root in CI)
+#   HAL0_GUARD_LIB       — point at a nonexistent path = guard not installed
+#   HAL0_SERVICE_HOME    — bypass the getent lookup; SET-BUT-EMPTY means
+#                          "no hal0 service user resolvable"
+
+
+def _run_wrapper(tmp_path: Path, extra_env: dict[str, str]) -> _subprocess.CompletedProcess[str]:
+    """Run the canonical wrapper against an env-dumping probe binary."""
+    probe = tmp_path / "probe.sh"
+    probe.write_text("#!/bin/sh\nenv\n", encoding="utf-8")
+    probe.chmod(0o755)
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "HAL0_HERMES_BIN": str(probe),
+        "HAL0_HERMES_SECRETS": "/nonexistent/secrets.env",
+        "HAL0_GUARD_LIB": "/nonexistent/run-as-hal0.sh",
+    }
+    env.update(extra_env)
+    return _subprocess.run(
+        ["/bin/sh", str(_HERMES_WRAPPER), "noop"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_wrapper_root_without_guard_points_home_at_service_home(tmp_path: Path) -> None:
+    """THE #2063 regression: unguarded root must NOT resolve ~/.hermes to
+    root's home. The wrapper points HOME at the hal0 service home so the
+    upstream CLI reads the same config the running agent uses."""
+    svc_home = tmp_path / "var-lib-hal0"
+    result = _run_wrapper(
+        tmp_path,
+        {
+            "HAL0_RUNAS_TEST_UID": "0",
+            "HAL0_SERVICE_HOME": str(svc_home),
+            "HOME": "/root",
+        },
+    )
+    assert result.returncode == 0
+    assert f"HOME={svc_home}" in result.stdout
+    assert "HOME=/root" not in result.stdout
+    # Diagnosability (#2063 option 3): the wrapper names the tree it resolved.
+    assert f"{svc_home}/.hermes" in result.stderr
+
+
+def test_wrapper_root_without_guard_strips_inherited_hermes_home(tmp_path: Path) -> None:
+    """An inherited HERMES_HOME (e.g. root's shell exporting a stale pin)
+    would override the corrected HOME inside upstream hermes — the fallback
+    must strip it, matching the guard's `env -u HERMES_HOME` posture."""
+    svc_home = tmp_path / "var-lib-hal0"
+    result = _run_wrapper(
+        tmp_path,
+        {
+            "HAL0_RUNAS_TEST_UID": "0",
+            "HAL0_SERVICE_HOME": str(svc_home),
+            "HOME": "/root",
+            "HERMES_HOME": "/root/.hermes",
+        },
+    )
+    assert result.returncode == 0
+    assert "HERMES_HOME=" not in result.stdout
+
+
+def test_wrapper_root_without_service_user_warns_with_resolved_path(tmp_path: Path) -> None:
+    """No hal0 user on the box (true dev shell): behavior is unchanged —
+    root's own home applies — but the wrapper must still name the config
+    tree so an empty `mcp list` is diagnosable, never silent."""
+    rootish = tmp_path / "rootish"
+    result = _run_wrapper(
+        tmp_path,
+        {
+            "HAL0_RUNAS_TEST_UID": "0",
+            "HAL0_SERVICE_HOME": "",  # set-but-empty = user not resolvable
+            "HOME": str(rootish),
+        },
+    )
+    assert result.returncode == 0
+    assert f"HOME={rootish}" in result.stdout
+    assert f"{rootish}/.hermes" in result.stderr
+
+
+def test_wrapper_allow_root_keeps_root_env_but_names_the_path(tmp_path: Path) -> None:
+    """HAL0_ALLOW_ROOT is the deliberate root-debug escape hatch: env stays
+    untouched, but the wrapper says which ~/.hermes it resolves so the
+    operator can't mistake root's empty tree for a broken install."""
+    rootish = tmp_path / "rootish"
+    result = _run_wrapper(
+        tmp_path,
+        {
+            "HAL0_RUNAS_TEST_UID": "0",
+            "HAL0_ALLOW_ROOT": "1",
+            "HAL0_SERVICE_HOME": str(tmp_path / "var-lib-hal0"),
+            "HOME": str(rootish),
+        },
+    )
+    assert result.returncode == 0
+    assert f"HOME={rootish}" in result.stdout
+    assert f"{rootish}/.hermes" in result.stderr
+
+
+def test_wrapper_non_root_stays_silent_and_untouched(tmp_path: Path) -> None:
+    """Acceptance guard: behavior as the service user (any non-root user)
+    is unchanged — no HOME override, no stderr chatter."""
+    user_home = tmp_path / "user-home"
+    result = _run_wrapper(
+        tmp_path,
+        {
+            "HAL0_RUNAS_TEST_UID": "1000",
+            "HAL0_SERVICE_HOME": str(tmp_path / "var-lib-hal0"),
+            "HOME": str(user_home),
+        },
+    )
+    assert result.returncode == 0
+    assert f"HOME={user_home}" in result.stdout
+    assert ".hermes" not in result.stderr
+
+
 # ── uninstall teardown: privilege seam + failure surfacing (#453) ────────────
 #
 # `_stop_services` had two defects beyond the test-isolation one #1357 fixed:


### PR DESCRIPTION
## Summary

`hermes mcp list` / `hermes mcp test` run as root resolved the config under `~root/.hermes` and falsely reported "No MCP servers configured" on a healthy install, sending an operator down a "broken install" path when the CLI had simply read the wrong home. This PR hardens hal0's `hermes` wrapper so root invocations resolve the hal0 service home, and makes every root-context path print which `~/.hermes` tree it resolved.

## Root cause

Upstream `hermes` resolves its state dir from `$HOME` (`~/.hermes`). The hermes CLI source is **not** in this repo — it is pinned from upstream `NousResearch/hermes-agent` (`installer/agents/hermes/requirements.txt`) — so the CLI-side fix (resolve the service home when euid == 0) is an upstream matter. hal0's seam is the wrapper at `installer/wrappers/hermes`.

That wrapper already drops root to the `hal0` service user via the run-as-hal0 guard (`/usr/lib/hal0/guards/run-as-hal0.sh`, #843), which covers a fully installed box. But two root paths remained silent and wrong:

- guard lib missing/unreadable (partial install, upgrade drift, dev box) or the `hal0` user absent → the wrapper proceeded as root unguarded, and hermes read `/root/.hermes`;
- `HAL0_ALLOW_ROOT=1` (deliberate root debug) → root's own tree was read with no indication of which config path was in play.

Either way the empty result was undiagnosable — exactly what turned a wrong-home read into a false diagnosis in the live session behind #2063.

## Fix

In `installer/wrappers/hermes`, after the guard block, if the process is still root:

- **Guard couldn't drop** → point `HOME` at the hal0 service home (`getent passwd hal0`, `HAL0_SERVICE_HOME` override for tests/nonstandard accounts), strip any inherited `HERMES_HOME` (matching the guard's `env -u` posture), and print the resolved `~/.hermes` path on stderr.
- **No `hal0` user resolvable** (true dev shell) → behavior unchanged, but the resolved path is printed so the empty result is diagnosable.
- **`HAL0_ALLOW_ROOT` set** → environment left alone, but the wrapper states it is reading root's tree, not the service home.

Non-root invocations (the service user, the systemd unit) are untouched and stay silent. The `--hal0-ready` installer sentinel stays silent too (the block sits after it). Docs: a short "Running `hermes` as root" section added to `docs/guides/run-agents.mdx`, noting that the euid-aware CLI fix belongs upstream.

## Test evidence

Test-first: the four new behavior tests in `tests/agents/test_hermes_wrapper.py` fail against the pre-fix wrapper —

```
FAILED test_wrapper_root_without_guard_points_home_at_service_home
FAILED test_wrapper_root_without_guard_strips_inherited_hermes_home
FAILED test_wrapper_root_without_service_user_warns_with_resolved_path
FAILED test_wrapper_allow_root_keeps_root_env_but_names_the_path
4 failed, 1 passed
```

With the fix: `pytest tests/agents/test_hermes_wrapper.py` → **36 passed** (all pre-existing wrapper tests included; notably `test_hermes_wrapper_does_not_pin_hermes_home` still holds — the fallback only redirects `HOME`, it never reintroduces a `HERMES_HOME` pin). `sh -n installer/wrappers/hermes` passes; shellcheck is not installed on this dev Mac — relying on CI for that. `tests/agents/test_run_as_hal0_guard.py::test_reexec_actually_runs_with_clean_env` fails on macOS before and after this change (the guard's `getent` lookup doesn't exist on Darwin) — pre-existing, untouched here.

Fixes #2063

🤖 Generated with [Claude Code](https://claude.com/claude-code)
