### PR TITLE
fix(docs-sync): retry Discourse 429s instead of aborting the run

### DIFF
--- a/scripts/docs_discourse_sync/discourse_client.py
+++ b/scripts/docs_discourse_sync/discourse_client.py
@@ -64,6 +64,12 @@ class Topic:
         return f"{base_url.rstrip('/')}/t/{self.slug}/{self.topic_id}"
 
 
+# What to wait after a 429 that carries neither ``extras.wait_seconds`` nor
+# a Retry-After header. Discourse's buckets are minute-shaped, so a value well
+# under a minute keeps the retry cheap while still yielding real time back.
+_DEFAULT_RATE_LIMIT_WAIT_S = 10.0
+
+
 class RateLimiter:
     """Sliding min-interval throttle: never issue two requests less than
     ``60 / requests_per_minute`` seconds apart. Simple and sufficient at
@@ -110,10 +116,14 @@ class DiscourseClient:
         requests_per_minute: int = 60,
         transport: httpx.BaseTransport | None = None,
         rate_limiter: RateLimiter | None = None,
+        max_rate_limit_retries: int = 5,
+        sleeper: Callable[[float], None] = time.sleep,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.dry_run = dry_run
         self._rate_limiter = rate_limiter or RateLimiter(requests_per_minute)
+        self._max_rate_limit_retries = max_rate_limit_retries
+        self._sleeper = sleeper
         self._client = httpx.Client(
             base_url=self.base_url,
             timeout=_DEFAULT_TIMEOUT_S,
@@ -134,9 +144,55 @@ class DiscourseClient:
     def __exit__(self, *exc: object) -> None:
         self.close()
 
+    @staticmethod
+    def _retry_after_seconds(response: httpx.Response) -> float:
+        """How long Discourse wants us to wait after a 429.
+
+        A throttled Discourse answers with
+        ``{"extras": {"wait_seconds": 10}, ...}`` and usually a
+        ``Retry-After`` header too. Prefer the body -- that is the number
+        the server actually enforces -- fall back to the header, and
+        finally to a fixed pause if a rate-limit response carries neither.
+        """
+        try:
+            wait = response.json().get("extras", {}).get("wait_seconds")
+            if wait is not None:
+                return float(wait)
+        except (ValueError, AttributeError, TypeError):
+            pass
+        header = response.headers.get("Retry-After")
+        if header:
+            try:
+                return float(header)
+            except ValueError:
+                pass
+        return _DEFAULT_RATE_LIMIT_WAIT_S
+
     def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
-        self._rate_limiter.wait()
-        return self._client.request(method, path, **kwargs)
+        """One request, retried while Discourse says we are going too fast.
+
+        The client's own RateLimiter paces steady-state traffic, but it
+        cannot know about the other buckets Discourse enforces (per-user,
+        per-IP, admin-API), so meeting a 429 mid-run is normal rather than
+        exceptional. Before this retry existed a single 429 aborted the
+        whole docs sync -- which is how the workflow failed from
+        2026-08-22 onward, part-way through resolving topics.
+
+        Only 429 is retried. Every other status, 5xx included, is returned
+        unchanged: this loop is for backpressure, not for papering over a
+        broken forum.
+        """
+        for attempt in range(self._max_rate_limit_retries + 1):
+            self._rate_limiter.wait()
+            response = self._client.request(method, path, **kwargs)
+            if response.status_code != 429 or attempt == self._max_rate_limit_retries:
+                return response
+            # wait_seconds counts down from when the bucket filled, so the
+            # reported value can elapse a hair before the server agrees;
+            # the extra second keeps the retry from landing on the same
+            # 429 and burning an attempt.
+            self._sleeper(self._retry_after_seconds(response) + 1.0)
+        raise AssertionError("unreachable: the loop returns or exhausts its attempts")
 
     def resolve_topic(self, external_id: str) -> Topic | None:
         """``GET /t/external_id/{id}.json?include_raw=true``.

--- a/tests/scripts/docs_discourse_sync/test_discourse_client.py
+++ b/tests/scripts/docs_discourse_sync/test_discourse_client.py
@@ -275,3 +275,98 @@ def test_rate_limiter_sleeps_to_maintain_min_interval() -> None:
 def test_rate_limiter_rejects_non_positive_rpm() -> None:
     with pytest.raises(ValueError):
         RateLimiter(0)
+
+
+# --- 429 backpressure -------------------------------------------------------
+#
+# Discourse throttles per-user, per-IP and per-API-key on buckets the client's
+# own RateLimiter knows nothing about, so a 429 arrives mid-run as a matter of
+# course. It used to abort the whole sync: the sync-docs-discourse workflow
+# failed exactly this way from 2026-08-22 onward, on a topic lookup.
+
+
+def _resolving_handler(responses: list[httpx.Response], calls: dict[str, int]):
+    """Handler that answers the external_id lookup from ``responses`` in
+    order (the last one repeats), then serves the canonical topic hop."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/t/external_id/hal0-docs--getting-started--install.json":
+            calls["n"] += 1
+            return responses[min(calls["n"] - 1, len(responses) - 1)]
+        if request.url.path == "/t/install-hal0/55.json":
+            return httpx.Response(200, json=_resolve_topic_json())
+        raise AssertionError(f"unexpected request: {request.url.path}")
+
+    return handler
+
+
+_REDIRECT = httpx.Response(301, headers={"Location": "/t/install-hal0/55.json?include_raw=true"})
+
+
+def test_rate_limited_request_is_retried_after_the_wait_the_server_asks_for() -> None:
+    slept: list[float] = []
+    calls = {"n": 0}
+    throttled = httpx.Response(
+        429,
+        json={
+            "errors": ["You've performed this action too many times."],
+            "error_type": "rate_limit",
+            "extras": {"wait_seconds": 10},
+        },
+    )
+
+    with _client(_resolving_handler([throttled, _REDIRECT], calls), sleeper=slept.append) as client:
+        topic = client.resolve_topic("hal0-docs--getting-started--install")
+
+    assert topic is not None
+    assert calls["n"] == 2, "the throttled lookup is retried once"
+    assert slept == [11.0], "waits the server's wait_seconds plus a second of slack"
+
+
+def test_rate_limit_retry_falls_back_to_the_retry_after_header() -> None:
+    slept: list[float] = []
+    calls = {"n": 0}
+    throttled = httpx.Response(429, headers={"Retry-After": "4"}, text="slow down")
+
+    with _client(_resolving_handler([throttled, _REDIRECT], calls), sleeper=slept.append) as client:
+        assert client.resolve_topic("hal0-docs--getting-started--install") is not None
+
+    assert slept == [5.0]
+
+
+def test_rate_limit_retries_are_bounded_and_then_the_error_surfaces() -> None:
+    """A forum that never lets up must still fail the run, not spin forever."""
+    slept: list[float] = []
+    calls = {"n": 0}
+    throttled = httpx.Response(429, json={"extras": {"wait_seconds": 1}})
+
+    with (
+        _client(
+            _resolving_handler([throttled], calls),
+            sleeper=slept.append,
+            max_rate_limit_retries=2,
+        ) as client,
+        pytest.raises(DiscourseAPIError) as excinfo,
+    ):
+        client.resolve_topic("hal0-docs--getting-started--install")
+
+    assert calls["n"] == 3, "the first attempt plus max_rate_limit_retries"
+    assert len(slept) == 2, "no sleep after the final attempt"
+    assert "429" in str(excinfo.value)
+
+
+def test_server_errors_are_not_retried() -> None:
+    """Only 429 is backpressure; a 500 is a broken forum and must surface."""
+    slept: list[float] = []
+    calls = {"n": 0}
+
+    with (
+        _client(
+            _resolving_handler([httpx.Response(500, text="boom")], calls), sleeper=slept.append
+        ) as client,
+        pytest.raises(DiscourseAPIError),
+    ):
+        client.resolve_topic("hal0-docs--getting-started--install")
+
+    assert calls["n"] == 1
+    assert slept == []


### PR DESCRIPTION
## Why

`sync-docs-discourse` has failed on **every** run since 2026-08-22, so `hal0/docs/**` and the forum Docs category have been drifting apart for six days. Same failure each time:

```
DiscourseAPIError: GET /t/external_id/hal0-docs--guides--choose-models.json
-> 429: {"errors":["You have performed this action too many times..."],
   "error_type":"rate_limit","extras":{"wait_seconds":10}}
```

The client has a `RateLimiter` that paces its own steady-state traffic, but it cannot know about the other buckets Discourse enforces (per-user, per-IP, admin-API). So a 429 mid-run is normal backpressure — and a single one aborted the entire sync.

## What

`DiscourseClient._request` now retries a 429 after the interval the server names: `extras.wait_seconds` from the body first (that is the number Discourse actually enforces), then the `Retry-After` header, then a 10s default — plus one second of slack so the retry does not land on the same bucket and burn an attempt. Bounded by `max_rate_limit_retries` (default 5), after which the `DiscourseAPIError` surfaces as before.

Only 429 is retried. A 5xx still fails immediately: that is a broken forum, not backpressure.

`sleeper` is injectable alongside the existing `rate_limiter`, so the tests assert the wait arithmetic without sleeping.

## Tests

Four new cases in `tests/scripts/docs_discourse_sync/test_discourse_client.py`, all through `httpx.MockTransport`:

- a 429 carrying `wait_seconds: 10` is retried once, sleeping exactly 11.0s
- a 429 with only `Retry-After: 4` falls back to the header, sleeping 5.0s
- an unrelenting forum stops after `max_rate_limit_retries` (3 attempts at 2 retries, 2 sleeps) and raises
- a 500 is not retried and does not sleep

`122 passed` for `tests/scripts/docs_discourse_sync/`; `ruff check` and `ruff format --check` clean.

## Follow-up, not in this PR

Once this lands, the first green run has six days of doc changes to push; if the forum throttles hard on that catch-up run, the durable fix is exempting the sync bot API key from rate limits on the forum side rather than raising the retry count here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VK1wkzRxdxBRJfHFa5zDYb
