### PR TITLE
fix(cli): run hermes gateway install as root on the root path (#2061)

### DIFF
--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -547,6 +547,16 @@ def _hermes_root_prelude(terminal_env: dict[str, str] | None = None) -> None:
             console.print(f"[dim]hermes prelude: could not pre-own {d}: {exc}[/dim]")
 
 
+def _agent_home() -> str:
+    """The hal0 service user's home dir (``/var/lib/hal0`` fallback)."""
+    import pwd as _pwd
+
+    try:
+        return _pwd.getpwnam(_AGENT_RUNTIME_USER).pw_dir or "/var/lib/hal0"
+    except KeyError:
+        return "/var/lib/hal0"
+
+
 def _run_as_hal0(
     argv: list[str], *, stdin: int | None = None, extra_env: dict[str, str] | None = None
 ) -> int:
@@ -568,14 +578,10 @@ def _run_as_hal0(
     three tools — the ``sudo`` fallback resets the environment, and relying on
     inheritance would silently lose it there (see HAL0_HERMES_TERMINAL).
     """
-    import pwd as _pwd
     import shutil as _shutil
     import subprocess as _subprocess
 
-    try:
-        home = _pwd.getpwnam(_AGENT_RUNTIME_USER).pw_dir or "/var/lib/hal0"
-    except KeyError:
-        home = "/var/lib/hal0"
+    home = _agent_home()
     assignments = [f"{k}={v}" for k, v in sorted((extra_env or {}).items())]
     env_argv = ["env", "-u", "HERMES_HOME", f"HOME={home}", *assignments, *argv]
     if _shutil.which("runuser"):
@@ -787,31 +793,31 @@ def _install_hermes_gateway() -> None:
     # HERMES_HOME is unset so the generator bakes the hal0 default
     # (~/.hermes) rather than a value inherited from the invoking shell.
     #
-    # m1 fix: "the hal0 default (~/.hermes)" is only actually hal0's home
-    # when THIS process is already running as hal0. `hal0 agent install
-    # hermes` (and installer/install.sh's equivalent inline block) run as
-    # root, so unqualified `~` resolved to /root — writing a stray
-    # root-owned /root/.hermes (the exact "split-brain" ownership drift
-    # `hal0 doctor perms` flags via check_hermes_ownership's stray_home
-    # check, and installer/lib/run-as-hal0.sh's own docstring calls out
-    # by name as the "root-clobber regression" #843). Drop to hal0 first,
-    # same seam `_provision_hermes` already uses, so this subprocess never
-    # runs as root in the first place.
+    # #2061 fix (reverts the m1 drop-to-hal0): `hermes gateway install
+    # --system` checks os.geteuid() == 0 INTERNALLY and refuses a non-root
+    # caller ("System gateway install requires root. Re-run with sudo."),
+    # so routing the root path through `_run_as_hal0` made the bridge
+    # sub-install fail on every root install — the same regression PR
+    # #1337 already fixed once in installer/install.sh's inline block.
+    # Run AS ROOT directly, exactly like install.sh: the #843 stray
+    # /root/.hermes safeguard is satisfied by env alone — HOME pinned to
+    # hal0's home + HERMES_HOME unset — so `~/.hermes` resolves under
+    # /var/lib/hal0, never /root. `--run-as-user hal0` only names the
+    # runtime user baked into the unit; it is not a privilege drop.
     gateway_argv = [_HERMES_BIN, "gateway", "install", "--system", "--run-as-user", "hal0"]
     # `hermes gateway install` prompts interactively with no bypass flag;
     # stdin=DEVNULL gives a clean EOF so it falls back to its built-in
     # defaults (install + enable on boot + start now) instead of blocking.
+    env = dict(_os.environ)
+    env.pop("HERMES_HOME", None)
     if _os.geteuid() == 0:
-        rc = _run_as_hal0(gateway_argv, stdin=_subprocess.DEVNULL)
-    else:
-        env = dict(_os.environ)
-        env.pop("HERMES_HOME", None)
-        rc = _subprocess.run(  # nosec B603 — fixed argv, known path
-            gateway_argv,
-            stdin=_subprocess.DEVNULL,
-            env=env,
-            check=False,
-        ).returncode
+        env["HOME"] = _agent_home()
+    rc = _subprocess.run(  # nosec B603 — fixed argv, known path
+        gateway_argv,
+        stdin=_subprocess.DEVNULL,
+        env=env,
+        check=False,
+    ).returncode
     if rc != 0:
         console.print(
             "[yellow]hermes gateway install failed — Telegram/Discord bridge "
@@ -822,7 +828,7 @@ def _install_hermes_gateway() -> None:
         console.print(
             f"[yellow]hermes-gateway unit not installed ({_HERMES_GATEWAY_UNIT} missing) — "
             "Telegram/Discord bridge unavailable.[/yellow]\n"
-            "[dim]retry with: sudo -u hal0 env -u HERMES_HOME "
+            f"[dim]retry with: sudo env -u HERMES_HOME HOME={_agent_home()} "
             f"{_HERMES_BIN} gateway install --system --run-as-user hal0 </dev/null[/dim]"
         )
         return

--- a/tests/cli/test_agent_install_hermes.py
+++ b/tests/cli/test_agent_install_hermes.py
@@ -369,12 +369,14 @@ def test_install_hermes_gateway_installs_and_enables_unit(monkeypatch, tmp_path)
     assert ["systemctl", "enable", "--now", "hermes-gateway.service"] in calls
 
 
-def test_install_hermes_gateway_drops_to_hal0_when_root(monkeypatch, tmp_path) -> None:
-    """m1: as root, `hermes gateway install` must run via ``_run_as_hal0``, not
-    a bare ``subprocess.run`` — a bare root invocation resolves ``~/.hermes``
-    to ``/root/.hermes``, the exact "split-brain" tree ``hal0 doctor perms``
-    flags as Hermes ownership drift (check_hermes_ownership's stray_home
-    check / installer/lib/run-as-hal0.sh's docstring, both naming #843).
+def test_install_hermes_gateway_runs_as_root_directly(monkeypatch, tmp_path) -> None:
+    """#2061: as root, `hermes gateway install --system` must run AS ROOT —
+    hermes checks ``os.geteuid() == 0`` internally and refuses a non-root
+    caller ("System gateway install requires root. Re-run with sudo."), so
+    routing the root path through ``_run_as_hal0`` skipped the bridge on
+    every root install. The #843 stray-/root/.hermes safeguard is preserved
+    by env alone: ``HOME`` pinned to hal0's home + ``HERMES_HOME`` unset,
+    exactly like installer/install.sh's inline gateway block (PR #1337).
     """
     gateway_unit = tmp_path / "hermes-gateway.service"
     monkeypatch.setattr("os.geteuid", lambda: 0)
@@ -383,29 +385,33 @@ def test_install_hermes_gateway_drops_to_hal0_when_root(monkeypatch, tmp_path) -
     monkeypatch.setattr("shutil.which", lambda _n: "/usr/bin/systemctl")
     monkeypatch.setattr(ac, "_wait_active_unit", lambda _unit, timeout=15.0: True)
     monkeypatch.setattr("hal0.agents.hermes_provision._detect_foreign_gateways", lambda **_k: [])
+    # Deterministic hal0 home regardless of the host's passwd database.
+    monkeypatch.setattr(ac, "_agent_home", lambda: "/var/lib/hal0")
+    # A leaked HERMES_HOME must not survive into the hermes subprocess.
+    monkeypatch.setenv("HERMES_HOME", "/root/.hermes-leaked")
 
     captured: dict[str, Any] = {}
 
-    def _fake_run_as_hal0(argv: list[str], *, stdin: Any = None) -> int:
-        captured["argv"] = argv
-        captured["stdin"] = stdin
-        gateway_unit.write_text("[Unit]\n")
-        return 0
-
-    monkeypatch.setattr(ac, "_run_as_hal0", _fake_run_as_hal0)
-
-    # A bare subprocess.run call for the gateway-install argv would mean the
-    # fix regressed — root path must route through _run_as_hal0 instead.
-    def _boom(argv, *_a, **_k):  # type: ignore[no-untyped-def]
+    def _fake_run(argv, *_a, **kwargs):  # type: ignore[no-untyped-def]
         if argv and argv[0] == ac._HERMES_BIN:
-            raise AssertionError("gateway install ran unprivileged-dropped as root")
+            captured["argv"] = list(argv)
+            captured["stdin"] = kwargs.get("stdin")
+            captured["env"] = kwargs.get("env")
+            gateway_unit.write_text("[Unit]\n")
 
         class _Done:
             returncode = 0
 
         return _Done()
 
-    monkeypatch.setattr(subprocess, "run", _boom)
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    # Dropping to hal0 would make hermes' internal root check refuse the
+    # --system install — the exact #2061 regression.
+    def _boom(argv: list[str], *, stdin: Any = None, extra_env: Any = None) -> int:
+        raise AssertionError("gateway install must not drop to hal0 when root (#2061)")
+
+    monkeypatch.setattr(ac, "_run_as_hal0", _boom)
 
     ac._install_hermes_gateway()
 
@@ -418,6 +424,9 @@ def test_install_hermes_gateway_drops_to_hal0_when_root(monkeypatch, tmp_path) -
         "hal0",
     ]
     assert captured["stdin"] == subprocess.DEVNULL
+    assert captured["env"] is not None
+    assert "HERMES_HOME" not in captured["env"]
+    assert captured["env"]["HOME"] == "/var/lib/hal0"
 
 
 def test_install_hermes_gateway_writes_dropin_before_gateway_install(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary

During rc.7 and rc.9 installs running entirely as root, the hermes gateway bridge sub-install refused with `System gateway install requires root. Re-run with sudo.` (rc.9 log line 2317), so the Telegram/Discord bridge was silently skipped on every install. This PR makes the bridge sub-install run as root when the caller is root, restoring the behavior PR #1337 already established for `installer/install.sh`'s inline gateway block.

## Root cause

`hermes gateway install --system` checks `os.geteuid() == 0` internally and refuses a non-root caller — that is where the "Re-run with sudo" message comes from. `installer/install.sh` learned this in PR #1337 and runs the inline gateway block as root. But the CLI path `_install_hermes_gateway()` in `src/hal0/cli/agent_commands.py` — which `hal0 agent install hermes` invokes, and which install.sh shells out to during provisioning — later reintroduced a privilege drop: when `euid == 0` it routed the hermes invocation through `_run_as_hal0()` (an "m1" change aimed at the #843 stray `/root/.hermes` concern). Dropping to the unprivileged `hal0` user made hermes' internal root check refuse the `--system` install, so the sub-install failed on exactly the runs that had the privileges it demands.

## Fix

- `_install_hermes_gateway()` now runs `hermes gateway install --system --run-as-user hal0` as root directly when `euid == 0`, mirroring install.sh's inline block: `HERMES_HOME` is stripped from the env and `HOME` is pinned to the hal0 service user's home (`/var/lib/hal0` fallback), which satisfies the #843 stray-`/root/.hermes` safeguard without a privilege drop. `--run-as-user hal0` continues to name the runtime user baked into the systemd unit.
- The genuinely-unprivileged path is unchanged: a non-root run still invokes hermes as the current user, hermes refuses, and the existing "Telegram/Discord bridge unavailable; continuing" fallback fires.
- The retry hint printed when the unit is missing no longer suggests `sudo -u hal0 ...` (the exact invocation hermes refuses); it now suggests the root invocation with the sanitized env.
- Factored the hal0-home lookup into `_agent_home()`, shared by `_run_as_hal0()` and the gateway install.

## Test evidence

Test-first: replaced `test_install_hermes_gateway_drops_to_hal0_when_root` (which enshrined the regression) with `test_install_hermes_gateway_runs_as_root_directly`, asserting that as root the gateway install runs via a bare `subprocess.run` with `HOME=/var/lib/hal0`, no `HERMES_HOME`, `stdin=DEVNULL`, and never routes through `_run_as_hal0`.

- `uv run pytest tests/cli/test_agent_install_hermes.py` — 36 passed (the new test fails against the pre-fix source, passes with the fix).
- `uv run pytest tests/cli/test_agent_shim.py` — 53 passed, 4 skipped (Linux-only /proc scans; run on macOS).
- `ruff check` and `ruff format --check` clean on both touched files.

Note: run on a macOS dev box, so the Linux-only shim tests skipped; CI covers those.

Fixes #2061

🤖 Generated with [Claude Code](https://claude.com/claude-code)
