### PR TITLE
release: v1.0.0-rc.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,106 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+## [1.0.0-rc.11] — 2026-08-28
+
+The default steward changes model, and the fresh-install path closes the last
+three defects the rc.10 validation lane surfaced — two of them introduced by
+the rc.10 fix wave itself, and reproducible only on the exact end-user shape
+(a fresh box with no system cosign; a fresh box installed from the preview
+channel).
+
+### Highlights
+
+- **LFM2.5-2.6B is the default brain model.** One plain-GGUF pick on every box
+  (Q8_0, 2.87 GB) replaces the hardware-forked `hal0-brain-sft` variants, whose
+  Q8/Q4 builds carry custom GGML tensor type ids that stock llama.cpp rejects.
+  The new default is a native tool-caller on the `hal0-combined:0826` runner and
+  an RL-trained thinker: `profile.brain` now leaves reasoning-format at the
+  runner default, so its `<think>` text is extracted into `reasoning_content`
+  instead of leaking into `message.content`. The sft variants remain available
+  through `HAL0_BRAIN_MODEL`.
+- **A fresh install completes, and can then update itself.** rc.10 could do
+  neither on a box without a system cosign: pre-flight died on an undefined
+  reporter helper, and the channel the box was installed from was never
+  persisted, so its updater fell back to `stable` and every `hal0 update
+  --check` failed.
+
+### Fixed
+
+- **Every cosign-less fresh install died at pre-flight step 1/16.** The cosign
+  persistence added in rc.10 reported success through an `ok` helper that no
+  installer source defines — `ui.sh` provides `info`/`warn`/`err`/`die`, and
+  only `bootstrap.sh` carries a private `ok()`. Under `set -euo pipefail` the
+  resulting 127 killed the install immediately after the cosign had been
+  written successfully. Hosts with a system cosign return early past that line,
+  which is why CI and every dev box missed it (#2081). The regression guard
+  added alongside the fix now resolves helper definitions per sourcing scope
+  rather than globally: as first written it counted `bootstrap.sh`'s private
+  `ok()` as a definition for every file, and stayed green over the very bug it
+  was added to pin (#2086).
+- **The bootstrap channel was never persisted.** A preview-channel install
+  installed correctly but left the updater resolving `stable`, whose pointer
+  still serves 0.9.8, so rc boxes could not self-update to the next rc and the
+  install-time update-check probe failed. The installer now writes
+  `telemetry.channel` into `hal0.toml` through a validated locked
+  read-modify-write, mirroring the cosign handoff. An explicit differing value
+  is never overwritten, and the schema default is deliberately not persisted so
+  that re-bootstrapping can still recover a preview box (#2083).
+- **Hermes ran with zero memory tools on every fresh install.** `hermes config
+  set` coerced the `X-hal0-Private` header to a YAML integer, and the integer
+  form wedges hermes' MCP client immediately after `initialize`: `hal0-admin`
+  connected normally while `hal0-memory` hung for 40 s and died with a
+  `CancelledError`, silently costing the agent all 26 memory tools. The header
+  is now rendered as a quoted string through the merge layer, with post-merge
+  coercion so an overrides file cannot re-poison it (#2085).
+
+### Audience
+
+Operators running a preview-channel box, and anyone doing a fresh install from
+`hal0.dev/install.sh`. Fresh installs gain the most: all three fixes above are
+fresh-install-shaped. Existing rc.10 boxes are unaffected by #2081 and #2083
+(both are install-time), but do pick up the hermes memory-MCP fix.
+
+### Known issues
+
+- The live `hal0.dev/install.sh` still lags the in-tree installer: the
+  `mirror-bootstrap` workflow is gated on a signed stable manifest, and the
+  stable pointer still serves 0.9.8, so the mirror has not published since
+  2026-08-09 (#2057, #1530). Installing from the one-liner may fetch an older
+  bootstrap than this release ships. Both are resolved together on the GA cut.
+- `scripts/release-test.sh`'s γ rows still target the retired v0.1 slot CLI, so
+  release-check gate 5 cannot pass and is waived for this cut (#2050). The
+  rc-validate kit is the effective release gate.
+- The brain steward can still answer live-platform questions from its prelude
+  without a tool round on small models (#2022); the LFM2.5 default is the
+  intended mitigation and is re-evaluated in this release's validation lane.
+- The python 3.14 CI leg remains allowed-fail (container-provider fixtures).
+
+### Supported upgrades
+
+`hal0 update` from 1.0.0-rc.9 or 1.0.0-rc.10 on the preview channel. Boxes
+installed fresh from rc.10 or earlier and never re-pointed may have no channel
+persisted — set it once with `hal0 update --channel preview` before checking
+for this release; installs from this release onward persist it themselves.
+
+### Operator migrations
+
+None required. The brain model default changes for NEW installs only: an
+existing box keeps whatever model its brain slot is already bound to, and
+nothing re-pulls or re-binds on upgrade. To adopt LFM2.5-2.6B on an existing
+box, pull it and rebind the brain slot deliberately. Slot image pins are
+unchanged from rc.10 (`hal0-combined:0826`).
+
+### Rollback
+
+`hal0 update --rollback` restores the previously installed tree, as usual. No
+schema or on-disk state changes ship in this release, so a rollback to rc.10
+needs no data migration. The one persisted value this release introduces
+(`telemetry.channel` in `hal0.toml`) is read by newer updaters and ignored by
+older ones, so it is safe to leave in place across a rollback.
+
+## [1.0.0-rc.10] — 2026-08-26
+
 The rc.9 validation sweep's fresh-install lane (ct151, minimal Ubuntu 26.04)
 surfaced a batch of install-process defects — several of them silent for
 multiple RCs. This wave closes all nine, plus the runner-side structured-output

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release — the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md §12 and §17 (maintainer-local).",
-  "version": "1.0.0-rc.10",
+  "version": "1.0.0-rc.11",
   "channel": "preview",
   "toolbox_images": {
     "vulkan": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "1.0.0-rc.10"
+version = "1.0.0-rc.11"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hal0-ui",
-  "version": "1.0.0-rc.10",
+  "version": "1.0.0-rc.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hal0-ui",
-      "version": "1.0.0-rc.10",
+      "version": "1.0.0-rc.11",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal0-ui",
   "private": true,
-  "version": "1.0.0-rc.10",
+  "version": "1.0.0-rc.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "hal0ai"
-version = "1.0.0rc10"
+version = "1.0.0rc11"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Release-prep PR for v1.0.0-rc.11, per the standing one-prep-PR recipe.

- Version bump via `scripts/set-version.py 1.0.0-rc.11`: pyproject.toml, manifest.json, ui/package.json + lock, uv.lock (dry-run validated first).
- `scripts/update-toolbox-digests.sh`: 7 digests resolved, 0 null — all already current, so manifest.json moves only for the version field.
- Runner pin unchanged from rc.10 (`hal0-combined:0826`); tag re-resolved live against ghcr's registry API this cut: `sha256:7aad020a0a7460988bb148652bb830a71f2071bc8899abad7b01e6a2f75c7678` — matches #2073's validated digest, tag unmoved.
- Ships #2076 (LFM2.5-2.6B default brain), #2082 (#2081 cosign-less fresh install), #2086 (guard scoping), #2087 (#2083 channel persist), #2088 (#2085 hermes memory MCP).

## Also in this PR: the release notes actually work again

`scripts/gen_release_notes.py` builds `RELEASE_NOTES.md` + `release.json` from the matching `## [<version>]` CHANGELOG section, and `hal0 update` renders the highlights/breaking/migrations callouts from it before applying. **The CHANGELOG's version sections stopped at rc.7**, so rc.8, rc.9 and rc.10 all fell through to the `source=git-log` path: a raw commit-subject dump, zero structured fields, and — because the preview channel requires them — five literal `TBD` headings shipped in the tarball each time.

Fixed here rather than deferred, since it is release-prep and the updater surface is user-facing:

- New `## [1.0.0-rc.11]` section with Highlights, Fixed, and the five preview-required headings (Audience, Known issues, Supported upgrades, Operator migrations, Rollback) written from the rc.10 validation record rather than stubbed.
- The old `## [Unreleased]` body is the install-fix wave, which actually shipped in rc.10 — recorded under `## [1.0.0-rc.10] — 2026-08-26` instead of continuing to claim it is unreleased. A fresh empty `## [Unreleased]` heading is kept for the next cycle.
- rc.8 and rc.9 are deliberately **not** reconstructed; their content lives in the PR threads and inventing it after the fact would be archaeology, not a changelog.

Verified: `gen_release_notes.py --tag v1.0.0-rc.11 --channel preview` → `source=CHANGELOG.md#1.0.0-rc.11`, highlights=2, **0 TBDs** (the same command on rc.10 → `source=git-log`, highlights=0, 5 TBDs).

## Known accepted state at this cut

- release-check gate 5 fails per #2050 (γ rows target the retired v0.1 slot CLI) — documented waiver, unchanged since rc.5; the rc-validate kit is the effective gate.
- python 3.14 CI leg remains allowed-fail.
- #2057/#1530 (live installer mirror + stable pointer) stay open and are GA-day items, not rc-cut items — called out in the release notes' Known issues.

Validation of the cut itself is the ct151 fresh lane, which runs against the tagged asset and is the gate for the LFM default's first real fresh-install exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
