### PR TITLE
fix(agents): X-hal0-Private must be a YAML string — hermes memory MCP dead on fresh installs (#2085)

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -2080,7 +2080,9 @@ def _merge_config_yaml_layers(
             if isinstance(_hdrs, dict) and "X-hal0-Private" in _hdrs:
                 _val = _hdrs["X-hal0-Private"]
                 if not isinstance(_val, str):
-                    _hdrs["X-hal0-Private"] = str(_val).lower() if isinstance(_val, bool) else str(_val)
+                    _hdrs["X-hal0-Private"] = (
+                        str(_val).lower() if isinstance(_val, bool) else str(_val)
+                    )
     out = yaml.safe_dump(merged, sort_keys=False, default_flow_style=False)
     if config_path.exists() and config_path.read_text(encoding="utf-8") == out:
         return False

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1756,7 +1756,10 @@ def terminal_tool_enabled(
 
 
 def _config_list_keys(
-    *, terminal_enabled: bool, existing_disabled: list[str] | None = None
+    *,
+    terminal_enabled: bool,
+    existing_disabled: list[str] | None = None,
+    mcp_servers: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """The list-valued overlay, with the terminal posture folded in.
 
@@ -1773,6 +1776,19 @@ def _config_list_keys(
     if not terminal_enabled:
         disabled += TERMINAL_OFF_TOOLSETS
     keys["agent"] = {"disabled_toolsets": disabled}
+    # X-hal0-Private must reach config.yaml as the STRING "1" (#2085): the
+    # config-set path can't express a numeric-looking string (hermes coerces
+    # it to the YAML int 1, which wedges hermes' MCP client post-initialize),
+    # so private servers get their header here, where safe_dump quotes it.
+    # The nested-dict merge preserves the sibling headers config set wrote
+    # (X-hal0-Agent, Authorization) and overlay-wins repairs poisoned boxes.
+    private_headers = {
+        srv["name"]: {"headers": {"X-hal0-Private": "1"}}
+        for srv in (mcp_servers or [])
+        if srv.get("private")
+    }
+    if private_headers:
+        keys["mcp_servers"] = private_headers
     return keys
 
 
@@ -1918,8 +1934,15 @@ def _build_config_overlay(
         ]
         if bearer:
             pairs.append((f"mcp_servers.{name}.headers.Authorization", f"Bearer {bearer}"))
-        if srv.get("private"):
-            pairs.append((f"mcp_servers.{name}.headers.X-hal0-Private", "1"))
+        # X-hal0-Private deliberately does NOT go through `hermes config set`:
+        # hermes coerces bare integers on the way in (see _fmt_config_value),
+        # so "1" lands in config.yaml as the YAML int 1 — and hermes' own MCP
+        # client wedges post-initialize on a non-string header value and dies
+        # with CancelledError at its outer ceiling (#2085: zero memory tools
+        # on every fresh install while hal0-admin connects fine). The header
+        # is layered as a real string by _config_list_keys via the PyYAML
+        # deep-merge, which runs AFTER these config-set writes — so a
+        # re-provision also repairs an already-poisoned config.yaml.
 
     pairs.append(("skills.creation_nudge_interval", 15))
     # terminal.cwd is the working directory Hermes' built-in `local` terminal
@@ -2327,6 +2350,7 @@ def _phase_config_write(ctx: _StepCtx) -> PhaseResult:
         list_keys=_config_list_keys(
             terminal_enabled=terminal_enabled,
             existing_disabled=_disabled_toolsets(_parse_yaml_config(pre_merge)),
+            mcp_servers=mcp_servers,
         ),
         overrides_path=OVERRIDES_PATH,
     )
@@ -3864,7 +3888,7 @@ def _build_brain_profile_mcp_servers() -> dict[str, Any]:
 
     bearer = service_key(prefer="admin")
     admin_headers: dict[str, Any] = {"X-hal0-Agent": BRAIN_PROFILE_AGENT_ID}
-    memory_headers: dict[str, Any] = {"X-hal0-Agent": BRAIN_PROFILE_AGENT_ID, "X-hal0-Private": 1}
+    memory_headers: dict[str, Any] = {"X-hal0-Agent": BRAIN_PROFILE_AGENT_ID, "X-hal0-Private": "1"}
     if bearer:
         admin_headers["Authorization"] = f"Bearer {bearer}"
         memory_headers["Authorization"] = f"Bearer {bearer}"

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -2068,6 +2068,19 @@ def _merge_config_yaml_layers(
     if overrides_path.exists():
         overlay = yaml.safe_load(overrides_path.read_text(encoding="utf-8")) or {}
         merged = _deep_merge(merged, overlay)
+    # #2085 hardening: X-hal0-Private must be a string wherever it ends up.
+    # An operator overrides.yaml copied from a pre-fix config.yaml carries
+    # the unquoted int 1 (overrides win by design), and that exact value
+    # hard-hangs hermes' MCP client post-initialize with zero diagnostics —
+    # so the known-poisonous leaf is normalized after the final merge, no
+    # matter which layer supplied it.
+    for _srv in (merged.get("mcp_servers") or {}).values():
+        if isinstance(_srv, dict):
+            _hdrs = _srv.get("headers")
+            if isinstance(_hdrs, dict) and "X-hal0-Private" in _hdrs:
+                _val = _hdrs["X-hal0-Private"]
+                if not isinstance(_val, str):
+                    _hdrs["X-hal0-Private"] = str(_val).lower() if isinstance(_val, bool) else str(_val)
     out = yaml.safe_dump(merged, sort_keys=False, default_flow_style=False)
     if config_path.exists() and config_path.read_text(encoding="utf-8") == out:
         return False

--- a/tests/agents/test_hermes_private_header_type.py
+++ b/tests/agents/test_hermes_private_header_type.py
@@ -1,0 +1,133 @@
+"""The X-hal0-Private header must reach hermes' config.yaml as a STRING — #2085.
+
+Root cause of #2085 (hermes runs with zero memory tools on fresh installs):
+hal0 handed ``("mcp_servers.<name>.headers.X-hal0-Private", "1")`` to
+``hermes config set``, and hermes coerces bare integers on the way in (the
+documented behavior :func:`hp._fmt_config_value` relies on for timeouts) —
+so config.yaml ends up with the unquoted YAML int ``1``. Hermes' own MCP
+client then wedges post-initialize on the non-string header value and dies
+with ``CancelledError`` at its outer ceiling, while ``hal0-admin`` (no
+private header) connects fine. Reproduced 2026-08-28 against a live rc.10
+gateway with the pinned hermes build: ``X-hal0-Private: 1`` hangs 40 s,
+``X-hal0-Private: "1"`` connects and lists all 26 memory tools.
+
+The fix moves the private header out of the ``config set`` pairs (which
+cannot express a numeric-looking string) into the PyYAML deep-merge layer
+(:func:`hp._config_list_keys` → :func:`hp._merge_config_yaml_layers`),
+where ``safe_dump`` quotes the string — and which runs AFTER config set,
+so a re-provision also repairs already-poisoned boxes. The brain-profile
+render (:func:`hp._build_brain_profile_mcp_servers`) carried a literal
+int ``1`` with the same downstream effect; it becomes ``"1"``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+from hal0.agents import hermes_provision as hp
+
+_MCP_SERVERS: list[dict[str, Any]] = [
+    {"name": "hal0-admin", "url": "http://x/mcp/admin/mcp", "type": "http"},
+    {
+        "name": "hal0-memory",
+        "url": "http://x/mcp/memory/mcp",
+        "type": "http",
+        "private": True,
+        "timeout": 900,
+    },
+]
+
+
+def _overlay(**over: Any) -> dict[str, Any]:
+    base = dict(
+        primary={
+            "model_id": "qwen3:8b",
+            "backend_url": "http://127.0.0.1:8080/v1",
+            "context_length": 16384,
+        },
+        chat_slots=[],
+        delegation=None,
+        auxiliary_tasks={},
+        mcp_servers=_MCP_SERVERS,
+        agent_id="hermes-agent",
+        system_prompt="",
+        personality_name="",
+        live_resolve_enabled=True,
+    )
+    base.update(over)
+    return dict(hp._build_config_overlay(**base))
+
+
+def test_overlay_never_routes_private_header_through_config_set() -> None:
+    """`hermes config set` coerces "1" -> int; the key must not go that way."""
+    overlay = _overlay()
+    private_keys = [k for k in overlay if "X-hal0-Private" in k]
+    assert private_keys == [], private_keys
+
+
+def test_config_list_keys_carry_private_header_as_string() -> None:
+    keys = hp._config_list_keys(
+        terminal_enabled=False,
+        existing_disabled=[],
+        mcp_servers=_MCP_SERVERS,
+    )
+    hdr = keys["mcp_servers"]["hal0-memory"]["headers"]["X-hal0-Private"]
+    assert hdr == "1"
+    assert isinstance(hdr, str)
+    # Non-private servers get no header overlay at all.
+    assert "hal0-admin" not in keys["mcp_servers"]
+
+
+def test_config_list_keys_omit_mcp_table_without_private_servers() -> None:
+    keys = hp._config_list_keys(
+        terminal_enabled=False,
+        existing_disabled=[],
+        mcp_servers=[{"name": "hal0-admin", "url": "http://x", "type": "http"}],
+    )
+    assert "mcp_servers" not in keys
+
+
+def test_merge_repairs_an_int_poisoned_config(tmp_path) -> None:
+    """Re-provision on an already-broken box must flip int 1 -> string "1"."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "mcp_servers": {
+                    "hal0-memory": {
+                        "type": "http",
+                        "url": "http://x/mcp/memory/mcp",
+                        "headers": {"X-hal0-Agent": "hermes", "X-hal0-Private": 1},
+                        "timeout": 900,
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    changed = hp._merge_config_yaml_layers(
+        config,
+        list_keys=hp._config_list_keys(
+            terminal_enabled=False, existing_disabled=[], mcp_servers=_MCP_SERVERS
+        ),
+        overrides_path=tmp_path / "overrides.yaml",
+    )
+    assert changed is True
+    data = yaml.safe_load(config.read_text(encoding="utf-8"))
+    hdr = data["mcp_servers"]["hal0-memory"]["headers"]["X-hal0-Private"]
+    assert hdr == "1"
+    assert isinstance(hdr, str)
+    # The sibling header written by config set must survive the merge.
+    assert data["mcp_servers"]["hal0-memory"]["headers"]["X-hal0-Agent"] == "hermes"
+    # And the on-disk YAML must carry the quoted form hermes' client needs.
+    assert "'1'" in config.read_text(encoding="utf-8")
+
+
+def test_brain_profile_private_header_is_a_string() -> None:
+    servers = hp._build_brain_profile_mcp_servers()
+    hdr = servers["hal0-memory"]["headers"]["X-hal0-Private"]
+    assert hdr == "1"
+    assert isinstance(hdr, str)

--- a/tests/agents/test_hermes_private_header_type.py
+++ b/tests/agents/test_hermes_private_header_type.py
@@ -123,7 +123,34 @@ def test_merge_repairs_an_int_poisoned_config(tmp_path) -> None:
     # The sibling header written by config set must survive the merge.
     assert data["mcp_servers"]["hal0-memory"]["headers"]["X-hal0-Agent"] == "hermes"
     # And the on-disk YAML must carry the quoted form hermes' client needs.
-    assert "'1'" in config.read_text(encoding="utf-8")
+    assert "X-hal0-Private: '1'" in config.read_text(encoding="utf-8")
+
+
+def test_overrides_cannot_repoison_the_private_header(tmp_path) -> None:
+    """overrides.yaml copied from a pre-fix config.yaml carries the int 1
+    (and overrides merge LAST, by design) — the known-poisonous leaf must
+    still come out a string, or the #2085 wedge comes back silently."""
+    config = tmp_path / "config.yaml"
+    config.write_text("mcp_servers: {}\n", encoding="utf-8")
+    overrides = tmp_path / "overrides.yaml"
+    overrides.write_text(
+        yaml.safe_dump(
+            {"mcp_servers": {"hal0-memory": {"headers": {"X-hal0-Private": 1}}}},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    hp._merge_config_yaml_layers(
+        config,
+        list_keys=hp._config_list_keys(
+            terminal_enabled=False, existing_disabled=[], mcp_servers=_MCP_SERVERS
+        ),
+        overrides_path=overrides,
+    )
+    data = yaml.safe_load(config.read_text(encoding="utf-8"))
+    hdr = data["mcp_servers"]["hal0-memory"]["headers"]["X-hal0-Private"]
+    assert hdr == "1"
+    assert isinstance(hdr, str)
 
 
 def test_brain_profile_private_header_is_a_string() -> None:

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1284,6 +1284,12 @@ def test_config_write_phase_writes_yaml_idempotently(
     assert out1.status == hp.PhaseStatus.OK
     cfg = Path(out1.details["config_path"])
     assert cfg.exists()
+    # #2085 phase-level wiring: the file the PHASE writes must carry the
+    # private header as a quoted string for hal0-memory. This is the only
+    # guard on the mcp_servers= kwarg into _config_list_keys — without it,
+    # dropping that kwarg keeps every unit test green while fresh installs
+    # ship no private header at all (memory writes silently land shared).
+    assert "X-hal0-Private: '1'" in cfg.read_text(encoding="utf-8")
     first_hash = out1.hash
     # Re-run is idempotent: config set re-writes the same values + the YAML
     # merge is a no-op, so the on-disk file (and its hash) is unchanged.

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1935,7 +1935,7 @@ def test_brain_profile_mcp_wire_merges_and_preserves_upstream_keys(tmp_path: Pat
     servers = merged["mcp_servers"]
     # hal0-owned servers wired under the brain profile identity…
     assert servers["hal0-admin"]["headers"]["X-hal0-Agent"] == "hermes__hal0-brain"
-    assert servers["hal0-memory"]["headers"]["X-hal0-Private"] == 1
+    assert servers["hal0-memory"]["headers"]["X-hal0-Private"] == "1"  # str, not int (#2085)
     assert servers["hal0-memory"]["headers"]["X-hal0-Agent"] == "hermes__hal0-brain"
     # memory provider is written too (scalar merge, safe)…
     assert merged["memory"]["provider"] == "hal0-memory"

--- a/tests/agents/test_hermes_provision_mcp_auth.py
+++ b/tests/agents/test_hermes_provision_mcp_auth.py
@@ -106,7 +106,7 @@ def test_brain_profile_servers_carry_bearer(
     assert servers["hal0-memory"]["headers"]["Authorization"] == "Bearer brain-admin-key"
     # Identity + private-mode headers are untouched by the bearer addition.
     assert servers["hal0-admin"]["headers"]["X-hal0-Agent"] == BRAIN_PROFILE_AGENT_ID
-    assert servers["hal0-memory"]["headers"]["X-hal0-Private"] == 1
+    assert servers["hal0-memory"]["headers"]["X-hal0-Private"] == "1"  # str, not int (#2085)
 
 
 def test_brain_profile_servers_omit_bearer_when_no_key(


### PR DESCRIPTION
## Why

Fixes #2085 — hermes runs with **zero hal0-memory tools** on every fresh rc.10 install (`CancelledError` after initialize, 184 admin tools registered, memory server failed) while `hal0-admin` works in the same process and the server answers every direct probe in milliseconds.

## Root cause (found by bisection against a live gateway)

The issue's config delta contained the whole answer:

```yaml
hal0-memory: {headers: {X-hal0-Agent: hermes, X-hal0-Private: 1}, timeout: 900}
```

That `1` is an **unquoted YAML int**. The provisioner passes `("mcp_servers.<name>.headers.X-hal0-Private", "1")` through `hermes config set`, and hermes coerces bare integers on the way in (the documented behavior `_fmt_config_value` already relies on for timeouts) — so the string `"1"` lands on disk as the int `1`. Hermes' own MCP client then wedges post-initialize on the non-string header value (`_discover_tools`/`tools/list` never completes) and dies with `CancelledError` at its outer ceiling. `hal0-admin` carries no private header — hence the clean admin-works/memory-hangs split. Manual probes never reproduced it because every hand-built probe sends the header as a proper string.

Reproduction (thinmint, pinned hermes build `9de9c25f` from `installer/agents/hermes/requirements.txt`, mcp 1.26.0, against ct150's live rc.10 gateway over an SSH tunnel):

- `X-hal0-Private: 1` (int, verbatim fresh-install rendering) → `✗ Connection failed (41230ms): MCP call timed out after 41.2s` — the exact #2085 signature
- header removed → `✓ Connected, 26 tools`
- `X-hal0-Private: "1"` (string) → `✓ Connected, 26 tools`

This also disproves the "fresh-install-shaped server" framing: ct150's server triggers it fine — the discriminator was always the client-side config rendering, which only fresh installs (and re-provisions) receive.

## What

`src/hal0/agents/hermes_provision.py`:

- `_build_config_overlay`: the private header no longer goes through `hermes config set` (which cannot express a numeric-looking string — quoting the argv stores literal quote characters, silently disabling private mode instead).
- `_config_list_keys` gains `mcp_servers`: private servers get `headers: {X-hal0-Private: "1"}` in the PyYAML deep-merge layer, where `safe_dump` renders `'1'` quoted. The nested-dict merge preserves the sibling headers config set wrote (`X-hal0-Agent`, `Authorization`), and because the merge runs **after** the config-set phase with overlay-wins semantics, a re-provision (`hal0 agent bootstrap hermes --repair`) also repairs an already-poisoned config.yaml.
- `_build_brain_profile_mcp_servers`: same bug as a literal int `1`; now `"1"`.

Two existing test asserts locked the int in (`== 1`); flipped to the string contract.

## Tests

`tests/agents/test_hermes_private_header_type.py`:

- overlay emits no `X-hal0-Private` config-set pair
- `_config_list_keys` carries the header as `str` `"1"` for private servers only; no `mcp_servers` table when none are private
- `_merge_config_yaml_layers` repairs an int-poisoned config (value becomes `str`, sibling headers survive, on-disk YAML carries `'1'`)
- brain-profile header is a `str`

**Proven red on the reverted fix**: all 5 fail with `src/` stashed, pass restored.

**End-to-end**: the fixed `_config_list_keys` + `_merge_config_yaml_layers` (real provision code, not a hand-written config) repaired an int-poisoned config.yaml, after which `hermes mcp test hal0-memory` → `✓ Connected (191ms), ✓ Tools discovered: 26` against ct150's live gateway.

Full `tests/agents/`: 802 passed, 1 skipped, 1 xfailed (the pre-existing terminal-backend drift watch).

#2021's regression entry ("both `hermes mcp test` connect") becomes honest again with this fix — no expectation change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtnrnWxxv8XEBiGrVRXqsh
