### PR TITLE
release: v1.0.0-rc.10

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release — the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md §12 and §17 (maintainer-local).",
-  "version": "1.0.0-rc.9",
+  "version": "1.0.0-rc.10",
   "channel": "preview",
   "toolbox_images": {
     "vulkan": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hal0-ui",
-  "version": "1.0.0-rc.9",
+  "version": "1.0.0-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hal0-ui",
-      "version": "1.0.0-rc.9",
+      "version": "1.0.0-rc.10",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal0-ui",
   "private": true,
-  "version": "1.0.0-rc.9",
+  "version": "1.0.0-rc.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "hal0ai"
-version = "1.0.0rc9"
+version = "1.0.0rc10"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Release-prep PR for v1.0.0-rc.10, per the standing one-prep-PR recipe.

- Version bump via `scripts/set-version.py 1.0.0-rc.10`: pyproject.toml, manifest.json, ui/package.json + lock, uv.lock.
- `scripts/update-toolbox-digests.sh`: 7 digests resolved, 0 null.
- Runner pin `hal0-combined:0826` digest verified live against ghcr: `sha256:7aad020a0a7460988bb148652bb830a71f2071bc8899abad7b01e6a2f75c7678` — matches #2073's pinned digest, tag unmoved.
- Ships the rc.9 install-fix wave (#2059–#2067 → #2068–#2078), #2056 parser fix + :0826 pin (#2073), #2052 cosign persist (#2058).
- **Not included by operator ruling:** #2076 (LFM brain default) stays draft — rc.10's fresh lane validates the known brain-sft + :0826 combination; #2076 lands after the lane passes, for rc.11/GA.
- Known accepted states: #2057 (mirror gated until signed stable, GA item), #2050 (gate-5 γ waiver per standing recipe, documented not hidden).

Tag lands on the merge commit after this merges; ct151 fresh lane runs against the published assets (release-validation session holds the box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)