### PR TITLE
release: v1.0.0-rc.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,86 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+## [1.0.0-rc.12] — 2026-08-28
+
+A repair release for the existing fleet. rc.11 fixed the hermes memory-MCP
+outage for fresh installs; this one reaches the boxes that were already
+installed — which, on a platform heading to 1.0, is all of them.
+
+### Highlights
+
+- **Upgrading now heals hermes' memory tools by itself.** rc.11's fix lived in
+  the config write path, which only runs when hermes is provisioned, so an
+  upgrade left the poisoned `X-hal0-Private` int in place and the agent
+  holding zero memory tools. The repair now runs as part of the migration
+  sequence `hal0 update` and `install.sh` both converge on, so an ordinary
+  update fixes it with no operator step.
+
+### Fixed
+
+- **Every box provisioned before rc.11 kept a broken hermes memory client
+  through any number of upgrades.** The unquoted YAML `1` in
+  `mcp_servers.hal0-memory.headers.X-hal0-Private` wedges hermes' MCP client
+  immediately after `initialize` — a 40 s hang ending in `CancelledError` —
+  and the agent runs on with no memory tools at all. Nothing keyed on
+  `provision.json` notices, because its `mcp_wire` counts the **server's**
+  tools, not the client's. Measured on identical rc.11 code: a fresh install
+  connected in 51 ms with 26 tools while an upgraded box and production both
+  failed at ~41 s. The new migration pass coerces every MCP header value to a
+  string, preserves the file's mode and ownership (it runs as root), and
+  bounces `hermes-gateway` only when it actually changed something (#2090).
+- **`hal0 agent reprovision` could silently run a different hal0 than the one
+  invoked.** The privilege-drop re-exec resolved its target from `PATH`, so on
+  a box carrying a stale wrapper at `/usr/local/bin/hal0` (#1844) running the
+  current binary as root re-exec'd the older one — which then resolved its
+  installer root relative to its own package and failed with a path present in
+  no release, while the command still exited 0. It now re-execs the console
+  script belonging to the running interpreter (#2092).
+
+### Audience
+
+Every operator with an existing install — this is the release that repairs
+them. Fresh rc.11 installs are already correct and gain nothing here beyond
+the reprovision fix. After updating, hermes should report its memory tools
+again; verify with `hermes mcp test hal0-memory` (expect a connect in
+milliseconds and 26 tools, not a 40 s timeout).
+
+### Known issues
+
+- The live `hal0.dev/install.sh` still lags the in-tree installer: the mirror
+  workflow is gated on a signed stable manifest, and the stable pointer still
+  serves 0.9.8, so it has not published since 2026-08-09 (#2057, #1530). Both
+  are resolved together on the GA cut.
+- `scripts/release-test.sh`'s γ rows still target the retired v0.1 slot CLI, so
+  release-check gate 5 is waived for this cut (#2050); the rc-validate kit is
+  the effective gate.
+- A box carrying rc.3-era residue (a stale `/usr/local/bin/hal0`, a
+  system-python `hal0` in dist-packages) still has that residue after this
+  release. The re-exec fix means the right code runs; the stray files remain
+  for an operator to clean up.
+- The python 3.14 CI leg remains allowed-fail (container-provider fixtures).
+
+### Supported upgrades
+
+`hal0 update` from 1.0.0-rc.9, rc.10 or rc.11 on the preview channel. The
+hermes repair runs automatically as part of the update; no `hal0 agent
+reprovision hermes` step is needed, and on boxes where that command previously
+appeared to succeed while failing, it is no longer the mechanism being relied
+on.
+
+### Operator migrations
+
+None required. The brain model default is unchanged from rc.11 and applies to
+new installs only — an existing box keeps whatever model its brain slot is
+bound to, and nothing re-pulls or re-binds on upgrade.
+
+### Rollback
+
+`hal0 update --rollback` restores the previous tree. No schema or on-disk state
+changes ship here. The one file this release rewrites — hermes' `config.yaml`,
+to quote a header — is valid for older releases too, so it is safe to leave in
+place across a rollback.
+
 ## [1.0.0-rc.11] — 2026-08-28
 
 The default steward changes model, and the fresh-install path closes the last

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release — the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md §12 and §17 (maintainer-local).",
-  "version": "1.0.0-rc.11",
+  "version": "1.0.0-rc.12",
   "channel": "preview",
   "toolbox_images": {
     "vulkan": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "1.0.0-rc.11"
+version = "1.0.0-rc.12"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hal0-ui",
-  "version": "1.0.0-rc.11",
+  "version": "1.0.0-rc.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hal0-ui",
-      "version": "1.0.0-rc.11",
+      "version": "1.0.0-rc.12",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal0-ui",
   "private": true,
-  "version": "1.0.0-rc.11",
+  "version": "1.0.0-rc.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "hal0ai"
-version = "1.0.0rc11"
+version = "1.0.0rc12"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Release-prep PR for v1.0.0-rc.12, per the standing one-prep-PR recipe.

- Version bump via `scripts/set-version.py 1.0.0-rc.12`: pyproject.toml, manifest.json, ui/package.json + lock, uv.lock.
- `scripts/update-toolbox-digests.sh`: 7 digests resolved, 0 null — all already current, so manifest.json moves only for the version field.
- Runner pin unchanged (`hal0-combined:0826`).
- New `## [1.0.0-rc.12]` CHANGELOG section; verified `gen_release_notes.py --tag v1.0.0-rc.12 --channel preview` → `source=CHANGELOG.md#1.0.0-rc.12`, highlights=1, **0 TBDs**.

## What it ships

One thing, deliberately: **#2093** (closes #2090 and #2092) — the hermes memory-MCP repair that reaches upgraded boxes, plus the re-exec fix that made the manual workaround unreliable.

rc.11 fixed the poisoned `X-hal0-Private` header in the config *write* path, which only runs when hermes is provisioned. `hal0 update` never re-provisions, so every box installed before rc.11 kept a wedged MCP client and an agent with zero memory tools — measured at ~41 s timeouts on an upgraded box and on production, against 51 ms / 26 tools on a fresh rc.11 install. The repair now runs inside `run_post_activation_migrations`, so an ordinary update heals it with no operator step.

## Validation plan for this cut

The fleet rehearsal is the point of the release, and is set up already:

- **ct150** has been deliberately returned to the poisoned state (`X-hal0-Private: 1`, owner `hal0:hal0`, mode **644**). After `hal0 update` it must come back quoted, still `hal0:hal0`, still 644 — a root-run migration that ignored ownership would hand the file back `root:root` and cost hermes the ability to rewrite its own config.
- **ct151** is a fresh rc.11 with the header already correct, owner `hal0:hal0`, mode **600**. It must show no rewrite and no gateway bounce — idempotence on real hardware, and a second distinct mode to prove per-file preservation.
- Both then verified with the live client (`hermes mcp test hal0-memory`), not with `provision.json`, whose `mcp_wire` counts server tools and reports a broken box healthy.

Production follows once those pass; with this release it needs no manual repair step.

## Known accepted state

- release-check gate 5 waived per #2050 (γ rows target the retired v0.1 CLI).
- python 3.14 leg remains allowed-fail.
- #2057/#1530 (live installer mirror + stable pointer) stay open as the GA-day pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
