### PR TITLE
fix(installer): grant the service user write access to /etc/avahi/services

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -756,6 +756,25 @@ if [[ "${DEV_MODE}" -eq 0 ]] && getent passwd hal0 >/dev/null 2>&1; then
     chmod 2775 "${VAR_DIR}/slots" "${VAR_DIR}/registry" "${VAR_DIR}/models" 2>/dev/null || true
 fi
 
+# mDNS addon advertisements (#2059): services/mdns.py (hal0-api, User=hal0)
+# writes /etc/avahi/services/hal0-addon-<id>.service via tmp+rename, which
+# needs *directory* write — the distro ships the dir root:root 0755, so every
+# dashboard advertise/withdraw died EACCES since the root-to-unprivileged
+# switch. Group-write grant (root:hal0, g+w) mirrors the OwnershipStore row in
+# src/hal0/install/perms.py (the `doctor perms --fix` backstop heals the same
+# values); done here too so the dir is correct before the daemon's first
+# touch. The chgrp of pre-existing hal0-addon-*.service files is the upgrade
+# path: root-era installs wrote them as root, and handing them to the hal0
+# group keeps the daemon's own advertisement surface consistently
+# group-readable. avahi-daemon inotify-watches the dir — no reload needed.
+# Guarded on avahi actually being present; idempotent on re-run.
+if [[ "${DEV_MODE}" -eq 0 && -d /etc/avahi/services ]] \
+    && getent group hal0 >/dev/null 2>&1; then
+    chgrp hal0 /etc/avahi/services 2>/dev/null || true
+    chmod g+w /etc/avahi/services 2>/dev/null || true
+    chgrp hal0 /etc/avahi/services/hal0-addon-*.service 2>/dev/null || true
+fi
+
 # Production (FHS, #495) ships the source tree into the versioned dir
 # ${PREFIX} (=${FHS_ROOT}/hal0-<version>) and points `current` at it, so
 # `hal0 update` can atomically swap `current` to a new versioned tree.

--- a/src/hal0/install/perms.py
+++ b/src/hal0/install/perms.py
@@ -191,6 +191,20 @@ def _shared_dir_roots() -> tuple[Path, ...]:
 # ── the declarative table ─────────────────────────────────────────────────────
 
 
+def _avahi_services_dir() -> Path:
+    """The avahi services dir the mDNS row declares (#2059).
+
+    Delegates to :func:`hal0.services.mdns.services_dir` — the writer's own
+    path authority, honoring its ``HAL0_AVAHI_SERVICES_DIR`` override — so the
+    table and the writer can never disagree about which dir the grant covers.
+    Imported lazily to keep this module free of the services layer at import
+    time.
+    """
+    from hal0.services.mdns import services_dir
+
+    return services_dir()
+
+
 @dataclass(frozen=True)
 class PermRow:
     """One path's declared ownership + mode.
@@ -838,6 +852,32 @@ def ownership_table(
         ),
         # ── /var/log/hal0 ─────────────────────────────────────────────────────
         PermRow(var_log, "hal0", "hal0", 0o755, role="/var/log/hal0"),
+        # ── /etc/avahi/services — mDNS addon advertisements (#2059) ────────────
+        # services/mdns.py (hal0-api, User=hal0) writes/removes
+        # ``hal0-addon-*.service`` files via tmp + rename, which needs
+        # *directory* write. The distro ships the dir root:root 0755, so every
+        # dashboard advertise/withdraw died EACCES since the root-to-
+        # unprivileged switch — the feature only ever worked in the root era.
+        # Group-write is the minimal grant: the OWNER stays root (this is
+        # avahi's dir, not hal0's — the one deliberately-foreign root in this
+        # table, resolved via mdns.services_dir() so the
+        # HAL0_AVAHI_SERVICES_DIR override keeps tests isolated). Like the
+        # agent-skills/ row above, dir-only on purpose: no glob into the addon
+        # files — a fresh advertise births them hal0-owned and rewrites/prunes
+        # need only dir write, so declaring a single owner for them would
+        # fight one era's files or the other's (install.sh chgrp's root-era
+        # leftovers once, on upgrade). ``optional`` is the avahi-presence
+        # guard: no avahi, no dir, no drift. No setgid: avahi-daemon
+        # inotify-watches the dir and reads the files as root either way.
+        # Root-era keeps the distro-default root:root 0755 byte-for-byte —
+        # that era ran the API as root and never needed the grant.
+        PermRow(
+            _avahi_services_dir(),
+            "root",
+            service_group if flipped else "root",
+            0o775 if flipped else 0o755,
+            role="/etc/avahi/services (mDNS addon advertisements)",
+        ),
     ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -306,11 +306,15 @@ def tmp_hal0_home(tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPa
     """Set HAL0_HOME to a temporary directory for filesystem isolation.
 
     Also opts the systemd-override renderer into the HAL0_HOME branch so
-    unit-template tests write under tmp_path instead of /etc/systemd/system.
+    unit-template tests write under tmp_path instead of /etc/systemd/system,
+    and points the avahi services dir under the same tree so the ownership
+    table's /etc/avahi/services row (#2059) never observes — or drifts
+    against — the host's real avahi install.
     """
     home = str(tmp_path)
     monkeypatch.setenv("HAL0_HOME", home)
     monkeypatch.setenv("HAL0_OVERRIDE_DIR", "hal0_home")
+    monkeypatch.setenv("HAL0_AVAHI_SERVICES_DIR", str(tmp_path / "etc" / "avahi" / "services"))
     return home
 
 

--- a/tests/install/test_perms.py
+++ b/tests/install/test_perms.py
@@ -171,7 +171,9 @@ def test_ownership_table_builds_under_hal0_home(tmp_hal0_home: str) -> None:
     assert table, "table must not be empty"
     assert all(isinstance(r, perms.PermRow) for r in table)
     home = Path(tmp_hal0_home)
-    # every declared path lives under the isolated HAL0_HOME tree
+    # every declared path lives under the isolated HAL0_HOME tree (the avahi
+    # services row (#2059) included — tmp_hal0_home points
+    # HAL0_AVAHI_SERVICES_DIR under the same tree)
     for row in table:
         assert home in row.target.parents or row.target == home, row.target
     # the config root + slots dir are non-optional anchors
@@ -273,6 +275,48 @@ def test_agent_skills_mirror_is_service_writable(tmp_hal0_home: str) -> None:
     root_rows = _by_target(perms.ownership_table(service_user="root"))
     root_mirror = root_rows[paths.etc() / "agent-skills"]
     assert (root_mirror.owner, root_mirror.group, root_mirror.mode) == ("root", "root", 0o755)
+
+
+def test_avahi_services_dir_is_group_writable_under_flip(tmp_hal0_home: str) -> None:
+    """#2059: /etc/avahi/services must be group-writable by the service account.
+
+    ``services/mdns.py`` (hal0-api, ``User=hal0``) writes/removes
+    ``hal0-addon-*.service`` files via tmp + rename, which needs *directory*
+    write — the distro ships the dir ``root:root 0755``, so every dashboard
+    advertise/withdraw died EACCES since the root-to-unprivileged switch.
+    Group-write on the dir (owner stays root — it is avahi's dir, not hal0's)
+    is the minimal grant; like agent-skills/ the row is dir-only, no
+    glob/recursion into the addon files themselves.
+    """
+    from hal0.services.mdns import services_dir
+
+    rows = _by_target(perms.ownership_table(service_user="hal0"))
+    avahi = rows[services_dir()]
+    assert (avahi.owner, avahi.group, avahi.mode) == ("root", "hal0", 0o775)
+    assert avahi.glob is None
+    assert avahi.recursive is False
+    # Optional is the avahi-presence guard: a box without avahi never has the
+    # dir, so plan() reports it absent and commit() writes nothing.
+    assert avahi.optional is True
+    # The root-era table keeps the distro-default root:root 0755 byte-for-byte
+    # (that era ran the API as root, so it never needed the grant).
+    root_rows = _by_target(perms.ownership_table(service_user="root"))
+    root_avahi = root_rows[services_dir()]
+    assert (root_avahi.owner, root_avahi.group, root_avahi.mode) == ("root", "root", 0o755)
+
+
+def test_avahi_services_dir_absent_is_never_drift(tmp_hal0_home: str) -> None:
+    """A box without avahi (dir absent) must plan clean — the presence guard."""
+    from hal0.services.mdns import services_dir
+
+    rows = _by_target(perms.ownership_table(service_user="hal0"))
+    avahi = rows[services_dir()]
+    absent = perms.PermObservation(
+        path=avahi.target, exists=False, owner=None, group=None, mode=None
+    )
+    pl = perms.plan([avahi], observe_fn=lambda p: absent)
+    assert pl.changed is False
+    assert pl.drifted == ()
 
 
 def test_flip_makes_state_root_service_owned(tmp_hal0_home: str) -> None:


### PR DESCRIPTION
## Summary

Dashboard mDNS advertise/withdraw (`POST /api/services/mdns`) has been dead on every unprivileged install: `services/mdns.py` runs as the `hal0` service user and writes `hal0-addon-*.service` files into `/etc/avahi/services`, which ships `root:root 0755` — every write dies EACCES. This adds the missing permission grant to the installer.

## Root cause

A regression from the root-to-unprivileged switch: the feature worked while the API ran as root, and nothing in `installer/install.sh` or the ownership table (`src/hal0/install/perms.py`) was ever taught to make the avahi services dir writable by the service user. `mdns.py` writes via tmp + rename, so *directory* write is the one capability it needs.

## Fix

Two small, mutually reinforcing pieces, both idempotent and guarded on avahi actually being present:

- **`src/hal0/install/perms.py`** — a new dir-only `PermRow` for the avahi services dir (resolved via `mdns.services_dir()`, the writer's own path authority): `root:hal0 0775` under the hardened flip — owner stays root because the dir belongs to avahi; group-write is the minimal grant, matching the manual workaround already verified on 10.0.1.142. `optional` is the avahi-presence guard (absent dir plans clean, never drifts), and the root-era table keeps the distro default `root:root 0755`. The installer's existing `doctor perms --fix --force` backstop applies it on fresh installs *and* upgrades, and `hal0 doctor perms` can now see/heal this drift forever. Deliberately no glob into the addon files: rewrites and prunes only need dir write, and a fresh advertise births files hal0-owned while root-era leftovers are root-owned — a single declared owner would fight one era or the other.
- **`installer/install.sh`** — the same `chgrp hal0` + `chmod g+w` at the filesystem-layout step so the dir is correct before the daemon's first touch, plus the upgrade path: pre-existing root-era `hal0-addon-*.service` files get `chgrp hal0`. avahi-daemon inotify-watches the dir, so no daemon interaction is needed.
- **`tests/conftest.py`** — `tmp_hal0_home` now also points `HAL0_AVAHI_SERVICES_DIR` under the isolated tree so the perms converge tests never observe (or drift against) the host's real avahi install.

`services/mdns.py` itself is unchanged.

## Test evidence

Test-first: the two new tests fail against `main`'s `perms.py` (`KeyError` — no row for the avahi dir) and pass with the fix:

- `test_avahi_services_dir_is_group_writable_under_flip` — row is `root:hal0 0775` dir-only under the flip, `root:root 0755` in the root-era table, `optional` (the presence guard).
- `test_avahi_services_dir_absent_is_never_drift` — a box without avahi plans clean.

Ran locally (macOS, uv): `tests/install/` + `tests/security/test_api_env_mode.py` → **306 passed, 1 skipped** (pre-existing sandbox skip); `tests/api/test_services_page.py` + `tests/cli/test_doctor_verify.py` → 34 passed. `ruff check` + `ruff format --check` clean on touched files; `bash -n installer/install.sh` clean (shellcheck not installed on this Mac — relying on CI for that).

Fixes #2059

🤖 Generated with [Claude Code](https://claude.com/claude-code)
