### PR TITLE
fix(providers): honest kfd-less refusal + documented device contract for the non-llama gpu-rocm seeds (#2067)

### DIFF
--- a/installer/etc-hal0/slots/img.toml
+++ b/installer/etc-hal0/slots/img.toml
@@ -15,6 +15,11 @@
 name = "img"
 type = "image"
 provider = "comfyui"
+# gpu-rocm is a contract, not a preference (#2067): the pinned ComfyUI image
+# is a ROCm-only build (RUNNER_IMAGES["comfyui"].supported_backends ==
+# ("rocm",)), so seeding never derives another device — there is no CPU or
+# Vulkan lane to derive. On a kfd-less box this seeds as an inactive tile and
+# first use refuses loudly, naming the absent /dev/kfd and how to forward it.
 device = "gpu-rocm"
 runtime = "container"
 profile = "comfyui"

--- a/installer/etc-hal0/slots/qwen3tts.toml
+++ b/installer/etc-hal0/slots/qwen3tts.toml
@@ -10,6 +10,12 @@
 # triggers a surprise download or a crash-loop.
 name = "qwen3tts"
 type = "tts"
+# gpu-rocm is a contract, not a preference (#2067): the Qwen3-TTS image is a
+# ROCm-only build (RUNNER_IMAGES["qwen3tts"].supported_backends == ("rocm",)),
+# so seeding never derives another device — there is no CPU or Vulkan lane to
+# derive; the cpu `tts`/kokoro sibling above IS the CPU speech lane. On a
+# kfd-less box this seeds as an inactive tile and first use refuses loudly,
+# naming the absent /dev/kfd and how to forward it.
 device = "gpu-rocm"
 runtime = "container"
 profile = "qwen3-tts"

--- a/src/hal0/install/static_seeds.py
+++ b/src/hal0/install/static_seeds.py
@@ -64,7 +64,14 @@ STATIC_SEED_SLOTS: tuple[str, ...] = (
 #:
 #: Deliberately absent: ``flm`` (npu), ``tts`` (kokoro/cpu), ``img``
 #: (ComfyUI) and ``qwen3tts`` — non-llama runtimes with their own device
-#: logic. Their seed device ships verbatim, whatever the host.
+#: logic. Their seed device ships verbatim, whatever the host. For the two
+#: that ship ``gpu-rocm`` (``img``, ``qwen3tts``) verbatim is a CONTRACT, not
+#: an omission (#2067): both runner images are ROCm-only builds
+#: (``RUNNER_IMAGES[...].supported_backends == ("rocm",)``), so a kfd-less box
+#: has no CPU or Vulkan lane to derive instead. The seed lands as an inactive
+#: tile (no ``[model].default`` pin, #1369 — nothing autoloads), and first use
+#: refuses loudly via ``_gpu.require_kfd_for_gpu_slot``'s ``rocm`` lane,
+#: naming the absent ``/dev/kfd`` and how to forward it.
 LLAMA_SEED_CAPABILITIES: dict[str, str] = {
     "agent": "chat",
     "brain": "chat",

--- a/src/hal0/providers/_gpu.py
+++ b/src/hal0/providers/_gpu.py
@@ -717,7 +717,9 @@ def require_kfd_for_gpu_slot(
       ROCmFPX runner. Gated, with #1888's silent-garbage explanation.
     * ``"rocm"`` — a non-llama runtime whose image resolves ROCm/HIP.
       Gated, but the refusal does not blame llama.cpp's fallback: quoting
-      #1888 at a ComfyUI operator sends them chasing the wrong defect.
+      #1888 at a ComfyUI operator sends them chasing the wrong defect. Its
+      missing-node remedy also never suggests ``device='cpu'`` (#2067):
+      these images are ROCm-only, so forwarding the node is the only fix.
     * ``"no-rocm"`` — a runtime that never touches HIP (Kokoro / Moonshine,
       and any genuinely-Vulkan image). Its ``gpu-vulkan`` slots are NOT
       gated; this is the class #1941 was filed for.
@@ -859,8 +861,18 @@ def require_kfd_for_gpu_slot(
         remedy = (
             "It is not visible here. Forward the device from the host (Proxmox "
             f"LXC: add 'dev1: {kfd_path}' to /etc/pve/lxc/<CTID>.conf, then pct "
-            "stop/start), or move this slot to device='cpu'."
+            "stop/start)"
         )
+        if runtime_lane == "rocm":
+            # #2067: the rocm lane means a ROCm-only image (ComfyUI /
+            # Qwen3-TTS — ``RUNNER_IMAGES[...].supported_backends ==
+            # ("rocm",)``). There is no CPU or Vulkan lane to move the slot
+            # to, so the other lanes' device='cpu' suggestion would be a
+            # remedy this runtime cannot honour; forwarding the node is the
+            # only fix, and the refusal says so.
+            remedy += ". This runtime's image is ROCm-only — no other device can serve it."
+        else:
+            remedy += ", or move this slot to device='cpu'."
     raise GpuPreflightError(preamble + remedy)
 
 

--- a/tests/install/test_seed_device_derivation.py
+++ b/tests/install/test_seed_device_derivation.py
@@ -218,3 +218,82 @@ def test_apply_derived_seed_devices_ignores_missing_files(
     dest.mkdir()
     rewritten = apply_derived_seed_devices(("agent",), slots_dir=dest, hw=hw)
     assert rewritten == {}
+
+
+# ── #2067 — the non-llama gpu-rocm seeds' first-use contract ─────────────────
+#
+# ``img`` (ComfyUI) and ``qwen3tts`` ship ``device = "gpu-rocm"`` verbatim on
+# every host — including a kfd-less one — and that is a CONTRACT, not a #2054
+# leftover: both runner images are ROCm-only builds, so there is no CPU or
+# Vulkan lane a derivation ladder could pick instead. What seeding owes the
+# operator instead is an honest first use: the load-time gate must refuse in
+# the ``rocm`` lane, plainly naming the absent ``/dev/kfd`` and how to forward
+# it — and must not offer a remedy the runtime cannot honour.
+
+
+def _non_llama_gpu_rocm_seed_cfgs() -> dict[str, dict]:
+    """The shipped non-llama seeds whose TOML carries ``device = "gpu-rocm"``."""
+    cfgs: dict[str, dict] = {}
+    for name in STATIC_SEED_SLOTS:
+        if name in LLAMA_SEED_CAPABILITIES:
+            continue
+        cfg = tomllib.loads((_SEED_SRC_DIR / f"{name}.toml").read_text(encoding="utf-8"))
+        if cfg.get("device") == "gpu-rocm":
+            cfgs[name] = cfg
+    return cfgs
+
+
+def test_the_gpu_rocm_non_llama_seeds_are_rocm_only_runtimes() -> None:
+    """Why derivation deliberately skips them: each resolves to a provider on
+    the ``rocm`` lane whose registered runner image supports NO other backend
+    — a kfd-less box has nothing to derive, so verbatim ``gpu-rocm`` is the
+    honest label. A new non-llama gpu-rocm seed, or a runner growing a second
+    backend, breaks this pin and must revisit the contract."""
+    from hal0.providers._gpu import runtime_lane_for_provider
+    from hal0.providers.container import _spec_provider_for
+    from hal0.runners import RUNNER_IMAGES
+
+    cfgs = _non_llama_gpu_rocm_seed_cfgs()
+    assert set(cfgs) == {"img", "qwen3tts"}
+    for name, cfg in cfgs.items():
+        provider = _spec_provider_for(cfg)
+        assert provider is not None, name
+        assert runtime_lane_for_provider(provider) == "rocm", name
+        assert RUNNER_IMAGES[provider.name].supported_backends == ("rocm",), name
+
+
+def test_kfd_less_first_use_refusal_is_plain_and_honourable(tmp_path: Path) -> None:
+    """The #2067 acceptance pin: first use of a seeded img / qwen3tts slot on
+    a kfd-less box states plainly that the seeded device's node is absent and
+    how to forward it — without llama.cpp's #1888 story (not this runtime's
+    defect) and without offering ``device='cpu'`` (these images have no CPU
+    lane to move to)."""
+    from hal0.providers._gpu import (
+        GpuPreflightError,
+        require_kfd_for_gpu_slot,
+        runtime_lane_for_provider,
+    )
+    from hal0.providers.container import _spec_provider_for
+
+    for name, cfg in _non_llama_gpu_rocm_seed_cfgs().items():
+        lane = runtime_lane_for_provider(_spec_provider_for(cfg))
+        with pytest.raises(GpuPreflightError) as exc:
+            require_kfd_for_gpu_slot(
+                name,
+                device=str(cfg["device"]),
+                runtime_lane=lane,
+                kfd_path=str(tmp_path / "kfd"),
+                env={},
+                amd_host=True,
+            )
+        msg = str(exc.value)
+        # Plainly names the slot, the seeded device, and the missing node…
+        assert f"slot {name!r}" in msg
+        assert "device=gpu-rocm" in msg
+        assert "/kfd" in msg
+        # …with the forward remedy…
+        assert "dev1:" in msg
+        # …no llama-lane blame…
+        assert "1888" not in msg
+        # …and no lane the runtime does not have.
+        assert "device='cpu'" not in msg, msg

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -775,6 +775,36 @@ class TestGuardRemedyText:
             require_kfd_for_gpu_slot("brain", device="gpu-rocm", kfd_path=str(tmp_path / "nope"))
         assert "dev1:" in str(err.value)
 
+    def test_the_llama_lane_missing_remedy_still_offers_the_cpu_lane(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """llama-server genuinely runs on CPU, so 'move this slot to
+        device=cpu' stays a real remedy for the llama lane."""
+        monkeypatch.setattr("hal0.providers._gpu.kfd_status", lambda *a, **k: KFD_MISSING)
+        with pytest.raises(GpuPreflightError) as err:
+            require_kfd_for_gpu_slot("brain", device="gpu-rocm", kfd_path=str(tmp_path / "nope"))
+        assert "device='cpu'" in str(err.value)
+
+    def test_the_rocm_lane_missing_remedy_does_not_offer_a_cpu_lane(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """#2067: the rocm lane means a ROCm-only image (ComfyUI / Qwen3-TTS —
+        ``RUNNER_IMAGES[...].supported_backends == ("rocm",)``). There is no
+        CPU lane to move the slot to, so suggesting ``device='cpu'`` is a
+        remedy the runtime cannot honour — the refusal must say so instead."""
+        monkeypatch.setattr("hal0.providers._gpu.kfd_status", lambda *a, **k: KFD_MISSING)
+        with pytest.raises(GpuPreflightError) as err:
+            require_kfd_for_gpu_slot(
+                "img",
+                device="gpu-rocm",
+                runtime_lane="rocm",
+                kfd_path=str(tmp_path / "nope"),
+            )
+        msg = str(err.value)
+        assert "device='cpu'" not in msg
+        assert "ROCm-only" in msg
+        assert "dev1:" in msg  # the forward remedy is still the fix
+
 
 class TestConvergeAgainstRealPermissionDenial:
     """#1953 gap 2 — exercise a GENUINE chgrp refusal, not a monkeypatched one.


### PR DESCRIPTION
## Summary

#2067 asked an either/or: extend #2054's device-derivation ladder to the non-llama seeds (img/ComfyUI, qwen3tts), or — if those providers legitimately own device selection — make their kfd-less load refusal honest and document the contract. This PR takes the second branch, because the first is impossible by construction: both runner images are ROCm-only builds (`RUNNER_IMAGES["comfyui"].supported_backends == ("rocm",)`, same for `qwen3tts`), so a kfd-less box has no CPU or Vulkan lane a derivation ladder could pick. Extending the ladder would only relabel the slot into a device/profile pair the runtime cannot serve.

## Root cause

The seeded `device = "gpu-rocm"` on a kfd-less box is deliberate and mostly safe: the seeds ship no `[model].default` pin, so nothing autoloads — the slot lands as an inactive tile, and first use hits `require_kfd_for_gpu_slot`, which already refuses `gpu-rocm` in every lane and (since #1952) explains the rocm lane without blaming llama.cpp's #1888 fallback. The one dishonest piece was the missing-node remedy's closing clause, shared across lanes: "…or move this slot to device='cpu'". For ComfyUI/Qwen3-TTS that is advice the runtime cannot honour — following it launches a HIP image with no GPU lane at all, trading a clear refusal for a confusing failure.

## Fix

- `src/hal0/providers/_gpu.py`: the missing-kfd remedy is now lane-scoped. The `rocm` lane states the image is ROCm-only and keeps only the forward-the-node remedy; the `llama` and `no-rocm` lanes keep the `device='cpu'` suggestion (llama-server genuinely runs on CPU; for `no-rocm` the device label is the actual defect). Docstring updated.
- `src/hal0/install/static_seeds.py` + `installer/etc-hal0/slots/{img,qwen3tts}.toml`: the contract is documented where the next reader will look — verbatim `gpu-rocm` on these two seeds is deliberate (#2067), why no derivation applies, and what the first-use failure looks like on a kfd-less box.
- Tests pin the contract end-to-end:
  - `tests/install/test_seed_device_derivation.py`: the shipped non-llama `gpu-rocm` seeds are exactly `img`/`qwen3tts`; each resolves (via `_spec_provider_for` on the actual seed TOML) to a rocm-lane provider over a ROCm-only runner; and the kfd-less first-use refusal names the slot, the device, the missing `/dev/kfd` and the forward remedy while containing neither "#1888" nor `device='cpu'`.
  - `tests/providers/test_gpu_kfd_preflight.py` (`TestGuardRemedyText`): lane-scoped remedy pins — rocm lane never offers a CPU lane, llama lane still does.

No regression on ROCm boxes: kfd-present hosts never reach the refusal path, and the #2054 llama-seed derivation is untouched (its ladder still picks `gpu-rocm` when kfd exists — pinned by the existing `test_kfd_present_host_still_derives_gpu_rocm`).

## Test evidence

Test-first, verified red on the pre-fix code: `TestGuardRemedyText::test_the_rocm_lane_missing_remedy_does_not_offer_a_cpu_lane` and `test_kfd_less_first_use_refusal_is_plain_and_honourable` both fail before the `_gpu.py` change and pass after.

Ran on the Mac dev checkout: `pytest tests/install/ tests/providers/test_gpu_kfd_preflight.py tests/providers/test_gpu_vulkan_lane_gate.py tests/providers/test_vulkan_lane_perimeter.py tests/providers/test_comfyui.py tests/providers/test_qwen3tts_container_spec.py tests/installer/test_seed_order.py` — all green except pre-existing environment failures unrelated to this diff (`tests/installer/*` bash-contract tests refuse Darwin, and `tests/install/test_perms_converge.py` trips a UnicodeDecodeError on NFS AppleDouble files); relying on CI for those. `ruff check` and `ruff format --check` clean on all touched files.

Fixes #2067

🤖 Generated with [Claude Code](https://claude.com/claude-code)
