### PR TITLE
feat(ui): put memory in the slot card's metric row, context in a chip

### DIFF
--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -519,9 +519,9 @@ export function SlotScard({
               <div className={'v' + (ttft ? '' : ' muted')}>{ttft ? ttft + 'ms' : '—'}</div>
             </div>
             <div className="m">
-              <div className="l">ctx</div>
-              <div className={'v' + (s.ctx_max ? '' : ' muted')} style={{ fontSize: 12 }}>
-                {ctxText(s)}
+              <div className="l">mem</div>
+              <div className={'v' + (memGb != null ? '' : ' muted')} style={{ fontSize: 12 }}>
+                {memGb != null ? memGb + ' GB' : '—'}
               </div>
             </div>
           </div>
@@ -532,7 +532,11 @@ export function SlotScard({
           <SlotBreakerChip s={s} />
           <BackendMismatch s={s} onEdit={onEdit} />
           <SlotImageUnknownChip s={s} />
-          {full && memGb != null && <span className="tag-chip">{memGb} GB</span>}
+          {full && typeof s.ctx_max === 'number' && s.ctx_max > 0 && (
+            <span className="tag-chip" title={`ctx used / max · ${ctxText(s)}`}>
+              {kCtx(s.ctx_max)} ctx
+            </span>
+          )}
           <span className="grow" />
           {controls}
         </div>


### PR DESCRIPTION
Swaps which of the two numbers gets the always-visible slot in `SlotScard`.

**Before**
```
metric row:   [ tok/s ] [ ttft ] [ ctx  12k / 32k ]
footer chip:  [ 24 GB ]                             (full cards only)
```

**After**
```
metric row:   [ tok/s ] [ ttft ] [ mem  24 GB ]
footer chip:  [ 32k ctx ]                           (full cards only)
              title="ctx used / max · 12k / 32k"
```

Memory is the number you scan a slot card for — it decides whether another model fits. Context capacity is mostly a static property of the slot, so it reads fine as a chip with the exact used/max on hover.

## The call I want reviewed

The chip keeps its `full &&` guard, so **compact cards now show no context at all** — they previously carried it in the metric row. I left the guard as the original author wrote it, on the reasoning that compact cards are deliberately sparse and answer "is this slot healthy, how big is it" rather than "what is its context window". If you disagree, dropping `full &&` restores context everywhere and costs one chip on compact cards.

Footer crowding is unchanged either way: the ctx chip **replaces** the mem chip rather than joining it, so `.scard-foot` still holds only short fixed-width chips, as #2038's comment asks.

## Provenance

This diff was sitting uncommitted in a stale worktree (`h0/reorder-slot-metrics`, last touched 2026-08-22) found during a repo cleanup — never committed, never PR'd, and it would have been deleted with the worktree. It is rebased onto current `main` here; `inference-pane.jsx` has moved since via #2040's breaker chip, and the patch applies cleanly around it.

## Verification

- `eslint .` clean
- `tsc --noEmit` clean
- 222 ui unit tests pass (26 files)
- No test asserted the old `ctx` label or the `GB` chip, so nothing needed updating

Not yet verified visually against a running dash — worth a look at a full and a compact card before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VK1wkzRxdxBRJfHFa5zDYb
