### PR TITLE
fix(installer): batch bootstrap dep preflight and auto-install via package manager

### DIFF
--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -171,7 +171,8 @@ dep_package() {
 
 # The one-liner an operator runs to install PKG… with the detected manager.
 # Mirrors distro.sh's pkg_install_cmd, including the apt DPkg lock timeout
-# (#1584: unattended-upgrades commonly holds the lock on fresh Ubuntu boots).
+# that #1733 added there for #1584 (unattended-upgrades commonly holds the
+# lock on fresh Ubuntu boots) — keep the two copies in step if either changes.
 pkg_install_hint() {
     local IFS=' '   # global IFS is \n\t; the hint must stay a one-liner
     local pm="$1"; shift

--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -130,17 +130,122 @@ banner() {
 }
 
 # ── preflight ──────────────────────────────────────────────────────────────
+# Missing deps are collected, not fatal one-by-one (#2062): a minimal host
+# lacking curl AND jq should learn about both in a single run instead of
+# paying one retry cycle per tool. preflight() then either auto-installs
+# the whole batch via the host's package manager or fails once with a
+# single copy-pasteable install command covering everything.
+_MISSING_DEPS=()
 need() {
-    command -v "$1" >/dev/null 2>&1 || die "missing dependency: $1 — install it and re-run"
+    command -v "$1" >/dev/null 2>&1 || _MISSING_DEPS+=("$1")
+}
+
+# Package-manager detection. Inline — NOT sourced from installer/lib/distro.sh
+# — because this script runs standalone via curl|bash before any repo file
+# exists on disk. Mirrors distro.sh's pkg_mgr(): command presence beats
+# os-release IDs for derivatives (CachyOS ships pacman, PikaOS ships apt),
+# first match in preference order wins.
+detect_pkg_mgr() {
+    local m
+    for m in apt-get dnf yum zypper pacman apk; do
+        if command -v "${m}" >/dev/null 2>&1; then
+            printf '%s\n' "${m}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Command name → package name for the detected manager. sha256sum ships in
+# coreutils everywhere; Arch names its Python package "python".
+dep_package() {
+    local pm="$1" dep="$2"
+    case "${dep}" in
+        sha256sum) printf 'coreutils\n' ;;
+        python3)
+            if [[ "${pm}" == "pacman" ]]; then printf 'python\n'; else printf 'python3\n'; fi
+            ;;
+        *) printf '%s\n' "${dep}" ;;
+    esac
+}
+
+# The one-liner an operator runs to install PKG… with the detected manager.
+# Mirrors distro.sh's pkg_install_cmd, including the apt DPkg lock timeout
+# (#1584: unattended-upgrades commonly holds the lock on fresh Ubuntu boots).
+pkg_install_hint() {
+    local IFS=' '   # global IFS is \n\t; the hint must stay a one-liner
+    local pm="$1"; shift
+    case "${pm}" in
+        apt-get) printf 'sudo apt-get -o DPkg::Lock::Timeout=120 install -y %s\n' "$*" ;;
+        dnf)     printf 'sudo dnf install -y %s\n' "$*" ;;
+        yum)     printf 'sudo yum install -y %s\n' "$*" ;;
+        zypper)  printf 'sudo zypper install -y %s\n' "$*" ;;
+        pacman)  printf 'sudo pacman -S --noconfirm %s\n' "$*" ;;
+        apk)     printf 'sudo apk add %s\n' "$*" ;;
+    esac
+}
+
+# Batch-resolve everything need() collected — the install-or-fail pattern of
+# install.sh's preflight_venv / preflight_container_runtime. One package-
+# manager transaction for the whole batch, then a re-check; anything still
+# missing (install failed, ran unprivileged, no recognised manager) fails
+# ONCE, listing every dep plus the exact command that installs them all.
+install_missing_deps() {
+    local IFS=' '   # global IFS is \n\t; keep "${arr[*]}" messages one-line
+    local pm="" dep pkgs=()
+    pm="$(detect_pkg_mgr)" || pm=""
+
+    if [[ -n "${pm}" ]]; then
+        for dep in "${_MISSING_DEPS[@]}"; do
+            pkgs+=("$(dep_package "${pm}" "${dep}")")
+        done
+        info "installing missing dependencies (${_MISSING_DEPS[*]}) via ${pm}"
+        case "${pm}" in
+            apt-get)
+                DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 update -qq || true
+                DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y -q "${pkgs[@]}" || true
+                ;;
+            dnf | yum) "${pm}" install -y "${pkgs[@]}" || true ;;
+            zypper)    zypper install -y "${pkgs[@]}" || true ;;
+            pacman)    pacman -S --noconfirm "${pkgs[@]}" || true ;;
+            apk)       apk add "${pkgs[@]}" || true ;;
+        esac
+
+        # The re-check, not the package manager's exit code, decides.
+        local still=()
+        for dep in "${_MISSING_DEPS[@]}"; do
+            command -v "${dep}" >/dev/null 2>&1 || still+=("${dep}")
+        done
+        if [[ ${#still[@]} -eq 0 ]]; then
+            ok "installed missing dependencies: ${_MISSING_DEPS[*]}"
+            _MISSING_DEPS=()
+            return 0
+        fi
+        _MISSING_DEPS=("${still[@]}")
+    fi
+
+    for dep in "${_MISSING_DEPS[@]}"; do
+        err "missing dependency: ${dep}"
+    done
+    if [[ -n "${pm}" ]]; then
+        pkgs=()
+        for dep in "${_MISSING_DEPS[@]}"; do
+            pkgs+=("$(dep_package "${pm}" "${dep}")")
+        done
+        die "install everything above and re-run: $(pkg_install_hint "${pm}" "${pkgs[@]}")"
+    fi
+    die "no supported package manager detected (apt-get/dnf/yum/zypper/pacman/apk) — install the dependencies above and re-run"
 }
 
 preflight() {
     [[ "$(uname -s)" == "Linux" ]] || die "hal0 only supports Linux right now (got $(uname -s))"
+    _MISSING_DEPS=()
     need curl
     need tar
     need sha256sum
     need jq
     need python3
+    [[ ${#_MISSING_DEPS[@]} -eq 0 ]] || install_missing_deps
 }
 
 validate_channel() {

--- a/tests/installer/test_bootstrap_dep_preflight.py
+++ b/tests/installer/test_bootstrap_dep_preflight.py
@@ -1,0 +1,153 @@
+"""Bootstrap batched dep preflight — #2062.
+
+``installer/bootstrap.sh``'s ``preflight()`` used to die on the FIRST
+missing dependency (``need curl`` → die, re-run, ``need jq`` → die, …),
+costing a minimal host one full retry cycle per missing tool, and never
+offered to install anything even though the host's package manager was
+sitting right there.
+
+The fix collects ALL missing deps in one pass, then either auto-installs
+the whole batch via the detected package manager (the install-or-fail
+pattern of install.sh's ``preflight_venv`` / ``preflight_container_runtime``)
+or fails ONCE listing every dep plus a single copy-pasteable install
+command. Boxes with all deps present must see no behavior change.
+
+Technique mirrors ``test_bootstrap_contract.py``: run the real script
+under a hermetic PATH whose contents decide which deps "exist". ``uname``
+is faked to report Linux so these tests are host-OS independent.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BOOTSTRAP = _REPO_ROOT / "installer" / "bootstrap.sh"
+
+# Everything bootstrap preflight checks beyond curl/jq (the two the issue
+# reproduced with). Real binaries are symlinked so only curl/jq are "missing".
+_PRESENT_TOOLS = ("bash", "tar", "sha256sum", "python3", "mktemp", "mkdir", "rm", "cat")
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _hermetic_bin(tmp_path: Path, *, tools: tuple[str, ...] = _PRESENT_TOOLS) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for tool in tools:
+        target = shutil.which(tool)
+        assert target is not None, f"test host lacks {tool}"
+        os.symlink(target, bin_dir / tool)
+    # Fake Linux regardless of the host running the suite.
+    _write_executable(bin_dir / "uname", "#!/usr/bin/env bash\necho Linux\n")
+    return bin_dir
+
+
+def _run_bootstrap(bin_dir: Path, extra_env: dict[str, str] | None = None):
+    bash = shutil.which("bash")
+    assert bash is not None
+    env = {"PATH": str(bin_dir), "TMPDIR": str(bin_dir.parent), **(extra_env or {})}
+    return subprocess.run(
+        [bash, str(_BOOTSTRAP)], env=env, capture_output=True, text=True, check=False
+    )
+
+
+class TestBatchReporting:
+    def test_missing_curl_and_jq_both_reported_in_one_run(self, tmp_path: Path) -> None:
+        proc = _run_bootstrap(_hermetic_bin(tmp_path))
+        assert proc.returncode != 0
+        assert "missing dependency: curl" in proc.stderr
+        assert "missing dependency: jq" in proc.stderr
+
+    def test_no_package_manager_fails_with_guidance(self, tmp_path: Path) -> None:
+        proc = _run_bootstrap(_hermetic_bin(tmp_path))
+        assert proc.returncode != 0
+        assert "no supported package manager" in proc.stderr
+
+
+class TestInstallCommandHint:
+    def test_failed_install_lists_single_copy_pasteable_command(self, tmp_path: Path) -> None:
+        bin_dir = _hermetic_bin(tmp_path)
+        apt_log = tmp_path / "apt.log"
+        # apt-get that records its argv and fails — deps stay missing.
+        _write_executable(
+            bin_dir / "apt-get",
+            f'#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "{apt_log}"\nexit 1\n',
+        )
+        proc = _run_bootstrap(bin_dir)
+        assert proc.returncode != 0
+        assert "missing dependency: curl" in proc.stderr
+        assert "missing dependency: jq" in proc.stderr
+        # ONE command covering everything, sudo-prefixed for copy-paste.
+        assert "sudo apt-get" in proc.stderr
+        assert "install -y curl jq" in proc.stderr
+
+    def test_batch_is_one_package_manager_transaction(self, tmp_path: Path) -> None:
+        bin_dir = _hermetic_bin(tmp_path)
+        apt_log = tmp_path / "apt.log"
+        _write_executable(
+            bin_dir / "apt-get",
+            f'#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "{apt_log}"\nexit 1\n',
+        )
+        _run_bootstrap(bin_dir)
+        calls = apt_log.read_text(encoding="utf-8").splitlines()
+        installs = [c for c in calls if " install " in f" {c} "]
+        assert len(installs) == 1, calls
+        assert "curl" in installs[0] and "jq" in installs[0]
+
+
+class TestAutoInstall:
+    def test_auto_install_resolves_missing_deps_and_proceeds(self, tmp_path: Path) -> None:
+        bin_dir = _hermetic_bin(tmp_path)
+        # apt-get that "installs" curl and jq by dropping stubs onto PATH.
+        _write_executable(
+            bin_dir / "apt-get",
+            "#!/usr/bin/env bash\n"
+            'case " $* " in\n'
+            "*\" install \"*)\n"
+            f'    for t in curl jq; do\n'
+            f'        printf \'#!/usr/bin/env bash\\nexit 0\\n\' > "{bin_dir}/$t"\n'
+            f'        /bin/chmod +x "{bin_dir}/$t"\n'
+            "    done ;;\n"
+            "esac\n"
+            "exit 0\n",
+        )
+        proc = _run_bootstrap(bin_dir)
+        out = proc.stdout + proc.stderr
+        # Preflight succeeded: no missing-dep failure. The run dies later
+        # (manifest/cosign fetch against stub curl), which is fine — the
+        # contract under test is the dep gate, not the trust chain.
+        assert "missing dependency" not in out
+        assert "installed missing dependencies: curl jq" in out
+
+
+class TestNoBehaviorChangeWhenDepsPresent:
+    def test_no_install_attempt_when_all_deps_present(self, tmp_path: Path) -> None:
+        bin_dir = _hermetic_bin(tmp_path)
+        # All deps present (stub curl/jq), plus a tripwire package manager
+        # that must never be called.
+        for t in ("curl", "jq"):
+            _write_executable(bin_dir / t, "#!/usr/bin/env bash\nexit 0\n")
+        apt_log = tmp_path / "apt.log"
+        _write_executable(
+            bin_dir / "apt-get",
+            f'#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "{apt_log}"\nexit 0\n',
+        )
+        proc = _run_bootstrap(bin_dir)
+        out = proc.stdout + proc.stderr
+        assert "missing dependency" not in out
+        assert not apt_log.exists(), apt_log.read_text(encoding="utf-8")
+
+
+def test_bash_syntax_check() -> None:
+    proc = subprocess.run(
+        ["bash", "-n", str(_BOOTSTRAP)], capture_output=True, text=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr

--- a/tests/installer/test_bootstrap_dep_preflight.py
+++ b/tests/installer/test_bootstrap_dep_preflight.py
@@ -111,9 +111,9 @@ class TestAutoInstall:
             bin_dir / "apt-get",
             "#!/usr/bin/env bash\n"
             'case " $* " in\n'
-            "*\" install \"*)\n"
-            f'    for t in curl jq; do\n'
-            f'        printf \'#!/usr/bin/env bash\\nexit 0\\n\' > "{bin_dir}/$t"\n'
+            '*" install "*)\n'
+            f"    for t in curl jq; do\n"
+            f"        printf '#!/usr/bin/env bash\\nexit 0\\n' > \"{bin_dir}/$t\"\n"
             f'        /bin/chmod +x "{bin_dir}/$t"\n'
             "    done ;;\n"
             "esac\n"


### PR DESCRIPTION
## Summary

`installer/bootstrap.sh`'s dependency preflight now collects **all** missing dependencies in one pass and then either auto-installs the whole batch via the host's detected package manager, or fails **once** with a single copy-pasteable install command listing everything. Boxes with all deps present see no behavior change.

## Root cause

`preflight()` called `need <tool>`, and `need` `die`d on the first absent command. On a minimal Ubuntu box missing both curl and jq, bootstrap died on curl; after hand-installing curl it died again on jq — one full retry cycle per missing tool, with no install offer, even though the repo already has the install-or-fail pattern (`preflight_venv`, `preflight_container_runtime` in `installer/lib/preflight.sh`).

## Fix

- `need` now appends to `_MISSING_DEPS` instead of dying; `preflight()` checks curl/tar/sha256sum/jq/python3 in one pass (the `need curl` / `need tar` / … lines are kept verbatim so the parity contract in `test_bootstrap_prereq_parity.py::TestMirrorsBootstrapSh` still holds).
- New `install_missing_deps()` mirrors the `preflight_venv` install-or-fail pattern: one package-manager transaction for the whole batch (non-interactive apt with the #1584 DPkg lock timeout; dnf/yum/zypper/pacman/apk supported), then a `command -v` re-check as the source of truth.
- Anything still missing (install failed, ran unprivileged, unrecognized manager) fails once, listing every dep (`missing dependency: X` per line, preserving the message contract of `test_bootstrap_contract.py`) plus one sudo-prefixed install command built from per-manager package names (`sha256sum` → `coreutils`, Arch `python3` → `python`).
- Package-manager detection is inline (not sourced from `installer/lib/distro.sh`) because bootstrap runs standalone via `curl|bash` before any repo file exists on disk; it mirrors `distro.sh`'s `pkg_mgr()` preference order.

## Test evidence

Test-first: `tests/installer/test_bootstrap_dep_preflight.py` was written before the fix and failed 5/7 against the old one-at-a-time behavior; all 7 pass with the fix (hermetic PATH, faked `uname`, stub `apt-get`). It covers: batch reporting of curl+jq in one run, single copy-pasteable command on failed install, exactly one package-manager transaction, auto-install success path, and the no-op path when deps are present.

Neighbors: `test_bootstrap_contract.py` / `test_bootstrap_prereq_parity.py` / `test_bootstrap_cosign_fetch.py` show **identical** failure sets before and after the change on this macOS dev host (63 pre-existing environment failures — the suites use the real `uname`, which reports Darwin, so they only pass on Linux; verified `test_bootstrap_missing_jq_fails_preflight_before_network` fails at the Linux gate on baseline too). The static contract tests (`TestMirrorsBootstrapSh`, `test_bootstrap_requires_jq_and_artifact_bundle_without_detached_fallback`) pass. `bash -n installer/bootstrap.sh` is clean; shellcheck is not installed on this host — relying on CI for the Linux run of the full installer suite.

Fixes #2062

🤖 Generated with [Claude Code](https://claude.com/claude-code)