### PR TITLE
fix(installer): persist bootstrap HAL0_CHANNEL so fresh preview installs can self-update (#2083)

### DIFF
--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -254,6 +254,11 @@ validate_channel() {
         stable|preview|nightly) ;;
         *) die "HAL0_CHANNEL must be one of: stable, preview, nightly (got ${HAL0_CHANNEL})" ;;
     esac
+    # The admitted channel must survive the exec into install.sh so the
+    # installed updater starts on the channel this install was actually
+    # verified against (persist_bootstrap_channel -> telemetry.channel,
+    # #2083) - same hand-off shape as HAL0_BOOTSTRAP_COSIGN (#2058).
+    export HAL0_CHANNEL
 }
 
 # ── cosign acquisition ─────────────────────────────────────────────────────

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1154,6 +1154,13 @@ fi
 chmod 0755 "${ETC_DIR}" 2>/dev/null || true
 chmod 0644 "${HAL0_TOML}" 2>/dev/null || true
 
+# Persist the channel this install was admitted from (bootstrap hand-off,
+# #2083) so the first `hal0 update --check` - including the update-check
+# smoke probe below - runs against it instead of the stable default (404
+# until GA, #1530). Must run before the hal0-api (re)start: the daemon
+# caches hal0.toml at startup.
+persist_bootstrap_channel "${HAL0_TOML}"
+
 # Pin the dashboard's built assets. Prod installs hal0 NON-editable, so the
 # package's __file__ lives in the venv site-packages and the walk-up that
 # finds ui/dist in a checkout no longer reaches it — point HAL0_UI_DIST at

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1651,6 +1651,140 @@ persist_bootstrap_cosign() {
     return 0
 }
 
+# ── bootstrap channel persistence (#2083) ──────────────────────────────────
+# bootstrap.sh admits and cosign-verifies the release against HAL0_CHANNEL,
+# then execs into install.sh — but nothing used to write that channel
+# anywhere durable, so the installed updater started life on its `stable`
+# default, whose manifest pointer is 404 until GA (#1530). Every preview/
+# nightly fresh install then failed the #2066 install-time update-check
+# probe with a false "the update path is broken" alarm, and an rc box could
+# never see the next rc via `hal0 update` without a manual channel flip.
+# Same hand-off shape as persist_bootstrap_cosign above: act only when the
+# env var came across the exec, never overwrite an explicit differing value
+# (warn instead), never die — the install itself is fine either way.
+# Writes telemetry.channel in hal0.toml: the exact key PUT
+# /api/updates/channel persists and the updater's _current_channel() reads.
+# Locked read-modify-write via system python3 with the same hal0.toml.lock
+# fcntl + O_NOFOLLOW discipline as install.sh's [models].store seeding —
+# this can run against a live daemon serving config writes, and /etc/hal0
+# is service-writable while we run as root.
+persist_bootstrap_channel() {
+    local toml="$1"
+    local channel="${HAL0_CHANNEL:-}"
+    [[ -n "${channel}" ]] || return 0
+    case "${channel}" in
+        stable|preview|nightly) ;;
+        *)
+            warn "HAL0_CHANNEL='${channel}' is not one of stable|preview|nightly — not persisting an update channel"
+            return 0
+            ;;
+    esac
+    if [[ ! -f "${toml}" ]]; then
+        warn "no ${toml} to persist update channel '${channel}' into — 'hal0 update' will use the stable default"
+        return 0
+    fi
+    local out
+    if out="$(python3 - "${toml}" "${channel}" <<'PYEOF'
+import fcntl, os, pathlib, re, stat, sys, tempfile
+path = pathlib.Path(sys.argv[1])
+channel = sys.argv[2]
+
+# Same lock file, same O_NOFOLLOW discipline as hal0.config.locking.file_lock
+# (and install.sh's [models].store seeding): /etc/hal0 is service-writable
+# while this runs as root, so following a symlink here would be a privilege
+# hole.
+lock_path = pathlib.Path(f"{path}.lock")
+created = False
+try:
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o664)
+    created = True
+except FileExistsError:
+    fd = os.open(lock_path, os.O_RDWR | os.O_NOFOLLOW)
+try:
+    if not stat.S_ISREG(os.fstat(fd).st_mode):
+        raise SystemExit(f"lock path is not a regular file: {lock_path}")
+    if created:
+        os.fchmod(fd, 0o664)
+        try:
+            st_src = path.stat()
+            if (st_src.st_uid, st_src.st_gid) != (0, 0):
+                os.fchown(fd, st_src.st_uid, st_src.st_gid)
+        except OSError:
+            pass
+    fcntl.flock(fd, fcntl.LOCK_EX)
+
+    if path.is_symlink():
+        raise SystemExit(f"refusing to write through a symlinked config: {path}")
+    tfd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    try:
+        if not stat.S_ISREG(os.fstat(tfd).st_mode):
+            raise SystemExit(f"config is not a regular file: {path}")
+        with os.fdopen(tfd, "r", encoding="utf-8") as fh:
+            tfd = -1
+            text = fh.read()
+    finally:
+        if tfd >= 0:
+            os.close(tfd)
+
+    # Section body = every following line that does not START with '[' —
+    # NOT `[^\[]*`, which would stop at the '[' of a list value and splice
+    # the table in half (the [models].store patcher bug class).
+    m = re.search(r"^\[telemetry\][ \t]*\n(?:(?!\[).*\n?)*", text, flags=re.MULTILINE)
+    if m:
+        block = m.group(0)
+        km = re.search(r"^\s*channel\s*=\s*\"?([^\"\n]*?)\"?\s*$", block, flags=re.MULTILINE)
+        if km:
+            existing = km.group(1)
+            print("same" if existing == channel else f"differs:{existing}")
+            raise SystemExit(0)
+        new_block = block if block.endswith("\n") else block + "\n"
+        new_block += f'channel = "{channel}"\n'
+        text = text[: m.start()] + new_block + text[m.end() :]
+    else:
+        if text and not text.endswith("\n"):
+            text += "\n"
+        text += f'\n[telemetry]\nchannel = "{channel}"\n'
+
+    st = path.stat()
+    fd_tmp, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd_tmp, "w", encoding="utf-8") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.chmod(tmp, stat.S_IMODE(st.st_mode))
+        try:
+            os.chown(tmp, st.st_uid, st.st_gid)
+        except OSError:
+            pass
+        os.replace(tmp, path)
+        tmp = None
+    finally:
+        if tmp is not None:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+    print("wrote")
+finally:
+    os.close(fd)
+PYEOF
+    )"; then
+        case "${out}" in
+            wrote) info "update channel: persisted '${channel}' to ${toml} (telemetry.channel)" ;;
+            same)  info "update channel: ${toml} already set to '${channel}'" ;;
+            differs:*)
+                warn "hal0.toml already sets telemetry.channel='${out#differs:}' — leaving it, though this install was admitted from '${channel}'"
+                warn "  switch with: hal0 update --channel ${channel}"
+                ;;
+            *) warn "unexpected result persisting update channel '${channel}' to ${toml}: ${out}" ;;
+        esac
+    else
+        warn "could not persist update channel '${channel}' to ${toml} — 'hal0 update' will use the stable default until 'hal0 update --channel ${channel}'"
+    fi
+    return 0
+}
+
 # ── bootstrap work-dir cleanup (#2065) ─────────────────────────────────────
 # bootstrap.sh arms an EXIT trap to delete its /tmp/hal0-install-* work dir
 # (release tarball + unpacked tree, ~150 MB), but that trap dies at the

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1685,7 +1685,7 @@ persist_bootstrap_channel() {
     fi
     local out
     if out="$(python3 - "${toml}" "${channel}" <<'PYEOF'
-import fcntl, os, pathlib, re, stat, sys, tempfile
+import fcntl, os, pathlib, re, stat, sys, tempfile, tomllib
 path = pathlib.Path(sys.argv[1])
 channel = sys.argv[2]
 
@@ -1726,17 +1726,34 @@ try:
         if tfd >= 0:
             os.close(tfd)
 
+    # Detect the existing value with a REAL parser, not a regex: inline
+    # comments (`channel = "x"  # set by ops`), single-quoted strings and
+    # every other valid-TOML spelling must be seen — a missed match here
+    # would append a duplicate key, and duplicate keys are a hard tomllib
+    # parse error that takes the daemon down with the config.
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        raise SystemExit(f"existing config does not parse, leaving it alone: {exc}")
+    existing = data.get("telemetry", {}).get("channel")
+    if existing is not None:
+        print("same" if str(existing) == channel else f"differs:{existing}")
+        raise SystemExit(0)
+    if channel == "stable":
+        # No key on disk and the admitted channel IS the schema default:
+        # persisting it would be behavior-identical for the updater today
+        # but would poison the never-overwrite rule above — a later
+        # deliberate `HAL0_CHANNEL=preview` re-bootstrap must still be able
+        # to persist cleanly onto a box that only ever ran defaults.
+        print("default")
+        raise SystemExit(0)
     # Section body = every following line that does not START with '[' —
     # NOT `[^\[]*`, which would stop at the '[' of a list value and splice
-    # the table in half (the [models].store patcher bug class).
-    m = re.search(r"^\[telemetry\][ \t]*\n(?:(?!\[).*\n?)*", text, flags=re.MULTILINE)
+    # the table in half (the [models].store patcher bug class). The header
+    # match tolerates a trailing inline comment.
+    m = re.search(r"^\[telemetry\][ \t]*(?:#.*)?\n(?:(?!\[).*\n?)*", text, flags=re.MULTILINE)
     if m:
         block = m.group(0)
-        km = re.search(r"^\s*channel\s*=\s*\"?([^\"\n]*?)\"?\s*$", block, flags=re.MULTILINE)
-        if km:
-            existing = km.group(1)
-            print("same" if existing == channel else f"differs:{existing}")
-            raise SystemExit(0)
         new_block = block if block.endswith("\n") else block + "\n"
         new_block += f'channel = "{channel}"\n'
         text = text[: m.start()] + new_block + text[m.end() :]
@@ -1744,6 +1761,15 @@ try:
         if text and not text.endswith("\n"):
             text += "\n"
         text += f'\n[telemetry]\nchannel = "{channel}"\n'
+    # Belt and braces: whatever the splice produced must itself parse and
+    # carry the value — any blind spot degrades to warn-and-leave-alone,
+    # never to an unloadable config.
+    try:
+        patched = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        raise SystemExit(f"patched config would not parse, leaving it alone: {exc}")
+    if patched.get("telemetry", {}).get("channel") != channel:
+        raise SystemExit("patched config did not take the channel, leaving it alone")
 
     st = path.stat()
     fd_tmp, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
@@ -1773,6 +1799,7 @@ PYEOF
         case "${out}" in
             wrote) info "update channel: persisted '${channel}' to ${toml} (telemetry.channel)" ;;
             same)  info "update channel: ${toml} already set to '${channel}'" ;;
+            default) info "update channel: '${channel}' is the built-in default — nothing to persist" ;;
             differs:*)
                 warn "hal0.toml already sets telemetry.channel='${out#differs:}' — leaving it, though this install was admitted from '${channel}'"
                 warn "  switch with: hal0 update --channel ${channel}"

--- a/tests/installer/test_install_channel_persist.py
+++ b/tests/installer/test_install_channel_persist.py
@@ -181,7 +181,7 @@ class TestValidTomlVariants:
     def test_section_followed_by_list_valued_table_is_not_spliced(self, tmp_path: Path) -> None:
         toml = tmp_path / "hal0.toml"
         toml.write_text(
-            "[telemetry]\nenabled = false\n\n[models]\nroots = [\"/x\", \"/y\"]\n",
+            '[telemetry]\nenabled = false\n\n[models]\nroots = ["/x", "/y"]\n',
             encoding="utf-8",
         )
         proc = _run_persist(toml, channel="preview")
@@ -240,7 +240,6 @@ class TestStableDefault:
         assert proc.returncode == 0, proc.stderr
         assert _telemetry_channel(toml) == "stable"
         assert "WARN:" in proc.stderr
-
 
 
 class TestWiring:

--- a/tests/installer/test_install_channel_persist.py
+++ b/tests/installer/test_install_channel_persist.py
@@ -1,0 +1,162 @@
+"""Fresh installs persist the bootstrap channel for the updater — #2083.
+
+``installer/bootstrap.sh`` admits and cosign-verifies the release against
+``HAL0_CHANNEL``, but nothing used to hand that channel to the installed
+system — the updater then starts life on its ``stable`` default, whose
+manifest pointer is 404 until GA (#1530). Every preview/nightly fresh
+install therefore failed the #2066 install-time update-check probe with a
+false "the update path is broken" alarm, and an rc box could never see the
+next rc via ``hal0 update`` without a manual channel flip.
+
+The fix mirrors the ``HAL0_BOOTSTRAP_COSIGN`` pattern from #2058:
+
+* ``bootstrap.sh`` exports ``HAL0_CHANNEL`` so the admitted channel
+  survives the ``exec`` into install.sh.
+* ``persist_bootstrap_channel`` (installer/lib/preflight.sh, called from
+  install.sh's Configuration step right after hal0.toml exists and before
+  the hal0-api restart) writes ``telemetry.channel`` into hal0.toml — the
+  exact key ``PUT /api/updates/channel`` persists and the updater reads.
+  It never overwrites an explicit existing value (it warns instead), and
+  it validates the channel name before touching the file.
+
+Technique: real-bash subprocess against the shell function (the
+``test_install_cosign_persist.py`` pattern), stubbing ONLY the reporters
+ui.sh actually defines (info/warn/err/die — no ``ok()``, #2081).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PREFLIGHT = _REPO_ROOT / "installer" / "lib" / "preflight.sh"
+_BOOTSTRAP = _REPO_ROOT / "installer" / "bootstrap.sh"
+_INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
+
+_STUBS = """
+info() { printf 'INFO:%s\\n' "$*"; }
+warn() { printf 'WARN:%s\\n' "$*" >&2; }
+err()  { printf 'ERR:%s\\n' "$*" >&2; }
+die()  { err "$*"; exit 1; }
+"""
+
+_FRESH_TOML = """\
+[meta]
+schema_version = 1
+
+[slots]
+port_range_start = 8081
+port_range_end = 8099
+
+[telemetry]
+enabled = false
+"""
+
+
+def _run_persist(
+    toml_path: Path,
+    *,
+    channel: str | None,
+) -> subprocess.CompletedProcess[str]:
+    """Drive persist_bootstrap_channel with a controlled HAL0_CHANNEL."""
+    env = dict(os.environ)
+    env.pop("HAL0_CHANNEL", None)
+    if channel is not None:
+        env["HAL0_CHANNEL"] = channel
+    script = _STUBS + f'source "{_PREFLIGHT}"\n' + f'persist_bootstrap_channel "{toml_path}"\n'
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def _telemetry_channel(toml_path: Path) -> str | None:
+    with toml_path.open("rb") as fh:
+        data = tomllib.load(fh)
+    return data.get("telemetry", {}).get("channel")
+
+
+class TestPersistBootstrapChannel:
+    def test_writes_channel_into_existing_telemetry_section(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text(_FRESH_TOML, encoding="utf-8")
+        proc = _run_persist(toml, channel="preview")
+        assert proc.returncode == 0, proc.stderr
+        assert _telemetry_channel(toml) == "preview", toml.read_text()
+        # The rest of the config must survive the edit intact.
+        with toml.open("rb") as fh:
+            data = tomllib.load(fh)
+        assert data["telemetry"]["enabled"] is False
+        assert data["slots"]["port_range_start"] == 8081
+        assert "INFO:" in proc.stdout
+
+    def test_appends_telemetry_section_when_absent(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text("[meta]\nschema_version = 1\n", encoding="utf-8")
+        proc = _run_persist(toml, channel="nightly")
+        assert proc.returncode == 0, proc.stderr
+        assert _telemetry_channel(toml) == "nightly", toml.read_text()
+
+    def test_noop_when_channel_unset(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text(_FRESH_TOML, encoding="utf-8")
+        proc = _run_persist(toml, channel=None)
+        assert proc.returncode == 0, proc.stderr
+        assert toml.read_text(encoding="utf-8") == _FRESH_TOML
+        assert "WARN:" not in proc.stderr
+
+    def test_noop_when_value_already_matches(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text(_FRESH_TOML + 'channel = "preview"\n', encoding="utf-8")
+        before = toml.read_text(encoding="utf-8")
+        proc = _run_persist(toml, channel="preview")
+        assert proc.returncode == 0, proc.stderr
+        assert toml.read_text(encoding="utf-8") == before
+        assert "WARN:" not in proc.stderr
+
+    def test_never_overwrites_a_differing_explicit_channel(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text(_FRESH_TOML + 'channel = "nightly"\n', encoding="utf-8")
+        proc = _run_persist(toml, channel="preview")
+        assert proc.returncode == 0, proc.stderr
+        assert _telemetry_channel(toml) == "nightly", toml.read_text()
+        # Must say so honestly, and point at the supported way to switch.
+        assert "WARN:" in proc.stderr
+        assert "hal0 update --channel" in proc.stderr
+
+    def test_rejects_invalid_channel_without_writing(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text(_FRESH_TOML, encoding="utf-8")
+        proc = _run_persist(toml, channel="jelly")
+        assert proc.returncode == 0, proc.stderr
+        assert toml.read_text(encoding="utf-8") == _FRESH_TOML
+        assert "WARN:" in proc.stderr
+
+    def test_warns_and_survives_when_toml_is_missing(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        proc = _run_persist(toml, channel="preview")
+        assert proc.returncode == 0, proc.stderr
+        assert not toml.exists()
+        assert "WARN:" in proc.stderr
+
+
+class TestWiring:
+    def test_bootstrap_exports_the_admitted_channel(self) -> None:
+        code = "\n".join(
+            line
+            for line in _BOOTSTRAP.read_text(encoding="utf-8").splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        assert "export HAL0_CHANNEL" in code
+
+    def test_install_sh_persists_after_config_write_before_smoke(self) -> None:
+        text = _INSTALL_SH.read_text(encoding="utf-8")
+        call = text.index("persist_bootstrap_channel")
+        assert call > text.index('ui_step "Configuration"')
+        assert call < text.index("smoke_update_check")

--- a/tests/installer/test_install_channel_persist.py
+++ b/tests/installer/test_install_channel_persist.py
@@ -146,6 +146,103 @@ class TestPersistBootstrapChannel:
         assert "WARN:" in proc.stderr
 
 
+class TestValidTomlVariants:
+    """Review findings on PR #2087: regex blind spots must degrade to
+    no-op/warn, never to a duplicate-key config the daemon cannot parse."""
+
+    def test_inline_comment_on_existing_channel_is_seen(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text(_FRESH_TOML + 'channel = "preview"  # set by ops\n', encoding="utf-8")
+        before = toml.read_text(encoding="utf-8")
+        proc = _run_persist(toml, channel="preview")
+        assert proc.returncode == 0, proc.stderr
+        # Same value: no duplicate key appended, no warn.
+        assert toml.read_text(encoding="utf-8") == before
+        assert "WARN:" not in proc.stderr
+        _telemetry_channel(toml)  # must still parse
+
+    def test_inline_comment_differing_channel_warns_not_duplicates(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text(_FRESH_TOML + 'channel = "nightly"  # set by ops\n', encoding="utf-8")
+        proc = _run_persist(toml, channel="preview")
+        assert proc.returncode == 0, proc.stderr
+        assert _telemetry_channel(toml) == "nightly"
+        assert "WARN:" in proc.stderr
+
+    def test_single_quoted_existing_value_is_seen_as_equal(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text(_FRESH_TOML + "channel = 'preview'\n", encoding="utf-8")
+        before = toml.read_text(encoding="utf-8")
+        proc = _run_persist(toml, channel="preview")
+        assert proc.returncode == 0, proc.stderr
+        assert toml.read_text(encoding="utf-8") == before
+        assert "WARN:" not in proc.stderr
+
+    def test_section_followed_by_list_valued_table_is_not_spliced(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text(
+            "[telemetry]\nenabled = false\n\n[models]\nroots = [\"/x\", \"/y\"]\n",
+            encoding="utf-8",
+        )
+        proc = _run_persist(toml, channel="preview")
+        assert proc.returncode == 0, proc.stderr
+        with toml.open("rb") as fh:
+            data = tomllib.load(fh)
+        assert data["telemetry"]["channel"] == "preview"
+        assert data["models"]["roots"] == ["/x", "/y"]
+
+    def test_commented_section_header_never_corrupts(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text("[telemetry]  # hal0-owned\nenabled = false\n", encoding="utf-8")
+        proc = _run_persist(toml, channel="preview")
+        assert proc.returncode == 0, proc.stderr
+        # Whatever happened, the file must still parse...
+        data = tomllib.loads(toml.read_text(encoding="utf-8"))
+        # ...and with the comment-tolerant header match, the key lands.
+        assert data["telemetry"]["channel"] == "preview"
+
+    def test_unparsable_existing_config_is_left_alone(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text("[telemetry\nenabled = ???\n", encoding="utf-8")
+        before = toml.read_text(encoding="utf-8")
+        proc = _run_persist(toml, channel="preview")
+        assert proc.returncode == 0, proc.stderr
+        assert toml.read_text(encoding="utf-8") == before
+        assert "WARN:" in proc.stderr
+
+
+class TestStableDefault:
+    """A silently-persisted default must not poison the never-overwrite rule
+    (review on PR #2087): default bootstrap -> no key; a later deliberate
+    HAL0_CHANNEL=preview re-bootstrap must persist cleanly."""
+
+    def test_stable_with_no_existing_key_is_not_persisted(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text(_FRESH_TOML, encoding="utf-8")
+        proc = _run_persist(toml, channel="stable")
+        assert proc.returncode == 0, proc.stderr
+        assert toml.read_text(encoding="utf-8") == _FRESH_TOML
+        assert "WARN:" not in proc.stderr
+
+    def test_default_install_then_preview_rebootstrap_persists(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text(_FRESH_TOML, encoding="utf-8")
+        assert _run_persist(toml, channel="stable").returncode == 0
+        proc = _run_persist(toml, channel="preview")
+        assert proc.returncode == 0, proc.stderr
+        assert _telemetry_channel(toml) == "preview"
+        assert "WARN:" not in proc.stderr
+
+    def test_explicit_stable_on_disk_still_respected_over_preview(self, tmp_path: Path) -> None:
+        toml = tmp_path / "hal0.toml"
+        toml.write_text(_FRESH_TOML + 'channel = "stable"\n', encoding="utf-8")
+        proc = _run_persist(toml, channel="preview")
+        assert proc.returncode == 0, proc.stderr
+        assert _telemetry_channel(toml) == "stable"
+        assert "WARN:" in proc.stderr
+
+
+
 class TestWiring:
     def test_bootstrap_exports_the_admitted_channel(self) -> None:
         code = "\n".join(


### PR DESCRIPTION
## Why

Fixes #2083 — the last code gap in the "first self-update works" story (#2052 → #2058 → #2082).

A preview-channel fresh install (`HAL0_CHANNEL=preview` at bootstrap) verifies and installs correctly, but nothing writes the channel anywhere durable. The installed updater defaults to `stable`, whose manifest pointer is 404 until GA (#1530), so:

1. the #2066 install-time update-check probe fails with a false "the update path is broken" alarm on every preview/nightly fresh install (rc.10 lane, ct151 `/root/rc10-install-2.log`), and
2. an rc box can never see the next rc via `hal0 update` until someone manually flips the channel.

## What

Mirrors the `HAL0_BOOTSTRAP_COSIGN` hand-off pattern from #2058:

- `installer/bootstrap.sh`: `export HAL0_CHANNEL` in `validate_channel()` so the admitted channel survives the `exec` into install.sh.
- `installer/lib/preflight.sh`: new `persist_bootstrap_channel <toml>` — writes `telemetry.channel` into `hal0.toml`, the exact key `PUT /api/updates/channel` persists and the updater's `_current_channel()` reads. Locked read-modify-write (system python3, `hal0.toml.lock` fcntl + O_NOFOLLOW — the `[models].store` seeding discipline) because a live daemon may be serving config writes. Acts only when `HAL0_CHANNEL` came across the exec; validates the value; never overwrites an explicit differing value (warns and points at `hal0 update --channel`); never dies.
- `installer/install.sh`: call site in the Configuration step, right after `hal0.toml` exists and before the hal0-api (re)start (the daemon caches config at startup) and before the update-check smoke probe.

Persistence only — verification/probe logic untouched, per the rc.10 lane finding that the update path is healthy end-to-end once the channel is set.

## Tests

`tests/installer/test_install_channel_persist.py` (real-bash subprocess, ui.sh reporter contract stubs only — info/warn/err/die, #2081):

- writes channel into existing `[telemetry]` (rest of config intact, valid TOML via tomllib)
- appends `[telemetry]` when absent
- no-op when `HAL0_CHANNEL` unset / value already matches
- never overwrites a differing explicit channel — warns with the `hal0 update --channel` pointer
- rejects invalid channel without writing; survives a missing toml with a warning
- wiring: bootstrap exports the channel; install.sh call sits after `ui_step "Configuration"` and before `smoke_update_check`

**Proven red on the reverted fix** (house rule from #2081/#2082/#2086): with only `installer/` stashed, all 9 fail (`persist_bootstrap_channel: command not found` + both wiring asserts); restored, 9 pass.

Full `tests/installer/`: 874 passed, 1 skipped, 1 failed — the pre-existing local-only `test_no_avahi_on_the_box_is_a_silent_noop` (thinmint runs avahi; CI is authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtnrnWxxv8XEBiGrVRXqsh
