### PR TITLE
fix(updater): re-converge a drifted hermes venv on upgrade (#2102)

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -960,7 +960,33 @@ def _phase_install(ctx: _StepCtx) -> PhaseResult:
 
     # ── hal0-owned artifacts (born hal0:hal0 when the provisioner runs as hal0) ─
     hermes_bin = _venv_python(venv).parent / "hermes"
-    if not hermes_bin.exists() or ctx.repair:
+    # #2102: `bin/hermes` existing is not proof the venv is USABLE. A venv that
+    # drifted off the vetted pin keeps the binary and loses the `mcp` package
+    # (the residual population of #2021), and the old existence gate skipped
+    # the install over it — recording `install: ok` immediately before
+    # `mcp_wire` hard-failed on the same venv, with no remedy named and plain
+    # `reprovision` unable to fix what only `--repair` could. Ask the venv
+    # whether it can import the client hermes actually uses (the same
+    # assertion `mcp_wire` makes, no URL, no server round-trip) and rebuild it
+    # when it cannot. The provisioner already holds both the diagnosis and the
+    # cure; this just stops it walking past one to fail on the other.
+    reinstall_reason: str | None = None
+    if not hermes_bin.exists():
+        reinstall_reason = "hermes binary missing"
+    elif ctx.repair:
+        reinstall_reason = "--repair"
+    else:
+        try:
+            probe = ctx.io.probe_mcp_client(_venv_python(venv), None, agent_id=state.agent_id)
+        except Exception as exc:  # a probe that cannot run is not a verdict
+            log.warning("hermes_provision.mcp_client_probe_failed", error=str(exc))
+            probe = {"ok": True}
+        if not probe.get("ok"):
+            reinstall_reason = "mcp client import failed"
+            details["mcp_client_before_reinstall"] = probe
+
+    if reinstall_reason is not None:
+        details["venv_reinstalled_reason"] = reinstall_reason
         try:
             ctx.io.install_venv(venv, requirements)
             changed = True
@@ -2791,7 +2817,8 @@ def _phase_mcp_wire(ctx: _StepCtx) -> PhaseResult:
             },
             reason=(
                 f"hermes venv has no working MCP client "
-                f"({client_import.get('stage')}): {client_import.get('error')}"
+                f"({client_import.get('stage')}): {client_import.get('error')} "
+                f"— run: hal0 agent reprovision hermes --repair"
             ),
         )
     allowlist = _load_agent_allowlist()

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -1699,7 +1699,11 @@ def agent_reprovision(
     repair: bool = typer.Option(
         False,
         "--repair",
-        help="Force re-run of every phase (re-writes persona seeds, re-renders config).",
+        help=(
+            "Force re-run of every phase: rebuilds the managed venv, re-writes "
+            "persona seeds, re-renders config. The venv rebuild is what recovers a "
+            "box whose agent has no MCP tools."
+        ),
     ),
     verbose: bool = typer.Option(False, "--verbose", "-v"),
 ) -> None:

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1734,12 +1734,139 @@ def repair_hermes_mcp_headers(
     return True
 
 
+#: Where the managed hermes venv lives. Mirrors ``HERMES_VENV_DEFAULT`` in
+#: :mod:`hal0.agents.hermes_provision`, duplicated for the same reason
+#: :data:`HERMES_CONFIG_PATH` is: this pass must stay importable from the
+#: post-swap subprocess without pulling the provisioning module in at import
+#: time. The one place that module IS needed — an actual repair — imports it
+#: lazily, inside the branch that has already proven the box is broken.
+HERMES_VENV_PATH = Path("/var/lib/hal0/venvs/hermes")
+
+#: What an operator runs by hand when the automatic repair could not (no
+#: network during the update, a resolver conflict). Logged with the failure so
+#: the remedy travels with the diagnosis — the omission #2102 is partly about.
+HERMES_VENV_REMEDY = "hal0 agent reprovision hermes --repair"
+
+
+def repair_hermes_mcp_client(
+    *,
+    job_id: str | None = None,
+    venv: Path | None = None,
+    install: bool = True,
+    restart_gateway: bool = True,
+) -> bool:
+    """Reinstall a hermes venv whose MCP client cannot import (#2102).
+
+    :func:`repair_hermes_mcp_headers` heals the YAML half of "the agent has no
+    memory tools". This is the other half, and it reaches the same population:
+    a venv that drifted off the vetted pin — no ``mcp`` package at all, the
+    residual of #2021 — survives every upgrade untouched, because nothing
+    outside provisioning ever re-converges the venv and ``hal0 update`` never
+    provisions. Measured on ct150 during the rc.12 lane: the #2090 header
+    repair landed correctly and the live client still failed at 7181 ms with
+    ``mcp.client.streamable_http is not available``.
+
+    The diagnosis is the provisioner's own import assertion
+    (``_probe_mcp_client`` with no URL — no server round-trip, just "can this
+    interpreter import the client stack"), and the cure is the provisioner's
+    own venv install. Both are reused rather than reimplemented, so a repaired
+    box lands on exactly the state a fresh install produces.
+
+    ``install=False`` diagnoses without touching the venv. The boot-time safety
+    net passes it: :func:`check_outstanding_migrations` runs on every
+    ``hal0-api`` start, crash-restarts included, and a pip run in that path
+    would put an unbounded network operation in the startup of a box that is
+    already unhealthy. There it logs the fault and the remedy instead, and the
+    next real update repairs it.
+
+    Verification is a re-probe, never pip's exit code: the #2021 lesson is that
+    an install step reporting success over an unusable artefact is precisely
+    how this class hides. Returns ``True`` only when the client imports
+    afterwards.
+
+    Every failure is a quiet ``False``. An absent venv (no hermes on this box),
+    a pip that cannot resolve, a repair that does not take — none of them is a
+    reason to fail an update, and each leaves the box no worse than it was.
+    """
+    venv = venv or HERMES_VENV_PATH
+    venv_python = venv / "bin" / "python"
+    if not venv_python.exists():
+        log.debug("updater.hermes_venv_absent", job_id=job_id, venv=str(venv))
+        return False
+
+    # Lazy: see HERMES_VENV_PATH. Only a box that reaches this line pays for it.
+    from hal0.agents import hermes_provision as hermes
+
+    try:
+        before = hermes._probe_mcp_client(venv_python, None, agent_id="hermes")
+    except Exception as exc:
+        log.warning("updater.hermes_mcp_client_probe_failed", job_id=job_id, error=str(exc))
+        return False
+    if before.get("ok"):
+        return False
+
+    log.warning(
+        "updater.hermes_mcp_client_broken",
+        job_id=job_id,
+        stage=before.get("stage"),
+        error=before.get("error"),
+        remedy=HERMES_VENV_REMEDY,
+        repairing=install,
+    )
+    if not install:
+        return False
+
+    try:
+        hermes._install_venv(venv, hermes.HERMES_REQUIREMENTS)
+    except Exception as exc:
+        log.warning(
+            "updater.hermes_venv_repair_failed",
+            job_id=job_id,
+            error=str(exc),
+            remedy=HERMES_VENV_REMEDY,
+        )
+        return False
+
+    try:
+        after = hermes._probe_mcp_client(venv_python, None, agent_id="hermes")
+    except Exception as exc:
+        log.warning("updater.hermes_mcp_client_probe_failed", job_id=job_id, error=str(exc))
+        return False
+    if not after.get("ok"):
+        log.warning(
+            "updater.hermes_venv_repair_ineffective",
+            job_id=job_id,
+            stage=after.get("stage"),
+            error=after.get("error"),
+            remedy=HERMES_VENV_REMEDY,
+        )
+        return False
+
+    log.info("updater.hermes_venv_repaired", job_id=job_id, venv=str(venv))
+
+    if restart_gateway:
+        # Same reason as the header repair: hermes builds its MCP client at
+        # start, so a running gateway keeps the broken one until it bounces.
+        try:
+            subprocess.run(
+                ["systemctl", "restart", "hermes-gateway.service"],
+                check=False,
+                capture_output=True,
+                timeout=120,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            log.warning("updater.hermes_gateway_bounce_failed", job_id=job_id, error=str(exc))
+
+    return True
+
+
 def run_post_activation_migrations(
     min_data_version: int = 1,
     *,
     job_id: str | None = None,
     ceiling: int | None = None,
     skip_image_retag: bool = False,
+    repair_hermes_venv: bool = True,
 ) -> tuple[int, int]:
     """Run every post-activation migration pass hal0 ships, in order.
 
@@ -1826,6 +1953,13 @@ def run_post_activation_migrations(
         # before this pass existed, and never a reason to fail an update.
 
     try:
+        repair_hermes_mcp_client(job_id=job_id, install=repair_hermes_venv)
+    except Exception as exc:
+        log.warning("updater.hermes_venv_repair_pass_failed", job_id=job_id, error=str(exc))
+        # Non-fatal, same posture as the header repair above: the box keeps
+        # the venv it had and the logged remedy names the manual repair.
+
+    try:
         relabel_stale_vulkan_slots(job_id=job_id)
     except Exception as exc:
         log.warning("updater.vulkan_migration_failed", job_id=job_id, error=str(exc))
@@ -1897,7 +2031,12 @@ def check_outstanding_migrations(*, job_id: str | None = None) -> tuple[int, int
     try:
         reset_outstanding = bool(profile_reset_status().get("due"))
         ceiling = PROFILE_CATALOG_SCHEMA_VERSION - 1 if reset_outstanding else None
-        return run_post_activation_migrations(job_id=job_id, ceiling=ceiling, skip_image_retag=True)
+        return run_post_activation_migrations(
+            job_id=job_id,
+            ceiling=ceiling,
+            skip_image_retag=True,
+            repair_hermes_venv=False,
+        )
     except Exception as exc:
         log.warning("updater.boot_migration_check_failed", job_id=job_id, error=str(exc))
         return None

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -304,9 +304,17 @@ def test_home_init_converges_on_second_run(tmp_path: Path) -> None:
     assert (hermes_home / "config.yaml").read_text() == "# operator file"
 
 
-def test_install_phase_skips_venv_when_binary_exists(
+def test_install_phase_skips_venv_when_binary_exists_and_client_imports(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """A converged venv is left alone — binary present AND client importable.
+
+    Re-baselined for #2102: the skip used to key on ``bin/hermes`` existing
+    alone, which is what let a venv with no ``mcp`` package sail through the
+    install phase and fail at ``mcp_wire``. The probe is injected healthy here
+    so this test still covers what it was written to cover (a converged venv is
+    not rebuilt); the drift case has its own test below.
+    """
     venv = tmp_path / "venv"
     (venv / "bin").mkdir(parents=True)
     (venv / "bin" / "hermes").write_text("#!/bin/sh\nexit 0\n")
@@ -324,10 +332,24 @@ def test_install_phase_skips_venv_when_binary_exists(
     def _no_install(*args: Any, **kwargs: Any) -> None:
         called.append(args)
 
-    out = hp._phase_install(hp._StepCtx(state=state, io=hp.InstallIO(install_venv=_no_install)))
+    out = hp._phase_install(
+        hp._StepCtx(
+            state=state,
+            io=hp.InstallIO(
+                install_venv=_no_install,
+                probe_mcp_client=lambda *_a, **_kw: {
+                    "ok": True,
+                    "stage": "import",
+                    "tools": [],
+                    "error": None,
+                },
+            ),
+        )
+    )
     assert out.status == hp.PhaseStatus.OK
-    # Venv binary already present → the venv build is skipped entirely.
+    # Venv binary present and its MCP client imports → no rebuild.
     assert called == []
+    assert "venv_reinstalled_reason" not in out.details
     # Canonical `hermes` wrapper is installed (the hal0-hermes back-compat
     # symlink is retired).
     assert hermes_cli_dst.is_file()
@@ -338,6 +360,57 @@ def test_install_phase_skips_venv_when_binary_exists(
     assert (hermes_home / "plugins" / "hal0-memory" / "__init__.py").is_file()
     assert (hermes_home / "plugins" / "model-providers" / "hal0" / "__init__.py").is_file()
     assert not any("hal0-provider" in s for s in out.details.get("plugins_skipped", []))
+
+
+def test_install_phase_reinstalls_a_venv_whose_mcp_client_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#2102: ``bin/hermes`` existing is not proof the venv is usable.
+
+    A venv that drifted off the vetted pin has the binary and no ``mcp``
+    package, so the old existence gate skipped the install, reported
+    ``install: ok``, and left ``mcp_wire`` to hard-fail over the very artefact
+    the previous phase had just blessed. The operator was then told
+    ``bootstrap failed in steps: mcp_wire`` with no remedy named, while plain
+    ``hal0 agent reprovision hermes`` could not fix it and ``--repair`` — which
+    could — advertised itself as a persona/config re-run.
+
+    The phase now re-runs the install when the venv cannot import the client,
+    with no ``--repair`` needed: the provisioner already knows both the
+    diagnosis and the cure.
+    """
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "hermes").write_text("#!/bin/sh\nexit 0\n")
+    (venv / "bin" / "hermes").chmod(0o755)
+
+    monkeypatch.setattr(hp, "WRAPPER_INSTALL_PATH", tmp_path / "usr" / "local" / "bin" / "hal0-hermes")
+    monkeypatch.setattr(hp, "HERMES_CLI_INSTALL_PATH", tmp_path / "usr" / "local" / "bin" / "hermes")
+    state = hp.BootstrapState(venv=str(venv), hermes_home=str(tmp_path / "hermes_home"))
+
+    install_calls: list[Path] = []
+
+    def _fake_install(v: Path, _req: Path, **_kwargs: Any) -> None:
+        install_calls.append(v)
+
+    out = hp._phase_install(
+        hp._StepCtx(
+            state=state,
+            io=hp.InstallIO(
+                install_venv=_fake_install,
+                probe_mcp_client=lambda *_a, **_kw: {
+                    "ok": False,
+                    "stage": "import",
+                    "tools": [],
+                    "error": "ModuleNotFoundError: No module named 'mcp'",
+                },
+            ),
+        )
+    )
+
+    assert out.status == hp.PhaseStatus.OK
+    assert install_calls == [venv]
+    assert out.details["venv_reinstalled_reason"] == "mcp client import failed"
 
 
 def test_install_phase_runs_venv_install_when_binary_missing(

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -384,8 +384,12 @@ def test_install_phase_reinstalls_a_venv_whose_mcp_client_is_missing(
     (venv / "bin" / "hermes").write_text("#!/bin/sh\nexit 0\n")
     (venv / "bin" / "hermes").chmod(0o755)
 
-    monkeypatch.setattr(hp, "WRAPPER_INSTALL_PATH", tmp_path / "usr" / "local" / "bin" / "hal0-hermes")
-    monkeypatch.setattr(hp, "HERMES_CLI_INSTALL_PATH", tmp_path / "usr" / "local" / "bin" / "hermes")
+    monkeypatch.setattr(
+        hp, "WRAPPER_INSTALL_PATH", tmp_path / "usr" / "local" / "bin" / "hal0-hermes"
+    )
+    monkeypatch.setattr(
+        hp, "HERMES_CLI_INSTALL_PATH", tmp_path / "usr" / "local" / "bin" / "hermes"
+    )
     state = hp.BootstrapState(venv=str(venv), hermes_home=str(tmp_path / "hermes_home"))
 
     install_calls: list[Path] = []

--- a/tests/updater/test_hermes_venv_repair.py
+++ b/tests/updater/test_hermes_venv_repair.py
@@ -1,0 +1,137 @@
+"""``repair_hermes_mcp_client`` — heal a drifted hermes venv on upgrade (#2102).
+
+rc.12 shipped the fleet repair for #2090: ``hal0 update`` rewrites the poisoned
+``X-hal0-Private`` header so an upgraded box gets its memory tools back. That
+pass is YAML-only, and it is not the only way a box ends up with zero memory
+tools. A venv that drifted off the vetted pin — no ``mcp`` package at all, the
+residual population of #2021 — survives every upgrade untouched: the header is
+correct, the client cannot import, and the agent runs on with no memory tools.
+
+Measured on ct150 during the rc.12 lane: header quoted by the #2090 pass, and
+``hermes mcp test hal0-memory`` still failed at 7181 ms with
+"mcp.client.streamable_http is not available". The remedy existed
+(``hal0 agent reprovision hermes --repair``) but nothing named it.
+
+So the capability check belongs beside the header repair, in the sequence both
+upgrade paths already converge on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.agents import hermes_provision as hp
+from hal0.updater.updater import repair_hermes_mcp_client
+
+
+def _venv(tmp_path: Path) -> Path:
+    venv = tmp_path / "venvs" / "hermes"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").write_text("#!/bin/sh\nexit 0\n")
+    return venv
+
+
+def _probe(verdicts: list[dict[str, Any]], seen: list[Path]) -> Any:
+    def _fake(venv_python: Path, url: str | None, **_kw: Any) -> dict[str, Any]:
+        seen.append(venv_python)
+        return verdicts.pop(0) if len(verdicts) > 1 else verdicts[0]
+
+    return _fake
+
+
+OK = {"ok": True, "stage": "import", "tools": [], "error": None}
+BROKEN = {
+    "ok": False,
+    "stage": "import",
+    "tools": [],
+    "error": "ModuleNotFoundError: No module named 'mcp'",
+}
+
+
+def test_reinstalls_the_venv_when_its_mcp_client_cannot_import(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    venv = _venv(tmp_path)
+    installs: list[tuple[Path, Path]] = []
+    probes: list[Path] = []
+
+    def _install(target: Path, requirements: Path, **_kw: Any) -> None:
+        installs.append((target, requirements))
+
+    monkeypatch.setattr(hp, "_probe_mcp_client", _probe([BROKEN, OK], probes))
+    monkeypatch.setattr(hp, "_install_venv", _install)
+
+    repaired = repair_hermes_mcp_client(venv=venv, restart_gateway=False)
+
+    assert repaired is True
+    assert [target for target, _ in installs] == [venv]
+    assert installs[0][1] == hp.HERMES_REQUIREMENTS
+    # Probed before repairing, then again to prove the repair took.
+    assert probes == [venv / "bin" / "python", venv / "bin" / "python"]
+
+
+def test_a_working_client_is_left_alone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    venv = _venv(tmp_path)
+    installs: list[Path] = []
+
+    monkeypatch.setattr(hp, "_probe_mcp_client", _probe([OK], []))
+    monkeypatch.setattr(hp, "_install_venv", lambda target, _req, **_kw: installs.append(target))
+
+    assert repair_hermes_mcp_client(venv=venv, restart_gateway=False) is False
+    assert installs == []
+
+
+def test_reports_without_installing_when_repair_is_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The boot-time safety net diagnoses; it must not pip-install at startup.
+
+    ``check_outstanding_migrations`` runs on every ``hal0-api`` boot, including
+    crash-restarts. A network install there would put an unbounded, failing
+    pip run in the startup path of a box that is already unhealthy.
+    """
+    venv = _venv(tmp_path)
+    installs: list[Path] = []
+
+    monkeypatch.setattr(hp, "_probe_mcp_client", _probe([BROKEN], []))
+    monkeypatch.setattr(hp, "_install_venv", lambda target, _req, **_kw: installs.append(target))
+
+    assert repair_hermes_mcp_client(venv=venv, install=False, restart_gateway=False) is False
+    assert installs == []
+
+
+def test_absent_venv_is_a_quiet_no_op(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A box with no hermes install must not have its update disturbed."""
+    probed: list[Path] = []
+    monkeypatch.setattr(hp, "_probe_mcp_client", _probe([BROKEN], probed))
+
+    assert repair_hermes_mcp_client(venv=tmp_path / "nope", restart_gateway=False) is False
+    assert probed == []
+
+
+def test_a_failed_reinstall_does_not_raise(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """pip can fail (no network, resolver conflict) — an update must survive it."""
+    venv = _venv(tmp_path)
+
+    def _boom(*_a: Any, **_kw: Any) -> None:
+        raise RuntimeError("pip exploded")
+
+    monkeypatch.setattr(hp, "_probe_mcp_client", _probe([BROKEN], []))
+    monkeypatch.setattr(hp, "_install_venv", _boom)
+
+    assert repair_hermes_mcp_client(venv=venv, restart_gateway=False) is False
+
+
+def test_a_reinstall_that_does_not_heal_reports_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only a re-probe proves the repair worked — pip exiting 0 does not."""
+    venv = _venv(tmp_path)
+
+    monkeypatch.setattr(hp, "_probe_mcp_client", _probe([BROKEN], []))
+    monkeypatch.setattr(hp, "_install_venv", lambda *_a, **_kw: None)
+
+    assert repair_hermes_mcp_client(venv=venv, restart_gateway=False) is False

--- a/tests/updater/test_post_activation_migrations.py
+++ b/tests/updater/test_post_activation_migrations.py
@@ -18,7 +18,7 @@ from typing import Any
 import pytest
 
 from hal0.errors import Hal0Error
-from hal0.updater.updater import run_post_activation_migrations
+from hal0.updater.updater import check_outstanding_migrations, run_post_activation_migrations
 
 
 @pytest.fixture(autouse=True)
@@ -32,6 +32,7 @@ def _stub_every_pass(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
         "vulkan_migration": [],
         "image_retag": [],
         "extra_args": [],
+        "hermes_venv": [],
     }
 
     def _config_migrations(min_data_version, *, job_id=None, ceiling=None):
@@ -58,12 +59,17 @@ def _stub_every_pass(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
         calls["extra_args"].append(job_id)
         return 0
 
+    def _hermes_venv(*, job_id=None, install=True, venv=None, restart_gateway=True):
+        calls["hermes_venv"].append((job_id, install))
+        return False
+
     monkeypatch.setattr("hal0.updater.updater._maybe_run_config_migrations", _config_migrations)
     monkeypatch.setattr("hal0.updater.updater.ensure_seed_profiles", _seed_profiles)
     monkeypatch.setattr("hal0.updater.updater.clear_stale_mtp_overrides", _mtp)
     monkeypatch.setattr("hal0.updater.updater.relabel_stale_vulkan_slots", _vulkan_migration)
     monkeypatch.setattr("hal0.updater.updater.retag_stale_slot_images", _image_retag)
     monkeypatch.setattr("hal0.updater.updater.sanitize_model_extra_args", _extra_args)
+    monkeypatch.setattr("hal0.updater.updater.repair_hermes_mcp_client", _hermes_venv)
     return calls
 
 
@@ -139,3 +145,32 @@ def test_schema_migration_failure_propagates(
     assert _stub_every_pass["vulkan_migration"] == []
     assert _stub_every_pass["image_retag"] == []
     assert _stub_every_pass["extra_args"] == []
+
+
+def test_update_path_repairs_a_drifted_hermes_venv(
+    _stub_every_pass: dict[str, list[Any]],
+) -> None:
+    """#2102: an upgrade heals a venv whose MCP client cannot import.
+
+    rc.12's #2090 pass repairs the config header only, so a box whose venv
+    drifted off the vetted pin (the residual of #2021) came out of a
+    successful ``hal0 update`` still holding zero memory tools.
+    """
+    run_post_activation_migrations(job_id="j1")
+    assert _stub_every_pass["hermes_venv"] == [("j1", True)]
+
+
+def test_boot_safety_net_diagnoses_the_venv_without_installing(
+    _stub_every_pass: dict[str, list[Any]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The boot path must not put a pip install in ``hal0-api``'s startup.
+
+    ``check_outstanding_migrations`` runs on every start, crash-restarts
+    included. It still probes — the fault and its remedy get logged — but the
+    repair itself waits for a real update.
+    """
+    monkeypatch.setattr("hal0.updater.updater.profile_reset_status", lambda: {"due": False})
+
+    check_outstanding_migrations(job_id="boot")
+
+    assert _stub_every_pass["hermes_venv"] == [("boot", False)]

--- a/tests/updater/test_post_swap_migrations.py
+++ b/tests/updater/test_post_swap_migrations.py
@@ -295,7 +295,7 @@ def test_zero_exit_with_no_envelope_raises_update_error(monkeypatch: pytest.Monk
 def test_never_raises_on_internal_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
 
-    def _boom(*, job_id=None, ceiling=None, skip_image_retag=False):
+    def _boom(*, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True):
         raise RuntimeError("disk full")
 
     monkeypatch.setattr(updater_module, "run_post_activation_migrations", _boom)
@@ -308,7 +308,7 @@ def test_forwards_the_real_migration_result_on_success(monkeypatch: pytest.Monke
     monkeypatch.setattr(
         updater_module,
         "run_post_activation_migrations",
-        lambda *, job_id=None, ceiling=None, skip_image_retag=False: (1, 2),
+        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True: (1, 2),
     )
 
     assert check_outstanding_migrations(job_id="boot") == (1, 2)
@@ -325,7 +325,7 @@ def test_caps_the_ceiling_while_the_profile_catalog_reset_is_outstanding(
     monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": True})
     seen: dict[str, Any] = {}
 
-    def _fake_migrations(*, job_id=None, ceiling=None, skip_image_retag=False):
+    def _fake_migrations(*, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True):
         seen["ceiling"] = ceiling
         return (1, 1)
 
@@ -339,7 +339,7 @@ def test_no_ceiling_when_the_reset_is_not_due(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
     seen: dict[str, Any] = {}
 
-    def _fake_migrations(*, job_id=None, ceiling=None, skip_image_retag=False):
+    def _fake_migrations(*, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True):
         seen["ceiling"] = ceiling
         return (1, 1)
 
@@ -356,7 +356,7 @@ def test_never_calls_reset_profile_catalog(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(
         updater_module,
         "run_post_activation_migrations",
-        lambda *, job_id=None, ceiling=None, skip_image_retag=False: (1, 1),
+        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True: (1, 1),
     )
 
     def _unexpected(**kwargs: Any) -> None:
@@ -375,7 +375,7 @@ def test_skips_the_image_retag_pass(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
     seen: dict[str, Any] = {}
 
-    def _fake_migrations(*, job_id=None, ceiling=None, skip_image_retag=False):
+    def _fake_migrations(*, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True):
         seen["skip_image_retag"] = skip_image_retag
         return (1, 1)
 

--- a/tests/updater/test_post_swap_migrations.py
+++ b/tests/updater/test_post_swap_migrations.py
@@ -308,7 +308,10 @@ def test_forwards_the_real_migration_result_on_success(monkeypatch: pytest.Monke
     monkeypatch.setattr(
         updater_module,
         "run_post_activation_migrations",
-        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True: (1, 2),
+        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True: (
+            1,
+            2,
+        ),
     )
 
     assert check_outstanding_migrations(job_id="boot") == (1, 2)
@@ -325,7 +328,9 @@ def test_caps_the_ceiling_while_the_profile_catalog_reset_is_outstanding(
     monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": True})
     seen: dict[str, Any] = {}
 
-    def _fake_migrations(*, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True):
+    def _fake_migrations(
+        *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True
+    ):
         seen["ceiling"] = ceiling
         return (1, 1)
 
@@ -339,7 +344,9 @@ def test_no_ceiling_when_the_reset_is_not_due(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
     seen: dict[str, Any] = {}
 
-    def _fake_migrations(*, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True):
+    def _fake_migrations(
+        *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True
+    ):
         seen["ceiling"] = ceiling
         return (1, 1)
 
@@ -356,7 +363,10 @@ def test_never_calls_reset_profile_catalog(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(
         updater_module,
         "run_post_activation_migrations",
-        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True: (1, 1),
+        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True: (
+            1,
+            1,
+        ),
     )
 
     def _unexpected(**kwargs: Any) -> None:
@@ -375,7 +385,9 @@ def test_skips_the_image_retag_pass(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
     seen: dict[str, Any] = {}
 
-    def _fake_migrations(*, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True):
+    def _fake_migrations(
+        *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True
+    ):
         seen["skip_image_retag"] = skip_image_retag
         return (1, 1)
 


### PR DESCRIPTION
Closes #2102.

## What was broken

rc.12 exists to repair boxes that are already installed, and its #2090 pass repairs the config
header only. A hermes venv that drifted off the vetted pin — no `mcp` package at all, the
residual population of #2021 — survives every upgrade untouched. The header is correct, the
client cannot import, and the agent runs on with **zero memory tools**, while nothing keyed on
`provision.json` notices (its `mcp_wire` counts the *server's* tools, not the client's).

Two independent gaps, both closed here:

1. **`hal0 update` could not see it.** `repair_hermes_mcp_headers` is YAML-only; `mcp_wire` — the
   phase carrying the #2021 client-import assertion — runs during provisioning, which `hal0
   update` never triggers.
2. **`hal0 agent reprovision hermes` detected it and refused to fix it.** The venv install was
   skipped whenever `bin/hermes` existed, so the run recorded `install: ok` and then hard-failed
   at `mcp_wire` over the very venv the previous phase had just blessed — naming no remedy, while
   plain `reprovision` could not fix it and `--repair`, which could, advertised itself as a
   persona/config re-run.

## The fix

**`repair_hermes_mcp_client`** joins the migration sequence beside the header repair — the one
sequence `hal0 update` and `install.sh`'s upgrade-in-place both converge on. It reuses the
provisioner's own import assertion for the diagnosis (`_probe_mcp_client` with no URL: no server
round-trip, just "can this interpreter import the client stack") and the provisioner's own venv
install for the cure, so a repaired box lands on exactly the state a fresh install produces.

Verification is a **re-probe, never pip's exit code**. The #2021 lesson is that an install step
reporting success over an unusable artefact is precisely how this class hides.

Every failure is a quiet `False` that logs the manual remedy: an absent venv (no hermes on this
box), a pip that cannot resolve, a repair that does not take. None of them is a reason to fail an
update, and each leaves the box no worse than it was.

**The boot-time safety net passes `repair_hermes_venv=False`.** `check_outstanding_migrations`
runs on every `hal0-api` start, crash-restarts included; a pip run there would put an unbounded
network operation in the startup path of a box that is already unhealthy. It diagnoses, logs the
fault and the remedy, and leaves the repair to the next real update.

**The provisioning gate now asks whether the venv works**, not just whether the binary exists —
so plain `hal0 agent reprovision hermes` heals a drifted box with no `--repair` needed. Plus the
two small honesty fixes the issue asks for: `mcp_wire`'s failure reason names
`hal0 agent reprovision hermes --repair`, and `--repair`'s help says it rebuilds the venv.

## Verified on a real box

ct151 (fresh rc.12), reproducing the exact ct150 signature:

```
$ /var/lib/hal0/venvs/hermes/bin/pip uninstall -y mcp
Successfully uninstalled mcp-1.26.0

$ hermes mcp test hal0-memory
  ✗ Connection failed (7098ms): ... mcp.client.streamable_http is not available.

$ python -c "from hal0.updater.updater import repair_hermes_mcp_client; \
             print('repaired:', repair_hermes_mcp_client(restart_gateway=False))"
Successfully installed mcp-1.26.0
[info] updater.hermes_venv_repaired venv=/var/lib/hal0/venvs/hermes
repaired: True

$ hermes mcp test hal0-memory
  ✓ Connected (36ms)
  ✓ Tools discovered: 26
```

Then re-broken, to prove gap 2 independently:

```
$ /var/lib/hal0/venvs/hermes/bin/pip uninstall -y mcp
$ hal0 agent reprovision hermes            # no --repair
Successfully installed mcp-1.26.0
EXIT=0
$ hermes mcp test hal0-memory
  ✓ Connected (67ms)  /  ✓ Tools discovered: 26
```

ct151 was restored to stock rc.12 code afterwards (`has_new_fn: False`), services active.

## Tests

Written red-first. `tests/updater/test_hermes_venv_repair.py` covers the repair itself: reinstall
on a failed import, no-op on a healthy client, diagnose-without-installing under `install=False`,
quiet no-op with no venv, survival of a pip that raises, and `False` when a reinstall does not
actually heal. `tests/agents/test_hermes_provision.py` gains the drift case for the install
phase. Wiring is pinned in `tests/updater/test_post_activation_migrations.py` — update path
repairs, boot path only diagnoses — and both wiring tests were proven red by removing the call.

Suite: `tests/updater tests/agents tests/cli tests/installer` → **2870 passed**, 1 failed
(`test_avahi_hostname.py::test_no_avahi_on_the_box_is_a_silent_noop`, pre-existing on this
workstation because it runs avahi; green in CI).

**One re-baselined test**, called out rather than buried:
`test_install_phase_skips_venv_when_binary_exists` asserted the skip on binary existence alone —
which *is* the defect. It now injects a healthy probe and asserts the skip on "binary present and
client imports", keeping the convergence coverage it was written for, and the drift case gets its
own test.

## Not done here

`install: ok` is still recorded when the phase reinstalled nothing and a later phase rejects the
artefact — with this change that pair can no longer occur for the MCP-client cause, but the
general "phase reports ok over work it skipped" shape remains. Likewise nothing verifies the
*installed* hermes-agent against `VETTED_HERMES_REFS` (only the requirement file is vetted),
which is how 0.19.0 persisted unnoticed on ct150. Both are worth their own issue rather than
widening this one.
