### PR TITLE
docs(changelog): rc.11 — #2085's fix does not reach upgraded boxes (#2090)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,11 @@ channel).
 Operators running a preview-channel box, and anyone doing a fresh install from
 `hal0.dev/install.sh`. Fresh installs gain the most: all three fixes above are
 fresh-install-shaped. Existing rc.10 boxes are unaffected by #2081 and #2083
-(both are install-time), but do pick up the hermes memory-MCP fix.
+(both are install-time). They do **not** automatically pick up the hermes
+memory-MCP fix either: `hal0 update` never re-renders the hermes agent config,
+so the poisoned header survives the upgrade and the agent stays without memory
+tools (#2090). Run `hal0 agent reprovision hermes` once after upgrading —
+verified on an rc.10 → rc.11 upgrade.
 
 ### Known issues
 
@@ -98,6 +102,11 @@ fresh-install-shaped. Existing rc.10 boxes are unaffected by #2081 and #2083
   without a tool round on small models (#2022); the LFM2.5 default is the
   intended mitigation and is re-evaluated in this release's validation lane.
 - The python 3.14 CI leg remains allowed-fail (container-provider fixtures).
+- #2088's `X-hal0-Private` fix reaches boxes only at hermes provision time, so
+  an upgraded box keeps the pre-fix header and its agent has no memory tools
+  until `hal0 agent reprovision hermes` is run (#2090). Note that
+  `provision.json`'s `mcp_wire` tool counts probe the server, not the hermes
+  client, so they report such a box as healthy.
 
 ### Supported upgrades
 


### PR DESCRIPTION
Corrects a claim I published in the v1.0.0-rc.11 release notes, and records the gap where operators will look for it.

## What was wrong

The rc.11 notes' Audience section said existing rc.10 boxes "do pick up the hermes memory-MCP fix" on upgrade. They do not. #2088 fixes the `X-hal0-Private` header where hermes is *provisioned*, and `hal0 update` never re-renders the hermes agent config — so an upgraded box keeps the pre-fix unquoted int and its agent has zero memory tools.

## Evidence (rc.11 upgrade lane, ct151, 2026-08-28)

Immediately after a clean `hal0 update -y` from rc.10 to 1.0.0rc11:

```
X-hal0-Private: 1                      # unquoted — the #2085 shape
hermes mcp test hal0-memory  →  ✗ Connection failed (41622ms)
```

`provision.json` and `config.yaml` still carried their rc.10 install timestamps and `hermes-gateway` had not restarted. After `hal0 agent reprovision hermes` the header became `'1'` and the client connected and listed the memory tools.

Tracked as #2090 (the updater needs a convergence step or a migration); this PR is the docs half only.

## Also recorded

A Known-issues entry noting that `provision.json`'s `mcp_wire` tool counts probe the **server**, not the hermes client — so they report an affected box as healthy. That is the same trap #2021 called out, and it is why this survived the upgrade lane's first read.

The published GitHub release body already carries the correction. The signed rc.11 tarball necessarily keeps the original text — that is inherent to shipping notes inside a signed artifact, and is why the correction lives in the release body and here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
