### PR TITLE
docs(changelog): restore rc.8/rc.9 and stop claiming 1.0.0 shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,6 +264,78 @@ repair that preceded it (#2056/#2073).
   `pct set --nameserver`, and minimal Ubuntu 26.04 needs curl+jq before
   bootstrap (#2064, #2068).
 
+## [1.0.0-rc.9] — 2026-08-25
+
+_Written after the fact: this release was tagged without a changelog section,
+so its published notes fell back to a raw commit list. Reconstructed from the
+merged PRs in the rc.8…rc.9 range._
+
+A correctness pass across the paths that report state — hermes' MCP health, a
+slot spawn failure, the config-drift comparator, and the brain answering
+questions about the running box.
+
+### Fixed
+
+- **`hermes` reported ok over a dead MCP client**, and shipped without the
+  `mcp` extra it needs to have a live one (#2053).
+- **Seeded llama.cpp slots picked their device by hand instead of via
+  `derive_device`**, so an install could seed a slot the box could not run
+  (#2023, #2054).
+- **A failed slot spawn surfaced as a raw `CalledProcessError`** rather than
+  the typed `SlotSpawnFailed` the callers handle (#1424, #2047).
+- **The config-drift comparator ignored the runner image**, so a slot whose
+  image had moved read as in-sync (#2035).
+- **`enable_thinking: false` was injected into grammar-constrained chat
+  bodies**, which is exactly where it must not go (#2036).
+- **The brain answered live-state questions from the model's own guesswork**
+  instead of grounding them in the box's actual state (#2034).
+
+### Added
+
+- **Per-tag runner-image pull** — route and job now accept a catalogued tag
+  (#2048).
+- **Typed registry capability fields fold into `_model_caps`** for bench
+  (#1826).
+- **ADR-0003 — ONNX text-gen via XDNA2 NPU: defer with triggers** (PROPOSAL)
+  (#1951).
+
+## [1.0.0-rc.8] — 2026-08-24
+
+_Written after the fact, same as rc.9 above: reconstructed from the merged PRs
+in the rc.7…rc.8 range._
+
+Runner images become a thing you can see and choose, and two failure modes
+that used to be quiet — a doomed model load and an unreadable stack state —
+now announce themselves.
+
+### Added
+
+- **A tag-tracked runner-image catalogue**, with a `default_images` override
+  and row enrichment that reports what is actually there (#2044) — surfaced in
+  the UI as runner images under Slots and profiles under Models, with a
+  defaults strip and a tag picker (#2043).
+- **The crash-loop breaker renders on slot cards and in the slot drawer**, so
+  a slot that keeps dying says so where you are already looking (#2038,
+  #2040).
+
+### Fixed
+
+- **A doomed model load ran to its full timeout** — the runner entrypoint now
+  exits 64 so the load fails fast instead of burning the budget (#2037,
+  #2039).
+- **Root-written stack state was left unreadable by the service**, and the
+  resulting error was untyped (#2042).
+
+### Changed
+
+- **The default runner pin rolls to `hal0-combined:0824`**, which carries the
+  #2037 fail-fast entrypoint (#2041).
+- `cosign-installer` is pinned to v4.1.2 — upstream ships no floating v4 alias
+  (#2046).
+- The γ-suite gets CI headroom over its own `globalTimeout` (#2033).
+- Docs: runner-image catalogue v2 spec and implementation plan (#2045), and
+  the rc.7 fleet validation report with kit v9 curation (#2031).
+
 ## [1.0.0-rc.7] — 2026-08-17
 
 The rc.6 validation sweep ran the fleet again — fresh installs, in-place

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,264 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+These are the 1.0.0 notes. They carried a `## [1.0.0] — 2026-08-07`
+heading for three weeks, which read as a shipped release: no `v1.0.0` tag
+exists, and the line has run rc.1 → rc.12 the whole time. They live here
+until 1.0.0 actually tags, at which point this content moves back under a
+`## [1.0.0] — <tag date>` heading so `scripts/gen_release_notes.py` can
+bundle it into the release.
+
+### Highlights
+
+- **The whole platform is agent-reachable.** The admin MCP catalog went from 92 to 180 tools — services, ComfyUI, updater/doctor/health, hardware and request telemetry, slots and models long-tail, bench, activity, approvals, runner images, NPU load/unload — plus the full 26-tool memory surface (was 5) at feature parity with Hindsight 0.8.4.
+- **Slots start when you say so.** New `autoload` setting: binding a model no longer implies boot start. New eviction `priority` (0-100) replaces the inert `lru = true` opt-in, so memory-pressure eviction actually works on a stock box.
+- **Voice is a device-keyed switch.** Moonshine is back as the CPU STT engine in its own toolbox image; `cpu` runs Moonshine, `npu` runs whisper-v3:turbo, GPU resolves to no STT engine instead of silently taking a llama chat profile.
+- **Image Gen and Slots panes got their lifecycle right** — state-typed engine indicators, a Stop that drives the GPU arbiter back to inference mode, dropdown-driven runner image/binary selection, and a `GET /api/slots` path that no longer multiplies `podman inspect` fan-out on wide boxes.
+- **Documentation moved into this repo.** `docs/` is the source of truth and publishes to hal0.dev through a mirror workflow, with a restored, v1.0-reconciled `getting-started/` section.
+
+### Breaking
+
+- **The experimental standalone browser MCP server is removed.**
+  (`hal0.mcp.browser_server`, port 9178, `HAL0_BROWSER_*` env.) It was
+  never mounted or registered as a bundled server, and its shipped unit
+  pointed at a retired path. Browser tooling is the agent's own
+  concern — Hermes brings its own.
+
+- **The `lru = true` eviction opt-in is retired — every non-pinned resident slot is now an eviction candidate, ordered by the new `priority` field.**
+  Memory-pressure and
+  pre-load eviction used to only ever touch a slot that explicitly set
+  `lru = true`; now every non-pinned resident slot is a candidate,
+  ordered by the new `priority` field. The key is still accepted in slot
+  TOML but ignored, with a one-time deprecation warning — remove it and
+  use `priority`/`pinned` instead. Practically: on a stock box that never
+  set `lru = true` on anything, pressure and pre-load eviction go from
+  inert (nothing was ever eligible) to ACTIVE the moment host memory gets
+  tight. Also note `idle_timeout_s = 0` never exempted a slot from
+  pressure or pre-load eviction — it only ever disabled that one slot's
+  idle-TTL path — and that distinction now matters more than it used to.
+  `pinned` (plus the built-in `agent`/`utility`/`npu` anchors) is the only
+  exemption from pressure and pre-load eviction.
+
+The R5 breaking changes below shipped in `1.0.0-rc.1` and apply equally to a
+box coming straight from 0.9.8 — the expected upgrade path into 1.0. Full
+rationale and code-path detail in the
+[1.0.0-rc.1 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100-rc1--2026-08-01-r5--the-rework-release).
+
+- **Launch flags, device, and chat-template moved off slots onto models.**
+  A slot is just `(id, name, model, port, state)`; `model.defaults` carries
+  the materialized tune. Slot TOMLs with the old fields still load but are
+  ignored at launch until you run the fold migrator (see Migrations).
+- **The Honcho memory engine is removed; memory is Hindsight-only.**
+  `hal0_memory_*` tools are renamed to `hindsight_*` (old names kept as
+  aliases this release). No data carry-over path exists.
+- **`SlotConfig.enabled` is gone — a bound model is the activation signal.**
+  `PUT /api/slots/{name}/config {"enabled": …}` now returns 400
+  `slot.removed_key_denied`; the boot migration sweeps the key from slot
+  TOMLs (see Migrations).
+- **`PUT /api/slots/{name}/config` no longer has a lifecycle side effect.**
+  Stopping a slot is `POST /api/slots/{name}/unload` (409 `slot.pinned` on
+  pinned slots, `?force=true` bypass).
+- **The NPU-exclusivity 409 moved from the toggle to the model write.**
+  Configuring a model on a second `device=npu` LLM anchor returns 409
+  `slot.npu_exclusivity_violation`; model-less NPU LLM slots coexist freely.
+- **NPU trio dispatch reads the anchor's `[npu]` table, not the shadow slots' own flags.**
+  `flm-stt`/`flm-embed` are display+dispatch records for the anchor's single
+  `flm serve` process; a modality that was never launched is no longer routable.
+- **`[brain_chat] tool_model` is removed — it was never read.**
+  A config that sets it explicitly now fails validation with a clear error;
+  the live `[brain_chat] model` override is the real steering knob.
+- **Deprecated surfaces are `HAL0-SUNSET`-stamped for scheduled removal:**
+  the `--backend` flag (use `--provider`), `SlotConfig.runtime`/`workers`,
+  the `cognee` engine literal, and several legacy CLI aliases.
+
+### Migrations
+
+These carry forward from `1.0.0-rc.1` for every box upgrading from 0.9.8;
+full detail in the
+[1.0.0-rc.1 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100-rc1--2026-08-01-r5--the-rework-release).
+
+- **Upgrade in place — re-run the installer (or `hal0 update`); idempotent, non-destructive, never clobbers existing config. No reinstall.**
+- **Slot-flag fold (operator-run): the fold migrator moves slot tunes into model defaults — dry-run by default; back up `hal0.db` + slot dirs before applying.**
+  It refuses the whole run (no partial write) if slots share a model with
+  divergent tunes — resolve each shared model (canonicalize or split) first.
+- **The one-shot `enabled` sweep runs automatically at first v1.0 boot; `hal0 slot migrate-enabled-removal` runs the same sweep on demand.**
+  (`hal0.config.migrations.slot_enabled_removal`.) `enabled = false` with a
+  bound model → the model is cleared so the slot stays off; every other shape
+  just loses the key. Idempotent; the CLI form is dry-run by default and safe live.
+- **Slot id-keying (operator-run, optional): run `hal0 slot migrate-id-keying` in a downtime window (takes a pre-flight backup).**
+  The runtime reads either layout; the flip is deliberate and reversible.
+- **A stale `[brain_chat] tool_model` key in `hal0.toml` no longer breaks config load.**
+  `load_hal0_config` drops it before validation on every load path.
+- **Disabling a capability now clears the slot's model instead of writing `enabled = false`.**
+  The pick survives in `capabilities.toml` and a re-enable rebinds it.
+- **Honcho → Hindsight (only boxes that ran Honcho): no migration step — Honcho support was removed outright and Hindsight starts fresh.**
+- **Rollback is one-way — restore from a config backup if you need the prior state.**
+  Pre-R5 code reads a missing `enabled` as `True`, so slots the sweep cleared
+  come back model-less rather than re-enabled.
+
+### Added
+
+- Admin MCP catalog expanded from 92 to 180 tools — the full platform
+  management surface is now agent-reachable: services lifecycle
+  (`service_list`/`service_health` + gated `service_action`), ComfyUI
+  (status/workflows reads, gated switchover/pin/launch/cancel/restart),
+  updater/doctor/health/features reads (`updater_state`, `updater_check`,
+  `doctor_report`, `health_system`, …), hardware and request telemetry
+  (`slot_stats`, `request_metrics`, `npu_occupancy`, `power_stats`,
+  `throughput_history`, …), slots and models long-tail (`slot_config`,
+  `slot_voices`, `hf_search`, `model_validate`, `model_health_check`),
+  bench plan/results reads + gated `bench_run`, `journal_snapshot` and
+  activity reads, `approval_list` (the brain can now tell the operator
+  what's pending), runner images, NPU backend load/unload, and MCP
+  self-management. `slot_create`/`slot_edit` param hints now advertise
+  `autoload` and `priority`. The admin mount also delegates the full
+  26-tool memory surface (previously 5). Brain chat reaches every
+  non-excluded new tool through the shared dispatch core.
+- Profiles: `POST /api/profiles/generate` (admin MCP: `profile_generate`)
+  drafts a profile from a registered model or a HuggingFace repo —
+  capability classification, device fit for the local host, and seed
+  selection reuse the install-time heuristics, with an optional
+  `use_llm` pass that summarizes the model card through the local
+  utility slot and degrades to heuristics when inference is down. The
+  draft is a portable envelope ready for the existing create/import
+  flow; the catalog is never written.
+- `hal0 doctor all` gains two MCP preflights: `mcp_mounts` (live
+  `initialize` + `tools/list` against `/mcp/admin` and `/mcp/memory`
+  with the configured agent token) and `hermes_mcp_auth` (the rendered
+  Hermes config carries `Authorization` whenever the box requires
+  auth). A 401 now fails doctor with the repair command instead of
+  silently breaking every agent.
+
+- Memory MCP surface brought to feature parity with the live Hindsight
+  0.8.4 server: `memory_reflect` (LLM-backed synthesis over memory),
+  `memory_curate`/`memory_history` (the non-destructive "this is wrong"
+  correction path — edit or reversibly invalidate a single fact), mental
+  model tools (`memory_mental_model_list`/`_get`/`_create`/`_update`/
+  `_delete`/`_refresh`), directive tools (`memory_directive_list`/`_get`/
+  `_create`/`_update`/`_delete`), async-operation tools
+  (`memory_operation_list`/`_get`/`_cancel`/`_retry` — retain is async by
+  default, so these are the poll target for `memory_add`'s `operation_id`),
+  and bank introspection (`memory_tags_list`, `memory_bank_stats`,
+  `memory_bank_consolidate`). `memory_add` gained `entities`/
+  `observation_scopes`/`strategy`/`update_mode`/`sync` (Hindsight's full
+  `RetainRequest` item shape) and now surfaces `operation_ids`/`items_count`
+  instead of dropping them. `memory_recall` gained `tag_groups`/`budget`/
+  `prefer_observations`/`include`/`query_timestamp`/`min_scores`, and its
+  results now carry the engine's native per-result relevance score plus
+  optional `entities`/`chunks`/`source_facts` response enrichment — a stale
+  comment claiming "Hindsight recall returns no numeric score" is fixed.
+  `memory_search` gained `tag_groups`/`min_scores`. Every new destructive
+  tool (`memory_mental_model_delete`, `memory_directive_delete`) goes
+  through the same operator-approval gate as a bulk `memory_delete`; no
+  destructive bank-level operation (delete/clear a whole bank) is exposed
+  over MCP.
+
+- Moonshine reinstated as hal0's CPU STT engine, packaged as its own
+  toolbox image (`hal0-toolbox-moonshine:v1`). `voice.stt` is now a
+  device-keyed engine switch exactly like `voice.tts`: `cpu` runs
+  Moonshine, `npu` runs whisper-v3:turbo via the FLM trio, and GPU
+  devices resolve to no STT engine (previously a fall-through bug handed
+  the `stt` slot the wrong llama chat profile). Moonshine's weights are
+  operator-staged under the model store and preflighted at slot spawn,
+  failing loudly by name (`slot.weights_missing`) instead of 500ing on
+  first request. This supersedes the `[v0.2.0]` "Moonshine STT retired in
+  favour of `whisper.cpp`" entry below — that justification never held,
+  since `whisper.cpp` never shipped as a standalone CPU service. See
+  [`docs/adr/0001-moonshine-cpu-stt-reinstatement.md`](docs/adr/0001-moonshine-cpu-stt-reinstatement.md).
+
+- Image Gen pane: proper engine lifecycle controls and running indicators.
+  The header pill is state-typed off the live engine (stopped / starting /
+  running / generating·% / error) with matching colors, and a Stop button
+  appears while the engine is up — it drives the GPU-arbiter switchover
+  back to inference mode (restoring the LLM slots) and then unloads the img
+  slot so the container actually goes down. Start/Restart/Logs unchanged.
+
+- Slots: explicit `autoload` setting — a slot starts at boot only when
+  `autoload = true` (slot drawer toggle). Binding a model no longer
+  implies boot start; existing slots with a bound model migrate as
+  `true`, so upgrade changes nothing until toggled.
+- Slots: eviction `priority` (0–100, default 50, drawer field) — memory
+  pressure and pre-load eviction unload the lowest-priority slot first
+  (least-recently-used as the tie-break within a tier). `pinned` still
+  exempts a slot entirely.
+
+### Changed
+
+- Slot drawer: the Profile field moved into the Model group, directly under
+  the model select (it rides the model choice). NPU slots keep a standalone
+  Profile group since the capability matrix replaces the Model group there.
+
+- Slot drawer: the Runner Image field is a dropdown of the runner-image
+  catalog (the same registry the Runtimes page shows) instead of a free-text
+  input; a "Custom image ref…" option keeps the debug/A-B/rollback escape
+  hatch. Picking an image repopulates the Runner Binary dropdown with the
+  binaries that image ships — dual-binary images (e.g. the shared
+  ROCm/Vulkan image) offer both, single-binary images hop the selection to
+  their sole binary.
+
+### Fixed
+
+- Hermes bootstrap MCP wiring actually works now: the seed TOML never
+  declared the builtin `[mcp.servers.*]` blocks so the allow-list
+  silently skipped wiring both servers, and the post-wire live probe
+  double-appended `/mcp` and 404ed — together the provisioning-time
+  handshake had never succeeded. Bootstrap also injects
+  `HAL0_MCP_TOKEN` (0600) into the agent driver env and renders
+  `Authorization: Bearer` into the Hermes MCP client config whenever
+  the box has auth enabled, and refreshes it on `--repair` after a key
+  rotation.
+
+- ComfyUI img slot reliability: the provider now creates its bind-mount
+  data dirs before spawn (a missing tree crash-looped the container with
+  podman exit 125), slot readiness waits on ComfyUI's real health probe
+  (`GET /system_stats`) instead of 404-polling the llama-style `/health`
+  for the full 180 s deadline and wedging the slot in WARMING, and the
+  fail-watcher's health probe delegates to the ComfyUI provider so a
+  READY img slot is no longer struck to ERROR seconds after coming up.
+
+- `GET /api/slots` latency cut sharply on wide boxes (#1507 follow-up):
+  the per-slot probe no longer runs `podman inspect` for stopped slots,
+  `podman image inspect` answers are TTL-cached per image ref, and the
+  whole snapshot is served single-flight with a 2 s TTL (any slot
+  mutation invalidates it immediately) so overlapping dashboard polls
+  stop multiplying the subprocess fan-out.
+
+- Slots page no longer stalls while the activity log backfills: the SSE
+  stream replayed the full 1000-row durable backlog one frame at a time on
+  every fresh connect, and the pane re-rendered once per frame. The stream
+  now takes a `limit` (the pane asks for its 200-row ring cap) and the
+  client coalesces frame bursts into one render per 50ms window.
+
+- hal0-brain tool-bearing requests no longer 500 with "Unknown (built-in)
+  filter 'min'": the GGUF-embedded chat template uses the `|min` filter,
+  which llama-server's jinja engine (minja) lacks. A corrected template
+  (`hal0-brain-sft.jinja`) now ships bundled, and the curated catalogue
+  stamps it into the model's `defaults.chat_template` at pull time so
+  fresh installs launch with `--chat-template-file` instead of the broken
+  embedded template.
+
+### Known Issues
+
+These carry forward from `1.0.0-rc.1`. The first two concern **upgrading from
+0.9.8** — the path most existing boxes take into 1.0; the third affects
+**fresh installs**; the fourth affects boxes that skipped straight from
+`rc.1` to this release.
+
+- **The profile-catalog reset does not fire during the 0.9.8 → 1.0 update itself** (#1585, still open). The update's commit phase runs inside the *old* (0.9.8) daemon, which predates the reset — so an upgraded box keeps its `profiles.toml` and `meta.schema_version = 1` until the **next** update applied by v1.0 code. Nothing is lost (the reset is biased against deletion), but `hal0 update` on such a box reports "nothing to apply" without mentioning the outstanding reset.
+- **Updating *from* 0.9.8 ends with a spurious error from the old client.** The 0.9.8 CLI polls job status through the API it is restarting, treats the mid-restart connection refusal as fatal, and exits 1 after the update has in fact applied. The fix (#1540) ships in the v1.0 CLI, but the client driving a 0.9.8 → 1.0 update is by definition the old one. Verify the real outcome with `hal0 --version` and `curl http://127.0.0.1:8080/api/health`.
+- **First-boot installs can lose the dpkg lock race to `unattended-upgrades`** (#1584, still open) — the hermes-agent provisioning step degrades gracefully with a remediation line (`hal0 agent install hermes`) rather than failing the install.
+- **A box still on `1.0.0-rc.1` sees no update available for this GA release** (#1663/#1640, fixed going forward but not retroactively — a running rc.1 daemon can't rerun its own fix). Its venv predates the prerelease-aware version comparison, so the old naive tuple fallback ranks `1.0.0rc1` above `1.0.0` and `hal0 update`/`/api/updates/check` both report nothing to do. Boxes that updated `rc.1` → `rc.2` first are unaffected — the rc-vs-rc comparison orders correctly even on the old fallback. If you're still on `rc.1`, pull this release directly with `hal0 update --target 1.0.0`, which bypasses the `update_available` gate entirely.
+
+### Security
+
+- The `/mcp/memory` mount is now CLIENT-tier (was ADMIN): memory-only
+  agents no longer need the platform-admin key; the fail-closed
+  namespace ACL and the operator-approval gate on destructive tools
+  bound its blast radius. `/mcp/admin` and any future `/mcp/*` mount
+  remain ADMIN. Docs that still claimed "no built-in network auth"
+  (pre-KB-1) are corrected everywhere.
+
+
 ## [1.0.0-rc.12] — 2026-08-28
 
 A repair release for the existing fleet. rc.11 fixed the hermes memory-MCP
@@ -797,7 +1055,7 @@ see Known issues.
   [1.0.0-rc.6 section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100-rc6--2026-08-12).
 - `0.9.8` → `1.0.0-rc.7` in place — re-run the installer or `hal0 update` on the
   preview channel; the R5 migration set applies (see the
-  [1.0.0 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100--2026-08-07)).
+  [1.0.0 notes, under Unreleased](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#unreleased)).
 - Older than 0.9.8: step through 0.9.8 first.
 
 ### Known issues
@@ -1244,7 +1502,7 @@ the stable channel are not offered this tag.
   directly, same mechanism.
 - `0.9.8` → `1.0.0-rc.6` in place — re-run the installer or `hal0 update` on the
   preview channel; the R5 migration set applies (see the
-  [1.0.0 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100--2026-08-07)).
+  [1.0.0 notes, under Unreleased](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#unreleased)).
 - Older than 0.9.8: step through 0.9.8 first.
 
 ### Known issues
@@ -1606,7 +1864,7 @@ not offered this tag.
   mechanism.
 - `0.9.8` → `1.0.0-rc.5` in place — re-run the installer or `hal0 update` on
   the preview channel; the R5 migration set applies (see the
-  [1.0.0 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100--2026-08-07)).
+  [1.0.0 notes, under Unreleased](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#unreleased)).
 - Older than 0.9.8: step through 0.9.8 first.
 
 ### Known issues
@@ -1789,7 +2047,7 @@ offered this tag.
 - `1.0.0-rc.2` / `1.0.0-rc.1` → `1.0.0-rc.4` directly, same mechanism.
 - `0.9.8` → `1.0.0-rc.4` in place — re-run the installer or `hal0 update` on
   the preview channel; the R5 migration set applies (see the
-  [1.0.0 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100--2026-08-07)).
+  [1.0.0 notes, under Unreleased](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#unreleased)).
   The profile-catalog reset that used to defer silently on this transition now
   converges on the first post-update `hal0 update` (#1585).
 - Older than 0.9.8: step through 0.9.8 first.
@@ -1922,7 +2180,7 @@ offered this tag.
 - `1.0.0-rc.1` → `1.0.0-rc.3` directly, same mechanism.
 - `0.9.8` → `1.0.0-rc.3` in place — re-run the installer or `hal0 update`
   on the preview channel; the R5 migration set applies (see the
-  [1.0.0 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100--2026-08-07)).
+  [1.0.0 notes, under Unreleased](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#unreleased)).
 - Older than 0.9.8: step through 0.9.8 first.
 
 ### Known issues
@@ -2006,258 +2264,6 @@ re-installing the previous tag (`v1.0.0-rc.1`) from its GitHub release.
 Note the `enabled`-sweep caveat from the R5 set: pre-R5 code reads a
 missing `enabled` as true, so a rollback past R5 needs the config backup
 taken before upgrading.
-
-## [1.0.0] — 2026-08-07
-
-### Highlights
-
-- **The whole platform is agent-reachable.** The admin MCP catalog went from 92 to 180 tools — services, ComfyUI, updater/doctor/health, hardware and request telemetry, slots and models long-tail, bench, activity, approvals, runner images, NPU load/unload — plus the full 26-tool memory surface (was 5) at feature parity with Hindsight 0.8.4.
-- **Slots start when you say so.** New `autoload` setting: binding a model no longer implies boot start. New eviction `priority` (0-100) replaces the inert `lru = true` opt-in, so memory-pressure eviction actually works on a stock box.
-- **Voice is a device-keyed switch.** Moonshine is back as the CPU STT engine in its own toolbox image; `cpu` runs Moonshine, `npu` runs whisper-v3:turbo, GPU resolves to no STT engine instead of silently taking a llama chat profile.
-- **Image Gen and Slots panes got their lifecycle right** — state-typed engine indicators, a Stop that drives the GPU arbiter back to inference mode, dropdown-driven runner image/binary selection, and a `GET /api/slots` path that no longer multiplies `podman inspect` fan-out on wide boxes.
-- **Documentation moved into this repo.** `docs/` is the source of truth and publishes to hal0.dev through a mirror workflow, with a restored, v1.0-reconciled `getting-started/` section.
-
-### Breaking
-
-- **The experimental standalone browser MCP server is removed.**
-  (`hal0.mcp.browser_server`, port 9178, `HAL0_BROWSER_*` env.) It was
-  never mounted or registered as a bundled server, and its shipped unit
-  pointed at a retired path. Browser tooling is the agent's own
-  concern — Hermes brings its own.
-
-- **The `lru = true` eviction opt-in is retired — every non-pinned resident slot is now an eviction candidate, ordered by the new `priority` field.**
-  Memory-pressure and
-  pre-load eviction used to only ever touch a slot that explicitly set
-  `lru = true`; now every non-pinned resident slot is a candidate,
-  ordered by the new `priority` field. The key is still accepted in slot
-  TOML but ignored, with a one-time deprecation warning — remove it and
-  use `priority`/`pinned` instead. Practically: on a stock box that never
-  set `lru = true` on anything, pressure and pre-load eviction go from
-  inert (nothing was ever eligible) to ACTIVE the moment host memory gets
-  tight. Also note `idle_timeout_s = 0` never exempted a slot from
-  pressure or pre-load eviction — it only ever disabled that one slot's
-  idle-TTL path — and that distinction now matters more than it used to.
-  `pinned` (plus the built-in `agent`/`utility`/`npu` anchors) is the only
-  exemption from pressure and pre-load eviction.
-
-The R5 breaking changes below shipped in `1.0.0-rc.1` and apply equally to a
-box coming straight from 0.9.8 — the expected upgrade path into 1.0. Full
-rationale and code-path detail in the
-[1.0.0-rc.1 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100-rc1--2026-08-01-r5--the-rework-release).
-
-- **Launch flags, device, and chat-template moved off slots onto models.**
-  A slot is just `(id, name, model, port, state)`; `model.defaults` carries
-  the materialized tune. Slot TOMLs with the old fields still load but are
-  ignored at launch until you run the fold migrator (see Migrations).
-- **The Honcho memory engine is removed; memory is Hindsight-only.**
-  `hal0_memory_*` tools are renamed to `hindsight_*` (old names kept as
-  aliases this release). No data carry-over path exists.
-- **`SlotConfig.enabled` is gone — a bound model is the activation signal.**
-  `PUT /api/slots/{name}/config {"enabled": …}` now returns 400
-  `slot.removed_key_denied`; the boot migration sweeps the key from slot
-  TOMLs (see Migrations).
-- **`PUT /api/slots/{name}/config` no longer has a lifecycle side effect.**
-  Stopping a slot is `POST /api/slots/{name}/unload` (409 `slot.pinned` on
-  pinned slots, `?force=true` bypass).
-- **The NPU-exclusivity 409 moved from the toggle to the model write.**
-  Configuring a model on a second `device=npu` LLM anchor returns 409
-  `slot.npu_exclusivity_violation`; model-less NPU LLM slots coexist freely.
-- **NPU trio dispatch reads the anchor's `[npu]` table, not the shadow slots' own flags.**
-  `flm-stt`/`flm-embed` are display+dispatch records for the anchor's single
-  `flm serve` process; a modality that was never launched is no longer routable.
-- **`[brain_chat] tool_model` is removed — it was never read.**
-  A config that sets it explicitly now fails validation with a clear error;
-  the live `[brain_chat] model` override is the real steering knob.
-- **Deprecated surfaces are `HAL0-SUNSET`-stamped for scheduled removal:**
-  the `--backend` flag (use `--provider`), `SlotConfig.runtime`/`workers`,
-  the `cognee` engine literal, and several legacy CLI aliases.
-
-### Migrations
-
-These carry forward from `1.0.0-rc.1` for every box upgrading from 0.9.8;
-full detail in the
-[1.0.0-rc.1 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100-rc1--2026-08-01-r5--the-rework-release).
-
-- **Upgrade in place — re-run the installer (or `hal0 update`); idempotent, non-destructive, never clobbers existing config. No reinstall.**
-- **Slot-flag fold (operator-run): the fold migrator moves slot tunes into model defaults — dry-run by default; back up `hal0.db` + slot dirs before applying.**
-  It refuses the whole run (no partial write) if slots share a model with
-  divergent tunes — resolve each shared model (canonicalize or split) first.
-- **The one-shot `enabled` sweep runs automatically at first v1.0 boot; `hal0 slot migrate-enabled-removal` runs the same sweep on demand.**
-  (`hal0.config.migrations.slot_enabled_removal`.) `enabled = false` with a
-  bound model → the model is cleared so the slot stays off; every other shape
-  just loses the key. Idempotent; the CLI form is dry-run by default and safe live.
-- **Slot id-keying (operator-run, optional): run `hal0 slot migrate-id-keying` in a downtime window (takes a pre-flight backup).**
-  The runtime reads either layout; the flip is deliberate and reversible.
-- **A stale `[brain_chat] tool_model` key in `hal0.toml` no longer breaks config load.**
-  `load_hal0_config` drops it before validation on every load path.
-- **Disabling a capability now clears the slot's model instead of writing `enabled = false`.**
-  The pick survives in `capabilities.toml` and a re-enable rebinds it.
-- **Honcho → Hindsight (only boxes that ran Honcho): no migration step — Honcho support was removed outright and Hindsight starts fresh.**
-- **Rollback is one-way — restore from a config backup if you need the prior state.**
-  Pre-R5 code reads a missing `enabled` as `True`, so slots the sweep cleared
-  come back model-less rather than re-enabled.
-
-### Added
-
-- Admin MCP catalog expanded from 92 to 180 tools — the full platform
-  management surface is now agent-reachable: services lifecycle
-  (`service_list`/`service_health` + gated `service_action`), ComfyUI
-  (status/workflows reads, gated switchover/pin/launch/cancel/restart),
-  updater/doctor/health/features reads (`updater_state`, `updater_check`,
-  `doctor_report`, `health_system`, …), hardware and request telemetry
-  (`slot_stats`, `request_metrics`, `npu_occupancy`, `power_stats`,
-  `throughput_history`, …), slots and models long-tail (`slot_config`,
-  `slot_voices`, `hf_search`, `model_validate`, `model_health_check`),
-  bench plan/results reads + gated `bench_run`, `journal_snapshot` and
-  activity reads, `approval_list` (the brain can now tell the operator
-  what's pending), runner images, NPU backend load/unload, and MCP
-  self-management. `slot_create`/`slot_edit` param hints now advertise
-  `autoload` and `priority`. The admin mount also delegates the full
-  26-tool memory surface (previously 5). Brain chat reaches every
-  non-excluded new tool through the shared dispatch core.
-- Profiles: `POST /api/profiles/generate` (admin MCP: `profile_generate`)
-  drafts a profile from a registered model or a HuggingFace repo —
-  capability classification, device fit for the local host, and seed
-  selection reuse the install-time heuristics, with an optional
-  `use_llm` pass that summarizes the model card through the local
-  utility slot and degrades to heuristics when inference is down. The
-  draft is a portable envelope ready for the existing create/import
-  flow; the catalog is never written.
-- `hal0 doctor all` gains two MCP preflights: `mcp_mounts` (live
-  `initialize` + `tools/list` against `/mcp/admin` and `/mcp/memory`
-  with the configured agent token) and `hermes_mcp_auth` (the rendered
-  Hermes config carries `Authorization` whenever the box requires
-  auth). A 401 now fails doctor with the repair command instead of
-  silently breaking every agent.
-
-- Memory MCP surface brought to feature parity with the live Hindsight
-  0.8.4 server: `memory_reflect` (LLM-backed synthesis over memory),
-  `memory_curate`/`memory_history` (the non-destructive "this is wrong"
-  correction path — edit or reversibly invalidate a single fact), mental
-  model tools (`memory_mental_model_list`/`_get`/`_create`/`_update`/
-  `_delete`/`_refresh`), directive tools (`memory_directive_list`/`_get`/
-  `_create`/`_update`/`_delete`), async-operation tools
-  (`memory_operation_list`/`_get`/`_cancel`/`_retry` — retain is async by
-  default, so these are the poll target for `memory_add`'s `operation_id`),
-  and bank introspection (`memory_tags_list`, `memory_bank_stats`,
-  `memory_bank_consolidate`). `memory_add` gained `entities`/
-  `observation_scopes`/`strategy`/`update_mode`/`sync` (Hindsight's full
-  `RetainRequest` item shape) and now surfaces `operation_ids`/`items_count`
-  instead of dropping them. `memory_recall` gained `tag_groups`/`budget`/
-  `prefer_observations`/`include`/`query_timestamp`/`min_scores`, and its
-  results now carry the engine's native per-result relevance score plus
-  optional `entities`/`chunks`/`source_facts` response enrichment — a stale
-  comment claiming "Hindsight recall returns no numeric score" is fixed.
-  `memory_search` gained `tag_groups`/`min_scores`. Every new destructive
-  tool (`memory_mental_model_delete`, `memory_directive_delete`) goes
-  through the same operator-approval gate as a bulk `memory_delete`; no
-  destructive bank-level operation (delete/clear a whole bank) is exposed
-  over MCP.
-
-- Moonshine reinstated as hal0's CPU STT engine, packaged as its own
-  toolbox image (`hal0-toolbox-moonshine:v1`). `voice.stt` is now a
-  device-keyed engine switch exactly like `voice.tts`: `cpu` runs
-  Moonshine, `npu` runs whisper-v3:turbo via the FLM trio, and GPU
-  devices resolve to no STT engine (previously a fall-through bug handed
-  the `stt` slot the wrong llama chat profile). Moonshine's weights are
-  operator-staged under the model store and preflighted at slot spawn,
-  failing loudly by name (`slot.weights_missing`) instead of 500ing on
-  first request. This supersedes the `[v0.2.0]` "Moonshine STT retired in
-  favour of `whisper.cpp`" entry below — that justification never held,
-  since `whisper.cpp` never shipped as a standalone CPU service. See
-  [`docs/adr/0001-moonshine-cpu-stt-reinstatement.md`](docs/adr/0001-moonshine-cpu-stt-reinstatement.md).
-
-- Image Gen pane: proper engine lifecycle controls and running indicators.
-  The header pill is state-typed off the live engine (stopped / starting /
-  running / generating·% / error) with matching colors, and a Stop button
-  appears while the engine is up — it drives the GPU-arbiter switchover
-  back to inference mode (restoring the LLM slots) and then unloads the img
-  slot so the container actually goes down. Start/Restart/Logs unchanged.
-
-- Slots: explicit `autoload` setting — a slot starts at boot only when
-  `autoload = true` (slot drawer toggle). Binding a model no longer
-  implies boot start; existing slots with a bound model migrate as
-  `true`, so upgrade changes nothing until toggled.
-- Slots: eviction `priority` (0–100, default 50, drawer field) — memory
-  pressure and pre-load eviction unload the lowest-priority slot first
-  (least-recently-used as the tie-break within a tier). `pinned` still
-  exempts a slot entirely.
-
-### Changed
-
-- Slot drawer: the Profile field moved into the Model group, directly under
-  the model select (it rides the model choice). NPU slots keep a standalone
-  Profile group since the capability matrix replaces the Model group there.
-
-- Slot drawer: the Runner Image field is a dropdown of the runner-image
-  catalog (the same registry the Runtimes page shows) instead of a free-text
-  input; a "Custom image ref…" option keeps the debug/A-B/rollback escape
-  hatch. Picking an image repopulates the Runner Binary dropdown with the
-  binaries that image ships — dual-binary images (e.g. the shared
-  ROCm/Vulkan image) offer both, single-binary images hop the selection to
-  their sole binary.
-
-### Fixed
-
-- Hermes bootstrap MCP wiring actually works now: the seed TOML never
-  declared the builtin `[mcp.servers.*]` blocks so the allow-list
-  silently skipped wiring both servers, and the post-wire live probe
-  double-appended `/mcp` and 404ed — together the provisioning-time
-  handshake had never succeeded. Bootstrap also injects
-  `HAL0_MCP_TOKEN` (0600) into the agent driver env and renders
-  `Authorization: Bearer` into the Hermes MCP client config whenever
-  the box has auth enabled, and refreshes it on `--repair` after a key
-  rotation.
-
-- ComfyUI img slot reliability: the provider now creates its bind-mount
-  data dirs before spawn (a missing tree crash-looped the container with
-  podman exit 125), slot readiness waits on ComfyUI's real health probe
-  (`GET /system_stats`) instead of 404-polling the llama-style `/health`
-  for the full 180 s deadline and wedging the slot in WARMING, and the
-  fail-watcher's health probe delegates to the ComfyUI provider so a
-  READY img slot is no longer struck to ERROR seconds after coming up.
-
-- `GET /api/slots` latency cut sharply on wide boxes (#1507 follow-up):
-  the per-slot probe no longer runs `podman inspect` for stopped slots,
-  `podman image inspect` answers are TTL-cached per image ref, and the
-  whole snapshot is served single-flight with a 2 s TTL (any slot
-  mutation invalidates it immediately) so overlapping dashboard polls
-  stop multiplying the subprocess fan-out.
-
-- Slots page no longer stalls while the activity log backfills: the SSE
-  stream replayed the full 1000-row durable backlog one frame at a time on
-  every fresh connect, and the pane re-rendered once per frame. The stream
-  now takes a `limit` (the pane asks for its 200-row ring cap) and the
-  client coalesces frame bursts into one render per 50ms window.
-
-- hal0-brain tool-bearing requests no longer 500 with "Unknown (built-in)
-  filter 'min'": the GGUF-embedded chat template uses the `|min` filter,
-  which llama-server's jinja engine (minja) lacks. A corrected template
-  (`hal0-brain-sft.jinja`) now ships bundled, and the curated catalogue
-  stamps it into the model's `defaults.chat_template` at pull time so
-  fresh installs launch with `--chat-template-file` instead of the broken
-  embedded template.
-
-### Known Issues
-
-These carry forward from `1.0.0-rc.1`. The first two concern **upgrading from
-0.9.8** — the path most existing boxes take into 1.0; the third affects
-**fresh installs**; the fourth affects boxes that skipped straight from
-`rc.1` to this release.
-
-- **The profile-catalog reset does not fire during the 0.9.8 → 1.0 update itself** (#1585, still open). The update's commit phase runs inside the *old* (0.9.8) daemon, which predates the reset — so an upgraded box keeps its `profiles.toml` and `meta.schema_version = 1` until the **next** update applied by v1.0 code. Nothing is lost (the reset is biased against deletion), but `hal0 update` on such a box reports "nothing to apply" without mentioning the outstanding reset.
-- **Updating *from* 0.9.8 ends with a spurious error from the old client.** The 0.9.8 CLI polls job status through the API it is restarting, treats the mid-restart connection refusal as fatal, and exits 1 after the update has in fact applied. The fix (#1540) ships in the v1.0 CLI, but the client driving a 0.9.8 → 1.0 update is by definition the old one. Verify the real outcome with `hal0 --version` and `curl http://127.0.0.1:8080/api/health`.
-- **First-boot installs can lose the dpkg lock race to `unattended-upgrades`** (#1584, still open) — the hermes-agent provisioning step degrades gracefully with a remediation line (`hal0 agent install hermes`) rather than failing the install.
-- **A box still on `1.0.0-rc.1` sees no update available for this GA release** (#1663/#1640, fixed going forward but not retroactively — a running rc.1 daemon can't rerun its own fix). Its venv predates the prerelease-aware version comparison, so the old naive tuple fallback ranks `1.0.0rc1` above `1.0.0` and `hal0 update`/`/api/updates/check` both report nothing to do. Boxes that updated `rc.1` → `rc.2` first are unaffected — the rc-vs-rc comparison orders correctly even on the old fallback. If you're still on `rc.1`, pull this release directly with `hal0 update --target 1.0.0`, which bypasses the `update_available` gate entirely.
-
-### Security
-
-- The `/mcp/memory` mount is now CLIENT-tier (was ADMIN): memory-only
-  agents no longer need the platform-admin key; the fail-closed
-  namespace ACL and the operator-approval gate on destructive tools
-  bound its blast radius. `/mcp/admin` and any future `/mcp/*` mount
-  remain ADMIN. Docs that still claimed "no built-in network auth"
-  (pre-KB-1) are corrected everywhere.
 
 ## [1.0.0-rc.1] — 2026-08-01 (R5 · the rework release)
 


### PR DESCRIPTION
Two fixes to the canonical changelog, both about it describing releases that did not happen the way it says.

## 1. rc.8 and rc.9 were missing entirely

Both shipped (2026-08-24, 2026-08-25) **without a CHANGELOG section**. Consequences:

- Their GitHub release notes are raw commit lists — `scripts/gen_release_notes.py` had no matching `## [<version>]` section to bundle — while rc.7 and rc.10 on either side carry real notes.
- hal0.dev/changelog, which mirrors this file, jumps from rc.10 straight to rc.7.

Both sections are now written from the merged PRs in each range (`v1.0.0-rc.7...v1.0.0-rc.8`, `v1.0.0-rc.8...v1.0.0-rc.9`), in the style of the sections around them, each opening with a one-line italic note that it was written after the fact.

## 2. `## [1.0.0] — 2026-08-07` claimed a release that never tagged

There is no `v1.0.0` tag; the line has run rc.1 → rc.12 for three weeks while that heading sat in the file. Anyone reading hal0.dev/changelog saw 1.0.0 as shipped.

The content is good — only the heading was a claim. It moves verbatim under `## [Unreleased]` with a note saying it returns to `## [1.0.0] — <tag date>` when 1.0.0 actually tags, which is the form `gen_release_notes.py` needs to bundle it.

The five in-file links pointing at the old `#100--2026-08-07` anchor **on main** now point at `#unreleased`. Four others are pinned to `blob/v1.0.0-rc.2/` and still resolve against that tag's copy, so they are untouched.

## Verification

`gen_release_notes.py` extracts `v1.0.0-rc.12`, `v1.0.0-rc.9` and `v1.0.0-rc.8` cleanly from the edited file (rc.9/rc.8 have no Highlights/Breaking/Migrations subsections, which is correct). No stale `#100--2026-08-07` anchors remain on main-tracking links.

## Still open, not addressed here

**rc.7 is dated 2026-08-17 but its tag and release are 2026-08-22** — five days off. Every other section reads as its ship date, so this is probably a typo, but correcting a shipped release's date is your call.

## Note on how this was committed

The `hal0` checkout on thinmint has a damaged object store (`git fsck` reports missing blobs, and a staged `.claude/branch-status.json` with an invalid blob), so commits there fail at tree-building. The second commit was made from a clean clone of this branch instead. Worth a look at that working copy — it also carries ~5000 uncommitted changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VK1wkzRxdxBRJfHFa5zDYb