### PR TITLE
fix(installer): persist_bootstrap_cosign called undefined `ok` — fresh cosign-less installs die at pre-flight (#2081)

### DIFF
--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1641,7 +1641,7 @@ persist_bootstrap_cosign() {
     fi
     if [[ -n "${HAL0_BOOTSTRAP_COSIGN:-}" && -x "${HAL0_BOOTSTRAP_COSIGN}" ]]; then
         if install -m 0755 "${HAL0_BOOTSTRAP_COSIGN}" "${dest_dir}/cosign"; then
-            ok "cosign: persisted bootstrap's pinned build to ${dest_dir}/cosign (hal0 update requires it)"
+            info "cosign: persisted bootstrap's pinned build to ${dest_dir}/cosign (hal0 update requires it)"
         else
             warn "could not persist cosign to ${dest_dir}/cosign — the first 'hal0 update' will fail its signature check until cosign is installed (https://docs.sigstore.dev/cosign/installation/)"
         fi

--- a/tests/installer/test_install_cosign_persist.py
+++ b/tests/installer/test_install_cosign_persist.py
@@ -37,12 +37,16 @@ _BOOTSTRAP = _REPO_ROOT / "installer" / "bootstrap.sh"
 _INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
 
 # ui.sh helpers the function calls; stubbed so output is capturable and the
-# restricted environment needs no extra sourcing.
+# restricted environment needs no extra sourcing. Stub ONLY the reporters
+# ui.sh actually defines (info/warn/err/die) — #2081 shipped because an
+# earlier version of this stub set also defined an `ok()` that exists
+# nowhere in the installer, masking the undefined-helper 127 that killed
+# every real cosign-less fresh install at pre-flight.
 _STUBS = """
 info() { printf 'INFO:%s\\n' "$*"; }
-ok()   { printf 'OK:%s\\n' "$*"; }
 warn() { printf 'WARN:%s\\n' "$*" >&2; }
 err()  { printf 'ERR:%s\\n' "$*" >&2; }
+die()  { err "$*"; exit 1; }
 """
 
 
@@ -97,7 +101,7 @@ class TestPersistBootstrapCosign:
         assert installed.read_bytes() == src.read_bytes()
         mode = stat.S_IMODE(installed.stat().st_mode)
         assert mode & stat.S_IXUSR, f"not executable: {oct(mode)}"
-        assert "OK:" in proc.stdout
+        assert "INFO:" in proc.stdout
 
     def test_never_overwrites_a_system_cosign(self, tmp_path: Path) -> None:
         src = _make_bootstrap_binary(tmp_path)

--- a/tests/installer/test_ui_helper_contract.py
+++ b/tests/installer/test_ui_helper_contract.py
@@ -62,6 +62,5 @@ def test_no_reporter_shaped_call_without_a_definition():
                 offenders.append(f"{f.relative_to(REPO)}:{n}: {line.strip()}")
     assert not offenders, (
         "reporter-shaped call to a helper no installer source defines "
-        "(#2081 class — this dies with 127 under set -e at runtime):\n"
-        + "\n".join(offenders)
+        "(#2081 class — this dies with 127 under set -e at runtime):\n" + "\n".join(offenders)
     )

--- a/tests/installer/test_ui_helper_contract.py
+++ b/tests/installer/test_ui_helper_contract.py
@@ -1,0 +1,67 @@
+"""Guard for #2081: installer shell code calling a reporter helper that ui.sh
+never defined.
+
+persist_bootstrap_cosign's success branch called ``ok "..."`` — no ``ok()``
+exists anywhere in the installer (ui.sh defines info/warn/err/die), so under
+``set -e`` the 127 killed every fresh bootstrap install that had no system
+cosign, at pre-flight 1/16, right after the cosign was successfully persisted.
+Hosts with a system cosign early-return past the line, which is why every CI
+and dev install missed it.
+
+The check is deliberately dumb: collect every function name defined across the
+installer's shell sources, then flag any command-position ``<word> "...`` line
+whose word looks like a reporter call (matches a known reporter name or the
+short lowercase shape ok/okay/success/fail/note) but is neither defined nor a
+real command the scripts legitimately use.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+INSTALLER = REPO / "installer"
+
+REPORTERS_DEFINED_IN_UI = {"info", "warn", "err", "die"}
+# Lowercase bare words that read as a status reporter; extend when a new
+# helper is added to ui.sh (and add it to REPORTERS_DEFINED_IN_UI).
+REPORTER_SHAPED = {"ok", "okay", "success", "fail", "note"} | REPORTERS_DEFINED_IN_UI
+
+FUNC_DEF = re.compile(r"^\s*(?:function\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\(\)\s*\{?")
+CALL = re.compile(r'^\s*([a-z_][a-z0-9_]*)\s+"')
+
+
+def shell_sources():
+    files = sorted(INSTALLER.rglob("*.sh"))
+    assert files, f"no installer shell sources under {INSTALLER}"
+    return files
+
+
+def test_ui_defines_the_reporter_contract():
+    ui = (INSTALLER / "lib" / "ui.sh").read_text()
+    defined = {m.group(1) for line in ui.splitlines() if (m := FUNC_DEF.match(line))}
+    missing = REPORTERS_DEFINED_IN_UI - defined
+    assert not missing, f"ui.sh no longer defines expected reporters: {sorted(missing)}"
+
+
+def test_no_reporter_shaped_call_without_a_definition():
+    defined = set()
+    for f in shell_sources():
+        for line in f.read_text().splitlines():
+            if m := FUNC_DEF.match(line):
+                defined.add(m.group(1))
+    defined |= REPORTERS_DEFINED_IN_UI
+
+    offenders = []
+    for f in shell_sources():
+        for n, line in enumerate(f.read_text().splitlines(), 1):
+            m = CALL.match(line)
+            if not m:
+                continue
+            word = m.group(1)
+            if word in REPORTER_SHAPED and word not in defined:
+                offenders.append(f"{f.relative_to(REPO)}:{n}: {line.strip()}")
+    assert not offenders, (
+        "reporter-shaped call to a helper no installer source defines "
+        "(#2081 class — this dies with 127 under set -e at runtime):\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
Fixes #2081.

## What

- `installer/lib/preflight.sh:1644` — `ok` → `info`. `persist_bootstrap_cosign()`'s success branch (added by #2058) reported via an `ok` helper that no installer source defines; ui.sh's reporters are `info`/`warn`/`err`/`die`. Under `set -euo pipefail` the 127 killed install.sh at pre-flight step 1/16 — right after the cosign was successfully persisted to /usr/local/bin.
- New `tests/installer/test_ui_helper_contract.py` — collects every function defined across `installer/**/*.sh` and flags any command-position reporter-shaped call (`ok`/`okay`/`success`/`fail`/`note`/known reporters) with no definition, so this class (a fix's success branch calling a nonexistent reporter — invisible to every existing test) cannot land again. Also pins ui.sh's reporter contract itself.

## Why every gate missed it

Hosts with a system cosign early-return before the broken line — that covers CI and every dev box. The failure needs the exact end-user shape: fresh box, no cosign, bootstrap-verified binary handed over via `HAL0_BOOTSTRAP_COSIGN`. Reproduced on the rc.10 validation fresh lane (ct151, pristine Ubuntu 26.04, preview channel); log in #2081.

## Impact

Every fresh one-liner install of v1.0.0-rc.10 on a cosign-less host dies. Re-runs mask it (run 1 leaves /usr/local/bin/cosign, run 2 early-returns past the bug).

Do not self-merge — needs independent review per kit process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
