### PR TITLE
fix(updater): heal pre-#2088 hermes headers on upgrade; re-exec the running hal0 (#2090, #2092)

### DIFF
--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -9,8 +9,12 @@ MCP-backend's approval queue at ``/api/agent/approvals``.
 from __future__ import annotations
 
 import json as jsonlib
+import os
+import shutil
+import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, Literal
 
 import typer
@@ -557,6 +561,30 @@ def _agent_home() -> str:
         return "/var/lib/hal0"
 
 
+def _running_hal0_bin() -> str:
+    """The ``hal0`` console script belonging to the code that is running.
+
+    #2092: the privilege-drop re-exec used to resolve its target with
+    ``shutil.which("hal0")`` — whatever is first on PATH, which is not
+    necessarily the tree doing the re-exec. On a box carrying a stale wrapper
+    at ``/usr/local/bin/hal0`` (#1844 documents exactly that condition), an
+    operator running the CURRENT ``/usr/lib/hal0/venv/bin/hal0 agent
+    reprovision hermes`` as root had it silently re-exec an rc.3 build, which
+    then resolved its installer root relative to its own package location and
+    failed with a path that exists in no release
+    (``/usr/local/lib/python3.12/installer/...``).
+
+    A venv install puts the console script next to the interpreter, so
+    ``sys.executable``'s sibling names the running tree exactly. Fall back to
+    PATH (dev checkouts invoked as ``python -m`` have no sibling script), then
+    to the bare name so the caller still produces a runnable argv.
+    """
+    sibling = Path(sys.executable).with_name("hal0")
+    if sibling.is_file() and os.access(sibling, os.X_OK):
+        return str(sibling)
+    return shutil.which("hal0") or "hal0"
+
+
 def _run_as_hal0(
     argv: list[str], *, stdin: int | None = None, extra_env: dict[str, str] | None = None
 ) -> int:
@@ -625,7 +653,6 @@ def _provision_hermes(
     provisioning that consumes it runs in a re-exec'd, privilege-dropped child.
     """
     import os as _os
-    import shutil as _shutil
 
     from hal0.agents.hermes_provision import HERMES_TERMINAL_ENV, bootstrap_cli
 
@@ -659,7 +686,8 @@ def _provision_hermes(
                     _os.environ[HERMES_TERMINAL_ENV] = previous
     else:
         _hermes_root_prelude(provision_env)
-        hal0_bin = _shutil.which("hal0") or "hal0"
+        # #2092: the running tree, not PATH's — see _running_hal0_bin.
+        hal0_bin = _running_hal0_bin()
         argv = [hal0_bin, "agent", "bootstrap", "hermes"]
         if repair:
             argv.append("--repair")

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -45,6 +45,7 @@ import json
 import os
 import re
 import shutil
+import stat as stat_mod
 import subprocess
 import sys
 import tarfile
@@ -56,6 +57,7 @@ from typing import Any, BinaryIO, Literal
 from urllib.parse import urlparse
 
 import structlog
+import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 import hal0
@@ -1615,6 +1617,123 @@ def _run_config_migrations_locked(
     return (source, new_version)
 
 
+#: Where hermes' merged config lands. Mirrors ``HermesTarget.hermes_home``'s
+#: default in :mod:`hal0.agents.hermes_provision` — kept as a module constant
+#: rather than imported so this pass stays usable from the post-swap
+#: subprocess without dragging the provisioning module in.
+HERMES_CONFIG_PATH = Path("/var/lib/hal0/.hermes/config.yaml")
+
+
+def repair_hermes_mcp_headers(
+    *,
+    job_id: str | None = None,
+    config_path: Path | None = None,
+    restart_gateway: bool = True,
+) -> bool:
+    """Coerce every hermes MCP header to a string — heals pre-#2088 boxes (#2090).
+
+    #2088 made ``X-hal0-Private`` reach ``config.yaml`` as the string ``"1"``:
+    the unquoted YAML int wedges hermes' MCP client immediately after
+    ``initialize`` (a 40 s hang ending in ``CancelledError``), leaving the
+    agent holding zero memory tools while every server-side probe reports
+    healthy — ``provision.json``'s ``mcp_wire`` counts the SERVER's tools, not
+    the client's, so nothing keyed on it notices.
+
+    That fix lives in the config WRITE path, which only runs when hermes is
+    provisioned. ``hal0 update`` never re-provisions, so it reached fresh
+    installs only: measured on the fleet, a box upgraded rc.10 → rc.11 still
+    failed its live client at 41.6 s and prod on rc.9 at 40.7 s, while a fresh
+    rc.11 install connected in 51 ms with 26 tools. Hence this pass, in the one
+    sequence both upgrade paths already converge on.
+
+    Every header value is coerced, not just the known-poisonous key: HTTP
+    header values are strings by definition, so any YAML scalar that survives
+    as a non-string is the same latent wedge.
+
+    Idempotent by construction — a converged box parses the file, finds nothing
+    to change, and returns ``False`` without writing or bouncing anything.
+    Failure modes (absent file, unreadable YAML) are quiet no-ops: a box with
+    no hermes install, or one whose config an operator hand-edited into
+    something unparseable, must not have its update aborted by a repair pass.
+    """
+    path = config_path or HERMES_CONFIG_PATH
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        log.debug("updater.hermes_header_repair_unreadable", job_id=job_id, error=str(exc))
+        return False
+
+    try:
+        doc = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        log.warning("updater.hermes_header_repair_unparseable", job_id=job_id, error=str(exc))
+        return False
+
+    if not isinstance(doc, dict):
+        return False
+    servers = doc.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return False
+
+    repaired: list[str] = []
+    for name, server in servers.items():
+        if not isinstance(server, dict):
+            continue
+        headers = server.get("headers")
+        if not isinstance(headers, dict):
+            continue
+        for key, value in list(headers.items()):
+            if isinstance(value, str):
+                continue
+            # Match the write path's coercion exactly (hermes_provision):
+            # bool renders lowercase so a YAML `true` does not become "True".
+            headers[key] = str(value).lower() if isinstance(value, bool) else str(value)
+            repaired.append(f"{name}.{key}")
+
+    if not repaired:
+        return False
+
+    rendered = yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
+    try:
+        # Preserve mode AND ownership: this pass runs as root from the
+        # post-swap subprocess, and a plain tmp-write + rename would hand
+        # hermes' own config back to it root-owned, breaking the born-owned
+        # contract $HERMES_HOME writes are held to (and hermes' later writes).
+        st = path.stat()
+        tmp = path.with_suffix(path.suffix + ".2090.tmp")
+        tmp.write_text(rendered, encoding="utf-8")
+        with contextlib.suppress(OSError):
+            os.chmod(tmp, stat_mod.S_IMODE(st.st_mode))
+        with contextlib.suppress(OSError, PermissionError):
+            os.chown(tmp, st.st_uid, st.st_gid)
+        os.replace(tmp, path)
+    except OSError as exc:
+        log.warning("updater.hermes_header_repair_write_failed", job_id=job_id, error=str(exc))
+        with contextlib.suppress(OSError):
+            path.with_suffix(path.suffix + ".2090.tmp").unlink()
+        return False
+
+    log.info("updater.hermes_header_repaired", job_id=job_id, headers=repaired)
+
+    if restart_gateway:
+        # Hermes reads config.yaml at start, so the repair only reaches the
+        # running agent after a bounce. Best-effort: the post-swap migration
+        # subprocess runs as root and can do it, while the boot-time safety
+        # net runs as the hal0 user and cannot — there the rewritten file
+        # still takes effect at the gateway's next restart.
+        try:
+            subprocess.run(
+                ["systemctl", "restart", "hermes-gateway.service"],
+                check=False,
+                capture_output=True,
+                timeout=120,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            log.warning("updater.hermes_gateway_bounce_failed", job_id=job_id, error=str(exc))
+
+    return True
+
+
 def run_post_activation_migrations(
     min_data_version: int = 1,
     *,
@@ -1697,6 +1816,14 @@ def run_post_activation_migrations(
         log.warning("updater.mtp_migration_failed", job_id=job_id, error=str(exc))
         # Non-fatal: the affected slot simply fails to load until the
         # operator flips MTP to Auto/Off in the drawer.
+
+    try:
+        repair_hermes_mcp_headers(job_id=job_id)
+    except Exception as exc:
+        log.warning("updater.hermes_header_repair_failed", job_id=job_id, error=str(exc))
+        # Non-fatal: hermes keeps its pre-#2088 header and the agent stays
+        # without memory tools until the next provision — no worse than
+        # before this pass existed, and never a reason to fail an update.
 
     try:
         relabel_stale_vulkan_slots(job_id=job_id)

--- a/tests/cli/test_agent_install_hermes.py
+++ b/tests/cli/test_agent_install_hermes.py
@@ -946,9 +946,24 @@ def test_provision_hermes_non_root_runs_in_process(monkeypatch) -> None:
     assert "adopt" not in seen  # retired flag no longer threaded (O14)
 
 
-def test_provision_hermes_root_drops_to_hal0(monkeypatch) -> None:
-    """euid == 0: run the root prelude then re-exec `agent bootstrap hermes` as hal0."""
+def test_provision_hermes_root_drops_to_hal0(monkeypatch, tmp_path) -> None:
+    """euid == 0: run the root prelude then re-exec `agent bootstrap hermes` as hal0.
+
+    Re-baselined for #2092: this used to assert the re-exec target came from
+    ``shutil.which("hal0")``. That is the defect — on a box with a stale
+    wrapper first on PATH (#1844) it silently re-exec'd an older hal0. The
+    contract is now "the console script belonging to the RUNNING interpreter",
+    so ``which`` is still stubbed here, deliberately, to prove it is NOT what
+    gets chosen.
+    """
     monkeypatch.setattr("os.geteuid", lambda: 0)
+
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    running = venv_bin / "hal0"
+    running.write_text("#!/bin/sh\n", encoding="utf-8")
+    running.chmod(0o755)
+    monkeypatch.setattr("sys.executable", str(venv_bin / "python"))
 
     events: list[str] = []
     monkeypatch.setattr(ac, "_hermes_root_prelude", lambda env=None: events.append("prelude"))
@@ -975,7 +990,8 @@ def test_provision_hermes_root_drops_to_hal0(monkeypatch) -> None:
     # Prelude runs BEFORE the drop.
     assert events == ["prelude", "run_as_hal0"]
     argv = captured["argv"]
-    assert argv[:4] == ["/usr/local/bin/hal0", "agent", "bootstrap", "hermes"]
+    assert argv[0] == str(running), "must re-exec the running hal0, not PATH's (#2092)"
+    assert argv[1:4] == ["agent", "bootstrap", "hermes"]
     assert "--repair" in argv and "--verbose" in argv
     assert "--adopt" not in argv  # retired flag never re-exec'd (O14)
     assert argv[argv.index("--skip-phase") + 1] == "mcp_wire"

--- a/tests/cli/test_provision_reexec.py
+++ b/tests/cli/test_provision_reexec.py
@@ -1,0 +1,97 @@
+"""The privilege-drop re-exec must run the RUNNING hal0, not PATH's (#2092).
+
+``_provision_hermes``'s root branch drops to the hal0 user by re-exec'ing
+``hal0 agent bootstrap hermes``. It resolved that binary with
+``shutil.which("hal0")`` — i.e. whatever is first on PATH, which is not
+necessarily the code doing the re-exec.
+
+Measured on ct150: ``/usr/local/bin/hal0`` is a stale rc.3 wrapper (#1844) with
+a ``#!/usr/bin/python3`` shebang that imports hal0 from system dist-packages.
+Invoking ``/usr/lib/hal0/venv/bin/hal0`` (rc.11) as root therefore re-exec'd
+**rc.3**, which resolved its installer root relative to its own package
+location and failed with ``requirements.txt missing at
+/usr/local/lib/python3.12/installer/agents/hermes/requirements.txt``.
+
+The venv's console script sits next to the running interpreter, so
+``Path(sys.executable).with_name("hal0")`` names the same tree that is
+executing — and that is what must be preferred.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from hal0.cli import agent_commands
+
+
+def test_prefers_the_console_script_next_to_the_running_interpreter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    running = venv_bin / "hal0"
+    running.write_text("#!/bin/sh\n", encoding="utf-8")
+    running.chmod(0o755)
+    monkeypatch.setattr(sys, "executable", str(venv_bin / "python"))
+
+    stale = tmp_path / "usr-local-bin" / "hal0"
+    stale.parent.mkdir(parents=True)
+    stale.write_text("#!/usr/bin/python3\n", encoding="utf-8")
+    stale.chmod(0o755)
+    monkeypatch.setattr(agent_commands.shutil, "which", lambda _n: str(stale))
+
+    assert agent_commands._running_hal0_bin() == str(running)
+
+
+def test_falls_back_to_path_when_no_sibling_script_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dev checkout run via ``python -m`` has no sibling console script; the
+    old behaviour is still the best available answer there."""
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "nowhere" / "python"))
+    monkeypatch.setattr(agent_commands.shutil, "which", lambda _n: "/usr/bin/hal0")
+
+    assert agent_commands._running_hal0_bin() == "/usr/bin/hal0"
+
+
+def test_falls_back_to_the_bare_name_when_nothing_resolves(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "nowhere" / "python"))
+    monkeypatch.setattr(agent_commands.shutil, "which", lambda _n: None)
+
+    assert agent_commands._running_hal0_bin() == "hal0"
+
+
+def test_provision_reexec_uses_the_running_binary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End of the story: the argv the root branch hands to the privilege drop
+    must start with the running hal0, not PATH's."""
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    running = venv_bin / "hal0"
+    running.write_text("#!/bin/sh\n", encoding="utf-8")
+    running.chmod(0o755)
+    monkeypatch.setattr(sys, "executable", str(venv_bin / "python"))
+    monkeypatch.setattr(agent_commands.shutil, "which", lambda _n: "/usr/local/bin/hal0")
+
+    monkeypatch.setattr(agent_commands.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(agent_commands, "_hermes_root_prelude", lambda _env: None)
+
+    seen: list[list[str]] = []
+
+    def _fake_run_as_hal0(argv, *, stdin=None, extra_env=None):
+        seen.append(argv)
+        return 0
+
+    monkeypatch.setattr(agent_commands, "_run_as_hal0", _fake_run_as_hal0)
+
+    agent_commands._provision_hermes(repair=True)
+
+    assert seen, "the root branch never re-exec'd"
+    assert seen[0][0] == str(running)
+    assert seen[0][1:4] == ["agent", "bootstrap", "hermes"]

--- a/tests/updater/test_hermes_header_repair.py
+++ b/tests/updater/test_hermes_header_repair.py
@@ -1,0 +1,203 @@
+"""``repair_hermes_mcp_headers`` — heal a pre-#2088 hermes config on upgrade (#2090).
+
+#2088 fixed the ``X-hal0-Private`` header where hermes is *provisioned*: the
+value must reach ``config.yaml`` as the string ``"1"``, because the unquoted
+YAML int wedges hermes' MCP client immediately after ``initialize`` (a 40 s
+hang, then ``CancelledError``, with the agent silently left holding zero
+memory tools).
+
+``hal0 update`` never re-provisions hermes, so that fix reached fresh installs
+only: every box provisioned before it keeps the poisoned int through any number
+of upgrades. Measured on the fleet — a box upgraded rc.10 → rc.11 still failed
+its live client at 41.6 s, and prod on rc.9 fails at 40.7 s — while a fresh
+rc.11 install connects in 51 ms with 26 tools.
+
+The documented manual workaround (``hal0 agent reprovision hermes``) is not a
+dependable substitute: it exits 0 even when it fails (#2092). So the repair
+belongs in the migration sequence both upgrade paths already converge on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hal0.updater.updater import repair_hermes_mcp_headers
+
+POISONED = """\
+mcp_servers:
+  hal0-admin:
+    type: http
+    url: http://127.0.0.1:8080/mcp/admin/mcp
+    headers:
+      X-hal0-Agent: hermes
+  hal0-memory:
+    type: http
+    url: http://127.0.0.1:8080/mcp/memory/mcp
+    headers:
+      X-hal0-Agent: hermes
+      X-hal0-Private: 1
+agent:
+  name: Hermes
+"""
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(text, encoding="utf-8")
+    return cfg
+
+
+def test_quotes_a_poisoned_private_header(tmp_path: Path) -> None:
+    cfg = _write(tmp_path, POISONED)
+
+    changed = repair_hermes_mcp_headers(config_path=cfg, restart_gateway=False)
+
+    assert changed is True
+    loaded = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    hdrs = loaded["mcp_servers"]["hal0-memory"]["headers"]
+    assert hdrs["X-hal0-Private"] == "1"
+    assert isinstance(hdrs["X-hal0-Private"], str)
+
+
+def test_is_a_no_op_on_an_already_correct_config(tmp_path: Path) -> None:
+    """A converged box must not be rewritten — no write, no gateway bounce."""
+    cfg = _write(tmp_path, POISONED.replace("X-hal0-Private: 1", "X-hal0-Private: '1'"))
+    before = cfg.read_text(encoding="utf-8")
+
+    changed = repair_hermes_mcp_headers(config_path=cfg, restart_gateway=False)
+
+    assert changed is False
+    assert cfg.read_text(encoding="utf-8") == before
+
+
+def test_preserves_every_other_setting(tmp_path: Path) -> None:
+    cfg = _write(tmp_path, POISONED)
+
+    repair_hermes_mcp_headers(config_path=cfg, restart_gateway=False)
+
+    loaded = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert loaded["agent"]["name"] == "Hermes"
+    assert loaded["mcp_servers"]["hal0-admin"]["url"] == "http://127.0.0.1:8080/mcp/admin/mcp"
+    assert loaded["mcp_servers"]["hal0-memory"]["headers"]["X-hal0-Agent"] == "hermes"
+
+
+@pytest.mark.parametrize(
+    ("literal", "expected"),
+    [("1", "1"), ("0", "0"), ("true", "true"), ("false", "false"), ("3.5", "3.5")],
+)
+def test_coerces_any_non_string_header_value(tmp_path: Path, literal: str, expected: str) -> None:
+    """Headers are strings by definition; any YAML scalar that survives as a
+    non-string is the same poison, so none of them are left behind."""
+    cfg = _write(tmp_path, POISONED.replace("X-hal0-Private: 1", f"X-hal0-Private: {literal}"))
+
+    repair_hermes_mcp_headers(config_path=cfg, restart_gateway=False)
+
+    val = yaml.safe_load(cfg.read_text(encoding="utf-8"))["mcp_servers"]["hal0-memory"]["headers"][
+        "X-hal0-Private"
+    ]
+    assert val == expected
+    assert isinstance(val, str)
+
+
+def test_missing_config_is_a_quiet_no_op(tmp_path: Path) -> None:
+    """A box with no hermes install must not fail its update."""
+    assert (
+        repair_hermes_mcp_headers(config_path=tmp_path / "absent.yaml", restart_gateway=False)
+        is False
+    )
+
+
+def test_unparseable_config_is_a_quiet_no_op(tmp_path: Path) -> None:
+    """Never let a hand-edited config abort the migration sequence."""
+    cfg = _write(tmp_path, "mcp_servers: [this is not: a mapping\n")
+    before = cfg.read_text(encoding="utf-8")
+
+    assert repair_hermes_mcp_headers(config_path=cfg, restart_gateway=False) is False
+    assert cfg.read_text(encoding="utf-8") == before
+
+
+def test_runs_as_part_of_the_post_activation_sequence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole point of #2090: the repair must be reached by the sequence
+    ``hal0 update`` and install.sh both call, not only by provisioning."""
+    from hal0.updater import updater as mod
+
+    seen: list[str | None] = []
+    monkeypatch.setattr(
+        mod, "repair_hermes_mcp_headers", lambda **kw: seen.append(kw.get("job_id")) or False
+    )
+    for name in (
+        "ensure_seed_profiles",
+        "clear_stale_mtp_overrides",
+        "relabel_stale_vulkan_slots",
+        "retag_stale_slot_images",
+        "sanitize_model_extra_args",
+    ):
+        monkeypatch.setattr(mod, name, lambda **kw: 0)
+    monkeypatch.setattr(mod, "_maybe_run_config_migrations", lambda *a, **kw: (1, 2))
+
+    mod.run_post_activation_migrations(1, job_id="job-2090")
+
+    assert seen == ["job-2090"]
+
+
+def test_a_failing_repair_never_blocks_the_update(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Best-effort, like every other data-cleanup pass: a raise here must not
+    abort an activation that has already swapped the tree."""
+    from hal0.updater import updater as mod
+
+    def _boom(**kw):
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr(mod, "repair_hermes_mcp_headers", _boom)
+    for name in (
+        "ensure_seed_profiles",
+        "clear_stale_mtp_overrides",
+        "relabel_stale_vulkan_slots",
+        "retag_stale_slot_images",
+        "sanitize_model_extra_args",
+    ):
+        monkeypatch.setattr(mod, name, lambda **kw: 0)
+    monkeypatch.setattr(mod, "_maybe_run_config_migrations", lambda *a, **kw: (1, 2))
+
+    assert mod.run_post_activation_migrations(1, job_id="job-2090") == (1, 2)
+
+
+def test_bounces_the_gateway_only_when_it_changed_something(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The repair only reaches the RUNNING agent after a restart — hermes reads
+    config.yaml at start. A converged box must not be bounced for nothing."""
+    from hal0.updater import updater as mod
+
+    ran: list[list[str]] = []
+    monkeypatch.setattr(mod.subprocess, "run", lambda argv, **kw: ran.append(argv))
+
+    poisoned = _write(tmp_path, POISONED)
+    assert repair_hermes_mcp_headers(config_path=poisoned) is True
+    assert ran == [["systemctl", "restart", "hermes-gateway.service"]]
+
+    ran.clear()
+    assert repair_hermes_mcp_headers(config_path=poisoned) is False
+    assert ran == []
+
+
+def test_a_failing_bounce_still_counts_as_repaired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The file rewrite is the durable half; if the bounce cannot run (the
+    boot-time caller is unprivileged), the config still takes effect at the
+    gateway's next restart, so the pass must not report failure."""
+    from hal0.updater import updater as mod
+
+    def _no_systemctl(argv, **kw):
+        raise OSError("systemctl: permission denied")
+
+    monkeypatch.setattr(mod.subprocess, "run", _no_systemctl)
+    cfg = _write(tmp_path, POISONED)
+
+    assert repair_hermes_mcp_headers(config_path=cfg) is True
+    hdrs = yaml.safe_load(cfg.read_text(encoding="utf-8"))["mcp_servers"]["hal0-memory"]["headers"]
+    assert hdrs["X-hal0-Private"] == "1"


### PR DESCRIPTION
Fixes the memory-tools outage on every existing box, and the reason its manual workaround could not be trusted.

## #2090 — the fix reached fresh installs only

#2088 made `X-hal0-Private` reach hermes' `config.yaml` as a string. It did that in the config **write** path, which only runs when hermes is provisioned — and `hal0 update` never re-provisions. So every box provisioned before that fix keeps the poisoned YAML int through any number of upgrades, and the int wedges hermes' MCP client immediately after `initialize`, leaving the agent with **zero memory tools**.

Measured across the fleet on identical rc.11 code:

| Box | State | Live `hermes mcp test hal0-memory` |
|---|---|---|
| ct151 | fresh rc.11 install | **✓ connected 51 ms, 26 tools** |
| ct151 | after rc.10 → rc.11 upgrade | ✗ 41.6 s timeout |
| ct150 | pre-existing box | ✗ 30 s timeout |
| ct105 (prod) | rc.9 | ✗ 40.7 s timeout |

`repair_hermes_mcp_headers` joins `run_post_activation_migrations` — the single sequence `hal0 update` and install.sh both already converge on, so both upgrade paths get it.

Design points worth review:
- **Coerces every MCP header value, not just the known-poisonous key.** HTTP header values are strings by definition; any YAML scalar that survives as a non-string is the same latent wedge.
- **Preserves mode *and* ownership.** This runs as root from the post-swap subprocess, so a plain tmp-write + rename would hand hermes' own config back root-owned, breaking the born-owned contract `$HERMES_HOME` writes are held to.
- **Bounces `hermes-gateway` only when it changed something.** Hermes reads the config at start, so the repair reaches a running agent only after a restart; a converged box is never bounced for nothing. A failed bounce still counts as repaired — the boot-time caller is unprivileged, and the rewritten file takes effect at the next restart anyway.
- **Quiet no-op on absent/unparseable config**, best-effort like every sibling pass: it can never fail an activation that has already swapped the tree.

## #2092 — why the manual workaround was not a substitute

On ct150, `hal0 agent reprovision hermes` printed `bootstrap failed in steps: install` and **exited 0**. The cause is upstream of the exit code: `_provision_hermes`'s root branch resolved its re-exec target with `shutil.which("hal0")` — PATH, not the running tree. That box carries a stale rc.3 wrapper at `/usr/local/bin/hal0` (#1844), whose `#!/usr/bin/python3` shebang imports hal0 from system dist-packages:

```
$ which hal0 ; hal0 --version                    → /usr/local/bin/hal0 ; hal0 1.0.0rc3
$ /usr/lib/hal0/venv/bin/hal0 --version          → hal0 1.0.0rc11
```

So invoking rc.11 as root silently re-exec'd **rc.3**, which resolved its installer root relative to its own package location and died on `requirements.txt missing at /usr/local/lib/python3.12/installer/agents/hermes/requirements.txt` — a path that exists in no release. `_running_hal0_bin()` now prefers the console script beside `sys.executable` (a venv install puts them together), falling back to PATH for `python -m` dev checkouts, then the bare name.

## Deliberately re-baselined test

`test_provision_hermes_root_drops_to_hal0` asserted `argv[:4] == ["/usr/local/bin/hal0", …]` — it encoded the defect. It now asserts the running binary wins, and still stubs `which()` to the stale wrapper so the wrong answer stays visible in the test.

## Verification

- New: `tests/updater/test_hermes_header_repair.py` (14) + `tests/cli/test_provision_reexec.py` (4).
- **Proven red on revert**, per house rule: reverting either fix fails 5 tests; restoring passes 54.
- `tests/updater tests/cli tests/agents tests/installer`: **2851 passed**, 2 skipped, 1 xfailed. Lint + format clean.
- Fleet rehearsal follows this merge: rc.12 cut → ct150/ct151 upgrade lanes prove the migration heals a poisoned box with no manual step → then prod.

Closes #2090, closes #2092.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
