### PR TITLE
fix(docs-sync): stop rewriting titles the forum itself prettifies

### DIFF
--- a/scripts/docs_discourse_sync/sync.py
+++ b/scripts/docs_discourse_sync/sync.py
@@ -60,6 +60,51 @@ class SyncReport:
         return sum(1 for a in self.actions if a.kind == kind)
 
 
+# Discourse rewrites a topic title on save when `title_prettify` is on
+# (it is, on forum.hal0.dev). The sync sends "hal0 docs: Start here" and
+# the server stores "Hal0 docs: Start here" -- so a verbatim title
+# comparison finds every such topic "changed" on EVERY run, rewrites it,
+# and finds it changed again next time. Seven docs topics were in that
+# loop, each one bumped and re-PUT on every sync, against a forum that
+# rate-limits (see the 429 backoff in _request).
+#
+# Mirrors lib/text_cleaner.rb's clean_title for the options this forum
+# runs with. Kept deliberately literal, in the same order as the Ruby, so
+# the two can be diffed by eye.
+_TRAILING_PERIODS = re.compile(r"([^.])\.+(\s*)\Z")
+_EXTRANEOUS_SPACE = re.compile(r"\s+([!?]\s*)\Z")
+_INTERIOR_SPACES = re.compile(r"[ \t]{2,}")
+_ZERO_WIDTH = re.compile("[\u200b\u200c\u200d\ufeff]")
+
+
+def prettified_title(title: str) -> str:
+    """*title* as Discourse will store it under ``title_prettify``."""
+    # Stripped up front: Ruby's `split(" ", 2)` is awk-style and ignores
+    # leading whitespace when it picks the first word, so a title with
+    # leading spaces still gets capitalized there. Python's partition does
+    # not, and the result is stripped either way.
+    text = _ZERO_WIDTH.sub("", title).strip()
+    text = re.sub(r"!+", "!", text)
+    text = re.sub(r"\?+", "?", text)
+    # All-caps titles are downcased whole (allow_uppercase_posts is off).
+    if text and text == text.upper():
+        text = text.lower()
+    # Capitalize the first letter -- but only when the whole first word is
+    # already lowercase, which is why "hal0 CLI reference" keeps its CLI.
+    first, _, rest = text.partition(" ")
+    if first and first == first.lower():
+        text = first.capitalize() + (" " + rest if rest else "")
+    text = _TRAILING_PERIODS.sub(r"\1\2", text)
+    text = _EXTRANEOUS_SPACE.sub(r"\1", text)
+    text = _INTERIOR_SPACES.sub(" ", text)
+    return text.strip()
+
+
+def title_matches(existing_title: str, expected_title: str) -> bool:
+    """Whether *existing_title* is *expected_title* as the server keeps it."""
+    return existing_title == expected_title or existing_title == prettified_title(expected_title)
+
+
 def _content_changed(
     existing: Topic, *, title: str, raw: str, category_id: int, dry_run: bool = False
 ) -> bool:
@@ -80,7 +125,7 @@ def _content_changed(
     there the comparison is exact and an actual content-level image swap
     should be caught.
     """
-    if existing.category_id != category_id or existing.title != title:
+    if existing.category_id != category_id or not title_matches(existing.title, title):
         return True
     existing_raw, new_raw = existing.raw.strip(), raw.strip()
     if dry_run:

--- a/tests/scripts/docs_discourse_sync/test_sync.py
+++ b/tests/scripts/docs_discourse_sync/test_sync.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import httpx
 from scripts.docs_discourse_sync.discourse_client import DiscourseClient
 from scripts.docs_discourse_sync.discovery import Doc
-from scripts.docs_discourse_sync.sync import sync_docs
+from scripts.docs_discourse_sync.sync import prettified_title, sync_docs, title_matches
 
 
 def _doc(key: str, title: str, body_md: str, *, order: float = 10.0) -> Doc:
@@ -427,3 +427,56 @@ def test_a_site_json_failure_does_not_fail_the_sync() -> None:
     with _client(forum) as client:
         sync_docs([_doc("guides/a", "A", "body a")], client=client, category_id=11)
     assert forum.topics["hal0-docs--guides--a"]["category_id"] == 11
+
+
+# --- title_prettify round-trip ----------------------------------------------
+#
+# forum.hal0.dev runs with `title_prettify` on, so Discourse rewrites a title
+# when it saves it. Comparing titles verbatim made the sync see those topics
+# as changed on every run, rewrite them, and see them changed again -- seven
+# topics stuck in that loop against a rate-limited forum.
+
+
+def test_prettified_title_matches_discourses_own_rules() -> None:
+    # capitalize the first letter, but only when the whole first word is
+    # lowercase -- which is what keeps "CLI" intact
+    assert prettified_title("hal0 docs: Start here") == "Hal0 docs: Start here"
+    assert prettified_title("hal0 CLI reference") == "Hal0 CLI reference"
+    assert prettified_title("Install hal0") == "Install hal0"
+    # all-caps is downcased whole, then first-letter capitalized
+    assert prettified_title("ALL CAPS TITLE") == "All caps title"
+    # trailing periods and doubled punctuation go
+    assert prettified_title("trailing period.") == "Trailing period"
+    assert prettified_title("really?!!!") == "Really?!"
+    # whitespace is tidied
+    assert prettified_title("  spaced   out  ") == "Spaced out"
+
+
+def test_title_matches_accepts_the_servers_prettified_form() -> None:
+    assert title_matches("Hal0 docs: Start here", "hal0 docs: Start here")
+    assert title_matches("Install hal0", "Install hal0")
+
+
+def test_title_matches_still_sees_a_real_rename() -> None:
+    assert not title_matches("Hal0 docs: Start here", "hal0 docs: Getting going")
+    assert not title_matches("Install hal0", "Install hal0 on Proxmox")
+
+
+def test_a_prettified_title_does_not_trigger_an_update_every_run() -> None:
+    """The regression itself: sync, let the server prettify the title, sync
+    again -- the second run must report no change."""
+    forum = FakeForum()
+    docs = [_doc("guides/a", "hal0 guide to a", "body a")]
+    with _client(forum) as client:
+        sync_docs(docs, client=client, category_id=11)
+
+    # Discourse capitalizes on save; emulate that on the stored state.
+    stored = forum.topics["hal0-docs--guides--a"]
+    stored["title"] = "Hal0 guide to a"
+
+    with _client(forum) as client:
+        report = sync_docs(docs, client=client, category_id=11)
+
+    assert report.count("update") == 0, "a prettified title must not look changed"
+    assert report.count("noop") == 1
+    assert forum.topics["hal0-docs--guides--a"]["title"] == "Hal0 guide to a"


### PR DESCRIPTION
## The loop

`forum.hal0.dev` runs with `title_prettify = true`, so Discourse rewrites a title as it saves it:

```
sync sends:        "hal0 docs: Start here"   "hal0 documentation"   "hal0 CLI reference"
Discourse stores:  "Hal0 docs: Start here"   "Hal0 documentation"   "Hal0 CLI reference"
```

`_content_changed` compared titles verbatim, so those seven topics looked changed on **every** run. Caught it right after a live sync, by dispatching a dry run that should have been all-quiet:

```
live run:  Docs — created 0, updated 2, unchanged 42
           Index topics — created 0, updated 5, unchanged 0
dry run:   Docs — created 0, updated 2, unchanged 42     <- the same seven, again
           Index topics — created 0, updated 5, unchanged 0
```

Every run bumped and re-PUT them against a forum that rate-limits — the same limiter that took this workflow down for six days (#2095).

## The fix

`prettified_title()` mirrors `lib/text_cleaner.rb`'s `clean_title` for the options this forum actually runs with (verified against the container's source and `SiteSetting` values: `title_prettify=true`, `allow_uppercase_posts=false`, `title_remove_extraneous_space=true`):

- deduplicate `!!!` / `???`
- downcase an all-caps title whole
- capitalize the first letter **only when the entire first word is lowercase** — this is what keeps `hal0 CLI reference` from becoming `Hal0 cli reference`
- drop trailing periods, tidy extraneous and interior spaces

`title_matches()` accepts either what we sent or what the server would store, so a genuine rename is still detected.

Two details worth a reviewer's eye:

- The up-front `.strip()` is deliberate. Ruby's `split(" ", 2)` is awk-style and ignores leading whitespace when picking the first word; Python's `partition` doesn't, so `"  spaced   out  "` would silently skip capitalization. My first cut had that bug and a test caught it.
- The helper is written in the same order as the Ruby so the two can be diffed by eye when Discourse changes.

## Tests

Four new cases, `133 passed` overall:

- `prettified_title` against each rule, including the CLI case and all-caps
- `title_matches` accepts the server's form, and still rejects a real rename
- **the regression itself**: sync, prettify the stored title the way the server would, sync again → `update == 0`, `noop == 1`

`ruff check` / `ruff format` clean.

## Verify after merge

The next sync run should report `Docs — updated 0` and `Index topics — updated 0` with no doc changes upstream. Today it reports 2 and 5 forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VK1wkzRxdxBRJfHFa5zDYb
