### PR TITLE
fix(runner): repair structured output in the chat parsers; roll pin to hal0-combined:0826 (#2056)

### DIFF
--- a/packaging/runner/rocmfpx/manifest.toml
+++ b/packaging/runner/rocmfpx/manifest.toml
@@ -11,7 +11,7 @@
 
 [image]
 #: The tag this recipe produces. Keep in lockstep with DEFAULT_ROCMFPX_IMAGE.
-tag = "ghcr.io/hal0ai/hal0-combined:0824"
+tag = "ghcr.io/hal0ai/hal0-combined:0826"
 
 [base]
 #: Runtime layer. A Kyuz0 amd-strix-halo-toolboxes derivative; the ROCm
@@ -131,6 +131,15 @@ deepseek_v3_2 parser, which uses the same <param name=> shape.
 Includes an explicit grammar_triggers entry: this tree's PEG API does not
 auto-derive triggers from trigger_rule, so a lazy grammar without one rejects
 every tools request with "no triggers set for lazy grammar!".
+
+:0826 revision (#2056): the reasoning branch consumes an optional closed
+<think>...</think> block even when reasoning extraction is off. The brain-sft
+template emits a pre-closed think block in its generation prompt whenever
+thinking is disabled, and common_sampler_init prefill-feeds that prompt into
+non-lazy grammars (response_format / forced tool choice); with the old
+`p.eps()` branch the grammar had no rule for the block, so the prefill token
+hit a grammar expecting `{` and every structured-output request died with
+"Failed to initialize samplers: std::exception".
 """
 
 [[patches]]
@@ -144,6 +153,21 @@ cause of #1888 — that was ruled out by test — but cheap insurance on a build
 whose output is a signed pin.
 """
 
+[[patches]]
+file = "0004-chat-lfm25-response-format-grammar.patch"
+why = """
+LFM2.5 response_format produced an EMPTY grammar: the parser set grammar_lazy
+from tool_choice alone (default AUTO), and a lazy grammar generates its root
+from trigger rules only — a request with no tools has none, so generation ran
+unconstrained and every response_format request 500'd at the parse
+(hal0 #2056 follow-up; found validating LFM2.5-2.6B as a default-brain
+candidate; reproduced on prod's live LFM slot). Non-lazy now whenever
+response_format is present, matching every sibling parser. Also consumes a
+weight-emitted or prompt-tail think block (plus trailing whitespace) when
+reasoning extraction is off — the same prefill/parse hole patch 0002 closed
+for MiniCPM5 — and tolerates trailing whitespace after the JSON body.
+"""
+
 [verification]
 #: What this image was proven against before the pin moved. Full matrix and
 #: evidence: https://github.com/Hal0ai/hal0/issues/1948
@@ -153,4 +177,6 @@ probes = [
     ">=256-token generation terminates with no )-repetition wedge",
     "native MiniCPM5 tool_calls on the Vulkan lane of a kfd-less box",
     "zero devices mapped -> readable diagnostic, exit 78, no SIGSEGV (#1936)",
+    "response_format json_object AND json_schema -> 200 on the seeded brain model, thinking kwarg absent/true/false (#2056)",
+    "doomed model with devices present -> exit 64 fail-fast (#2037)",
 ]

--- a/packaging/runner/rocmfpx/patches/0002-chat-minicpm5-tool-call-parser.patch
+++ b/packaging/runner/rocmfpx/patches/0002-chat-minicpm5-tool-call-parser.patch
@@ -52,13 +52,13 @@ index 58a193f..83cc09a 100644
 +        auto reasoning = p.eps();
 +        if (extract_reasoning && inputs.enable_thinking) {
 +            reasoning = p.optional(THINK_START + p.reasoning(p.until(THINK_END)) + THINK_END);
-+        } else if (extract_reasoning) {
-+            reasoning = p.optional(p.literal(THINK_START) + p.until(THINK_END) + p.literal(THINK_END));
++        } else {
++            reasoning = p.optional(p.literal(THINK_START) + p.until(THINK_END) + p.literal(THINK_END) + p.space());
 +        }
 +
 +        if (has_response_format) {
 +            return generation_prompt + reasoning +
-+                   p.content(p.schema(p.json(), "response-format", inputs.json_schema)) + end;
++                   p.content(p.schema(p.json(), "response-format", inputs.json_schema)) + p.space() + end;
 +        }
 +
 +        if (has_tools && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE) {

--- a/packaging/runner/rocmfpx/patches/0004-chat-lfm25-response-format-grammar.patch
+++ b/packaging/runner/rocmfpx/patches/0004-chat-lfm25-response-format-grammar.patch
@@ -1,0 +1,40 @@
+diff --git a/common/chat.cpp b/common/chat.cpp
+index a63baf4..365ae6b 100644
+--- a/common/chat.cpp
++++ b/common/chat.cpp
+@@ -1590,12 +1590,20 @@ static common_chat_params common_chat_params_init_lfm2_5(const common_chat_templ
+         auto reasoning = p.eps();
+         if (extract_reasoning) {
+             reasoning = p.optional(THINK_START + p.reasoning(p.until(THINK_END)) + THINK_END);
++        } else {
++            // Not extracting reasoning does not stop the model (or the
++            // template's generation prompt) from emitting a think block —
++            // LFM2.5 thinks from its weights. Consume it as plain text, plus
++            // any trailing whitespace, or a non-lazy response_format grammar
++            // dies in sampler-init prefill and the parse rejects honest
++            // output (hal0 #2056 class).
++            reasoning = p.optional(p.literal(THINK_START) + p.until(THINK_END) + p.literal(THINK_END) + p.space());
+         }
+ 
+         if (!has_tools || inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_NONE) {
+             if (has_response_format) {
+                 auto response_format = p.content(p.schema(p.json(), "response-format-schema", inputs.json_schema));
+-                return generation_prompt + reasoning + response_format + end;
++                return generation_prompt + reasoning + response_format + p.space() + end;
+             }
+             return generation_prompt + reasoning + p.content(p.rest()) + end;
+         }
+@@ -1615,7 +1623,12 @@ static common_chat_params common_chat_params_init_lfm2_5(const common_chat_templ
+     data.parser = parser.save();
+ 
+     if (include_grammar) {
+-        data.grammar_lazy = inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_AUTO;
++        // response_format must produce an eager grammar: a lazy grammar's
++        // root is generated from trigger rules only, and a request with no
++        // tools has none — the grammar came out empty (root ::= <nothing>),
++        // generation ran unconstrained, and every response_format request
++        // 500'd at the parse instead. Matches the sibling parsers' shape.
++        data.grammar_lazy = !has_response_format && inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_AUTO;
+         data.grammar      = build_grammar([&](const common_grammar_builder & builder) {
+             foreach_function(inputs.tools, [&](const json & tool) {
+                 const auto & function = tool.at("function");

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1010,13 +1010,24 @@ MTP_FLAG_BUNDLE = build_mtp_flag_bundle("rocm")
 #: (debug builds, A/B tests, etc.).  See #__hal0_image_control__ for the
 #: phasing: 0.9.5 wires slot.image + DEFAULT_ROCMFPX_IMAGE; 0.9.6 will
 #: drop ``image`` from SEED_PROFILES entirely.
-#: 0824 lineage (2026-08-24): byte-for-byte the 0822 recipe — same pinned
-#: ROCmFPX source ref, same three patches, same base digest — rebuilt via
-#: packaging/runner/rocmfpx/build.sh for exactly one delta: the #2037
-#: fail-fast entrypoint (supervises llama-server, translates a non-signal
-#: death before /health ever answered 200 into exit 64 so the template's
-#: RestartPreventExitStatus=64 can park a doomed model immediately).
-DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-combined:0824"
+#: 0826 lineage (2026-08-26): the 0824 recipe — same pinned ROCmFPX source
+#: ref, same base digest, same #2037 fail-fast entrypoint — rebuilt via
+#: packaging/runner/rocmfpx/build.sh for two chat-parser deltas (#2056):
+#: patch 0002's reasoning branch now consumes an optional closed <think>
+#: block even with reasoning extraction off (without it, the brain-sft
+#: template's pre-closed think block in the generation prompt made
+#: common_sampler_init's non-lazy grammar prefill throw, hard-400ing EVERY
+#: structured-output request against the seeded model — which took all
+#: Hindsight fact extraction down with it on fresh installs); and new patch
+#: 0004 fixes the LFM2.5 parser's response_format grammar (it was built
+#: lazy with no trigger rules — an empty root — so generation ran
+#: unconstrained and every JSON-mode request 500'd at the parse; reproduced
+#: on prod's live LFM slot).
+#: 0824 lineage (2026-08-24): byte-for-byte the 0822 recipe rebuilt for the
+#: #2037 fail-fast entrypoint (supervises llama-server, translates a
+#: non-signal death before /health ever answered 200 into exit 64 so the
+#: template's RestartPreventExitStatus=64 can park a doomed model).
+DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-combined:0826"
 
 #: Historical DEFAULT_ROCMFPX_IMAGE values (and their pre-consolidation
 #: equivalents). A slot-level ``image`` pin equal to one of these is a STALE
@@ -1046,9 +1057,13 @@ DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-combined:0824"
 #: control-token pieces are stripped before the parser sees them).
 STALE_ROCMFPX_IMAGE_REFS = frozenset(
     {
-        # Former default (rc.7). Same recipe lineage as the current 0824 pin
-        # but with the pre-#2037 exec-only entrypoint, so a slot still pinned
-        # here never fail-fasts a doomed model — creation-time debris, retag.
+        # Former default (rc.9). Same lineage as the current 0826 pin but
+        # with the pre-#2056 parser, so every response_format request against
+        # the seeded brain model 400s at sampler init — creation-time debris,
+        # retag.
+        "ghcr.io/hal0ai/hal0-combined:0824",
+        # Former default (rc.7). Pre-#2037 exec-only entrypoint (never
+        # fail-fasts a doomed model) and pre-#2056 parser — retag.
         "ghcr.io/hal0ai/hal0-combined:0822",
         # Former default (rc.6). Its Vulkan backend emits invalid tokens for
         # every model (#1888) — a slot still pinned here is debris from an
@@ -1080,13 +1095,17 @@ STALE_ROCMFPX_IMAGE_REFS = frozenset(
 #: ``tool_calls`` on the shipped brain, and a readable diagnostic instead of
 #: a SIGSEGV with zero devices mapped (#1936).
 #:
-#: ``:0824`` re-earned membership per the rule below rather than inheriting
-#: it: same pinned source/patches/base as ``:0822`` (only the #2037 entrypoint
-#: differs), but the builder stage's dnf toolchain is unpinned, so "same
-#: recipe" does not prove same binaries. Probed 2026-08-24 on ct105
-#: (kfd present) and ct151 (kfd ABSENT): temp-0 Paris probe on the Vulkan
-#: lane, ≥256-token clean tail, and the #1936 device-less diagnostic.
-VULKAN_FIXED_IMAGE = "ghcr.io/hal0ai/hal0-combined:0824"
+#: ``:0826`` re-earned membership per the rule below rather than inheriting
+#: it (the builder stage's dnf toolchain is unpinned, so "same recipe" does
+#: not prove same binaries): probed 2026-08-26 on ct150 (kfd present) and
+#: ct151 (kfd ABSENT) — temp-0 Paris probe, ≥256-token clean tail, the #1936
+#: device-less diagnostic, and (new with #2056) response_format json_object
+#: and json_schema returning 200 on the seeded brain model with the thinking
+#: kwarg absent, true, and false. The structured-output rows exist because
+#: ``:0822``/``:0824`` passed every earlier probe while 400-ing every
+#: structured-output request against the seeded model — the exact class the
+#: old matrix could not see.
+VULKAN_FIXED_IMAGE = "ghcr.io/hal0ai/hal0-combined:0826"
 
 #: Runner images allowed to serve the ``gpu-vulkan`` llama.cpp lane on an AMD
 #: host. Consulted by :func:`hal0.providers._gpu.image_serves_vulkan_lane`,


### PR DESCRIPTION
## Why

#2056: every `response_format` request against the installer-seeded brain model failed at sampler init (`400 Failed to initialize samplers: std::exception`) on the shipped runner — deterministically, direct-to-slot, both backends — which killed 100% of Hindsight fact extraction on fresh installs and JSON mode for any OpenAI-compatible client. Validation of the fix then surfaced a second, independent defect with the same blast radius in the LFM2.5 parser (reproduced on prod's live LFM slot). Both are chat-parser bugs in our own patches/tree, not model or backend defects: the same model on the old `ade07ba` runner passes, and plain chat + tools passed everywhere.

## Root causes

**MiniCPM5 (patch 0002, the seeded-brain path).** `common_sampler_init` prefill-feeds the full generation prompt into non-lazy grammars. With thinking disabled (`--reasoning off --reasoning-format none`, the rendered argv), the brain-sft template emits a pre-closed `<think>\n</think>\n` block in its generation prompt — but the parser's reasoning branch was `p.eps()` when reasoning extraction is off, so the grammar had no rule for the block: prefill reached `<think>`, the grammar expected `{`, and `llama_sampler_accept` threw. This also retro-explains rc.7's #2020 matrix (`enable_thinking=false` → 400 even direct-to-slot): the gateway-injection fix was real but sat on top of this deeper defect — fresh-surface extraction has never worked on the combined-image lineage.

**LFM2.5 (new patch 0004).** `data.grammar_lazy = tool_choice == AUTO` — missing the `!has_response_format &&` term every sibling parser has. `tool_choice` defaults to AUTO, so a response_format-only request built a *lazy* grammar; a lazy grammar's root is generated from tool-call trigger rules, and a no-tools request has none — the server's own dump shows `root ::= ` (empty). Generation ran unconstrained, the model wrote think-prose instead of JSON, and the peg parse rejected it (500) on every JSON-mode request.

Both parsers also now consume a weight-emitted or prompt-tail think block (plus trailing whitespace) when reasoning extraction is off, and tolerate a trailing whitespace tail after the JSON body — grammar-admitted trailing tabs previously failed the parse on degenerate prompts.

Out of scope, noted for follow-up: `functionary_v3_2` and `kimi_k2` ignore `response_format` entirely (no grammar, no parse branch) — a different gap; and the deepseek-path `json_schema` init-400 recorded in the #2056 comments shares the prefill mechanism and should get the same treatment when that template family is next validated.

## The image

`ghcr.io/hal0ai/hal0-combined:0826` (digest `sha256:7aad020a0a7460988bb148652bb830a71f2071bc8899abad7b01e6a2f75c7678`), built with `packaging/runner/rocmfpx/build.sh` from this branch's 4-patch series against the same pinned source ref (`0a59add8`) and base digest as `:0822`/`:0824`, keeping the #2037 fail-fast entrypoint. Pushed to GHCR.

## Pin changes

- `DEFAULT_ROCMFPX_IMAGE` / `VULKAN_FIXED_IMAGE` → `:0826`; manifest tag in lockstep (pinned by `test_the_manifest_tag_matches_the_shipped_pin`).
- `:0824` joins `STALE_ROCMFPX_IMAGE_REFS` — the updater retags creation-time debris; deliberate operator pins stay untouched.
- The §3-C membership probe list now includes structured-output rows (json_object AND json_schema, thinking kwarg absent/true/false, against the seeded model) — `:0822` and `:0824` passed every earlier probe while failing all of these, which is exactly how this class shipped three releases running.

## Validation (2026-08-26, throwaway slots/containers)

| Probe | ct150 (ROCm, kfd) | ct151 (Vulkan, NO kfd) |
|---|---|---|
| temp-0 Paris canary | 200 ✓ | 200 ✓ |
| json_object — kwarg absent / true / false | 200/200/200 ✓ | 200 ✓ |
| json_schema (incl. degenerate contentless prompt) | 200 ✓ `{"a": "Paris"}` | 200 ✓ |
| native tool_calls (seeded brain) | 200 ✓ `get_weather{"city":"Paris"}` | — |
| LFM2.5-2.6B: canary / json_object / json_schema / degenerate / tools | all 200 ✓ | — |
| #1936 device-less | exit 78 + readable diagnostic ✓ | — |
| #2037 doomed model | exit 64 ✓ | — |
| ≥256-token tail | clean with `repeat_penalty 1.1`; temp-0 unpenalized long-form can repetition-loop on the 1.1B (well-formed words, not #1888 token garbage; both builds default `repeat_penalty 1.0`) | clean ✓ |

Hindsight extraction end-to-end on a fresh box intentionally left to the rc.10 fresh-lane re-run, per the rc.9 readiness verdict.

Test suites: `tests/packaging tests/config tests/providers tests/updater tests/registry` — 2369 passed, 9 pre-existing skips.

Closes #2056

🤖 Generated with [Claude Code](https://claude.com/claude-code)
