### PR TITLE
feat(installer): post-install smoke — structured-output probe + hal0 update --check (#2066)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2952,6 +2952,77 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
     fi
 fi
 
+# ── Post-install smoke probes (#2066) ──────────────────────────────────────
+# Two blind spots the v1.0 RC cycle proved expensive:
+#   1. Structured output — a plain chat probe passes while every json_object
+#      consumer is broken (extraction silently dead since the :0820 lineage).
+#   2. The updater — #2052 shipped through three RCs because nothing ever
+#      dry-ran `hal0 update --check`; the breakage only surfaced at the NEXT
+#      release.
+# Both probes are fail-soft like the rest of the verify step: warn loudly and
+# repeat the failure inside the summary box (via SMOKE_FAILED), never abort a
+# finished install. Defined at top level so tests/installer/
+# test_install_smoke_probes.py can extract and drive them through fakes.
+SMOKE_FAILED=()
+
+smoke_structured_output() {
+    # Probe shape is load-bearing (live-verified on ct151, rc.9 validation):
+    #   * via the GATEWAY (:${HAL0_PORT}/v1), never direct-to-slot — a
+    #     direct-to-slot 200 masks gateway-path failures (rc.7's #2020);
+    #   * kwarg-ABSENT body — model + messages + response_format ONLY.
+    #     Extra kwargs (temperature, max_tokens, …) mask template-branch
+    #     differences between slot backends.
+    # hal0/utility is the canonical virtual alias (normalize/resolver.py):
+    # it routes to the cheap helper slot and falls back to the anchor, so
+    # the probe works on any box with at least one loaded model.
+    local body resp
+    body='{"model":"hal0/utility","messages":[{"role":"user","content":"Reply with only a JSON object of the form {\"ok\": true}."}],"response_format":{"type":"json_object"}}'
+    # KB-1 auth: same key discovery as the hindsight EnvironmentFile above —
+    # a fresh open-LAN box has no api.env and needs no header.
+    local -a auth=()
+    local key
+    if [[ -f /etc/hal0/api.env ]]; then
+        key="$(grep -oP '(?<=^HAL0_CLIENT_KEY=).*' /etc/hal0/api.env 2>/dev/null | head -1 || true)"
+        [[ -n "${key}" ]] && auth=(-H "Authorization: Bearer ${key}")
+    fi
+    resp="$(curl -fsS -m 120 -X POST "http://127.0.0.1:${HAL0_PORT}/v1/chat/completions" \
+        -H 'Content-Type: application/json' ${auth[@]+"${auth[@]}"} \
+        -d "${body}" 2>/dev/null)" || return 1
+    # The assertion: the CONTENT of the reply parses as JSON — an HTTP 200
+    # carrying prose ("Paris") is exactly the failure this probe exists for.
+    printf '%s' "${resp}" | "${PY}" -c 'import json, sys
+try:
+    reply = json.load(sys.stdin)
+    json.loads(reply["choices"][0]["message"]["content"])
+except Exception:
+    sys.exit(1)' 2>/dev/null
+}
+
+smoke_update_check() {
+    # Dry-run the updater end to end (manifest fetch + cosign path via the
+    # daemon's /api/updates/check); --check applies nothing. A clean exit is
+    # the whole assertion — a #2052-class gap surfaces HERE, not at the next
+    # release.
+    "${HAL0_BIN}" update --check >/dev/null 2>&1
+}
+
+run_post_install_smoke() {
+    if smoke_structured_output; then
+        info "structured-output probe ok (gateway /v1, json_object)"
+    else
+        SMOKE_FAILED+=("structured-output")
+        warn "structured-output probe FAILED — a json_object request via the gateway (:${HAL0_PORT}/v1) did not return parseable JSON"
+        warn "  extraction/structured-output consumers are likely broken even if plain chat works — check 'hal0 status' for a loaded model, then 'journalctl -u hal0-api -n 40'"
+    fi
+    if smoke_update_check; then
+        info "update-check probe ok ('hal0 update --check' exits cleanly)"
+    else
+        SMOKE_FAILED+=("update-check")
+        warn "'${HAL0_BIN} update --check' FAILED — the update path is broken and the next release will not install"
+        warn "  re-run '${HAL0_BIN} update --check' to see why (daemon reachability / manifest fetch / cosign verify)"
+    fi
+}
+
 if [[ "${DEV_MODE}" -eq 1 || "${NO_START}" -eq 1 ]]; then
     warn "not starting services automatically (dev / --no-start)."
     warn "  start manually: ${HAL0_BIN} serve --host ${API_BIND_HOST} --port ${HAL0_PORT}"
@@ -3335,6 +3406,12 @@ else
         info "hal0-agent@hermes not enabled — provision with '${HAL0_BIN} agent install hermes'"
     fi
 
+    # Last verify action before the summary (#2066): everything the probes
+    # depend on — hal0-api, slots, the steward/agent model pulls — is as up
+    # as this install will get it. Fail-soft by construction (see the probe
+    # definitions above the Service start branch).
+    run_post_install_smoke
+
 fi
 
 # Real LAN IPv4 addresses — filtered to skip container / virtual bridge
@@ -3433,6 +3510,20 @@ if [[ "${DEV_MODE}" -eq 0 && "${NO_START}" -eq 0 && ${#REACH_LINES[@]} -gt 0 ]];
         label="${entry%%$'\t'*}"
         url="${entry##*$'\t'}"
         SUMMARY_LINES+=("$(printf '  %s%-12s%s %s%s%s' "${DIM}" "${label}" "${RST}" "${BLU}" "${url}" "${RST}")")
+    done
+fi
+
+# Post-install smoke failures (#2066) — repeated INSIDE the summary box so an
+# rc-validate run (or a human skimming it) can't miss them among the
+# scrolled-away warns above. The probes themselves are fail-soft; this is the
+# loud part of that contract.
+if [[ ${#SMOKE_FAILED[@]} -gt 0 ]]; then
+    SUMMARY_LINES+=(
+        ""
+        "$(printf '%s%sVerify FAILED:%s' "${BOLD}" "${RED}" "${RST}")"
+    )
+    for probe in "${SMOKE_FAILED[@]}"; do
+        SUMMARY_LINES+=("$(printf '  %s%s%s probe failed — see the warnings above' "${RED}" "${probe}" "${RST}")")
     done
 fi
 

--- a/tests/installer/test_install_smoke_probes.py
+++ b/tests/installer/test_install_smoke_probes.py
@@ -1,0 +1,161 @@
+"""Post-install smoke probes: structured output + `hal0 update --check` (#2066).
+
+Two blind spots this release cycle proved expensive:
+
+* The verify step probed plain chat coherence but never a ``json_object``
+  request — so extraction was silently dead on every fresh install of the
+  :0820 lineage while the install summary stayed green.
+* It never dry-ran ``hal0 update --check`` — which is how #2052 shipped
+  through three RCs: install green, update path broken, discovered at the
+  NEXT release.
+
+Probe shape is load-bearing (live-verified on ct151 during rc.9 validation):
+
+* the structured-output probe must go via the GATEWAY (``:$HAL0_PORT/v1``),
+  never direct-to-slot — direct-to-slot 200s mask gateway-path failures
+  (rc.7's #2020);
+* the body must be kwarg-ABSENT (model + messages + response_format only) —
+  kwarg-present bodies mask template-branch differences between backends.
+
+Both probes are fail-soft: they warn loudly and land in the summary box,
+but never abort a finished install.
+
+Functions are extracted from install.sh and driven through fakes on PATH
+(the ``test_api_restart_on_upgrade.py`` shim technique) — real daemons are
+not available in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+INSTALL_SH = Path(__file__).resolve().parents[2] / "installer" / "install.sh"
+_TEXT = INSTALL_SH.read_text(encoding="utf-8")
+
+
+def _extract(func_name: str) -> str:
+    """Pull one top-level ``name() { ... }`` body out of install.sh."""
+    start = _TEXT.index(f"{func_name}()")
+    end = _TEXT.index("\n}\n", start) + 3
+    return _TEXT[start:end]
+
+
+def _write_exec(path: Path, body: str) -> None:
+    path.write_text(f"#!/usr/bin/env bash\n{body}\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _chat_completion(content: str) -> str:
+    """A minimal OpenAI-shaped chat-completion reply carrying ``content``."""
+    return json.dumps({"choices": [{"message": {"role": "assistant", "content": content}}]})
+
+
+# ── Contract: probe shape ──────────────────────────────────────────────────
+
+
+def test_structured_output_probe_exists_and_targets_the_gateway() -> None:
+    """The probe must hit /v1/chat/completions on the gateway port — a
+    direct-to-slot probe would 200 while the gateway path is broken (#2020)."""
+    func = _extract("smoke_structured_output")
+    assert "/v1/chat/completions" in func
+    assert "${HAL0_PORT}" in func, "probe must go through the gateway port, not a slot port"
+
+
+def test_structured_output_body_is_kwarg_absent_json_object() -> None:
+    """Body carries response_format json_object and NOTHING else beyond
+    model + messages — extra kwargs mask template-branch differences."""
+    func = _extract("smoke_structured_output")
+    m = re.search(r"body='(\{.*?\})'", func, re.DOTALL)
+    assert m, "expected a single-quoted JSON body literal in smoke_structured_output"
+    body = json.loads(m.group(1))
+    assert body.get("response_format") == {"type": "json_object"}
+    assert set(body) == {"model", "messages", "response_format"}, (
+        f"probe body must be kwarg-absent; got extra keys: {set(body)}"
+    )
+
+
+def test_update_check_probe_exists() -> None:
+    func = _extract("smoke_update_check")
+    assert "update --check" in func
+
+
+# ── Behavior: driven through fakes ─────────────────────────────────────────
+
+
+def _drive(tmp_path: Path, script_body: str) -> subprocess.CompletedProcess[str]:
+    script = tmp_path / "drive.sh"
+    script.write_text(
+        "#!/usr/bin/env bash\nset -uo pipefail\n"
+        "info() { :; }\n"
+        'warn() { echo "WARN: $*" >&2; }\n'
+        "HAL0_PORT=8080\nPY=python3\n"
+        f"HAL0_BIN={tmp_path}/hal0\n"
+        f"{_extract('smoke_structured_output')}\n"
+        f"{_extract('smoke_update_check')}\n"
+        f"{_extract('run_post_install_smoke')}\n"
+        "SMOKE_FAILED=()\n"
+        f"{script_body}\n",
+        encoding="utf-8",
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    env = {"PATH": f"{tmp_path}:/usr/bin:/bin", "HOME": str(tmp_path)}
+    return subprocess.run(
+        ["bash", str(script)], env=env, capture_output=True, text=True, timeout=30, check=False
+    )
+
+
+def test_probe_passes_when_gateway_returns_parseable_json(tmp_path: Path) -> None:
+    reply = _chat_completion('{"ok": true}')
+    _write_exec(tmp_path / "curl", f"echo '{reply}'")
+    res = _drive(tmp_path, "smoke_structured_output")
+    assert res.returncode == 0, res.stderr
+
+
+def test_probe_fails_on_non_json_content(tmp_path: Path) -> None:
+    """The regression this probe exists for: a coherent chat reply ('Paris')
+    is NOT structured output — the probe must fail on it."""
+    reply = _chat_completion("Paris")
+    _write_exec(tmp_path / "curl", f"echo '{reply}'")
+    res = _drive(tmp_path, "smoke_structured_output")
+    assert res.returncode != 0
+
+
+def test_probe_fails_when_gateway_is_down(tmp_path: Path) -> None:
+    _write_exec(tmp_path / "curl", "exit 7")
+    res = _drive(tmp_path, "smoke_structured_output")
+    assert res.returncode != 0
+
+
+def test_update_check_invokes_hal0_update_check(tmp_path: Path) -> None:
+    calls = tmp_path / "hal0.calls"
+    _write_exec(tmp_path / "hal0", f'echo "$@" >> "{calls}"')
+    res = _drive(tmp_path, "smoke_update_check")
+    assert res.returncode == 0, res.stderr
+    assert "update --check" in calls.read_text(encoding="utf-8")
+
+
+def test_smoke_is_fail_soft_and_records_failures(tmp_path: Path) -> None:
+    """Both probes failing must not abort the driver (exit 0) — install
+    completes; failures land in SMOKE_FAILED for the summary box."""
+    _write_exec(tmp_path / "curl", "exit 7")
+    _write_exec(tmp_path / "hal0", "exit 1")
+    res = _drive(
+        tmp_path,
+        'run_post_install_smoke\nprintf "%s\\n" "${SMOKE_FAILED[@]}"\nexit 0',
+    )
+    assert res.returncode == 0, res.stderr
+    assert "structured-output" in res.stdout
+    assert "update-check" in res.stdout
+    assert "WARN:" in res.stderr, "fail-soft still has to be LOUD"
+
+
+def test_smoke_failures_surface_in_the_summary_box() -> None:
+    """The summary builder must fold SMOKE_FAILED into SUMMARY_LINES so an
+    rc-validate run catches failures without scrolling the warn stream."""
+    assert "SMOKE_FAILED" in _TEXT.split("SUMMARY_LINES=(", 1)[1], (
+        "SMOKE_FAILED is never referenced after the summary box starts building"
+    )


### PR DESCRIPTION
## Summary

Adds two fail-soft probes to the installer's post-install verify step (end of the Service start branch in `installer/install.sh`), closing the two blind spots the v1.0 RC cycle proved expensive: a green install with structured output silently dead, and a green install with a broken updater (#2052 shipped through three RCs that way).

## Root cause

The verify step only checked that services came up (`wait_active`, `/health` polls). It never exercised a `json_object` request — so a coherent plain-chat reply masked a dead extraction path — and never dry-ran the updater, so update-path breakage stayed invisible until the next release.

## Fix

- **`smoke_structured_output`** — POSTs a chat completion **via the gateway** (`http://127.0.0.1:${HAL0_PORT}/v1/chat/completions`), never direct-to-slot (direct-to-slot 200s mask gateway-path failures, rc.7's #2020). The body is **kwarg-absent** — exactly `model` (`hal0/utility`, the canonical virtual alias with anchor fallback) + `messages` + `response_format: {"type": "json_object"}` — because extra kwargs mask template-branch differences between slot backends (probe shape per the issue comments, live-verified on ct151 during rc.9 validation). Asserts the reply *content* parses as JSON; an HTTP 200 carrying prose fails the probe. Reuses the same `/etc/hal0/api.env` key discovery as the hindsight block for KB-1 auth boxes.
- **`smoke_update_check`** — runs `hal0 update --check` (thin client over `/api/updates/check`; manifest fetch + cosign path exercised daemon-side, nothing applied) and asserts a clean exit.

Both are fail-soft consistent with the rest of the verify step: loud `warn` lines at probe time, and the failures are repeated **inside the "hal0 is ready" summary box** as a `Verify FAILED:` section (driven by `SMOKE_FAILED`), so an rc-validate run can't scroll past them. Neither probe can abort a finished install. No new `ui_step` (step total stays 16).

## Test evidence

New `tests/installer/test_install_smoke_probes.py` (written failing-first, 9 tests): contract tests that the probe targets the gateway port with a kwarg-absent `json_object` body, plus behavioral tests driving the extracted functions through fake `curl`/`hal0` shims (the `test_api_restart_on_upgrade.py` technique) — parseable-JSON content passes, a coherent non-JSON reply ("Paris") fails, gateway-down fails, `update --check` is invoked and its exit code respected, and both probes failing leaves the driver at exit 0 with both failures recorded and warned.

Ran on the dev Mac:

- `uv run --no-project --with pytest pytest tests/installer/test_install_smoke_probes.py` — 9 passed
- `pytest tests/installer/test_api_restart_on_upgrade.py test_install_single_entry_point.py test_install_cosign_persist.py test_hal0_update_wrapper.py` — 83 passed
- `bash -n installer/install.sh` — clean (shellcheck not installed locally)

Note: the full `tests/installer/` run has pre-existing failures on this macOS host (bash 3.2 lacks `mapfile`, Linux-only wrapper tests) unrelated to this diff — CI on Linux is the real gate there.

Fixes #2066

🤖 Generated with [Claude Code](https://claude.com/claude-code)
