### PR TITLE
feat(install): LFM2.5-2.6B Q8_0 as the default seeded brain model

### DIFF
--- a/installer/etc-hal0/slots/brain.toml
+++ b/installer/etc-hal0/slots/brain.toml
@@ -18,20 +18,23 @@
 # `[model].default` only once the bytes have landed. That is why no
 # `[model].default` is hardcoded below:
 #
-#   * The right variant is hardware-dependent. All three live in the public
-#     repo Hal0ai/hal0-brain-sft-ROCmFPX-GGUF, but the Q8/Q4 builds carry
-#     CUSTOM GGML tensor type ids (103 / 100) that STOCK llama.cpp REJECTS —
-#     they need the ROCmFPX runner. A GPU box gets the small, fast
-#     `hal0-brain-sft-q8-rocmfpx` (agent/tool-use preset); a box with no
-#     ROCm/Vulkan device gets the portable `hal0-brain-sft-f16`. Pinning
-#     either one here would crash-loop the other kind of box.
+#   * The default is `lfm2.5-2.6b` (LFM2.5-2.6B Q8_0, 2.87 GB — plain GGUF,
+#     loads on every runner class, so it is no longer hardware-forked). The
+#     hal0-brain-sft variants remain as HAL0_BRAIN_MODEL overrides, and THEY
+#     are hardware-constrained: the sft Q8/Q4 builds carry CUSTOM GGML
+#     tensor type ids (103 / 100) that STOCK llama.cpp REJECTS (ROCmFPX
+#     runner only); only the sft F16 is portable. Pinning any id here
+#     instead of letting the installer stamp it would still race the pull.
 #   * Model-presence IS the activation signal (#1369), so an id written
 #     before the file exists on disk is precisely the start-before-model
 #     race (#1108). If the pull cannot happen (no network, no space) the
 #     slot stays model-less and the install still succeeds — a grey tile,
 #     not a crash loop.
 #
-# WHAT REPLACED WHAT — the previous seed pinned `MiniCPM5-1B-Agentic-Tooluse`.
+# WHAT REPLACED WHAT — lineage: MiniCPM5-1B pin → hal0-brain-sft variants
+# (hardware-forked) → `lfm2.5-2.6b` default (rc.10, #2073 runner pin is the
+# prerequisite). The sft story below is kept for the override path.
+# The previous seed pinned `MiniCPM5-1B-Agentic-Tooluse`.
 # That is a REAL, PULLABLE model: the public GGUF repack of the upstream
 # tool-use base at ewinregirgojr/MiniCPM5-1B-Agentic-Tooluse-GGUF
 # (`...Nemotron-DPO.F16.gguf`, 2,166,552,576 B, anonymous read). Moving to the
@@ -47,11 +50,14 @@
 #
 # Port 8089: 8088 belongs to the flm seed.
 #
-# Tool calling: as of runner ade07ba (DEFAULT_ROCMFPX_IMAGE) the brain
-# models are NATIVE tool-callers — llama.cpp's MiniCPM5 specialized parser
-# preserves the vocab's tool-syntax control tokens and grammar-locks the
-# call shape, so the steward executes its own calls on this slot (verified
-# live on both the SFT quants and the MiniCPM5 base). The `[brain_chat]
+# Tool calling: the LFM2.5 default is a NATIVE tool-caller on the
+# hal0-combined:0826+ runner — its LFM2.5 parser detects the template and
+# grammar-locks the <|tool_call_start|> dialect (verified on ct150, rc.9
+# validation). The sft override variants parse natively via the MiniCPM5
+# specialized parser as of runner ade07ba. Reasoning: LFM2.5 emits <think>
+# from weights; profile.brain leaves reasoning-format at the runner
+# default so think text extracts into reasoning_content instead of leaking
+# into message.content (see seed_profiles.toml). The `[brain_chat]
 # tool_model` reroute (default `hal0/agent`, ADR-0023) remains as the
 # FALLBACK: it catches artefact rounds and covers older runner images or
 # off-dialect models, and the tool-capable model still owns a chain's

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2103,7 +2103,9 @@ fi
 # migrations below: bare invocation, `|| warn`, never `set -e`-fatal.
 #
 # HAL0_SKIP_BRAIN_MODEL=1 skips it entirely; HAL0_BRAIN_MODEL=<curated-id>
-# forces a specific quant instead of the hardware-derived pick.
+# forces a specific variant instead of the default (lfm2.5-2.6b — 2.87 GB,
+# plain GGUF, every runner class; the hal0-brain-sft ids are the override
+# set, and their Q8/Q4 quants are ROCmFPX-runner-only).
 #
 # The AGENT anchor offer below shares this step (no extra ui_step banner, so
 # UI_STEP_TOTAL is unchanged) because it is the second half of one story: the

--- a/src/hal0/config/data/seed_profiles.toml
+++ b/src/hal0/config/data/seed_profiles.toml
@@ -118,26 +118,33 @@ intent = "ComfyUI"
 quant = ""
 
 [profile.brain]
-# Brain steward workload + MiniCPM5-family quirks (per
-# spec-p3-brain.final.md §5a). Brain is 1:1 with its model (the only
-# 1B model the steward runs), so a single combined profile is cleaner
-# than overlay. Reasoning off — the 1B rambles past any completion budget
-# with thinking on, so the profile suppresses it at launch. On runner
-# ade07ba the model emits NATIVE tool calls on this slot; artefact rounds
-# still reroute per turn to `[brain_chat] tool_model` (ADR-0023 fallback).
+# Brain steward workload + LFM2.5-family quirks (per
+# spec-p3-brain.final.md §5a). Brain is 1:1 with its model (LFM2.5-2.6B
+# Q8_0, curated id lfm2.5-2.6b — see installer/etc-hal0/slots/brain.toml),
+# so a single combined profile is cleaner than overlay.
 #
-# Sampler values are MiniCPM5-1B's own published no-think recommendation
-# (temp 0.7, top_p 0.95; the model card's think mode is 0.9/0.95, and this
-# profile launches with reasoning off). Upstream recommends no top_k at
-# all — the previous `--top-p 0.9 --top-k 20` was the Qwen3 sampler default
-# carried over from a Qwen-family profile, not a MiniCPM5 fact. Batch is
-# llama.cpp's default 2048/512, matching every other seeded profile: the
-# earlier 512/256 measured ~12-14% SLOWER prefill on rocm with no decode
-# benefit, reproduced across two independent windows (#1811).
-flags = "--jinja -fa auto -b 2048 -ub 512 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift --temp 0.7 --top-p 0.95 --no-mmproj"
+# Reasoning: LFM2.5 is an RL-trained thinker — it emits <think> from
+# weights, and `chat_template_kwargs enable_thinking=false` does NOT
+# suppress it. The old `--reasoning off --reasoning-format none` pair
+# therefore LEAKED raw think prose into message.content; leaving
+# reasoning-format at the runner default extracts it cleanly into
+# reasoning_content instead (verified on hal0-combined:0826, ct150).
+# Cost note: structured-output/extraction calls still pay the think
+# tokens (~100-300/call at ct150-class 66-76 tok/s) before the
+# grammar-constrained JSON starts — that is the model's contract, not a
+# profile bug. Native tool calls (<|tool_call_start|> dialect) parse
+# cleanly on the :0826+ runner; artefact rounds still reroute per turn to
+# `[brain_chat] tool_model` (ADR-0023 fallback).
+#
+# Sampler: temp 0.7 / top_p 0.95 carried over unchanged from the prior
+# brain profile — the rc.9 validation matrix (canary, json_object,
+# json_schema, tool_calls) ran green with these values on :0826. Batch is
+# llama.cpp's default 2048/512, matching every other seeded profile
+# (#1811).
+flags = "--jinja -fa auto -b 2048 -ub 512 --reasoning-budget -1 --no-context-shift --temp 0.7 --top-p 0.95 --no-mmproj"
 mtp = false
-intent = "Brain steward (1B MiniCPM5 + persona + tool-call routing) · 64K ctx"
-quant = ""
+intent = "Brain steward (LFM2.5-2.6B + persona + tool-call routing) · 64K ctx"
+quant = "Q8_0"
 
 [profile.chadrock-dense]
 # Chadrock 27B dense coder recipe (from

--- a/src/hal0/install/brain_model.py
+++ b/src/hal0/install/brain_model.py
@@ -295,7 +295,11 @@ def main(argv: list[str] | None = None) -> int:
 
         entry = _get_curated(chosen)
         size = f", {entry.size_gb:g} GB download" if entry is not None else ""
-        why = "override" if override and chosen == override else "default — loads on every runner class"
+        why = (
+            "override"
+            if override and chosen == override
+            else "default — loads on every runner class"
+        )
         print(f"  brain model: {chosen} ({why}{size})")
         if already_pulled(chosen) is not None:
             print("  already on disk from an earlier run — binding it, no download")

--- a/src/hal0/install/brain_model.py
+++ b/src/hal0/install/brain_model.py
@@ -14,12 +14,15 @@ warning and leaves the brain slot MODEL-LESS. The install still succeeds. This
 mirrors the absent-``HF_TOKEN`` posture in install.sh: an optional model pull
 must not be able to fail a platform install.
 
-**Hardware-aware quant choice.** The Q8/Q4 files in the brain repo carry custom
-GGML tensor type ids (103 / 100) that **stock llama.cpp rejects at load**; they
-only run on the ROCmFPX runner (``DEFAULT_ROCMFPX_IMAGE``). The F16 file is
-plain GGUF. So a ROCm/Vulkan box gets the small, fast Q8 agent preset and a
-CPU-only box gets the portable F16 — never the other way round, which would
-download a gigabyte only to crash-loop the container.
+**One default, hardware-blind (rc.10).** The default is
+:data:`BRAIN_MODEL_DEFAULT` (LFM2.5-2.6B Q8_0) on every box: plain GGUF, no
+custom tensor types, loadable by the FPX runner and stock llama.cpp alike.
+The hardware fork only survives for ``HAL0_BRAIN_MODEL`` overrides naming an
+sft build — the sft Q8/Q4 files carry custom GGML tensor type ids (103 / 100)
+that **stock llama.cpp rejects at load** (ROCmFPX runner only,
+``DEFAULT_ROCMFPX_IMAGE``); the sft F16 is the plain-GGUF one. An operator
+forcing an FPX-only quant onto a CPU box gets the crash-loop they asked for —
+the default can no longer produce it.
 
 **Reuses the existing activation gate.** The pull runs through
 :func:`~hal0.install.orchestrate.run_pull_and_activate`, which stamps
@@ -51,17 +54,26 @@ log = logging.getLogger(__name__)
 #: ``installer/etc-hal0/slots/brain.toml``).
 BRAIN_SLOT_NAME = "brain"
 
-#: Public GGUF repo holding every brain variant. The ``Hal0ai/hal0-brain-sft``
-#: BASE repo is private AND safetensors-only — no chat runner consumes
-#: safetensors, so the installer must never reach for it.
+#: Public GGUF repo holding the hal0-brain-sft variants. The
+#: ``Hal0ai/hal0-brain-sft`` BASE repo is private AND safetensors-only — no
+#: chat runner consumes safetensors, so the installer must never reach for it.
 BRAIN_HF_REPO = "Hal0ai/hal0-brain-sft-ROCmFPX-GGUF"
 
-#: Curated id pulled on a box with a ROCm/Vulkan device: the Q8_0 agent/tool-use
-#: preset. Custom GGML tensor type 103 — ROCmFPX runner ONLY.
+#: The default brain on EVERY box (rc.10): LFM2.5-2.6B Q8_0. Plain GGUF —
+#: no custom tensor types — so the FPX runner and stock llama.cpp both load
+#: it and the hardware split below no longer forks the default. 2.87 GB
+#: (disclosed at the install.sh "Brain model" step; up from the 1.1 GB sft
+#: Q8). Requires the hal0-combined:0826+ runner for native tool-call
+#: parsing and think-extraction (#2073) — do not roll this default onto
+#: older image pins.
+BRAIN_MODEL_DEFAULT = "lfm2.5-2.6b"
+
+#: hal0-brain-sft Q8_0 agent/tool-use preset — the pre-rc.10 GPU default,
+#: kept as an override. Custom GGML tensor type 103 — ROCmFPX runner ONLY.
 BRAIN_MODEL_ROCMFPX = "hal0-brain-sft-q8-rocmfpx"
 
-#: Curated id pulled on a box with no usable GPU: plain F16 GGUF, loadable by a
-#: stock llama.cpp image. Bigger, but it actually starts.
+#: hal0-brain-sft plain F16 GGUF — the pre-rc.10 CPU default, kept as an
+#: override. Loadable by a stock llama.cpp image.
 BRAIN_MODEL_PORTABLE = "hal0-brain-sft-f16"
 
 #: Smallest variant. Custom GGML tensor type 100 — ROCmFPX runner ONLY. NOT
@@ -69,7 +81,12 @@ BRAIN_MODEL_PORTABLE = "hal0-brain-sft-f16"
 BRAIN_MODEL_SMALL = "hal0-brain-sft-q4-rocmfp4"
 
 #: Every brain variant, for callers that want to validate an override.
-BRAIN_MODEL_IDS = (BRAIN_MODEL_ROCMFPX, BRAIN_MODEL_SMALL, BRAIN_MODEL_PORTABLE)
+BRAIN_MODEL_IDS = (
+    BRAIN_MODEL_DEFAULT,
+    BRAIN_MODEL_ROCMFPX,
+    BRAIN_MODEL_SMALL,
+    BRAIN_MODEL_PORTABLE,
+)
 
 
 def rocmfpx_capable(hw: HardwareInfo) -> bool:
@@ -93,10 +110,18 @@ def brain_model_for_hardware(hw: HardwareInfo, *, override: str | None = None) -
     """Return the curated brain model id to pull on this box.
 
     *override* (``HAL0_BRAIN_MODEL`` at the install.sh call site) wins when it
-    names a known variant, so an operator can force the Q4 build or pin F16 on
-    a GPU box. An unrecognised override is ignored with a warning rather than
-    honoured — a typo must not turn into a 404 pull.
+    names a known variant, so an operator can force an sft build (mind the
+    ROCmFPX-only quants on a CPU box). An unrecognised override is ignored
+    with a warning rather than honoured — a typo must not turn into a 404
+    pull.
+
+    ``hw`` no longer forks the default: :data:`BRAIN_MODEL_DEFAULT` is plain
+    Q8_0 GGUF that every runner class loads, so hardware only matters to
+    override users now. The parameter stays — dropping it would ripple
+    through every call site for no behavioural gain, and a future
+    memory-tiered default would need it right back.
     """
+    del hw  # retained for call-site stability; see docstring
     if override:
         override = override.strip()
         if override in BRAIN_MODEL_IDS:
@@ -104,7 +129,7 @@ def brain_model_for_hardware(hw: HardwareInfo, *, override: str | None = None) -
         log.warning(
             "install.brain_model_override_unknown id=%s known=%s", override, BRAIN_MODEL_IDS
         )
-    return BRAIN_MODEL_ROCMFPX if rocmfpx_capable(hw) else BRAIN_MODEL_PORTABLE
+    return BRAIN_MODEL_DEFAULT
 
 
 def already_pulled(model_id: str, *, capability: str = "chat") -> Path | None:
@@ -266,12 +291,12 @@ def main(argv: list[str] | None = None) -> int:
 
         hw = _load_hardware()
         chosen = brain_model_for_hardware(hw, override=override)
-        why = (
-            "ROCm/Vulkan device present — ROCmFPX runner can load the custom tensor types"
-            if rocmfpx_capable(hw)
-            else "no ROCm/Vulkan device — using the portable F16 build (stock llama.cpp)"
-        )
-        print(f"  brain model: {chosen} ({why})")
+        from hal0.registry.curated import get_curated as _get_curated
+
+        entry = _get_curated(chosen)
+        size = f", {entry.size_gb:g} GB download" if entry is not None else ""
+        why = "override" if override and chosen == override else "default — loads on every runner class"
+        print(f"  brain model: {chosen} ({why}{size})")
         if already_pulled(chosen) is not None:
             print("  already on disk from an earlier run — binding it, no download")
         slot_manager, registry = _build_offline_deps()

--- a/src/hal0/registry/curated.py
+++ b/src/hal0/registry/curated.py
@@ -442,6 +442,43 @@ CURATED_MODELS: list[CuratedModel] = [
         architecture="llama",
         backend="llamacpp",
     ),
+    # ── LFM2.5 — the default brain pick (rc.10) ────────────────────────────
+    # Replaces hal0-brain-sft-q8-rocmfpx as the id ``install.brain_model``
+    # pulls by default. Plain Q8_0 GGUF (no custom tensor types), so ONE
+    # variant loads on the FPX runner and stock llama.cpp alike — the
+    # hardware split above no longer applies to the default; the sft
+    # variants stay as explicit HAL0_BRAIN_MODEL overrides.
+    CuratedModel(
+        id="lfm2.5-2.6b",
+        display_name="LFM2.5 2.6B",
+        description=(
+            "The default hal0 platform steward (brain): RL-trained thinker "
+            "with native tool calling and validated structured output."
+        ),
+        family="lfm",
+        size_gb=2.87,
+        vram_gb_min=4.0,
+        license="LFM-Open-1.0",
+        license_url="https://huggingface.co/LiquidAI/LFM2.5-2.6B-GGUF/blob/main/LICENSE",
+        hf_repo="LiquidAI/LFM2.5-2.6B-GGUF",
+        hf_file="LFM2.5-2.6B-Q8_0.gguf",
+        context_length=131072,
+        tool_calling=True,
+        recommended_slot="chat",
+        tags=["chat", "brain", "steward", "tools", "reasoning"],
+        notes=(
+            "Q8_0, 2.87 GB — the pull layer verifies the HF LFS sha256. Emits "
+            "<think> from weights (enable_thinking=false does NOT suppress "
+            "it); profile.brain leaves reasoning-format at the runner default "
+            "so think text extracts into reasoning_content. Native tool "
+            "calls (<|tool_call_start|> dialect) verified on the "
+            "hal0-combined:0826 runner — do not flip the brain default to "
+            "this id on images older than that pin (#2073)."
+        ),
+        capability="chat",
+        architecture="lfm2",
+        backend="llamacpp",
+    ),
     # ── Kept-in-featured legacy picks (explicit user ask): qwen3-4b for
     # mid-tier Vulkan hosts, phi3-mini for the MIT-licensed pick.  Slot
     # below the 2026-05 refresh — wizard still surfaces them in the main

--- a/tests/config/test_schema_seeds_c5.py
+++ b/tests/config/test_schema_seeds_c5.py
@@ -159,8 +159,7 @@ def test_brain_seed_defers_its_model_to_the_installer() -> None:
 
     slot = _load_seed_slot(_SEEDED_SLOTS_DIR / "brain.toml")
     assert slot.model.default == "", (
-        "brain.toml must not pin a model: the installer binds the model "
-        "after its bytes land"
+        "brain.toml must not pin a model: the installer binds the model after its bytes land"
     )
     # The auto-selected default must resolve to real HF pull coordinates.
     default = get_curated(BRAIN_MODEL_DEFAULT)

--- a/tests/config/test_schema_seeds_c5.py
+++ b/tests/config/test_schema_seeds_c5.py
@@ -152,27 +152,32 @@ def test_brain_seed_defers_its_model_to_the_installer() -> None:
     either hardware class the installer can land on.
     """
     from hal0.install.brain_model import (
+        BRAIN_MODEL_DEFAULT,
         BRAIN_MODEL_IDS,
-        BRAIN_MODEL_PORTABLE,
-        BRAIN_MODEL_ROCMFPX,
     )
     from hal0.registry.curated import get_curated
 
     slot = _load_seed_slot(_SEEDED_SLOTS_DIR / "brain.toml")
     assert slot.model.default == "", (
-        "brain.toml must not pin a model: the installer binds the "
-        "hardware-appropriate variant after its bytes land"
+        "brain.toml must not pin a model: the installer binds the model "
+        "after its bytes land"
     )
-    # Both auto-selectable variants must resolve to real HF pull coordinates.
-    for model_id in (BRAIN_MODEL_ROCMFPX, BRAIN_MODEL_PORTABLE):
-        curated = get_curated(model_id)
-        assert curated is not None, f"{model_id!r} has no curated catalogue entry"
-        assert curated.hf_repo and curated.hf_file
-    # Every declared variant lives in the one PUBLIC repo. The base repo
-    # (Hal0ai/hal0-brain-sft) is private and safetensors-only — no chat runner
-    # consumes safetensors, so the installer must never point at it.
+    # The auto-selected default must resolve to real HF pull coordinates.
+    default = get_curated(BRAIN_MODEL_DEFAULT)
+    assert default is not None, f"{BRAIN_MODEL_DEFAULT!r} has no curated catalogue entry"
+    assert default.hf_repo and default.hf_file
+    # Every declared variant lives in a PUBLIC repo: the LFM default in
+    # LiquidAI's GGUF repo, the sft overrides in the one public sft repo.
+    # The base repo (Hal0ai/hal0-brain-sft) is private and safetensors-only —
+    # no chat runner consumes safetensors, so the installer must never point
+    # at it.
     for model_id in BRAIN_MODEL_IDS:
         curated = get_curated(model_id)
         assert curated is not None
-        assert curated.hf_repo == "Hal0ai/hal0-brain-sft-ROCmFPX-GGUF"
+        expected_repo = (
+            "LiquidAI/LFM2.5-2.6B-GGUF"
+            if model_id == BRAIN_MODEL_DEFAULT
+            else "Hal0ai/hal0-brain-sft-ROCmFPX-GGUF"
+        )
+        assert curated.hf_repo == expected_repo
         assert curated.hf_file.endswith(".gguf")

--- a/tests/install/test_brain_model.py
+++ b/tests/install/test_brain_model.py
@@ -28,6 +28,7 @@ import pytest
 from hal0.config.schema import GPUInfo, HardwareInfo
 from hal0.install.brain_model import (
     BRAIN_HF_REPO,
+    BRAIN_MODEL_DEFAULT,
     BRAIN_MODEL_IDS,
     BRAIN_MODEL_PORTABLE,
     BRAIN_MODEL_ROCMFPX,
@@ -48,34 +49,30 @@ def _hw(*, platform: str = "generic", gpus: list[GPUInfo] | None = None) -> Hard
     return HardwareInfo(platform=platform, gpus=gpus or [])
 
 
-def test_cpu_only_box_gets_the_portable_f16_build() -> None:
-    """No GPU → the ONLY variant a stock llama.cpp image can load.
-
-    This is the regression that matters most: the Q8 build is half the size and
-    the obvious "default", but its custom tensor type 103 makes it unloadable
-    here, so a box with no ROCm/Vulkan device must get F16.
+def test_cpu_only_box_gets_the_default_lfm_build() -> None:
+    """No GPU → still the LFM default: plain Q8_0 GGUF, no custom tensor
+    types, so a stock llama.cpp image loads it fine. (Under the sft lineage
+    this box HAD to divert to F16 — that split is now override-only.)
     """
     hw = _hw()
     assert rocmfpx_capable(hw) is False
-    assert brain_model_for_hardware(hw) == BRAIN_MODEL_PORTABLE
+    assert brain_model_for_hardware(hw) == BRAIN_MODEL_DEFAULT
 
 
-def test_strix_halo_box_gets_the_rocmfpx_agent_preset() -> None:
+def test_strix_halo_box_gets_the_default_lfm_build() -> None:
     hw = _hw(platform="strix-halo")
     assert rocmfpx_capable(hw) is True
-    assert brain_model_for_hardware(hw) == BRAIN_MODEL_ROCMFPX
+    assert brain_model_for_hardware(hw) == BRAIN_MODEL_DEFAULT
 
 
-def test_compute_capable_gpu_box_gets_the_rocmfpx_agent_preset() -> None:
+def test_compute_capable_gpu_box_gets_the_default_lfm_build() -> None:
     hw = _hw(gpus=[GPUInfo(vendor="amd", compute_capable=True)])
-    assert brain_model_for_hardware(hw) == BRAIN_MODEL_ROCMFPX
+    assert brain_model_for_hardware(hw) == BRAIN_MODEL_DEFAULT
 
 
-def test_vulkan_only_gpu_box_still_gets_the_rocmfpx_agent_preset() -> None:
-    """``gpu-vulkan`` resolves to the ``vulkanfpx`` runner row, whose image is
-    the same ``DEFAULT_ROCMFPX_IMAGE`` — so Vulkan-only is ROCmFPX-capable."""
+def test_vulkan_only_gpu_box_gets_the_default_lfm_build() -> None:
     hw = _hw(gpus=[GPUInfo(vendor="amd", vulkan_capable=True)])
-    assert brain_model_for_hardware(hw) == BRAIN_MODEL_ROCMFPX
+    assert brain_model_for_hardware(hw) == BRAIN_MODEL_DEFAULT
 
 
 def test_override_selects_a_known_variant() -> None:
@@ -88,42 +85,44 @@ def test_override_selects_a_known_variant() -> None:
 
 
 class TestHardwareDecisionMatrix:
-    """The full selection matrix hal0#1790 asked for: gpu-rocm / gpu-vulkan /
-    cpu-only, each driven through :func:`brain_model_for_hardware` exactly as
-    ``hal0.install.brain_model.main`` calls it (hardware first, no override).
+    """The selection matrix from hal0#1790, updated for the LFM default:
+    gpu-rocm / gpu-vulkan / cpu-only all land on ``BRAIN_MODEL_DEFAULT`` —
+    plain Q8_0 GGUF loads on the FPX runner and stock llama.cpp alike, so
+    hardware no longer forks the pick. ``rocmfpx_capable`` assertions stay:
+    other callers (``install.agent_model``) still fork on it.
     """
 
-    def test_gpu_rocm_box_selects_rocmfpx(self) -> None:
+    def test_gpu_rocm_box_selects_the_default(self) -> None:
         hw = _hw(gpus=[GPUInfo(vendor="amd", compute_capable=True, vulkan_capable=False)])
         assert rocmfpx_capable(hw) is True
-        assert brain_model_for_hardware(hw) == BRAIN_MODEL_ROCMFPX
+        assert brain_model_for_hardware(hw) == BRAIN_MODEL_DEFAULT
 
-    def test_gpu_vulkan_box_selects_rocmfpx(self) -> None:
+    def test_gpu_vulkan_box_selects_the_default(self) -> None:
         hw = _hw(gpus=[GPUInfo(vendor="amd", compute_capable=False, vulkan_capable=True)])
         assert rocmfpx_capable(hw) is True
-        assert brain_model_for_hardware(hw) == BRAIN_MODEL_ROCMFPX
+        assert brain_model_for_hardware(hw) == BRAIN_MODEL_DEFAULT
 
-    def test_cpu_only_box_selects_portable_f16(self) -> None:
-        """No compute, no Vulkan, no strix-halo platform — the F16 build."""
+    def test_cpu_only_box_selects_the_default(self) -> None:
         hw = _hw(gpus=[])
         assert rocmfpx_capable(hw) is False
-        assert brain_model_for_hardware(hw) == BRAIN_MODEL_PORTABLE
+        assert brain_model_for_hardware(hw) == BRAIN_MODEL_DEFAULT
 
-    def test_gpu_present_but_neither_compute_nor_vulkan_capable_selects_f16(self) -> None:
-        """hal0#1790's exact shape one layer up: an AMD GPU row IS present in
-        ``hw.gpus`` (sysfs saw it) but both capability flags are False — this
-        is what ``hal0.hardware.probe._amd_gpu_info`` now produces for a
-        GPU-less LXC once its render-node gate is in place. Before that fix
-        this GPUInfo would have carried ``vulkan_capable=True`` unconditionally
-        and this test would have asserted BRAIN_MODEL_ROCMFPX instead — the
-        regression this matrix exists to pin.
+    def test_gpu_present_but_neither_compute_nor_vulkan_capable_selects_the_default(
+        self,
+    ) -> None:
+        """hal0#1790's exact shape: an AMD GPU row IS present in ``hw.gpus``
+        (sysfs saw it) but both capability flags are False — the GPU-less LXC
+        case. Under the sft lineage the capability split decided F16 vs Q8
+        here; with the LFM default the answer is the same id either way, and
+        this test pins that the capability probe still returns False (the
+        agent-model chooser depends on it).
         """
         hw = _hw(
             platform="lxc",
             gpus=[GPUInfo(vendor="amd", compute_capable=False, vulkan_capable=False)],
         )
         assert rocmfpx_capable(hw) is False
-        assert brain_model_for_hardware(hw) == BRAIN_MODEL_PORTABLE
+        assert brain_model_for_hardware(hw) == BRAIN_MODEL_DEFAULT
 
 
 def test_unknown_override_falls_back_instead_of_404ing() -> None:
@@ -136,7 +135,7 @@ def test_unknown_override_falls_back_instead_of_404ing() -> None:
     """
     hw = _hw()
     assert brain_model_for_hardware(hw, override="MiniCPM5-1B-Agentic-Tooluse") == (
-        BRAIN_MODEL_PORTABLE
+        BRAIN_MODEL_DEFAULT
     )
 
 
@@ -144,18 +143,22 @@ def test_unknown_override_falls_back_instead_of_404ing() -> None:
 
 
 @pytest.mark.parametrize("model_id", BRAIN_MODEL_IDS)
-def test_every_brain_variant_is_pullable_from_the_public_repo(model_id: str) -> None:
-    """Each declared variant must resolve to real HF coordinates in the PUBLIC
-    GGUF repo. The base repo (``Hal0ai/hal0-brain-sft``) is private and
-    safetensors-only, and no chat runner consumes safetensors."""
+def test_every_brain_variant_is_pullable_from_a_public_repo(model_id: str) -> None:
+    """Each declared variant must resolve to real HF coordinates in a PUBLIC
+    repo: the LFM default from LiquidAI's GGUF repo, the sft overrides from
+    ``BRAIN_HF_REPO`` (the ``Hal0ai/hal0-brain-sft`` base repo is private and
+    safetensors-only — no chat runner consumes safetensors)."""
     curated = get_curated(model_id)
     assert curated is not None, f"{model_id!r} missing from CURATED_MODELS"
-    assert curated.hf_repo == BRAIN_HF_REPO
+    if model_id == BRAIN_MODEL_DEFAULT:
+        assert curated.hf_repo == "LiquidAI/LFM2.5-2.6B-GGUF"
+    else:
+        assert curated.hf_repo == BRAIN_HF_REPO
     assert curated.hf_file.endswith(".gguf")
     assert curated.capability == "chat"
 
 
-def test_the_three_variants_are_distinct_files() -> None:
+def test_every_variant_is_a_distinct_file() -> None:
     files = {get_curated(m).hf_file for m in BRAIN_MODEL_IDS}  # type: ignore[union-attr]
     assert len(files) == len(BRAIN_MODEL_IDS)
 
@@ -205,9 +208,9 @@ def test_successful_pull_binds_the_model_to_the_brain_slot(
     landed = asyncio.run(
         provision_brain_model(hw=_hw(platform="strix-halo"), slot_manager=sm, registry=reg)
     )
-    assert landed == BRAIN_MODEL_ROCMFPX
-    assert reg.ensured == [BRAIN_MODEL_ROCMFPX]
-    assert sm.updates == [(BRAIN_SLOT_NAME, {"model": {"default": BRAIN_MODEL_ROCMFPX}})]
+    assert landed == BRAIN_MODEL_DEFAULT
+    assert reg.ensured == [BRAIN_MODEL_DEFAULT]
+    assert sm.updates == [(BRAIN_SLOT_NAME, {"model": {"default": BRAIN_MODEL_DEFAULT}})]
 
 
 def test_failed_pull_leaves_the_slot_model_less_and_marked(
@@ -384,18 +387,18 @@ def test_provisioning_reuses_an_existing_pull_without_downloading(
         raise AssertionError("run_pull must not be called when the file is already on disk")
 
     monkeypatch.setattr(pull_mod, "run_pull", _explode)
-    _place(store, BRAIN_MODEL_PORTABLE)
+    _place(store, BRAIN_MODEL_DEFAULT)
     sm, reg = _FakeSlotManager(), _FakeRegistry()
     landed = asyncio.run(provision_brain_model(hw=_hw(), slot_manager=sm, registry=reg))
-    assert landed == BRAIN_MODEL_PORTABLE
-    assert sm.updates == [(BRAIN_SLOT_NAME, {"model": {"default": BRAIN_MODEL_PORTABLE}})]
+    assert landed == BRAIN_MODEL_DEFAULT
+    assert sm.updates == [(BRAIN_SLOT_NAME, {"model": {"default": BRAIN_MODEL_DEFAULT}})]
 
 
 def test_provisioning_still_pulls_when_the_prior_file_is_untrustworthy(
     store, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _stub_run_pull(monkeypatch, state="completed")
-    _place(store, BRAIN_MODEL_PORTABLE, meta=False)  # type: ignore[arg-type]
+    _place(store, BRAIN_MODEL_DEFAULT, meta=False)  # type: ignore[arg-type]
     sm, reg = _FakeSlotManager(), _FakeRegistry()
     landed = asyncio.run(provision_brain_model(hw=_hw(), slot_manager=sm, registry=reg))
-    assert landed == BRAIN_MODEL_PORTABLE
+    assert landed == BRAIN_MODEL_DEFAULT


### PR DESCRIPTION
## DO NOT MERGE before #2073

The runner pin to `hal0-combined:0826` (PR #2073) is a hard prerequisite: LFM2.5's native tool-call parsing and think-extraction need that image. Draft until #2073 merges; validate the combination in the rc.10 fresh lane. Trees are independent (installer/ + registry vs packaging/runner pins), so no merge conflict is expected.

## What changes

- **Curated entry `lfm2.5-2.6b`** — `LiquidAI/LFM2.5-2.6B-GGUF` / `LFM2.5-2.6B-Q8_0.gguf`, 2.87 GB, context 131072, `tool_calling=True`, `architecture=lfm2`. The pull layer verifies the HF LFS sha256 automatically.
- **`install/brain_model.py`** — new `BRAIN_MODEL_DEFAULT = "lfm2.5-2.6b"`, selected on every hardware class: plain Q8_0 GGUF loads on the FPX runner and stock llama.cpp alike, so the ROCm-vs-CPU fork collapses to override-only. The `hal0-brain-sft` ids remain valid `HAL0_BRAIN_MODEL` overrides with their existing runner constraints. The install step now discloses the download size (2.87 GB, up from the 1.1 GB sft Q8 — per operator decision: brain stays default-install, size disclosed).
- **`profile.brain`** — drops `--reasoning off --reasoning-format none`. LFM2.5 emits `<think>` from weights and `enable_thinking=false` does not suppress it, so that pair leaked raw think prose into `message.content`; the runner-default reasoning-format extracts it cleanly into `reasoning_content`. Cost note documented in the profile: extraction/JSON calls pay ~100-300 think tokens per call before the grammar-constrained output starts.
- **`[brain_chat] tool_model` routing unchanged** (default `hal0/agent`). Flipping steward tool turns to the brain natively is the rc.10 steward re-eval's call, not this PR's.
- brain.toml / install.sh comments updated; the model-less-seed + stamp-after-pull design (#1108/#1369) is untouched.

## Provenance (verified tonight)

- HF LFS sha256 `1e22128dfa128bdfb684da167e74e072d0a056baa7d06d9f280291e2839b0fc9`, 2,874,779,648 bytes — exact match to the ct150 reference copy (sha256sum run on the box).
- GGUF header read from the actual file: `general.architecture=lfm2`, `lfm2.context_length=131072`, embedded chat template present and carries the `List of tools:` parser-detection string.
- Validation matrix on `:0826` (ct150, rc.9 lane): temp-0 canary, `json_object`, `json_schema`, degenerate contentless prompt, native `tool_calls` — all 200.

## Tests

- `tests/install/test_brain_model.py` rewritten contract-first: selection matrix asserts every hardware class gets the default; pullability parametrized per repo (LiquidAI for the default, the public sft repo for overrides); provisioning reuse/untrustworthy-file tests moved to the default id.
- `tests/config/test_schema_seeds_c5.py` brain-seed test updated the same way (seed still ships model-less).
- Batch result: 143 passed (install/registry/slots/config target files); wider sweep `tests/install tests/registry tests/slots tests/config tests/brain`: 2579 passed, 10 skipped. Ran on macOS via a local-disk uv env; CI is the authoritative Linux run.

Depends-on: #2073. Related: #2056 (parser fix lineage), #2054 (seed device derivation — untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)