### PR TITLE
docs: platform-wide 1.0 sweep — new surfaces, corrections, dead-link repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,9 +87,6 @@ rationale and code-path detail in the
 - **NPU trio dispatch reads the anchor's `[npu]` table, not the shadow slots' own flags.**
   `flm-stt`/`flm-embed` are display+dispatch records for the anchor's single
   `flm serve` process; a modality that was never launched is no longer routable.
-- **`[brain_chat] tool_model` is removed — it was never read.**
-  A config that sets it explicitly now fails validation with a clear error;
-  the live `[brain_chat] model` override is the real steering knob.
 - **Deprecated surfaces are `HAL0-SUNSET`-stamped for scheduled removal:**
   the `--backend` flag (use `--provider`), `SlotConfig.runtime`/`workers`,
   the `cognee` engine literal, and several legacy CLI aliases.
@@ -110,8 +107,6 @@ full detail in the
   just loses the key. Idempotent; the CLI form is dry-run by default and safe live.
 - **Slot id-keying (operator-run, optional): run `hal0 slot migrate-id-keying` in a downtime window (takes a pre-flight backup).**
   The runtime reads either layout; the flip is deliberate and reversible.
-- **A stale `[brain_chat] tool_model` key in `hal0.toml` no longer breaks config load.**
-  `load_hal0_config` drops it before validation on every load path.
 - **Disabling a capability now clears the slot's model instead of writing `enabled = false`.**
   The pick survives in `capabilities.toml` and a re-enable rebinds it.
 - **Honcho → Hindsight (only boxes that ran Honcho): no migration step — Honcho support was removed outright and Hindsight starts fresh.**
@@ -206,6 +201,18 @@ full detail in the
   exempts a slot entirely.
 
 ### Changed
+
+- **`[brain_chat] tool_model` is a real steering knob again, and this time it
+  is wired.** #1453 deleted the field in `1.0.0-rc.1` because nothing read it;
+  #1644 brought it back with an implementation behind it. Tool rounds now run
+  on `tool_model` (default `hal0/agent`) while chat stays on the brain slot,
+  so a brain model whose runner cannot emit parseable tool calls reroutes
+  instead of failing the turn. Set it to `off`, `none` or `disabled` to route
+  tool turns nowhere — an empty string is *not* a disable spelling, because on
+  disk it is indistinguishable from a key nobody set, and it coerces back to
+  the default with a warning. `[brain_chat] model` still points the whole
+  steward chat at one model. Boxes coming from 0.9.8 see no schema change
+  here: the key existed there too (as a no-op) and is accepted now.
 
 - Slot drawer: the Profile field moved into the Model group, directly under
   the model select (it rides the model choice). NPU slots keep a standalone

--- a/README.md
+++ b/README.md
@@ -31,16 +31,19 @@ process to babysit.
 curl -fsSL https://hal0.dev/install.sh | sudo bash
 ```
 
+> **v1.0.0 is the GA release.** It is what the `stable` channel has been
+> waiting for since 0.9.8 shipped on 2026-07-13: the 1.0 line ran rc.1
+> through rc.12 on `preview`, each candidate validated on a real-hardware
+> fleet. From v1.0.0 the project follows semver proper. If you are upgrading
+> from 0.9.8, read [Upgrading from 0.9.8](#upgrading-from-098) first — that
+> hop has three specific gotchas. Boxes already on a late rc get an ordinary
+> `hal0 update` with nothing special to do.
+
 > **⚡ The installer is the whole setup.** There is no separate first-run
 > wizard afterwards. `install.sh` asks where models should live, optionally
 > takes a HuggingFace token, seeds every capability slot, downloads the hal0
 > brain steward model, and starts the API. When it finishes, open the
 > dashboard and assign models to slots.
-
-> **Status: release candidate — `v1.0.0-rc.7`.** v1.0.0 stable is the target
-> of the current cut. Every release candidate is validated on a real-hardware
-> fleet before the next cut; see [`CHANGELOG.md`](./CHANGELOG.md) for what
-> each candidate closed.
 
 ## Screenshots
 
@@ -69,6 +72,197 @@ curl -fsSL https://hal0.dev/install.sh | sudo bash
 <sub>More in the <a href="https://hal0.dev/docs/">docs</a>.</sub>
 
 </div>
+
+## Install
+
+### The one-liner
+
+```sh
+curl -fsSL https://hal0.dev/install.sh | sudo bash
+```
+
+That fetches `installer/bootstrap.sh`, which needs `jq` and `cosign` on the
+box. It authenticates the channel manifest before parsing it, sha256- and
+Sigstore-bundle-verifies the release tarball, then hands off to
+[`installer/install.sh`](./installer/install.sh). Piped through `bash` it
+never prompts. Re-running it is safe: every provisioning step is idempotent
+and existing slot configs are never overwritten.
+
+Pick a channel with `HAL0_CHANNEL` (`stable` is the default; `preview` and
+`nightly` are the other two):
+
+```sh
+curl -fsSL https://hal0.dev/install.sh | sudo HAL0_CHANNEL=preview bash
+```
+
+### What the installer actually does
+
+1. **Pre-flight** — systemd, Python 3.12–3.14, x86_64, a container runtime
+   (podman preferred, auto-installed), GPU/NPU device visibility, disk space,
+   free ports.
+2. **Code + venv** — a versioned tree under `/usr/lib/hal0/` with a `current`
+   symlink and a shared venv.
+3. **Config** — `/etc/hal0/` with `hal0.toml`, `profiles.toml`, the ten
+   curated slot seeds, and `api.env`.
+4. **Hardware probe** — writes `/etc/hal0/hardware.json` and prints the
+   detected backends.
+5. **Brain steward model** — pulls the curated `lfm2.5-2.6b` (LiquidAI
+   LFM2.5-2.6B-Q8_0, ~2.87 GB, 131k context) and binds it to the `brain`
+   slot, so the dashboard's steward chat and its tool calls work out of the
+   box. On an interactive terminal only, it then *offers* a larger agent
+   model (15–31 GB, size printed first, default **No**).
+6. **ComfyUI share** — creates the bind-mount directories the `img` slot
+   needs and seeds custom nodes.
+7. **Service start** — enables and starts `hal0-api` + `hal0.target`, the
+   Hindsight memory engine, OpenWebUI on `:3001`, and the bundled Hermes
+   agent.
+
+Full step list and the complete env-var table:
+[`installer/README.md`](./installer/README.md).
+
+### Common install knobs
+
+| Variable / flag | Effect |
+|---|---|
+| `--models-dir=PATH` / `HAL0_MODELS_DIR=PATH` | Put model pulls somewhere other than `/var/lib/hal0/models` |
+| `HAL0_PORT=9090` | Bind the API somewhere other than `:8080` |
+| `HAL0_CHANNEL=preview` | Install from a channel other than `stable` |
+| `HAL0_NONINTERACTIVE=1` | Force flag/env defaults; never prompt, even on a TTY |
+| `HAL0_SKIP_SETUP=1` | Skip first-run seeding **and** both model steps |
+| `HAL0_SKIP_BRAIN_MODEL=1` | Keep the seeding, skip the brain pull (`brain` stays model-less) |
+| `HAL0_BRAIN_MODEL=<id>` | Force a specific curated brain quant |
+| `HAL0_PULL_AGENT_MODEL=1` / `=0` | Opt in to the big agent pull unattended / force-skip it on a TTY |
+| `HAL0_PY_AUTOINSTALL=1` | Let the installer install a compatible `python3.12` |
+| `HAL0_SKIP_HINDSIGHT=1`, `HAL0_SKIP_OPENWEBUI=1`, `HAL0_SKIP_HERMES=1`, `HAL0_SKIP_COMFYUI=1` | Skip individual companion services |
+| `--no-start` | Provision everything, leave services stopped |
+
+### Proxmox VE, one line
+
+On a Proxmox host:
+
+```sh
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/Hal0ai/hal0/main/scripts/proxmox-ve/hal0.sh)"
+```
+
+Creates an unprivileged Debian 13 LXC and runs the standard bootstrap inside
+it. `--advanced` opens whiptail prompts; every parameter has an env-var
+override (`CTID`, `RAM_MB`, `STORAGE`, …). Hardware-agnostic — Strix Halo
+passthrough still needs the privileged-LXC recipe. See
+[`scripts/proxmox-ve/README.md`](./scripts/proxmox-ve/README.md).
+
+### Uninstall
+
+```sh
+hal0 uninstall                 # prompts before deleting config + model data
+hal0 uninstall --keep-data     # keep /etc/hal0 and /var/lib/hal0
+```
+
+## First ten minutes
+
+The dashboard is at `http://<box>:8080`, the API at `http://<box>:8080/v1`.
+Assign models from the dashboard, or from the shell:
+
+```sh
+hal0 model pull <hf-repo>/<file.gguf>   # resumable, disk-preflighted
+hal0 slot load agent --model <id>       # bind a model and start the container
+hal0 status                             # system + slot summary
+hal0 chat --brain                       # terminal REPL against the steward
+```
+
+Then point any OpenAI-compatible client at the box:
+
+```sh
+curl http://<box>:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"<id>","messages":[{"role":"user","content":"hello"}]}'
+```
+
+`hal0 model pull` streams from Hugging Face into `registry.toml` under the
+`user.*` namespace — a disk-space preflight fails fast before a multi-GB
+pull, and an interrupted pull resumes via HTTP `Range` instead of restarting
+from zero.
+
+## What's new in 1.0
+
+### The whole platform is agent-reachable
+
+The admin MCP catalog went from 92 to **180 tools**: services lifecycle,
+ComfyUI, updater/doctor/health, hardware and request telemetry, the slots and
+models long-tail, bench, activity, approvals, runner images and NPU
+load/unload. The memory surface went from 5 tools to **26**, at feature parity
+with Hindsight 0.8.4 — including `memory_reflect` (LLM-backed synthesis),
+`memory_curate`/`memory_history` (the non-destructive "this is wrong"
+correction path), mental models, directives and async-operation polling.
+
+### Slots start when you say so
+
+New `autoload` setting: binding a model no longer implies a boot start. New
+eviction `priority` (0–100) replaces the inert `lru = true` opt-in, so
+memory-pressure eviction actually works on a stock box — pressure and
+pre-load eviction unload the lowest-priority slot first, LRU as the tie-break
+within a tier, and `pinned` still exempts a slot entirely.
+
+### Voice is a device-keyed switch
+
+Moonshine is back as the CPU STT engine in its own toolbox image. `cpu` runs
+Moonshine, `npu` runs whisper-v3:turbo, and a GPU device resolves to *no* STT
+engine instead of silently picking up a llama chat profile.
+
+### Image Gen and Slots got their lifecycle right
+
+State-typed engine indicators, a Stop that drives the GPU arbiter back to
+inference mode, dropdown-driven runner image / binary selection (picking an
+image repopulates the binary dropdown with what that image actually ships),
+and a `GET /api/slots` that no longer multiplies `podman inspect` fan-out on
+wide boxes.
+
+### Documentation moved into this repo
+
+`docs/` is the source of truth and publishes to hal0.dev through a mirror
+workflow, with a restored, v1.0-reconciled `getting-started/` section.
+
+### Stability work that landed in the rc line
+
+- **Hermes bootstrap MCP wiring actually works.** The seed TOML never
+  declared the builtin `[mcp.servers.*]` blocks, so the allow-list silently
+  skipped wiring both servers, and the post-wire probe double-appended `/mcp`
+  and 404ed. Bootstrap now also injects `HAL0_MCP_TOKEN` (0600) and renders
+  `Authorization: Bearer` into the Hermes MCP client config when the box has
+  auth on, refreshing it on `--repair` after a key rotation.
+- **ComfyUI `img` slot reliability.** Bind-mount dirs are created before
+  spawn (a missing tree crash-looped podman with exit 125), readiness waits
+  on ComfyUI's real `GET /system_stats` probe instead of 404-polling a
+  llama-style `/health` for 180 s, and the fail-watcher no longer strikes a
+  READY img slot to ERROR seconds after it comes up.
+- **`GET /api/slots` latency cut sharply on wide boxes** — no `podman
+  inspect` for stopped slots, TTL-cached `podman image inspect`, and a
+  single-flight 2 s snapshot that any slot mutation invalidates immediately.
+- **The Slots page no longer stalls on activity backfill** — the SSE stream
+  takes a `limit` and the client coalesces frame bursts into one render per
+  50 ms.
+- **Brain tool calls no longer 500** with `Unknown (built-in) filter 'min'`.
+  A corrected `hal0-brain-sft.jinja` ships bundled and the curated catalogue
+  stamps it into the model's `defaults.chat_template` at pull time.
+- **A drifted hermes venv re-converges on upgrade** instead of staying broken.
+
+### Quality-of-life
+
+- `hal0 doctor all` — one read-only pass over every surface with a rolled-up
+  verdict and an exit code you can branch on.
+- `hal0 doctor bundle` — a redacted support bundle in one command.
+- `hal0 doctor ports --fix` — prune stale netavark DNAT rules that black-hole
+  a port; it is the drill-down the `Slot ports` row used to lack.
+- `POST /api/profiles/generate` (`profile_generate` over MCP) drafts a profile
+  from a registered model or a HuggingFace repo, with an optional `use_llm`
+  pass that degrades to heuristics when inference is down.
+- Slot drawer: Profile moved under the model select (it rides the model
+  choice); Runner Image is a catalog dropdown with a "Custom image ref…"
+  escape hatch.
+- The `/mcp/memory` mount is now CLIENT-tier (was ADMIN), so memory-only
+  agents no longer need the platform-admin key.
+
+Breaking changes, migrations and known issues for this release are in
+[`CHANGELOG.md`](./CHANGELOG.md).
 
 ## Why hal0
 
@@ -117,10 +311,10 @@ services prewired to the local API and MCP servers.
 
 **Reliability bar.** Atomic env-file writes. Schema-validated TOML.
 Structured error envelopes (`{"error":{"code":"slot.not_ready",...}}`).
-Cosign-verified self-update with one-flag rollback. Per-type LRU concurrency
-with active-inference protection — a serving slot cannot be evicted out from
-under a streaming request. Privileged operations run through an allow-listed
-root seam, never a free-form shell.
+Cosign-verified self-update with one-flag rollback. Priority-ordered
+concurrency with active-inference protection — a serving slot cannot be
+evicted out from under a streaming request. Privileged operations run
+through an allow-listed root seam, never a free-form shell.
 
 ## Benchmarks
 
@@ -166,13 +360,13 @@ content-addressed, host-redacted archive you can attach anywhere, and
   `http://localhost:8080/v1` and go.
 - **Slots** — each named target carries a `type`
   (`llm | embedding | reranking | transcription | tts | image`), a `device`
-  (`gpu-rocm | gpu-vulkan | gpu-cuda | cpu | npu | img`), a `model`, plus
-  `enabled` and an optional `default`. Ten curated slots (`agent`, `brain`,
-  `coder`, `embed`, `flm`, `img`, `qwen3tts`, `rerank`, `tts`, `utility`)
-  are seeded into `/etc/hal0/slots/<name>.toml` on install and each gates on
-  its own runtime validation at load time — the `flm` NPU slot simply stays
-  grey without FastFlowLM hardware. Add your own with
-  `hal0 slot create NAME --type TYPE --model MODEL`. A deliberate
+  (`gpu-rocm | gpu-vulkan | gpu-cuda | cpu | npu`), a `model`, plus
+  `autoload`, an eviction `priority` and an optional `default`. Ten curated
+  slots (`agent`, `brain`, `coder`, `embed`, `flm`, `img`, `qwen3tts`,
+  `rerank`, `tts`, `utility`) are seeded into `/etc/hal0/slots/<name>.toml`
+  on install and each gates on its own runtime validation at load time — the
+  `flm` NPU slot simply stays grey without FastFlowLM hardware. Add your own
+  with `hal0 slot create NAME --type TYPE --model MODEL`. A deliberate
   `hal0 slot delete` is tombstoned, so re-running the installer never
   resurrects it.
 - **Model owns its tune** — since v1.0 the *model*, not the slot, owns
@@ -183,14 +377,6 @@ content-addressed, host-redacted archive you can attach anywhere, and
   `hal0-slot@<name>.service`, bound to a loopback port (8081–8099 + fixed
   seeds). `hal0-api` on `:8080` is the only control plane. See
   [docs/concepts/architecture.mdx](./docs/concepts/architecture.mdx).
-- **Provisioning lives in the installer** — `install.sh` is the single
-  user-facing entry point: model storage, optional HuggingFace token (on a
-  terminal only), curated slot seeds, the `brain` steward pull, an optional
-  agent-model offer, and service start. `HAL0_SKIP_SETUP=1` skips first-run
-  seeding, `HAL0_SKIP_BRAIN_MODEL=1` skips the brain pull, and
-  `HAL0_NONINTERACTIVE=1` suppresses both prompts. See
-  [`installer/README.md`](./installer/README.md) for the full step list and
-  env-var table.
 - **Hardware-aware probe** — detects GPU / NPU / unified memory, writes
   `/etc/hal0/hardware.json`, and surfaces VRAM/RAM fit warnings inline in
   the slot form and during install.
@@ -234,32 +420,17 @@ content-addressed, host-redacted archive you can attach anywhere, and
   `/usr/lib/hal0/current` symlink; `--rollback` reverts. Staging happens in
   a root-only directory with the authenticated digest pinned to the very
   file object the archive is extracted from.
-- **One-line install** — `curl -fsSL https://hal0.dev/install.sh | sudo bash`.
-  The only model it downloads is the `brain` steward; every other slot lands
-  model-less for you to fill. Piped through `bash` it never prompts.
-  (`--models-dir=PATH` or `HAL0_MODELS_DIR=PATH` redirects model pulls off
-  `/var/lib/hal0/models`.) The bootstrap requires `jq` and `cosign`,
-  authenticates the exact channel manifest before strict schema/channel
-  parsing, then sha256- and Sigstore-bundle-verifies the tarball before
-  handing off to [`installer/install.sh`](./installer/install.sh). Re-running
-  it is safe: every provisioning step is idempotent and existing slot
-  configs are never overwritten.
-- **One-line Proxmox VE install** — on a Proxmox host, `bash -c "$(curl
-  -fsSL https://raw.githubusercontent.com/Hal0ai/hal0/main/scripts/proxmox-ve/hal0.sh)"`
-  creates an unprivileged Debian 13 LXC and runs the standard bootstrap
-  inside it. `--advanced` opens whiptail prompts; every parameter has an
-  env-var override (`CTID`, `RAM_MB`, `STORAGE`, …). Hardware-agnostic —
-  Strix Halo passthrough still needs the privileged-LXC recipe. See
-  [`scripts/proxmox-ve/README.md`](./scripts/proxmox-ve/README.md).
 
 ### Agents, MCP, and the brain steward
 
 hal0 ships **two MCP servers** and **two bundled agents**. The MCP servers
 (`/mcp/admin` for slot / model / capability / config / hardware / log admin,
 `/mcp/memory` for Hindsight-backed long-term memory) are reachable by any
-MCP-speaking client — Claude Code, RAG services, your own scripts. Both
-bundled agents can be installed simultaneously: `pi-coder` (CLI shape, from
-the `Hal0ai/pi-mono` fork via `@earendil-works/pi-coding-agent` on npm) and
+MCP-speaking client — Claude Code, RAG services, your own scripts.
+`/mcp/admin` is ADMIN-tier; `/mcp/memory` is CLIENT-tier as of 1.0, so a
+memory-only agent does not need the platform-admin key. Both bundled agents
+can be installed simultaneously: `pi-coder` (CLI shape, from the
+`Hal0ai/pi-mono` fork via `@earendil-works/pi-coding-agent` on npm) and
 `Hermes-Agent` (service shape, via the hal0-owned `hermes` wrapper —
 `hal0-hermes` remains a back-compat symlink — connecting to `hal0-api` at
 `HAL0_INFERENCE_BASE=http://127.0.0.1:8080`). Install either with
@@ -278,10 +449,13 @@ a `POLICY_NO_LOOSEN` floor keeps destructive and secret-bearing tools
 persona edit can disarm them. Gated calls **pause the turn** for inline
 approve/deny. A `[brain_chat]` config gives operators a hard kill switch, a
 read-only mode, loop-budget knobs and a slot override (run the steward on
-any slot, e.g. `hal0/npu`) from **Settings → Agents / Brain**. The shipped
-brain models are native tool-callers, so the steward executes its own calls
-on the brain slot out of the box; binding a larger model to the `agent` slot
-is the optional upgrade path via the `[brain_chat]` `tool_model` fallback.
+any slot, e.g. `hal0/npu`) from **Settings → Agents / Brain**. The seeded
+brain model is a native tool-caller, so the steward executes its own calls on
+the `brain` slot out of the box. Binding a larger model to the `agent` slot is
+the optional upgrade path: `[brain_chat] tool_model` (default `hal0/agent`)
+runs tool rounds there while chat stays on the brain slot, so a runner that
+cannot emit parseable tool calls reroutes instead of failing the turn. Set it
+to `off`, `none` or `disabled` to route tool turns nowhere.
 
 See [docs/concepts/agents.mdx](./docs/concepts/agents.mdx),
 [docs/reference/mcp-tools.mdx](./docs/reference/mcp-tools.mdx) and
@@ -290,19 +464,44 @@ See [docs/concepts/agents.mdx](./docs/concepts/agents.mdx),
 ## Backends
 
 Each capability runs in its own container, supervised by
-`hal0-slot@<name>.service`. The profile in `/etc/hal0/profiles.toml` pins
-the flag bundle; the image is slot-owned.
+`hal0-slot@<name>.service`. Two things compose to launch a slot: the
+**runner image** (slot-owned — `image` plus `binary`) supplies the engine,
+and the **profile** in the catalog supplies the bench-tuned flag bundle.
+Profiles are device-agnostic tune templates; they no longer carry an image.
 
-| Capability               | Profile / image                  | Device              | Notes                                                        |
-|--------------------------|----------------------------------|---------------------|--------------------------------------------------------------|
-| chat + embed + rerank    | `rocm` / `rocm-dnse` / `rocm-moe` / `vulkan` / `cuda` (experimental) | ROCm / Vulkan / CUDA / CPU | ROCm FP4 fork baked into the image; MTP via `--spec-type draft-mtp` on the `rocm-dnse`/`rocm-moe` profiles |
-| chat + STT + embed (NPU) | `flm` (`hal0-toolbox-flm`)  | AMD XDNA (opt-in)   | FLM trio: one container, `[npu] asr/embed` toggles, ~2 GB NPU mem |
-| transcription            | `stt` (`hal0-toolbox-moonshine`) / FLM trio above | CPU / AMD XDNA | `voice.stt` switches Moonshine (CPU) ⇄ FLM's whisper-v3:turbo (NPU) without reconfiguring the slot; no GPU STT engine |
-| TTS                      | `tts` (`hal0-toolbox-kokoro`) / `tts-qwen3` (`hal0-toolbox-qwen3tts`) | CPU / ROCm | `voice.tts` switches Kokoro (CPU) ⇄ Qwen3-TTS (GPU) without reconfiguring the slot |
-| image                    | `comfyui` (`docker.io/kyuz0/amd-strix-halo-comfyui`) | ROCm | Exclusive GPU via arbiter; SD Turbo / Flux-2-Klein-9B        |
+| Capability | Runner (binary) | Device | Profile |
+|---|---|---|---|
+| chat | `rocmfpx`, `vulkanfpx` (`llama-server`) | `gpu-rocm`, `gpu-vulkan` | `chat`, `chat-long-context`, `dense`, `moe`, `thinking`, `coding`, `brain` |
+| chat (NVIDIA, experimental) | `cuda` (`llama-server`) | `gpu-cuda` | `chat` |
+| chat (fallback) | `cpu` (`llama-server`) | `cpu` | `cpu-chat` |
+| embeddings / rerank | `rocmfpx`, `vulkanfpx` (`llama-server`) | `gpu-rocm`, `gpu-vulkan` | `embedding`, `reranking` |
+| chat + STT + embed (NPU) | `flm` | `npu` | `flm` |
+| transcription | `moonshine` / the FLM trio above | `cpu` / `npu` | `moonshine` / `flm` |
+| TTS | `kokoro` / `qwen3tts` | `cpu` / `gpu-rocm` | `kokoro` / `qwen3-tts` |
+| image | `comfyui` | `gpu-rocm` | `comfyui` |
 
-Every seeded profile requests `-fa auto`, so Flash Attention is probed at
-startup and falls back cleanly when it cannot be scheduled on its layer's
+A device also has a *default* profile it resolves to when a slot names none —
+`gpu-rocm`, `gpu-vulkan` and `gpu-cuda` resolve to `chat`, `cpu` to
+`cpu-chat`, `npu` to `flm`. The seeded slots override that where it matters:
+`agent` ships on `chadrock-moe`, `coder` on `coding`, `brain` on `brain`,
+`utility` on `chat`.
+
+The seeded profile catalog is virtual — it lives in code
+(`SEED_PROFILES`) and is overlaid on every load, so a re-tuned seed reaches
+every install on upgrade instead of being frozen by a stale on-disk copy.
+`/etc/hal0/profiles.toml` is for *your* profiles: `chat`,
+`chat-long-context`, `dense`, `moe`, `thinking`, `coding`, `brain`,
+`embedding`, `reranking`, `cpu-chat`, `flm`, `kokoro`, `moonshine`,
+`qwen3-tts` and `comfyui` are immutable seeds you clone under a new name to
+customize.
+
+`voice.stt` switches Moonshine (CPU) ⇄ FLM's whisper-v3:turbo (NPU) and
+`voice.tts` switches Kokoro (CPU) ⇄ Qwen3-TTS (GPU) without reconfiguring
+the slot. There is no GPU STT engine — a GPU device resolves to none rather
+than silently borrowing a chat profile.
+
+Every seeded chat profile requests `-fa auto`, so Flash Attention is probed
+at startup and falls back cleanly when it cannot be scheduled on its layer's
 device. A model with a measured win from forcing it can set `-fa on` in its
 own `defaults.extra_args`.
 
@@ -327,34 +526,20 @@ Linux + systemd is the only hard requirement
 |-----------------|---------------------------------------------------------------------------|--------|
 | **First-class** | AMD Ryzen AI Max+ 395 ("Strix Halo") with iGPU + XDNA NPU + 128 GB unified | Reference deployment. All published perf numbers come from this box. |
 | **First-class** | AMD Ryzen AI Max 385 / 390 with 64 GB unified                              | Same path; small + mid tiers fit, 70B Q4 with shorter context. |
-| **Experimental** | NVIDIA RTX 30/40/50 (10–32 GB)                                           | Dedicated `cuda` seed profile — upstream `ghcr.io/ggml-org/llama.cpp:server-cuda` via CDI (`nvidia-container-toolkit`), with multi-GPU `gpu_index` pinning on the `gpu-cuda` device. Auto-falls back to the `vulkan` profile when CDI isn't present. `/api/backends` doesn't yet auto-advertise `gpu-cuda`. |
-| **Supported**   | AMD Radeon RX 7000 / discrete (16–24 GB)                                  | ROCm or Vulkan container profiles; same `hal0-slot@<name>` lifecycle. |
-| **Fallback**    | CPU-only x86_64                                                            | `cpu-llm` profile — the Vulkan toolbox image run CPU-only (no GPU passed to the container). Usable for tiny models / smoke tests, not the headline experience. |
+| **Experimental** | NVIDIA RTX 30/40/50 (10–32 GB)                                           | Dedicated `cuda` runner — upstream `ghcr.io/ggml-org/llama.cpp:server-cuda` via CDI (`nvidia-container-toolkit`), with multi-GPU `gpu_index` pinning on the `gpu-cuda` device. Auto-falls back to the Vulkan runner when CDI isn't present. `/api/backends` doesn't yet auto-advertise `gpu-cuda`. |
+| **Supported**   | AMD Radeon RX 7000 / discrete (16–24 GB)                                  | ROCm or Vulkan runner images; same `hal0-slot@<name>` lifecycle. |
+| **Fallback**    | CPU-only x86_64                                                            | `cpu` runner + `cpu-chat` profile — the Vulkan toolbox image run CPU-only (no GPU passed to the container). Usable for tiny models / smoke tests, not the headline experience. |
 
-## Setup and day-2 operation
-
-After the one-liner finishes, the dashboard is at `http://<box>:8080` and
-the API at `http://<box>:8080/v1`. Assign models from the dashboard, or:
+## Day-2 operation
 
 ```sh
-hal0 model pull <hf-repo>/<file.gguf>   # resumable, disk-preflighted
-hal0 slot load agent --model <id>       # bind a model and start the container
-hal0 status                             # system + slot summary
-hal0 chat --brain                       # terminal REPL against the steward
-```
-
-`hal0 model pull` streams from Hugging Face into `registry.toml` under the
-`user.*` namespace — a disk-space preflight fails fast before a multi-GB
-pull, and an interrupted pull resumes via HTTP `Range` instead of restarting
-from zero.
-
-Diagnostics:
-
-```sh
-hal0 doctor all              # full pre-flight against the live host
-hal0 doctor ports            # port claims + netavark DNAT rule audit
-hal0 doctor ports --fix      # prune stale DNAT rules that black-hole a port
-hal0 system-info             # host / GPU / NPU / runtime evidence (read-only)
+hal0 status                          # system + slot summary
+hal0 slot list                       # every slot, state, port, bound model
+hal0 slot load agent --model <id>    # bind + start
+hal0 slot unload agent               # stop without unbinding
+hal0 slot restart agent
+hal0 model list                      # the registry
+hal0 update --check                  # is there anything newer?
 ```
 
 Services and logs:
@@ -366,9 +551,6 @@ journalctl -fu hal0-api
 journalctl -fu 'hal0-slot@*'
 systemctl restart hal0-slot@agent    # restart a wedged slot container
 ```
-
-`hal0 uninstall [--keep-data]` tears down a running install (a thin wrapper
-over `installer/uninstall.sh`).
 
 ### Auth posture
 
@@ -408,6 +590,269 @@ other-tenant + kernel pressure. The token is sensitive, stored 0600 at
 `/etc/hal0/proxmox.json`, and never echoed back by the API. Bare-metal and
 VM installs leave the panel off.
 
+## Troubleshooting
+
+### Start here: `hal0 doctor`
+
+`hal0 doctor` with no subcommand re-runs the installer's own pre-flight
+battery against the live host (systemd, Python, container runtime, GPU/NPU
+device visibility, disk, ports) and exits with the script's own status code,
+so it composes: `hal0 doctor && hal0 status`.
+
+```sh
+hal0 doctor                       # re-run installer pre-flight
+hal0 doctor --plain               # ASCII-only output (for logs / CI)
+hal0 doctor --ports "8080 3001"   # override the port-collision check list
+```
+
+`hal0 doctor all` is the one to reach for when something is wrong but you
+don't know where. It is strictly read-only and rolls every surface up into
+one verdict:
+
+```sh
+hal0 doctor all           # human table
+hal0 doctor all --json    # same rows as JSON
+```
+
+It composes the `doctor verify` report card (API, runners, DNS, capability
+slots, memory, OpenWebUI, Hermes) with auth posture, secret-file modes,
+model-store integrity, pending migrations, bound slot ports, the
+`hal0.target` boot anchor, the MCP mount probes and the privileged sudo
+seams. **Exit codes: `0` clean, `1` an actionable failure, `2` critical**
+(API unreachable, or zero healthy runners). Every failing row names the
+follow-up command.
+
+Those follow-ups, and what each one is for:
+
+| Command | What it audits | Repair flag |
+|---|---|---|
+| `hal0 doctor verify` | Post-setup report card: live health seams, computed URLs, doc links. `--json` for machines. Exits 2 only on a critical. | — |
+| `hal0 doctor perms` | Ownership: Hermes runtime state, the editable checkout's group-share, the canonical path-ownership table. | `--fix` (needs root), `--force`/`-f` to skip the prompt |
+| `hal0 doctor models` | Registry paths vs disk, store/roots agreement, unregistered files in the store, FLM store ownership. | `--fix` (needs root), `--force`/`-f` |
+| `hal0 doctor ports` | Which port each slot bound, collisions, corrupt netavark DNAT rules. | `--fix` prunes stale DNAT rules |
+| `hal0 doctor profiles` | Dangling slot→profile references and un-pulled runner images. | — (read-only, `--json`) |
+| `hal0 doctor migrations` | A pending model-layout migration. | — (read-only, `--json`) |
+| `hal0 doctor toolbox-pull` | Every image pinned in `manifest.json` is anonymously pullable from ghcr.io. | — (`--json`, `--manifest PATH`) |
+| `hal0 doctor logs` | `hal0-api`'s own journal. | `--unit`, `--follow`/`-f`, `--lines`/`-n`, `--level`, `--since` |
+| `hal0 doctor bundle` | Writes a redacted support bundle (system / config / diagnostics / logs). | `--out DIR`, `--no-rocm-smi`, `--include-logs auto\|yes\|no` |
+
+`--json` on `perms` and `models` implies audit-only — `--fix` is ignored
+under it. Both emit stable `Diagnosis` JSON (`HAL0-PERMS-*`,
+`HAL0-MODEL-*`) so you can gate a script on a specific finding.
+
+Two more read-only evidence commands:
+
+```sh
+hal0 system-info    # host / GPU / NPU / runtime evidence
+hal0 ports          # port claims across the box
+```
+
+### Install troubleshooting
+
+**`✗ pre-flight failed: port 8080 is already in use.`** Find the squatter
+with `lsof -i :8080`, then either stop it or move hal0:
+
+```sh
+HAL0_PORT=9090 sudo bash installer/install.sh
+```
+
+After changing the port, update `/etc/hal0/api.env` and
+`/etc/hal0/openwebui.env` to match, then
+`systemctl restart hal0-api hal0-openwebui`.
+
+**`✗ pre-flight failed: less than 20GB free in /var/lib`** — free space or
+redirect model pulls to a bigger disk:
+
+```sh
+sudo bash installer/install.sh --models-dir=/mnt/large-disk/hal0-models
+```
+
+The installer records this under `[models].pull_root` in
+`/etc/hal0/hal0.toml`, so subsequent `hal0 model pull` calls honor it too.
+
+**Python too old.** hal0 needs 3.12–3.14. Let the installer provision one:
+`HAL0_PY_AUTOINSTALL=1`, or point it at an interpreter you already have with
+`HAL0_PYTHON=/usr/bin/python3.12`.
+
+**No container runtime.** `install.sh` sets `HAL0_CONTAINER_REQUIRED=1` and
+auto-installs podman via the detected package manager — if that is not
+possible it hard-fails with the exact one-liner for your distro. A box that
+finishes without a runtime would have every slot dead, which is why this one
+is fatal during install and only a warning under `hal0 doctor`.
+
+**GPU/NPU devices not visible inside an LXC.** Pre-flight prints the exact
+Proxmox `dev0`/gid fix. CPU-only is a valid install and never blocks.
+
+**The hermes step failed on a fresh box.** First-boot installs can lose the
+dpkg lock race to `unattended-upgrades` (#1584). The step degrades
+gracefully — re-run it afterwards:
+
+```sh
+hal0 agent install hermes
+```
+
+**`hal0 doctor: AMDXDNA NPU detected but FastFlowLM not installed`.** The
+host-side sanity probe wants the FLM `.deb`. If you installed on a non-NPU
+host and later added the hardware, re-run `installer/install.sh` to pick up
+the prerequisite. If `flm validate` fails because `libxrt-npu2` is
+unavailable from your apt sources, the NPU **container** slot still works —
+it bundles its own XRT runtime.
+
+**A slot won't load.**
+
+```sh
+systemctl status hal0-slot@<name>
+journalctl -u hal0-slot@<name> -n 60
+hal0 doctor profiles          # dangling profile ref? un-pulled image?
+```
+
+Usual causes: the runner image hasn't been pulled yet (the first load blocks
+on a multi-GB pull — watch the journal), the model named in
+`/etc/hal0/slots/<name>.toml` isn't in the registry (`hal0 model list`), or
+the GPU is held by image mode (the dispatcher returns 503 while the `img`
+slot owns the GPU — stop image mode or wait for idle-restore).
+
+**Something bound the port but nothing answers on it.** That is usually a
+stale netavark DNAT rule left by a container that died badly:
+
+```sh
+hal0 doctor ports          # audit
+hal0 doctor ports --fix    # prune the stale rules
+```
+
+### Update troubleshooting
+
+```sh
+hal0 update                       # check + apply if newer
+hal0 update --check               # check only, apply nothing
+hal0 update -y                    # skip the confirmation prompt
+hal0 update --channel preview     # persist a channel, then check
+hal0 update --target 1.0.0        # require the manifest to match exactly
+hal0 update --rollback            # restore the previous tree
+hal0 update --restart-slots       # bounce only slots still on the old launch command
+```
+
+The CLI is a thin client over `/api/updates/*` — the swap happens in the
+daemon, so the same code path runs whether you update from the shell or the
+dashboard. After a successful apply the daemon try-restarts `hal0-api`
+itself.
+
+**`Error: prepare failed: cosign is not installed`** — you are on 0.9.8,
+whose updater verifies with `cosign verify-blob` and aborts without it. Its
+`HAL0_UPDATE_SKIP_COSIGN` escape hatch is ignored on `stable`, so there is
+no bypass. Re-run the install one-liner (it installs cosign for you), or
+install cosign by hand and retry — see
+[Upgrading from 0.9.8](#upgrading-from-098).
+
+**`hal0 update` exits 1 but the update worked.** The 0.9.8 client polls job
+status through the API it just restarted and treats the mid-restart
+connection refusal as fatal (#1540, fixed in the 1.0 client — which by
+definition is not the one driving a 0.9.8 upgrade). Check the real outcome
+before retrying anything:
+
+```sh
+hal0 --version
+curl -s http://127.0.0.1:8080/api/health
+```
+
+**`release manifest fetch returned HTTP 302`** — `HAL0_RELEASES_URL` is
+pointed at a GitHub release-asset URL. 0.9.8's updater does not follow
+redirects. Leave it at the default; `releases.hal0.dev` serves manifests
+directly.
+
+**"Nothing to apply" when you know there is something.** Two known shapes:
+
+- You are on `1.0.0-rc.1`, whose venv predates prerelease-aware version
+  comparison and ranks `1.0.0rc1` above `1.0.0` (#1663/#1640). Bypass the
+  gate: `hal0 update --target 1.0.0`.
+- You came from 0.9.8 via `hal0 update` rather than the one-liner, so the
+  profile-catalog reset is still outstanding (#1585). Nothing is lost — it
+  applies on the next update run by 1.0 code.
+
+**Something is wedged after an update.** Roll the tree back, then look:
+
+```sh
+hal0 update --rollback
+hal0 doctor all
+```
+
+Rollback restores the previous tree from `/var/lib/hal0/hal0.previous`.
+Config and state are **not** rewound — schema migrations are forward-only.
+Treat rollback as a way to get serving again quickly, not as an undo.
+
+**Slots still running the pre-update launch command.** By design, an update
+never bounces a slot on its own. Converge them when you're ready:
+
+```sh
+hal0 update --restart-slots
+```
+
+### Filing a bug
+
+```sh
+hal0 doctor bundle
+```
+
+Writes `./hal0-doctor-bundle-<host>-<ts>/` — system, config, diagnostics and
+logs in one directory, with every config dump redacted (SECRET / TOKEN /
+PASSWORD / API_KEY / PRIVATE_KEY / ENCRYPTION_KEY / SALT-named keys). It is
+read-only and never uploads anything: `tar czf` it and attach it yourself.
+Exit `1` means some probe commands failed — see `commands.tsv` inside.
+
+## Upgrading from 0.9.8
+
+`hal0 update` supports any `1.0.0-rc` and **0.9.8**, the version every
+stable-channel box has been pinned at since 2026-07-13.
+
+**The one-liner is the supported 0.9.8 path.** It is an upgrade in place, not
+a reinstall: `/etc/hal0` and `/var/lib/hal0` carry across, your slot TOMLs
+stay where they are, and the installer adds what 1.0 needs rather than
+replacing what you had.
+
+```sh
+curl -fsSL https://hal0.dev/install.sh | sudo bash
+```
+
+It resolves the dependencies 0.9.8 never installed — **cosign included** —
+and that is the whole reason to prefer it. Its migrations also run under the
+*new* code, so the box lands on `meta.schema_version = 2` in the same pass.
+
+If you would rather drive the updater yourself, install cosign first:
+
+```sh
+curl -fsSL -o /usr/local/bin/cosign \
+  https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64
+chmod +x /usr/local/bin/cosign
+hal0 update -y
+```
+
+Three things to know before you start, all specific to being on 0.9.8:
+
+- **The CLI may exit 1 on a successful update** — the old client losing the
+  API across the restart it triggered. Check `hal0 --version` before you
+  retry anything.
+- **Your channel does not change.** 0.9.8 persisted `stable` and the
+  installer will not overwrite a channel already on disk, so
+  `HAL0_CHANNEL=preview` on the upgrade command is ignored. Stable is what
+  you want at 1.0; set preview afterwards with
+  `hal0 update --channel preview` if you are deliberately tracking it.
+- **Do not point `HAL0_RELEASES_URL` at a GitHub release-asset URL** — 0.9.8
+  does not follow the `302`.
+
+Two migrations are deliberately left to you, because both rewrite state in
+ways that want a human deciding when. The **slot-flag fold**
+(`hal0 slot migrate-flags`) moves per-slot tunes onto their bound model; it
+is a dry run until `--apply`, and `--apply` refuses while `hal0-api` or any
+`hal0-slot@*` unit is active unless you add `--stop-services`. Back up
+`hal0.db` and your slot dirs first, and expect it to refuse the whole run —
+rather than write half of it — when slots share a model with divergent
+tunes. **Slot id-keying** (`hal0 slot migrate-id-keying`) is optional and
+reversible; the runtime reads either layout, so run it in a downtime window.
+
+Everything else — schema migrations, the one-shot `enabled` sweep at first
+v1.0 boot, the config-load repairs — runs itself. Full breaking-change,
+migration and known-issue detail is in [`CHANGELOG.md`](./CHANGELOG.md).
+
 ## Project layout
 
 ```
@@ -415,11 +860,12 @@ hal0/
 ├── src/hal0/         # Python package (FastAPI API + capability layer + ContainerProvider + CLI)
 │   ├── providers/    # ContainerProvider, FLMProvider, ComfyUI, etc.
 │   ├── slots/        # slot manager, state machine, GpuArbiter
+│   ├── runners/      # RUNNER_IMAGES — the runner-image registry
 │   ├── bench/        # benchmark planner, runner, store, publish
 │   └── omni_router/  # client-side tool-calling loop + tool definitions
 ├── ui/               # React 18 + TypeScript + Vite + Tailwind 4 dashboard
 ├── installer/        # install.sh (writes /etc/hal0/, systemd units, hal0-api.service)
-│   ├── etc-hal0/     # curated slot seeds + profiles.toml
+│   ├── etc-hal0/     # curated slot seeds + operator profiles.toml
 │   └── systemd/      # hal0-agent@ template units
 ├── tests/            # pytest suite (α unit, β integration, γ release-gate)
 │   └── release-validation/   # versioned RC validation kit (lanes, regressions, boxes)
@@ -457,13 +903,16 @@ running on your box. Full version at
 ### Shipped (v1.0)
 
 - **Per-slot podman containers** — every inference workload in its own
-  `hal0-slot@<name>.service`; `ContainerProvider` + `profiles.toml` replaced
-  the single-daemon model
+  `hal0-slot@<name>.service`; `ContainerProvider` + the runner-image registry
+  replaced the single-daemon model
 - **hal0-brain steward** — top-bar agent chat driving the 180-tool
   `hal0-admin` catalog under a per-persona tool policy, pausing turns on
   gated tools for inline approve/deny
 - **Model-owned tuning** — the model, not the slot, owns context size, MTP
   and launch flags; profiles supply a floor, never an override
+- **Slot autoload + eviction priority** — binding a model no longer implies
+  a boot start, and pressure eviction orders by `priority` instead of an
+  opt-in nobody set
 - **Stacks** — declarative model/slot layouts applied atomically with
   rollback, drift detection and a portable export envelope
 - **In-dashboard benchmarks** — the `hal0.bench` engine, `/api/benchmarks`,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,8 @@
 
 ## Supported Versions
 
-hal0 is pre-1.0 and ships from `main`. Security fixes land on the latest
-release and the current `main` branch. Older tagged releases are not
-back-patched.
+Security fixes land on the latest release and the current `main` branch.
+Older tagged releases are not back-patched.
 
 | Version        | Supported          |
 | -------------- | ------------------ |
@@ -15,8 +14,15 @@ back-patched.
 
 **Treat the bundled agent as root-equivalent on the box it runs on.**
 
-hal0 ships a bundled agent (Hermes) provisioned with `terminal.backend = local`,
-so it can execute arbitrary shell commands on the host. It runs under
+hal0 ships a bundled agent (Hermes). Its terminal tool — the one that executes
+arbitrary shell commands on the host — is **off by default** as of v1.0 and is
+an explicit opt-in (`sudo hal0 agent install hermes --terminal-tool`, or
+`HAL0_HERMES_TERMINAL=1` for an unattended install). A piped, headless or
+non-interactive install never enables it. `hal0 agent status hermes` prints the
+current posture.
+
+Turning it on makes the agent root-equivalent, and the rest of this section
+describes that state. Even with the terminal tool off, the agent runs under
 `hal0-agent@<instance>.service` as `User=hal0` — the same user `hal0-api.service`
 runs as. Two consequences follow, and neither is hypothetical:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,20 +2,32 @@
 
 This directory has two halves:
 
-## Top-level `docs/*.mdx` — user docs
+## The published sections — user docs
 
 The **canonical source** of the documentation published at
-<https://hal0.dev/docs/>. `.github/workflows/mirror-docs.yml` pushes the
-published sections (`getting-started/`, `concepts/`, `guides/`,
-`operate/`, `reference/`) from here into `Hal0ai/hal0-web`
-(`src/content/docs/docs/**`, Starlight/Astro) on every push to `main` —
-the direction was reversed by #1622; `hal0-web` used to be the source and
-mirror into this repo, but is now the generated copy.
+<https://forum.hal0.dev/c/docs/11>. `hal0.dev/docs/*` no longer hosts the
+pages; it 301s to the matching forum topic.
 
-**Edit these files here, in `Hal0ai/hal0`.** Hand-editing the mirrored
-copy in `hal0-web` is pointless: the next push to `hal0/main` touching a
-published section `rsync --delete`s that section on the web side and
-silently discards the change.
+`.github/workflows/sync-docs-discourse.yml` pushes the published sections
+(`getting-started/`, `concepts/`, `guides/`, `operate/`, `reference/`)
+from here into Discourse on every push to `main` that touches them. Each
+doc becomes a topic keyed by a path-derived `external_id`; a section lands
+in its own subcategory when the forum has one, and gets an index topic
+either way. The implementation is `scripts/docs_discourse_sync/`;
+`discovery.py` walks the five section directories with a plain `rglob`, so
+a **new `.mdx` in one of them publishes itself** — there is no manifest and
+no registration step.
+
+Publishing and redirecting are separate, though. The sync run uploads a
+redirect-map artifact, but hal0-web's 301 layer reads a copy committed in
+that repo (`src/content/../docs-redirects.json`), so a newly-added doc is
+live on the forum before any `hal0.dev/docs/<path>` redirect exists for it.
+Only old links need that redirect, so this matters when a doc is **renamed
+or moved**, not when one is added.
+
+**Edit these files here, in `Hal0ai/hal0`.** The forum copy is generated:
+editing a topic by hand is discarded by the next sync run that touches
+that doc.
 
 The `.mdx` extension is preserved verbatim — the files import Starlight
 components (`Card`, `Tabs`, `Steps`, …) that only render inside the

--- a/docs/concepts/agents.mdx
+++ b/docs/concepts/agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agents
-description: "hal0's agent model: Hermes runs as the sandboxed bundled agent, shaped by personas and a policy-layer MCP client, with the hal0-brain steward driving hal0's own admin tools, an approval queue, and per-persona spending budgets."
+description: "hal0's agent model: Hermes runs as the sandboxed bundled agent, shaped by personas and a policy-layer MCP client, with an approval queue and per-persona spending budgets. hal0-brain, the platform steward, is a separate, related piece — see Brain."
 sidebar:
   order: 60
 ---
@@ -10,9 +10,11 @@ import { Aside, Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 hal0 doesn't build its own agent runtime — it **bundles** one, and hal0's job
 is to run it safely: as a sandboxed service, shaped by a persona that controls
 what it can do, with a human in the loop for risky actions and a spending cap
-for paid calls. A second, distinct piece — the **hal0-brain steward** — is
-hal0's own small model driving hal0's own admin tool catalog. The two are
-easy to conflate; they aren't the same thing.
+for paid calls. A second, distinct piece — the **hal0-brain steward**, hal0's
+own resident model that chats and drives hal0's own admin tool catalog — sits
+alongside it and shares the persona, approval-queue, and memory machinery
+described on this page. The two are easy to conflate; they aren't the same
+thing, and the steward has its own concept page: see [Brain](/docs/concepts/brain).
 
 ## Hermes: the bundled agent runtime
 
@@ -45,18 +47,20 @@ the agent runtime; it doesn't reimplement one.
 ## hal0-brain: the steward that drives hal0 itself
 
 Separately from the bundled agent runtime, hal0 runs its own **brain
-steward** — a small, always-available model (tuned via the dedicated `brain`
-profile) whose job is routing tool calls against hal0's own curated
-`hal0-admin` MCP tool catalog, not general-purpose coding or chat. It's the
-mechanism behind features like the Operator Board, and it's deliberately kept
-1:1 with a small model rather than sharing a slot with the general agent's
-model — the steward handles its own tool-call turns, including routing
-specific rounds to a dedicated `tool_model` where that's a better fit than
-the conversational model.
+steward** — a small, always-available model that chats with the operator and
+routes tool calls against hal0's own curated `hal0-admin` MCP tool catalog,
+not general-purpose coding or chat. It's the mechanism behind features like
+the Operator Board, and it's deliberately kept 1:1 with a small model rather
+than sharing a slot with the general agent's model — the steward handles its
+own tool-call turns, including routing specific rounds to a dedicated
+`tool_model` where that's a better fit than the conversational model.
 
 Where Hermes is "a general-purpose agent hal0 governs," hal0-brain is "hal0's
 own operator, wired straight into the admin surface." Both speak MCP and both
-go through the same approval queue for anything gated.
+go through the same approval queue for anything gated. The default model,
+the `[brain_chat]` config table, tool routing, and the native-tool-calling
+capability gate are covered in full on the dedicated [Brain](/docs/concepts/brain)
+page — this page stops at "what it is and how it relates to Hermes."
 
 ## Personas: the agent's character and limits
 
@@ -150,6 +154,7 @@ cross-agent brain described in [Memory](/docs/concepts/memory).
 ## Where to go next
 
 <CardGrid>
+  <LinkCard title="Brain" href="/docs/concepts/brain" description="The hal0-brain steward, in full: default model, config, tool routing." />
   <LinkCard title="Memory" href="/docs/concepts/memory" description="The opt-in brain the agent reads and writes." />
   <LinkCard title="Security" href="/docs/concepts/security" description="Identity, gating, and the auth layer." />
   <LinkCard title="Architecture" href="/docs/concepts/architecture" description="Where the agent surfaces sit under the API." />

--- a/docs/concepts/brain.mdx
+++ b/docs/concepts/brain.mdx
@@ -1,0 +1,259 @@
+---
+title: Brain
+description: "hal0-brain: the resident platform steward that chats and calls tools against hal0's own admin surface. What it is, its default model, the [brain_chat] config table, and how tool routing and native tool calling resolve."
+sidebar:
+  order: 65
+---
+
+import { Aside, Steps, LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+**hal0-brain** is hal0's own resident operator — a small, always-on model whose
+job is chatting with you and driving hal0's own admin tool catalog: slots,
+models, hardware, the Operator Board, orchestration settings. It is mounted at
+`POST /api/brain/chat` (`POST /api/board/chat` is a thin back-compat alias for
+the same route) and is a first-class module in its own right: it carries
+**no import dependency on Hermes** at all, and works whether or not a
+bundled agent is installed.
+
+## Brain, slot, agent, chat UI — four different things
+
+These four terms get used loosely; the code draws sharp lines between them.
+
+- **A slot** is an inference unit — one model bound to one backend on one
+  port (see [Slots](/docs/concepts/slots)). The brain is not a slot; it
+  *drives* one. The virtual model it speaks through, `hal0/brain`, resolves
+  to the `brain` slot when one is loaded, and falls back to the `agent` slot
+  otherwise, via the normal `hal0/<slot>` resolver chain.
+- **An agent** — as of v1.0, Hermes — is a bundled, sandboxed general-purpose
+  agent runtime hal0 governs but doesn't build. The brain is not an agent
+  runtime: it's hal0's own conversational front end onto hal0's own admin
+  API, described in [Agents](/docs/concepts/agents).
+- **The chat UI** is a client of the brain, not the brain itself. Two ship
+  today: the dashboard's top-bar "Agent Chat" slide-out (configured under
+  Settings → Integrations → Agent Chat), and `hal0 chat --brain`, a terminal
+  REPL for SSH/headless boxes. Both stream the same
+  `{"type": "token"|"thinking"|"tool_call"|"tool_result"|"approval_required"|"notice"|"error"|"done"}`
+  SSE contract from `/api/brain/chat`.
+
+The brain embodies the **`hal0-brain` persona** — a persona TOML in the same
+store Hermes personas live in (see
+[Agents → Personas](/docs/concepts/agents)). `seed_default_personas` writes
+`hal0-brain.toml` unconditionally, both at install time and again on every
+`hal0-api` startup, so the persona is present on every v1.0 box unless an
+operator deletes the file. Its own system prompt and `preferred_model =
+"hal0/brain"` are what the brain actually runs on; the built-in system
+prompt baked into `hal0.brain.chat` is only a fallback, used when the
+persona TOML is missing or fails to parse. A persona's `tools_allowed` /
+approval policy narrows the brain's tool surface exactly the way it narrows
+Hermes's.
+
+<Aside type="note">
+The `brain` **slot's** `profile = "brain"` (in `installer/etc-hal0/slots/brain.toml`)
+is a third, unrelated "profile" — an inference-runtime profile (context size,
+reasoning-format) from the [profiles catalog](/docs/concepts/capabilities-and-profiles),
+not the persona. Don't confuse the two.
+</Aside>
+
+## The default model, and how to change it
+
+Every fresh v1.0 install pulls the same brain model unconditionally, before
+any hardware fork: **LFM2.5-2.6B, Q8_0** (curated id `lfm2.5-2.6b`,
+`LiquidAI/LFM2.5-2.6B-GGUF`, 2.87 GB), bound to the `brain` slot. It's a
+plain GGUF with no custom tensor types, so it loads on the ROCmFPX runner
+and on stock llama.cpp alike — unlike the earlier `hal0-brain-sft` family it
+replaced as the default, whose Q8/Q4 quants carry custom GGML tensor types
+that only the ROCmFPX runner accepts.
+
+<Steps>
+1. **At install time**: set `HAL0_BRAIN_MODEL` before running `install.sh` to
+   pull a different curated id instead — `hal0-brain-sft-q8-rocmfpx` (1.1 GB,
+   ROCm/Vulkan boxes only), `hal0-brain-sft-q4-rocmfp4` (0.65 GB, smallest,
+   ROCm/Vulkan only), or `hal0-brain-sft-f16` (2.0 GB, portable, runs on a
+   CPU-only box too). An unrecognized id is ignored with a warning and the
+   default is pulled instead.
+2. **After install, per-turn**: point `[brain_chat] model` in `hal0.toml` (or
+   the "Model / slot override" field on the dashboard's Agent Chat settings
+   page) at any `hal0/<slot>` — e.g. `hal0/npu` to run the steward on the NPU
+   chat slot. Empty (the default) means "use the persona's `preferred_model`,
+   or `hal0/brain` if there's no persona."
+3. **Per-request**: a client can send an explicit `model` in the chat body,
+   which wins over both of the above for that turn.
+</Steps>
+
+Whichever slot ends up serving the brain needs at least **8k tokens of
+context** — sized for the built-in fallback prompt, which alone is roughly
+7.3k tokens (the seeded persona's own prompt is considerably shorter, but the
+floor has to cover the fallback case too) — and it must actually be loaded,
+or `/api/brain/chat` 404s with an actionable error naming the model it
+tried. The seeded `brain` slot ships with a 65536-token context window, well
+above the floor.
+
+## `[brain_chat]`
+
+The config table that governs the steward chat. `extra="forbid"` — an unknown
+key fails validation rather than being silently ignored.
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `enabled` | bool | `true` | Hard kill switch — `false` refuses every turn before any model call. |
+| `read_only` | bool | `true` | Refuses every mutating or admin-write tool **server-side**, independent of the persona's own tool policy. Ships `true`: a fresh v1.0 box answers questions and reads state, but cannot mutate the board or write admin config until an operator sets this to `false`. |
+| `model` | str | `""` | Chat-model override; empty defers to the persona / `hal0/brain`. |
+| `tool_model` | str | `"hal0/agent"` | Where tool-calling rounds reroute when the chat model can't carry them (see below). `""` on disk is treated as "nobody set this" and coerced back to the default with a logged warning — to genuinely turn routing off, set it to `"off"`, `"none"`, or `"disabled"` explicitly. |
+| `max_rounds` | int | `8` | `1`–`100`. Runaway backstop on the tool loop per turn. |
+| `completion_timeout_s` | float | `300.0` | `> 0`. Transport timeout for each LLM round. |
+
+The dashboard's Agent Chat settings page (Settings → Integrations) edits
+`enabled`, `read_only`, `model`, `max_rounds`, and `completion_timeout_s`
+live — `tool_model` is not exposed there; it's a `hal0.toml`-only knob today.
+
+### How tool routing resolves
+
+Every turn starts on the **chat model** (`model` above) — that's the whole
+point of running a small, fast steward for plain conversation. A round only
+reroutes to `tool_model` when one of three things happens on the chat model's
+round: it produced a real tool call (native or text-embedded — nothing is
+rerun, that call just dispatches); it produced a tool-call *artefact* it
+couldn't fully express (garbled `<function name=...>` syntax, or reasoning
+that says "I'll call X()" with nothing usable in the visible reply); or the
+operator asked a live-box-state question and the chat model answered without
+calling anything, which on the shipped small models is reliably a fabricated
+answer rather than a skipped lookup. Once a turn enters a tool chain by any
+of those paths, every remaining round of that turn stays on `tool_model` —
+the model that owns the tool chain finishes it; the brain's own voice returns
+on the next user turn.
+
+`tool_model` defaults to `hal0/agent`, the always-on anchor from ADR-0023.
+That default has a real gap on a fresh v1.0 box: the `agent` slot ships with
+no bound model — it's an explicit, size-disclosed opt-in at install time (15
+to 31 GB) — so the first tool-needing turn on an unmodified install gets a
+plain-English explanation that tool routing has no live target yet, with the
+fix (bind a model to `agent`, or point `tool_model` at a slot that's
+already loaded).
+
+## Native tool calling: a capability question, not an image check
+
+Whether a round can carry OpenAI-style `tools` at all depends on the
+**runner** behind the resolved slot, checked as a capability — not by
+comparing the image to one known-good tag. An older gate asked "is this
+exactly the current default ROCmFPX image?", which answered "no" for every
+runner that simply wasn't that one release — including the plain upstream
+llama.cpp toolboxes a CPU-only or CUDA box resolves to by default, which
+parse `tools` perfectly well. That false negative silently stripped tools
+from every brain round on those boxes, and the steward answered platform
+questions from imagination instead of admitting it couldn't look.
+
+The fix, as shipped: a short deny list of runner images known to reject a
+`tools`-attached request outright (the pre-`ade07ba` ROCmFPX lineage, which
+500s with a "peg-native format" parser error), plus a small in-process
+learned set — if an unlisted image's first tools-attached round *does* get
+rejected, that round is retried without `tools` and the image is remembered
+as incapable for the rest of the process. Everything else is assumed
+capable by default.
+
+For an operator, this means: if tools look silently unavailable on a chat
+model whose runner isn't on the deny list, the most likely explanation is
+that the runner rejected a tools round once already and got learned as
+incapable for this process — the learned set lives in the hal0-api process,
+not the slot's container, so restarting the slot's backend does *not* clear
+it; `systemctl restart hal0-api` does. If **both** the chat model's runner can't carry tools **and**
+`tool_model` is off or points at the same model, the brain has genuinely no
+way to see live state that turn: it says so explicitly (a system notice
+constrains its reply, and the SSE stream carries a `{"type": "notice", "code":
+"tools_unavailable"}` frame) rather than inventing slot names or numbers.
+
+## The tool loop: what the brain can and cannot call
+
+The brain drives the same shared tool-calling core
+(`hal0.toolloop.engine.run_tool_loop`) that OmniRouter's `/v1/chat/completions`
+tool loop uses — one provider-agnostic "send `tools`, extract calls, dispatch,
+fold the result back, repeat" machine, decoupled from either caller's
+transport.
+
+The surface offered to the model is two catalogs combined, then filtered by
+the `hal0-brain` persona's tool policy (when one exists):
+
+- A local set of board and platform tools purpose-built for the steward:
+  board reads/writes (`get_board`, `move_task`, `create_task`, `comment_task`,
+  dependency and orchestration verbs, `nudge_dispatcher`, …) against hal0's
+  own `BoardStore` — the same store `/api/board/*` answers from, not a Hermes
+  proxy — and platform tools (`list_slots`, `get_slot`, `slot_load/unload/
+  restart`, `list_models`, `hardware_stats`, `list_agents`) that re-enter
+  hal0-api's own REST routes over self-HTTP.
+- The full [`hal0-admin` MCP catalog](/docs/reference/mcp-tools) minus a
+  short exclusion list: names that collide with the local tools above (e.g.
+  `slot_load`/`slot_list`/`model_list`), and every `memory_*` tool — the
+  brain reaches its own memory through Hindsight directly (see below), not
+  through the agent memory engine's MCP dispatcher. That's well over 100
+  tools once the exclusions are removed — this page doesn't enumerate them;
+  see the catalog reference.
+
+Everything in that combined surface is classified exactly as `/mcp/admin`
+classifies it — autonomous read, autonomous write, or **gated**. A gated call
+(model pulls/deletes, slot create/delete/restart, capability or config
+writes, credential writes, stack/profile CRUD, log tails, …) doesn't run: it
+enqueues on the same `ApprovalQueue` the dashboard's Approvals panel and bell
+read from, the chat turn pauses (up to five minutes, pinging the stream every
+15 seconds) for the operator's decision, and the turn continues once it
+lands.
+
+Two things enforce the boundary at dispatch time, both independent of what
+the model was shown: the persona's `tools_allowed` policy is checked again
+against the call the model actually made (never trust the advertised list),
+and `[brain_chat] read_only` — when true, the default — refuses any tool
+that isn't a read, full stop, regardless of what the persona would otherwise
+allow.
+
+<Aside type="tip">
+Because `read_only` ships `true`, a freshly installed v1.0 brain can read and
+converse but cannot move a board card, load a slot, or write config until an
+operator flips it — that's a deliberate default, not a bug.
+</Aside>
+
+## Memory and MCP
+
+When [memory](/docs/concepts/memory) is enabled, the `hal0-brain` persona
+gets its own namespace (`private:hermes__hal0-brain`), separate from
+Hermes's own agent namespace, reached through Hindsight directly rather than
+the `memory_*` MCP tools an agent uses — which is exactly why `memory_*` is
+excluded from the tool surface described above.
+
+For everything else the brain's admin surface *is* MCP under the hood: it
+calls the same `hal0.mcp.admin.dispatch()` core, the same tool descriptions
+and parameter schemas, and the same `ApprovalQueue` that `/mcp/admin` serves
+externally — it just calls that core in-process instead of going out over
+the MCP wire protocol. A client that wants raw MCP access (rather than a
+chat front end) talks to `/mcp/admin` directly; see
+[MCP tools reference](/docs/reference/mcp-tools).
+
+## Observing the brain
+
+- **`hal0 chat --brain`** — a terminal REPL over `POST /api/brain/chat`,
+  useful on an SSH session where the dashboard isn't reachable. It always
+  streams; `--no-stream` is ignored in this mode.
+- **The dashboard** — the top-bar "Agent Chat" toggle opens the same route's
+  browser client; Settings → Integrations → Agent Chat exposes the
+  `[brain_chat]` knobs listed above as live settings.
+- **Slot health** — because the brain ultimately runs on a real slot
+  (`brain`, or the `agent` fallback), watch it the way you'd watch any slot:
+  `hal0 slot list` / `hal0 slot show brain`, or the dashboard's Slots panel.
+  The brain can also answer questions about itself, since `list_slots` and
+  `hardware_stats` are in its own tool surface.
+- **Logs** — structured `structlog` events worth grepping for:
+  `hal0.brain_chat.tools_unavailable`, `hal0.brain_chat.native_tools_unsupported`,
+  `hal0.brain_chat.tool_round_rerouted`, `hal0.brain_chat.ungrounded_round_rerouted`,
+  `hal0.brain_chat.tool_model_unavailable`, and
+  `hal0.brain_chat.completion_budget_raised`.
+
+hal0 does not currently ship a `hal0 brain` CLI subcommand group or a
+dedicated `hal0 doctor` check for the steward — the paths above are what
+exist today.
+
+## Where to go next
+
+<CardGrid>
+  <LinkCard title="Agents" href="/docs/concepts/agents" description="Hermes, personas, and the approval queue the brain shares." />
+  <LinkCard title="Memory" href="/docs/concepts/memory" description="The Hindsight-backed store the brain's persona namespace lives in." />
+  <LinkCard title="MCP tools reference" href="/docs/reference/mcp-tools" description="The full hal0-admin catalog the brain surfaces a filtered slice of." />
+  <LinkCard title="Slots" href="/docs/concepts/slots" description="What the brain and agent slots actually are underneath the virtual model." />
+  <LinkCard title="Config schema reference" href="/docs/reference/config-schema" description="Every hal0.toml table, including [brain_chat]." />
+</CardGrid>

--- a/docs/concepts/capabilities-and-profiles.mdx
+++ b/docs/concepts/capabilities-and-profiles.mdx
@@ -55,7 +55,7 @@ about hardware. As of v1.0, a profile carries **no container image and no
 placement information at all**: no device, no GPU index, no thread count, no
 `-c`/`--ctx-size` (that flag is on hal0's own managed-args denylist and can
 never appear in a profile's flags). All of that lives on the
-[slot](/docs/concepts/slots#the-hardwaremodel-write-boundary).
+[slot](/docs/concepts/slots), in the hardware/model write boundary.
 
 This is a genuine v1.0 change, not a renaming exercise: pre-1.0 profiles were
 identity-bound to a backend (`rocm`, `vulkan`, `cuda`) and carried an image.
@@ -162,7 +162,8 @@ never deduped, since llama-server treats repeats of those additively):
 
 1. **base** — `--host`/`--port`/`--model`/`--alias`/`--ctx-size`, always
    present. Context size here is the model's resolved window, capped by the
-   slot's own ceiling — see [Slots](/docs/concepts/slots#context-size-is-a-ceiling-not-an-override).
+   slot's own ceiling — see the "context size is a ceiling, not an
+   override" section of [Slots](/docs/concepts/slots).
 2. **profile** — the profile's `flags`.
 3. **model defaults** — the registry model's `defaults.extra_args` (plus
    `-ngl` from the slot, not the model), with the model's **family default**

--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -1,6 +1,6 @@
 ---
 title: Memory
-description: hal0's memory subsystem — a Hindsight-backed brain that operators and agents share. Gated by [memory].enabled in hal0.toml (on by default on a fresh install) and degrades cleanly to a no-op when off.
+description: hal0's memory subsystem — a Hindsight-backed brain that operators and agents share. Gated by [memory].enabled in hal0.toml (on by default on a fresh install) and degrades cleanly to a volatile fallback when the engine is unreachable.
 sidebar:
   order: 50
 ---
@@ -14,6 +14,11 @@ completely absent when it's off. A fresh install turns it on for you; it stays
 a conscious, revertible choice rather than something that silently accumulates
 data on an existing box.
 
+Memory was rebuilt for v1.0 ("memory v2"): a redesigned dashboard workspace
+(ranked fact list, curate, history, a force-directed graph) sits behind the
+same engine-neutral backend described on this page. See
+[Browse the Bank workspace](/docs/guides/memory-workspace) for the UI tour.
+
 ## What memory is
 
 The memory subsystem is an engine-neutral layer behind two surfaces: the
@@ -22,27 +27,31 @@ The memory subsystem is an engine-neutral layer behind two surfaces: the
 the same provider, so a fact written by an agent over MCP is the same fact
 the dashboard shows.
 
-The MCP surface covers the full read/write/curate/synthesize lifecycle, not
-just add-and-search:
+The MCP surface covers the full read/write/curate/synthesize lifecycle:
 
 - **Core**: `memory_add`, `memory_search`, `memory_list`, `memory_delete`,
   `memory_recall` — the token-budgeted, observation-aware retrieval path
   (preferred over `memory_search`), with native per-result relevance scores
   and optional entity/chunk/source-fact enrichment.
 - **Reflect**: `memory_reflect` — ask a question and get an LLM-written
-  answer grounded in recalled facts, instead of a raw fact list.
+  answer grounded in recalled facts, instead of a raw fact list. Answers
+  `{status: "unsupported"}` on an engine without the capability (the
+  pgvector fallback) instead of erroring.
 - **Curation**: `memory_curate` edits a fact or soft-invalidates/reverts it
-  (reversible) — the non-destructive "this is wrong" correction path, as
-  distinct from `memory_delete`. `memory_history` shows a fact's revision
-  trail.
+  (reversible, no approval gate) — the non-destructive "this is wrong"
+  correction path, as distinct from `memory_delete`. `memory_history` shows
+  a fact's revision trail — but only **observation** facts have history;
+  world/experience facts 404 there by design — see Fact types below.
 - **Mental models**: `memory_mental_model_list` / `_get` / `_create` /
   `_update` / `_delete` / `_refresh` — standing questions ("what does the
-  user prefer for X") whose answer is kept refreshed from memory.
+  operator prefer for X") whose answer is kept refreshed from memory.
 - **Directives**: `memory_directive_list` / `_get` / `_create` / `_update` /
-  `_delete` — standing instructions injected into prompts.
+  `_delete` — standing instructions injected into an agent's prompt every
+  turn.
 - **Async operations**: `memory_operation_list` / `_get` / `_cancel` /
   `_retry` — retain is async by default, so these are the poll target for
-  `memory_add`'s `operation_id` and for mental-model refreshes.
+  `memory_add`'s `operation_id` and for mental-model refreshes and bank
+  consolidation.
 - **Bank introspection**: `memory_tags_list`, `memory_bank_stats`,
   `memory_bank_consolidate` — read-only counts plus an early-trigger for
   consolidation. No destructive bank operations (delete/clear a whole bank)
@@ -52,38 +61,44 @@ Every write/destructive tool goes through the same namespace ACL and
 approval-gate pattern as `memory_add`/`memory_delete` — `memory_curate`'s
 `state` toggle is reversible so it stays autonomous, while
 `memory_mental_model_delete` and `memory_directive_delete` gate for operator
-approval the same way a bulk `memory_delete` does.
+approval the same way a bulk `memory_delete` does. The full tool-by-tool
+schema lives in [MCP tools](/docs/reference/mcp-tools) — this page covers the
+concepts those tools operate on.
 
 ![Memory interface showing stored facts and recall](/screenshots/memory-view.png)
-*Memory view in the hal0 dashboard*
+*The dashboard's Memory view (Bank workspace, list mode)*
 
 The engine is **Hindsight** — a memory service that powers the shared operator
-and agent "brain." (Cognee, the prior engine, was fully removed; `hal0 memory
-migrate` remains only for boxes still carrying a Cognee-era store.) When
-configured, hal0 builds a Hindsight client and wraps it with a reranker so
-recall surfaces the most relevant facts. If the Hindsight daemon is
-unavailable at boot, hal0 degrades to an in-memory PgVector fallback rather
-than failing — the subsystem stays usable, but that fallback is volatile
-(writes don't survive a restart) and exists to keep the tools answering, not
-as a durable substitute.
-
-![Memory graph visualization showing relationships between facts](/screenshots/memory-graph.png)
-*Fact relationships in the knowledge graph*
+and agent "brain." When configured, hal0 builds a Hindsight client and wraps
+it with a second-pass reranker so recall surfaces the most relevant facts. If
+the Hindsight daemon is unreachable at boot, hal0 degrades to an in-memory
+PgVector fallback rather than failing — the subsystem stays usable, but that
+fallback is volatile (every write is lost on restart) and exists to keep the
+tools answering, not as a durable substitute. Once the daemon comes back,
+hal0 swaps the durable engine back in on its own (no restart required) — but
+writes accepted while degraded are gone; they were never on the durable side.
 
 <Aside type="note">
 The memory layer is engine-neutral by design — a `MemoryProvider` interface is
-the explicit anti-lock-in seam. Hindsight is the default, but the provider is
-selected from config, so the surfaces (REST + MCP) stay the same regardless of
-which engine backs them.
+the explicit anti-lock-in seam. `[memory].engine` accepts `hindsight` (the
+default and the only fully-implemented engine), `pgvector` (the volatile
+fallback, selectable directly), or `mem0` — but `mem0` is **accepted by
+config validation and not implemented**: selecting it logs a warning and
+silently runs Hindsight instead. The legacy `cognee` engine was retired in
+v1.0.0 and now fails config validation outright; there is no automated
+migration path off a Cognee-era store, and Cognee itself has been dark since
+v0.4.
 </Aside>
 
 ## Memory is gated by one config flag
 
 This is the most important thing to know: hal0 only constructs a memory
-provider when `[memory].enabled` is set in `hal0.toml`. This replaces the
-older `HAL0_MEMORY_ENABLED` environment variable — the toggle is now a
-persisted config value, editable from the dashboard settings without an env
-edit. When it's off:
+provider when `[memory].enabled` is `true`, and it **defaults to `true`** —
+no shipped `hal0.toml` and no installer step writes the key, so a box with no
+`[memory]` section at all comes up with memory *on*. This replaces the older
+`HAL0_MEMORY_ENABLED` environment variable — the toggle is now a persisted
+config value, editable from `hal0 memory enable`/`disable` or the dashboard's
+Settings without an env edit. Set `enabled = false` and memory is off:
 
 - No memory provider is built.
 - Every downstream caller degrades to a no-op or a clean error — the
@@ -92,33 +107,155 @@ edit. When it's off:
 - The dashboard hides the Memory navigation.
 
 Flipping the flag is the *entire* toggle — no code change required either way.
-A fresh install turns memory on for you and stands up the local Hindsight
-daemon automatically. An upgrade never rewrites an existing config, so a box
-that was installed before memory shipped on by default, or that had it turned
-off by hand, stays off until you set it yourself. Either way it's a conscious,
-revertible choice, not something that quietly starts accumulating data you
-didn't ask for.
+A fresh install leaves memory on (the default) and stands up the local
+Hindsight daemon automatically. An upgrade never rewrites an existing config,
+so a box that already had `enabled = false` written by hand keeps memory off
+across the upgrade — but a box with no `[memory]` key at all picks up the
+`true` default and comes up with memory on, upgrade or not.
 
 <Aside type="caution">
-The flag is the whole toggle. Until `[memory].enabled` is set (by the
-installer or by hand) and the API is restarted, the memory surfaces are inert.
+The flag is the whole toggle, but the flag's *absence* means on, not off:
+memory is inert only once you (or the installer) have written
+`[memory].enabled = false` to `hal0.toml` and restarted `hal0-api`.
 </Aside>
 
-## Namespaces: who a fact belongs to
+## Namespaces and banks: who a fact belongs to
 
 Every memory operation is scoped to a namespace, and the grammar is a closed
 set: `shared`, `agents`, `project:<id>`, or the caller's own
 `private:<client_id>`. A write with no explicit namespace defaults to
-`shared`. Passing `--private` promotes the write to `private:<client_id>` and
-**wins over an explicit `dataset` field in the request body** — so a
-private-mode client can't smuggle data into `shared` by naming it directly in
-the payload. An unknown namespace on write raises an error; on read it
-silently drops (fail-open-empty), so a typoed namespace can't leak data but
-also won't crash a caller mid-conversation.
+`shared`. Setting the `X-hal0-Private` header over REST (or `private=true`
+over MCP) promotes the write to `private:<client_id>` and **wins over an
+explicit `dataset` field in the request body** — so a private-mode client
+can't smuggle data into `shared` by naming it directly in the payload. An
+unknown namespace on write raises an error. A read naming
+several namespaces drops just the unknown ones and still answers from
+whichever are valid — but if *every* named namespace is unknown, the read
+now raises rather than silently falling back to `shared`: an earlier version
+collapsed "nothing addressable" into "nothing requested," which let an
+approval-gated `memory_delete` scoped to a bank the caller couldn't even
+name execute against `shared` instead.
 
 Callers identify themselves via the `X-hal0-Agent` header, and the same
 identity resolves the same memory namespace whether it arrives over REST or
 MCP.
+
+Namespaces map onto Hindsight **banks** — `shared` is the `shared` bank,
+`private:<agent>` is the `private__<agent>` bank. `[memory].unified_bank`
+(default `true`) changes what a private write actually does: instead of
+forking a separate `private:<agent>` bank, the write still lands in `shared`
+but is stamped with a `visibility:private` tag plus an `agent:<id>` tag, and
+recall stays single-bank (no cross-bank fan-out). Set it `false` to restore
+the pre-unified model — real `private:<agent>` / `project:<id>` banks and
+fan-out recall across them.
+
+## Fact types: world, experience, observation
+
+Every stored fact carries a `fact_type`:
+
+- **world** — a stable fact or configuration detail.
+- **experience** — something that happened.
+- **observation** — a noticed pattern, derived by Hindsight's own
+  consolidation pass over world/experience facts.
+
+Only `world` and `experience` are operator- or agent-authored — `memory_add`
+and the dashboard's Add-fact form only offer those two, and `memory_curate`
+only accepts `"world"`/`"experience"` as a *new* `fact_type` value. History
+runs in reverse of what you'd expect from the name: `memory_history` is
+*only* available for observations (their revision trail comes from
+consolidation re-runs). Curation (edit text, soft-invalidate) has no such
+backend restriction — `memory_curate` over MCP accepts an observation's id
+and will edit or invalidate it; it's the dashboard inspector that hides the
+Curate/Invalidate buttons for observation facts, as a UI convenience rather
+than an engine rule. Either fact type can be deleted outright.
+
+Facts relate to each other through typed links, surfaced in the dashboard's
+graph views: `temporal` (near in time), `semantic` (related meaning),
+`entity` (shared entity), and `caused_by` (led to). `causal` and
+`cooccurrence` are legacy/prototype spellings that don't appear in real
+Hindsight payloads — the dashboard still renders them if it ever sees them,
+but don't expect to.
+
+## Directives and mental models
+
+Two concepts sit alongside plain facts:
+
+<CardGrid>
+  <Card title="Directives" icon="document">
+    A standing instruction injected verbatim into an agent's prompt every
+    turn it uses a bank — "shape behaviour, not memory." Created with a
+    `name`, `content`, `priority`, and `is_active` flag; toggled on/off
+    without deleting them. Deleting a directive is destructive and gated for
+    operator approval.
+  </Card>
+  <Card title="Mental models" icon="brain">
+    A standing question ("what does the operator prefer for X") whose
+    answer is kept refreshed from memory rather than re-derived on every
+    ask. Created with a `name` and `source_query`; the first answer builds
+    as an async operation, and later refreshes are triggered manually or
+    (per the dashboard's Add-model form) on a schedule — though only the
+    manual `memory_mental_model_refresh` trigger is actually wired to the
+    backend today; a mental model can be marked `is_stale`, surfaced in the
+    dashboard as a warning badge.
+  </Card>
+</CardGrid>
+
+## Reranking
+
+Recall unions results across banks under one token budget, then re-ranks
+that union so the most relevant facts surface first. Configured under
+`[memory.embedding]` in `hal0.toml`:
+
+- `rerank_gateway_url` (default `http://127.0.0.1:8080`) — the
+  OpenAI-compatible gateway the reranker POSTs `/v1/rerankings` to (hal0-api
+  itself by default, whose dispatcher routes to the `rerank` capability
+  slot).
+- `rerank_model` (default `builtin.jina-reranker-v1-tiny-en-q8`) — the model
+  id sent to the gateway.
+- `rerank_connect_timeout_s` / `rerank_read_timeout_s` (defaults `1.0` /
+  `8.0`) — HTTP budgets. A timeout or an unreachable reranker never blocks
+  recall: it fails soft back to the fused vector ordering.
+
+The dashboard's Settings → Memory page has a picker for `rerank_model`: the
+schema default is offered as "builtin", plus every model in the
+capabilities catalog tagged for reranking (labelled with its serving
+backend), plus whatever is currently saved if it's outside both lists. Free
+text isn't offered — an id the gateway can't resolve just makes every recall
+fail soft to vector-only ordering. The picker links out to Settings →
+Capabilities, where the underlying `rerank` slot itself is configured.
+
+## Graph extraction
+
+Storing facts is one thing; running an LLM over them to build a knowledge
+graph and observations is heavier and separately gated — **off by default**
+even on a fresh install, under `[memory.graph]`:
+
+- `enabled` (default `false`) — Hindsight builds its graph natively, so this
+  flag is a *reporting and routing* gate, not a hard stop. Disabling it does
+  **not** cancel in-flight extraction or stop the daemon — Hindsight keeps
+  extracting either way; the flag only controls how hal0 labels and routes
+  it.
+- `extraction_slot` (default `"utility"`) — the local `type=llm` slot
+  Hindsight's extraction/consolidation/reflect calls are routed to.
+- `llm_timeout_s` (default `300`, range 30–3600) — timeout for the Hindsight
+  daemon's LLM calls, covering cold slot starts and long reflects.
+
+Both are propagated to the `hindsight-api` service as
+`HINDSIGHT_API_LLM_MODEL=hal0/<slot>` and `HINDSIGHT_API_LLM_TIMEOUT=<n>` via
+a systemd drop-in at `/etc/systemd/system/hindsight-api.service.d/extraction-model.conf`,
+followed by `daemon-reload` + a service restart — all routed through hal0's
+privileged-operation seam rather than hal0-api (which runs unprivileged)
+touching `/etc/systemd` directly.
+
+<Aside type="note">
+A memory write is refused (fast, with a clear error) rather than silently
+corrupted if the extraction slot's model can't clear a context-window floor
+(8192 tokens by default — an estimate of the extraction prompt's own
+footprint, overridable via the `HAL0_MEMORY_EXTRACTION_FLOOR` environment
+variable on the hal0-api service). Without this guard, a too-small context
+window either drops the retain silently or persists prompt scaffolding as a
+"fact." Chat is unaffected — only memory extraction is gated.
+</Aside>
 
 ## What memory powers
 
@@ -127,20 +264,24 @@ When enabled, memory becomes the shared brain that ties the platform together:
 <CardGrid>
   <Card title="Hermes's durable memory, by default" icon="comment">
     Provisioning a fresh bundled agent wires it straight to this subsystem
-    with no manual config: a `private:hermes` bank for its own facts and a
-    `shared` bank every agent on the host can read, both backed by Hindsight
-    via the hal0-api REST front door. Reads union both banks; recalled context
-    is injected automatically every turn, and the agent can also call the MCP
-    tools directly.
+    with no manual config, backed by Hindsight via the hal0-api REST front
+    door. Under the default `unified_bank = true`, Hermes' private writes
+    land in the single `shared` bank tagged `visibility:private` and
+    `agent:hermes` rather than forking a separate bank, and recall is
+    single-bank. Set `unified_bank = false` to give Hermes a real
+    `private:hermes` bank plus `shared`, with recall unioning both. Recalled
+    context is injected automatically every turn either way, and the agent
+    can also call the MCP tools directly.
   </Card>
   <Card title="Operator memory" icon="document">
-    The dashboard Memory view and the `/api/memory/*` routes let you add,
-    search, browse the graph, and prune facts directly — across banks,
-    documents, mental models, and directives.
+    The dashboard's Memory view (Overview + Bank workspace) and the
+    `/api/memory/*` routes let you add, search, browse the graph, and curate
+    facts directly — across banks, documents, mental models, and directives.
+    See [Browse the Bank workspace](/docs/guides/memory-workspace).
   </Card>
   <Card title="Namespaced writes" icon="setting">
     Callers identify themselves (via the `X-hal0-Agent` header), so private
-    writes land in the right per-agent namespace rather than a shared pool.
+    writes land in the right per-agent scope rather than a shared pool.
   </Card>
   <Card title="Destructive ops are audited" icon="approve-check">
     Bank deletes and every memories / config / document / directive /
@@ -154,7 +295,8 @@ When enabled, memory becomes the shared brain that ties the platform together:
 ## Where to go next
 
 <CardGrid>
+  <LinkCard title="Enable memory" href="/docs/guides/enable-memory" description="Turn it on, pick an engine, configure graph extraction and reranking." />
+  <LinkCard title="Browse the Bank workspace" href="/docs/guides/memory-workspace" description="The dashboard's fact list, filters, curation, and graph views." />
   <LinkCard title="Agents" href="/docs/concepts/agents" description="The agent that uses memory as its brain." />
   <LinkCard title="Security" href="/docs/concepts/security" description="Identity, namespaces, and the auth layer." />
-  <LinkCard title="Architecture" href="/docs/concepts/architecture" description="Where the memory surfaces sit in the API." />
 </CardGrid>

--- a/docs/concepts/slots.mdx
+++ b/docs/concepts/slots.mdx
@@ -18,17 +18,21 @@ a lifecycle the platform manages for you. Slots are what the dispatcher routes
 to, what the GPU arbiter coordinates, and — as of v1.0 — the sole owner of
 *where* a model runs and *how much context it gets*. That last point is a real
 v1.0 behavior change from earlier releases, and it's worth understanding
-precisely: see [The hardware/model write boundary](#the-hardwaremodel-write-boundary)
-below.
+precisely: see The hardware/model write boundary, below.
 
 ## One slot, one container
 
 Each slot is backed by a systemd template unit named
-`hal0-slot@<name>.service` whose `ExecStart` runs `podman run`. That launches
-exactly one container — `hal0-slot-<name>` — serving one model on a loopback
-port. The container runtime defaults to podman; the unit uses `--replace` so a
-restart never trips over a stale container name, and publishes its port on
-`127.0.0.1` only.
+`hal0-slot@<name>.service`, generated as a Podman **Quadlet** unit (a
+`.container` file of typed `[Container]` keys — `Image=`, `AddDevice=`,
+`Volume=`, `PublishPort=`, and so on — rather than a hand-assembled `podman
+run` command line). Podman's systemd generator turns that into the
+`[Unit]`/`[Service]` skeleton and the actual `podman run` invocation.
+Quadlet auto-removes any prior container of the same name on start, so
+there's no more `--replace` / `ExecStartPre rm` dance to guard against a
+stale container name. That launches exactly one container —
+`hal0-slot-<name>` — serving one model on a loopback port, publishing its
+port on `127.0.0.1` only.
 
 **`SlotManager`** owns this. It renders the unit, starts and stops it, tracks
 state, and registers the running container as an internal upstream so the
@@ -38,8 +42,9 @@ for the workload tune; the model itself (and the model's own settings) come
 from the registry.
 
 <Aside type="note">
-The container runtime is podman. A docker fallback exists, but podman is the
-supported path — slot units are generated for it.
+The container runtime is Podman only. Quadlet is Podman's declarative unit
+generator and has no Docker equivalent, so Docker is unsupported — the old
+Docker fallback has been removed.
 </Aside>
 
 ## The hardware/model write boundary
@@ -87,9 +92,17 @@ GGUF-derived native window (dense-capped), else a safe 8192 floor. A slot's
 `[model].context_size` value, if set, is honored only as a **cap** on that
 resolved window (`effective = min(model_window, slot_value)`) — because a
 slot owns hardware, and the installer uses this field to write a VRAM-budget
-clamp. It can never *raise* the effective window above what the model
-resolves to. Leaving it unset (the default for a new slot) means "follow the
+clamp. Leaving it unset (the default for a new slot) means "follow the
 model."
+
+There's one exception: when the model has no explicit
+`defaults.context_size` and its window is instead *derived* from the GGUF's
+native context (the dense-capped path), a slot ceiling replaces that
+blanket dense cap rather than being applied underneath it — so on that path
+the ceiling can raise the effective window above the model's own
+dense-capped default, though it's still bounded by the model's native GGUF
+window. Every case where the ceiling changes the answer is logged
+(`journalctl -u hal0-api`), so the effect is visible rather than silent.
 
 ## Pinning a slot to one GPU
 
@@ -131,7 +144,7 @@ transition, not a systemd snapshot:
 | `pulling` | Model files are downloading or being verified. |
 | `starting` | The unit has started; waiting for the container to come up. |
 | `warming` | Container is up; the model is loading into the GPU/GTT pool. |
-| `ready` | Health probe passed; ready to serve. |
+| `ready` | Health probe passed; ready to serve. For a `type = "llm"` slot, this also requires passing an output-sanity probe — a known-answer completion that catches a backend serving garbage while `/health` reads green. See the [Slot lifecycle reference](/docs/reference/slot-lifecycle) for the gate's mechanics. |
 | `serving` | A request is actively in flight. |
 | `idle` | Up but not serving — either warm-but-quiet, or up with no loadable model. |
 | `unloading` | Graceful shutdown in progress. |
@@ -160,6 +173,18 @@ For a streamed response, the slot stays `serving` until the stream drains. A
 background idle monitor demotes a quiet `ready` slot to `idle` after its idle
 timeout (300 seconds by default), so the dashboard can distinguish "warm and
 working" from "warm but quiet."
+
+### The crash-loop breaker
+
+A slot that keeps failing to load isn't retried at request cadence. After a
+load failure, `SlotManager` throttles further attempts with an exponential
+backoff; once a slot racks up five consecutive failures it is **parked** —
+loads are refused outright until a cooldown elapses, at which point a single
+**half-open** trial load runs. Success closes the breaker; failure re-parks it
+at a longer cooldown. A manual load, restart, or config edit resets the
+breaker immediately regardless of the clock. The dashboard surfaces the live
+state as a chip on the slot card and in the slot drawer; see the [Slot
+lifecycle reference](/docs/reference/slot-lifecycle) for the exact timing.
 
 ## Single-flight dispatch
 
@@ -248,38 +273,39 @@ fails on longer inputs.
 ## MTP: an Auto / On / Off decision, not a switch
 
 Multi-token prediction (speculative decoding against the model's own draft
-heads) is resolved from independent signals, in this order:
+heads) is entirely a **model-owned** decision, resolved from
+`defaults.mtp`: an explicit `true` or `false` wins in either direction;
+left unset (**Auto**), hal0 falls back to the registry's legacy `mtp` tag
+when present. There is no filename- or id-based sniff — an uncurated pull
+with neither the tag nor an explicit `defaults.mtp` is simply not
+MTP-eligible.
 
-1. **Model eligibility** — does the model actually ship MTP heads? hal0 checks
-   the registry's `mtp` tag or an `mtp` marker in the model's id/filename.
-2. **Slot override** — the slot's own `mtp` field is a tri-state: forced
-   **On**, forced **Off**, or **Auto** (the default, shown as the middle
-   position of the dashboard's Auto/On/Off control in the slot drawer). MTP is
-   a model capability, gated by the launching runner's support for it — a
-   profile's `mtp` field is informational only and is never read by the
-   launch path.
-
-An explicit slot override always wins. Left on **Auto**, MTP only turns on
-when the model is actually eligible — so a plain chat model dropped onto a
-slot no longer launches with dead speculative-decoding flags.
+`mtp` is one of the keys The hardware/model write boundary (above) forbids
+on a slot, so there is no slot-level MTP override. The control lives in the
+dashboard's model drawer as an Auto/On/Off toggle — **Auto is the first,
+default position** — not in the slot drawer; see [Choose
+models](/docs/guides/choose-models).
 
 Forcing **On** for a model that turns out to have no MTP heads is a launch
 crash waiting to happen (`context type MTP requested but model doesn't
 contain MTP layers`), so hal0 defuses that specific combination rather than
-letting it recur: swapping a forced-on slot onto an ineligible model clears
-the override back to Auto, and an update sweeps existing slot configs for the
-same stale combination.
+letting it recur: swapping a slot onto an ineligible model with `mtp`
+forced on clears the model's override back to Auto, and an update sweeps
+existing configs for the same stale combination.
 
 ## Seeded slots, roles, and aliases
 
 Every install starts with a set of **seeded slots** so the common capabilities
 have a home before you create anything:
 
-`utility`, `embed`, `rerank`, `stt`, `tts`, `img`, `vision`, and `agent`.
+`flm`, `tts`, `rerank`, `utility`, `img`, `agent`, `brain`, `qwen3tts`,
+`coder`, and `embed`.
 
-When the NPU runtime (FLM) is present, two more shadow slots are seeded:
-`stt-npu` and `embed-npu` (riding the NPU chat anchor's own `npu` slot).
-Seeded slots are reserved — you can't create a conflicting name or delete them.
+When the NPU runtime (FastFlowLM) is present, two more shadow slots are
+seeded: `flm-stt` and `flm-embed`, riding the NPU chat anchor's own `flm`
+slot. Seeded slots are reserved — you can't create a conflicting name, and
+deleting one requires `--force` (see [Manage slots](/docs/guides/manage-slots)),
+which an install or update reconcile may later re-seed.
 
 The two canonical LLM roles are **`agent`** (the capable default — the
 dispatch fallback anchor every routing chain ends in) and **`utility`** (the
@@ -297,11 +323,13 @@ they're a transparent translation at dispatch time.
 
 Addressing a slot by its name (e.g. `model: "agent"`) is the stable way to pin
 a co-resident model: the name doesn't change when you swap the underlying
-model file. hal0 also advertises three virtual model names that resolve to
-whichever slot is actually loaded — `hal0/agent`, `hal0/utility`, and
-`hal0/npu` — and generalizes the pattern to any enabled `type: llm` slot: a
-custom slot named `research` is addressable as `hal0/research` even though
-it isn't one of the three advertised names.
+model file. hal0 also resolves `hal0/<slot>`-style virtual model names —
+`hal0/agent`, `hal0/utility`, `hal0/npu`, and the same pattern for any
+custom `type: llm` slot (`hal0/research`, say) — to whichever slot is
+actually loaded. As of v1.0 these canonical names are no longer advertised
+as separate entries in `/v1/models`: each enabled LLM slot's own alias
+already covers its listing, so a `hal0/<slot>` request is resolved on
+demand at dispatch time instead of being double-listed.
 
 ## The NPU trio
 

--- a/docs/concepts/stacks.mdx
+++ b/docs/concepts/stacks.mdx
@@ -22,7 +22,8 @@ exactly what the stack describes, in one guarded operation.
 **An honest maturity note.** Stacks is hal0's youngest major subsystem —
 real, working, not a stub, but with a track record worth knowing about. The
 guard that stops a stack from writing a slot config a manual edit would be
-refused (the [model-owned-key partition](/docs/concepts/slots#the-hardwaremodel-write-boundary))
+refused (the model-owned-key partition described in the hardware/model
+write boundary section of [Slots](/docs/concepts/slots))
 had to be retrofitted into the stacks-apply path more than once, because the
 apply engine originally hand-rolled its own merge instead of routing through
 the same guarded pipeline every other slot writer used. A shared gate

--- a/docs/concepts/strix-halo.mdx
+++ b/docs/concepts/strix-halo.mdx
@@ -135,9 +135,10 @@ reads the cgroup limit and treats it as a third constraint, so the reported
 headroom reflects what you can really use.
 
 Because one pool is shared, two GPU workloads can't both hold their weights at
-once. That's exactly why the [GPU arbiter](/docs/concepts/slots#the-gpu-arbiter)
-exists: it gives the GPU's memory to either the LLM slots or the image slot, one
-group at a time, rather than letting them fight over the pool.
+once. That's exactly why the GPU arbiter exists (see the GPU arbiter
+section of [Slots](/docs/concepts/slots)): it gives the GPU's memory to
+either the LLM slots or the image slot, one group at a time, rather than
+letting them fight over the pool.
 
 ![The Slots view: the iGPU GTT carve-out bar above the Inference Engine, where iGPU and FLM (NPU) slots share the unified-memory pool](/screenshots/npu-occupancy.png)
 *The shared GTT carve-out above the Inference Engine — iGPU slots and FLM (NPU) slots both draw from one unified-memory pool.*

--- a/docs/getting-started/bare-metal.mdx
+++ b/docs/getting-started/bare-metal.mdx
@@ -44,12 +44,13 @@ sudo apt-get update && sudo apt-get install -y python3-venv python3-pip
 Before installing on GPU hardware, make sure the host kernel already
 exposes the iGPU (and NPU, if present) as device nodes — hal0 ships the
 ROCm/XRT userspace inside its containers, but it cannot load a kernel
-driver from inside one. See [GPU drivers and memory](/docs/getting-started/drivers/#kernel-and-firmware)
+driver from inside one. See the Kernel and firmware section of
+[GPU drivers and memory](/docs/getting-started/drivers/)
 for the kernel/firmware requirements and verification steps.
 
 On a Strix Halo box, also size the amdgpu **GTT** pool on the host kernel
-command line before you install — see
-[Size the GTT pool](/docs/getting-started/drivers/#size-the-gtt-pool) for
+command line before you install — see the Size the GTT pool section of
+[GPU drivers and memory](/docs/getting-started/drivers/) for
 the reference `grub` parameters.
 
 ## 3. Install hal0
@@ -67,8 +68,8 @@ for the full sequence and every environment variable and flag.
 <Aside type="tip" title="GPU device groups">
 On a GPU host the installer adds the `hal0` service user to the `render`
 and `video` groups so slot containers can open `/dev/kfd` and
-`/dev/dri/renderD*`. See
-[Render-group gids](/docs/getting-started/drivers/#render-group-gids) if
+`/dev/dri/renderD*`. See the Render-group gids section of
+[GPU drivers and memory](/docs/getting-started/drivers/) if
 you need to hand-wire device access (e.g. in an LXC).
 </Aside>
 

--- a/docs/getting-started/proxmox.mdx
+++ b/docs/getting-started/proxmox.mdx
@@ -17,9 +17,10 @@ a Proxmox VM instead of a container.
 ## 1. Prepare the PVE host
 
 Everything the accelerators need lives on the **host kernel**, because an
-LXC shares it. See [GPU drivers and memory](/docs/getting-started/drivers/#kernel-and-firmware)
-for the `amdgpu`/`amdxdna` kernel and firmware requirements, and
-[Size the GTT pool](/docs/getting-started/drivers/#size-the-gtt-pool) for
+LXC shares it. See the Kernel and firmware section of
+[GPU drivers and memory](/docs/getting-started/drivers/)
+for the `amdgpu`/`amdxdna` kernel and firmware requirements, and the
+Size the GTT pool section for
 the GRUB parameters that raise the amdgpu GTT window — both are set on the
 **Proxmox host**, not inside the container.
 
@@ -82,8 +83,8 @@ pct stop <CTID> && pct start <CTID>
 
 <Aside type="caution" title="gid means the CONTAINER's gid, not the host's">
 The `gid=` value must be the render group's id **inside the container**,
-not on the host — the two gid spaces can disagree. See
-[Render-group gids](/docs/getting-started/drivers/#render-group-gids) for
+not on the host — the two gid spaces can disagree. See the Render-group
+gids section of [GPU drivers and memory](/docs/getting-started/drivers/) for
 how to read the correct value with `stat -c %g` and why `getent group
 render` can silently resolve to the wrong group.
 </Aside>

--- a/docs/guides/choose-models.mdx
+++ b/docs/guides/choose-models.mdx
@@ -59,6 +59,38 @@ than the per-id model directory — see
 picks span the licensing spectrum on purpose (research-only through
 fully permissive) — read the license before using output commercially.
 
+## Filter and sort the catalog
+
+The Models view's toolbar offers a search box, a row of multi-select
+filter chips (OR semantics — pick several to widen the match, none to show
+everything), and a sort dropdown (name / size / params / added, either
+direction). The filter chips are:
+
+| Chip | Matches |
+|---|---|
+| MTP | `defaults.mtp === true`, or the model carries the legacy `mtp` tag — a plain OR, so the tag still matches even when `defaults.mtp` is explicitly `false` (see "Vision and MTP" below) |
+| MOE | a mixture-of-experts architecture (`qwen3next`, `mixtral`, `deepseek-moe`), or — since no registry row persists `architecture` yet — the `moe`/`a3b`/`mtp` tag or an `a3b` token in the id |
+| DENSE | neither MTP nor MOE |
+| Embed | `type === "embedding"` |
+| Rerank | `type === "reranking"` |
+| Voice | `type === "tts"` or `type === "transcription"` |
+| Vision | `vision` in the model's capabilities |
+
+The backend's own context-sizing heuristic (a local `is_moe` variable
+inside `hal0.hardware.recommend._resolve_primary_ctx`, not an importable
+symbol) uses a narrower signal than the chip above: it prefers a curated
+row's backfilled `architecture` field when present, and otherwise falls
+back to just the `mtp` tag or an `a3b` token in the model id — no `moe`
+tag check. Since no curated row has an `architecture` backfilled yet,
+every row currently falls through to that narrower id/tag heuristic for
+context sizing, which is not quite the same rule as the MOE filter chip
+above.
+
+The **Profiles** tab lives alongside Inference / Image / Upstream at the
+top of the Models view (`#models/profiles`) — that's where you manage the
+runtime-profile templates the model drawer's template picker draws from.
+See [Manage slots](/docs/guides/manage-slots) for what a profile controls.
+
 ## Launch flags now live on the model, not the slot
 
 As of v1.0, tuning knobs that used to be per-slot — `extra_args`, `mtp`,
@@ -69,22 +101,109 @@ model's defaults; the old per-slot fields still round-trip in TOML for
 compatibility but are inert at launch, and a one-shot migrator folds any
 value you had set there into the model.
 
-There's no dedicated `hal0 model edit` CLI verb for these fields yet —
-set them via `PUT /api/models/{model_id}` or, more practically, from the
+There's no dedicated `hal0 model edit` CLI verb for these fields — set
+them via `PUT /api/models/{model_id}` or, more practically, from the
 dashboard's model drawer.
+
+Curated type-tag chips (mtp / coder / reasoning / vision, ticked on the
+old recipe editor) are retired: behavior is now owned by typed fields —
+`defaults.mtp`, `capability_flags.tool_calling`, `defaults.enable_thinking`,
+and the `capabilities` list + `mmproj` path for vision. The old tags still
+exist in the registry as inert, freeform labels; nothing routes on them
+anymore.
 
 ## Edit a model from the dashboard
 
-Every model row in the **Models** view carries a kebab (⋮) menu. Today it
-has one action, **Edit model settings**, which opens the docked model
-drawer for that row directly — independent of whichever row is currently
-selected in the catalogue list, so you can jump straight from any row to
-its settings without first clicking to select it.
+Every model row in the **Models** view carries a kebab (⋮) menu. It has
+**Edit model settings**, which opens the docked model drawer for that row
+directly — independent of whichever row is currently selected in the
+catalogue list, so you can jump straight from any row to its settings
+without first clicking to select it — and, for a row that's installed and
+not an upstream-served model, **Delete model…**, which removes its
+registry entry and bytes (the same confirm-by-typing-the-name flow as the
+detail pane's Delete button). The row's detail pane also has an **Edit
+options** button that opens the same drawer for whichever row is currently
+selected.
 
 The same drawer opens from a slot card's pencil icon (see
-[Manage slots](/docs/guides/manage-slots#dashboard-the-inline-model-edit-pencil))
-for whichever model is currently bound to that slot — same drawer, two
-entry points.
+[Manage slots](/docs/guides/manage-slots), which covers the inline
+model-edit pencil) for whichever model is currently bound to that slot —
+same drawer, two entry points.
+
+The drawer is organized top to bottom as:
+
+- **Display name** — what the dashboard shows; empty keeps the model id.
+- **Default for `<type>`** — a badge plus a Set/Remove toggle for the
+  per-type default marker (see below).
+- **Launch flags** — a hero textarea framed as the resolved launch
+  command, with a profile picker beside it (see "Templates, flags, and
+  divergence" below).
+- **Typed capabilities** — Thinking, MTP, Jinja, and Vision, each an
+  Auto/On/Off toggle, plus an editable Chat template picker (saved as
+  `defaults.chat_template`) and a read-only Modality readout derived from
+  capabilities.
+- **Context size** — tokens; empty means the launcher default. Must be a
+  whole number ≥ 128 if set; the server enforces the same floor
+  (`400 model.context_size_out_of_range`).
+- **Routing** — the Capabilities and Backends chip sets (dispatch/omni
+  eligibility and slot-compat filtering).
+- **Source · re-pull coords** — MMProj sidecar path, HF repo, HF filename.
+
+Saving writes only the fields that changed, plus the full `defaults` block
+(model defaults merge one level deep server-side, so every typed-capability
+key is always sent explicitly — a value, or `null` to clear it). The
+drawer's footer warns that changes require the slot to restart to take
+effect, and the Save button stays disabled until something is actually
+dirty.
+
+### Templates, flags, and divergence
+
+The flags textarea is literally what launches — hal0 computes and rejects
+a short managed-argument set inline before save: `--model`, `--ctx-size` /
+`-c`, `--host`, `--port`, `--n-gpu-layers` / `-ngl`, and `--alias`. Slot
+hardware flags (`-ngl`/`--n-gpu-layers`, `-dev`/`--device`, `-t`/`--threads`)
+are rejected too, with a message pointing at the slot's hardware grid
+instead — the model is device-agnostic and carries no runner or image.
+
+Picking a profile from the dropdown **stamps** its flags into the
+textarea — a one-time copy, not a live link. If your edits would be
+overwritten a confirm dialog asks first. Once stamped, editing the
+textarea further diverges the model from the profile; a "diverged"
+badge appears along with an inline diff (added / changed / removed
+flags) and a "reset to profile" action that re-stamps the profile's
+current text over your edits.
+
+### Vision and MTP
+
+Vision is Auto/On/Off, same as the other typed caps: Auto loads the
+`mmproj` sidecar whenever the model carries one; Off force-suppresses it
+even on a vision-capable model (frees roughly 0.9 GB of resident VRAM).
+Setting `capabilities` to include `vision` with no `mmproj` path blocks
+save with an inline error.
+
+MTP eligibility is a tri-state on `defaults.mtp`: an explicit `true` or
+`false` wins in either direction over the registry's legacy `mtp` tag;
+leaving it at Auto falls back to that tag when present. There is no
+filename-based MTP sniff anymore — an uncurated pull with neither the tag
+nor an explicit `defaults.mtp` is simply not MTP-eligible. That tri-state
+precedence is what the drawer's MTP toggle and the backend launch path
+(`hal0.model_meta.model_is_mtp_eligible`) both use — but the Models list's
+MTP filter **chip** doesn't: it's a plain OR of `defaults.mtp === true`
+and the legacy tag (`ui/src/dash/model-sort.js`), so a model tagged `mtp`
+still shows the MTP chip even when its `defaults.mtp` is explicitly set to
+`false`. The chip and the toggle can disagree on the same row.
+
+### Per-type default
+
+"Default for `<type>`" marks the model that its dispatcher type
+(`llm`/`embedding`/`reranking`/…) falls back to. At most one model per
+type can hold it — promoting one demotes whichever model currently holds
+it. Set or clear it from the drawer, or from the CLI:
+
+```sh
+hal0 model default qwen3.6-27b          # promote (demotes the current holder)
+hal0 model default qwen3.6-27b --clear  # clear — the type is left with no default
+```
 
 ## Preferred profile
 

--- a/docs/guides/configure.mdx
+++ b/docs/guides/configure.mdx
@@ -18,7 +18,7 @@ running daemon; most subcommands are simple wrappers over
 
 | File | What it holds |
 |------|---------------|
-| `hal0.toml` | Top-level config: `[meta] schema_version`, `[slots]` policy, `[dispatcher]` prefetch tuning, `[models]` roots/store, `[memory]` engine + `[memory.graph]` extraction, `[telemetry] channel`. |
+| `hal0.toml` | Top-level config: `[meta] schema_version`, `[slots]` policy, `[dispatcher]` prefetch tuning, `[telemetry] channel`, `[models]` roots/store, `[memory]` engine + `[memory.graph]` extraction, `[activity]`, `[brain_chat]`, `[security]`, `[realtime]` — all fields of the root `Hal0Config` model. The same file also carries `[metrics]` (sampling/retention tuning), read independently by its own small loader rather than through `Hal0Config`. |
 | `upstreams.toml` | External/upstream provider routing — one `[[upstream]]` block per remote or local endpoint. |
 | `providers.toml` | Provider credential *references* — env-var **names**, never plaintext secrets. |
 | `profiles.toml` | Optional reusable backend/flag templates. Built-in seed profiles are always overlaid from code on load and never written back here, even if the file exists. |
@@ -79,8 +79,12 @@ restart:
 hal0 config reload
 ```
 
-This hits `POST /api/settings/reload`. Structural edits to
-`upstreams.toml` still need a full `hal0-api` restart — see
+This hits `POST /api/settings/reload`, which re-reads `hal0.toml`. It
+does not touch `upstreams.toml` — but that's fine for day-to-day use,
+because `hal0 upstream create`/`update`/`delete`/`advertise` already
+apply to the running daemon live, no reload or restart needed. A
+restart is only required after a hand-edit of `upstreams.toml` outside
+the CLI/API — see
 [Connect external providers](/docs/guides/connect-external-providers).
 
 ![Settings page showing live reload status](/screenshots/settings-page.png)

--- a/docs/guides/connect-external-providers.mdx
+++ b/docs/guides/connect-external-providers.mdx
@@ -81,7 +81,7 @@ than pointing an upstream straight at `api.anthropic.com`.
 hal0 upstream update openrouter --timeout 120
 hal0 upstream test openrouter
 hal0 upstream show openrouter
-hal0 upstream advertise openrouter    # toggle whether its models are advertised
+hal0 upstream advertise openrouter on # required on|off — set /v1/models visibility
 hal0 upstream delete openrouter
 ```
 
@@ -90,11 +90,41 @@ reachability report: `{ok, status, latency_ms, models_count, error?}`. If
 the declared env var is empty, the probe fails fast without making an
 HTTP call.
 
+## Curate which models are advertised
+
+`[upstream.model_filters]` narrows which of an upstream's models show up
+in the aggregated `/v1/models` catalog, without touching dispatch — a
+model can be filtered out of the catalog and still be reachable by its
+explicit id.
+
+```sh
+hal0 upstream update openrouter --include 'anthropic/*' --exclude '*:free'
+hal0 upstream update openrouter --model gpt-4o-mini
+hal0 upstream update openrouter --clear-filters
+```
+
+- **`--model`** (repeatable) — allowlist one exact model id.
+- **`--include`** (repeatable) — an fnmatch glob; a model is advertised if
+  it's in `--model` or matches any `--include` glob (both empty means
+  everything is included).
+- **`--exclude`** (repeatable) — an fnmatch glob that always wins over
+  `--model`/`--include`.
+- **`--clear-filters`** — drop all filters and advertise everything again.
+
+`hal0 upstream list` shows a **Filters** column summarizing what's
+active per upstream. Like `--advertise-models`/`--enabled`, filter
+changes apply live — no restart.
+
 ## Write a credential without recreating the upstream
 
 ```sh
-hal0 upstream update openrouter --api-key sk-or-new-key
+hal0 upstream credentials set openrouter --key sk-or-new-key
 ```
+
+`credentials set` posts to `/api/providers/{name}/credentials` and binds
+the key to the upstream's declared `auth_value_env` — pass `--env-var` to
+target a different env-var name instead of the upstream's default. Omit
+`--key` to be prompted for it securely.
 
 Or directly over the API:
 
@@ -125,9 +155,20 @@ if it needs to be exposed beyond the LAN.
 
 ## Picking up changes
 
-Credential writes apply to the running process immediately — no restart
-needed. Structural edits to `upstreams.toml` (adding, removing, or
-retiming an upstream through the CLI) are read once at `hal0-api`
-startup — `hal0 config reload` re-reads `hal0.toml`, **not**
+Credential writes, and every `hal0 upstream create` / `update` / `delete`
+/ `advertise` call, apply to the running `hal0-api` process immediately —
+no restart needed. Creating an upstream registers it live; patching one
+(visibility flags, auth, URL, timeout, model filters) applies live too. A
+patch that flips `advertise_models` or `enabled` punches only that
+upstream's entry in the per-upstream model cache (and only if it's
+already cached), so the next `/api/upstreams` or `/v1/models` request
+refetches it. The composite `/v1/models` catalogue itself is served from
+a separate, module-level TTL cache that per-upstream visibility patches
+do not touch — it's refreshed by its own TTL (default 5s) and by slot
+readiness events, not by upstream PATCH calls.
+
+The one case that still needs a restart is a **hand-edit** of
+`upstreams.toml` outside the CLI/API — nothing watches that file for
+changes, and `hal0 config reload` only re-reads `hal0.toml`, not
 `upstreams.toml`. Run `hal0 config validate` after a hand-edit, then
-`systemctl restart hal0-api` to pick it up.
+`sudo systemctl restart hal0-api` to pick it up.

--- a/docs/guides/connect-mcp.mdx
+++ b/docs/guides/connect-mcp.mdx
@@ -60,8 +60,8 @@ connect to directly:
 <Aside type="note">
 hal0 supports optional static-key network auth (`hal0 auth status` / `hal0
 auth rotate`) — **off by default** on a fresh loopback/LAN install. When
-it's armed, both MCP mounts are token-gated — see
-[Authenticate](#authenticate) below. Auth or not, run hal0 on a trusted LAN
+it's armed, both MCP mounts are token-gated — see the Authenticate
+section below. Auth or not, run hal0 on a trusted LAN
 or behind your own reverse proxy — do not expose `/mcp/*` to the internet.
 </Aside>
 
@@ -164,9 +164,10 @@ live.
 
 Connecting **from a workstation to a hal0 box on the LAN** — rather than a
 client running on the box itself — needs three things: the box's
-hostname/IP [widened into the allowlist](#widen-the-host-and-origin-allowlists)
-above, the mount URL pointed at the box instead of `127.0.0.1`, and — if
-[auth is armed](#authenticate) — the bearer header.
+hostname/IP widened into the allowlist (see Widen the host and origin
+allowlists, above), the mount URL pointed at the box instead of
+`127.0.0.1`, and — if auth is armed (see Authenticate, above) — the
+bearer header.
 
 A workstation Hermes' `config.yaml` (the same `mcp_servers.*` shape `hal0
 agent bootstrap hermes` renders for the box's own bundled agent):
@@ -198,7 +199,7 @@ Replace `<host>` with the hal0 box's LAN hostname or IP, and `<key>` with
 the value read from `/etc/hal0/api.env` **on the hal0 box** — never commit
 it into a workstation dotfile checked into git. `HAL0_ADMIN_KEY` satisfies
 both mounts; a client-tier `HAL0_CLIENT_KEY` only satisfies `/mcp/memory`
-(see the [tier table above](#authenticate)).
+(see the tier table in Authenticate, above).
 
 ### Memory tools (`/mcp/memory`)
 
@@ -236,8 +237,9 @@ routes to the gated tier at call time.
 `config_write`, `provider_credential_write`, `stack_apply`,
 `stack_import`, `stack_delete`, `profile_import`, `profile_delete`, and
 `logs_tail`. `slot_create` and `config_write` here follow the same
-[server].extra_args screening as every other slot write path — see
-[Edit configuration](/docs/guides/configure#server-extra_args-is-screened-everywhere).
+[server].extra_args screening as every other slot write path — see the
+"[server].extra_args is screened everywhere" section of
+[Edit configuration](/docs/guides/configure).
 
 ### The approval flow
 

--- a/docs/guides/dashboard-and-settings.mdx
+++ b/docs/guides/dashboard-and-settings.mdx
@@ -1,0 +1,205 @@
+---
+title: Find your way around the dashboard
+description: The dashboard's persistent chrome — command palette, notifications bell, Agent Chat drawer, sidebar, and footer — and a map of every page under Settings, including what the Storage model-store migration actually does.
+sidebar:
+  order: 5
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The dashboard has two layers: a shell that's on screen no matter what page
+you're looking at, and the pages themselves. This guide maps the shell —
+the command palette, the notifications bell, the Agent Chat launcher, the
+sidebar, and the footer — and then walks every page under **Settings**, so
+nothing in the operator surface is a surprise.
+
+## The chrome
+
+### Command palette
+
+Press **⌘K** (or **Ctrl+K**) anywhere in the dashboard to open the command
+palette — a fuzzy-search launcher over everything the dashboard knows
+about. On mobile, the same surface opens from the **Quick actions** row in
+the nav drawer.
+
+Typing filters a grouped list:
+
+- **Routes** — jump to Dashboard, Slots, Runner Images, Models, Profiles,
+  Operator Board, Benchmarks, Hardware, Logs, Agent, or Settings.
+- **Slots** — every configured slot, live; selecting one opens its edit
+  drawer.
+- **Models** — every catalogue and installed model; selecting one opens
+  the Models page.
+- **Settings** — a deep link straight into most Settings pages (see
+  below) — the palette has an entry for every page except **Model
+  Defaults**, which has no deep link.
+- **Actions** — global actions that are always live: Create slot, Add
+  model from HF, Open Chat Pro UI (when OpenWebUI is reachable), and Open
+  docs. A Cancel download action appears only while a model pull is
+  actually running.
+- **Copy** — clipboard utilities for hitting the API directly, currently
+  just Copy API base URL. Rendered as its own group, separate from
+  Actions.
+- **Slot actions** — per-slot verbs (Restart, Stop or Start, View logs,
+  Copy curl) that only show up once you type a verb or a slot name — they
+  stay out of the default list to keep it uncluttered.
+
+Arrow keys move the selection, Enter runs it, Escape closes the palette.
+
+### Notifications bell
+
+The bell in the top bar aggregates everything that needs your attention
+into one panel, grouped into sections:
+
+- **needs attention** — pending agent tool-call approvals and slots that
+  have failed and need a restart.
+- **downloads** — active and failed model pulls, with cancel/retry
+  controls and a link to the full downloads pane.
+- **updates** — an available hal0 release, slots running a pre-update
+  config that need a restart, and any model updates available on
+  Hugging Face.
+- **messages** — developer/system notices pushed into the dashboard at
+  runtime.
+
+The badge shows a live count; when nothing needs you, the panel says so.
+
+### Agent Chat drawer
+
+The **Agent Chat** button in the top bar (the two-hemisphere brain icon)
+toggles a slide-out drawer — the UI surface for talking to hal0's brain.
+This page only covers the drawer as a piece of chrome; for what the brain
+is and how it's configured, see [Brain](/docs/concepts/brain).
+
+### Documentation and sidebar
+
+The book icon next to Agent Chat opens the hosted docs in a new tab. The
+sidebar below it lists the primary destinations — Overview, Slots (with
+Endpoints, Runner Images, and Stacks as sub-pages), Models (with
+Profiles), Benchmarks, Agents (with Memory, when the memory subsystem is
+enabled, and MCP), Services, Logs, and Settings — plus a **Services**
+zone pinned to the bottom of the sidebar with quick external launchers:
+**Kanban** (the in-app Operator Board, also reachable with ⌘B),
+**OpenWebUI**, and **Hermes Dash** — the latter two only appear when the
+backend reports them reachable.
+
+### Footer
+
+The footer is always visible as a thin strip and expands into a pane when
+toggled. Collapsed, it shows two LED-pip groups plus a toggle:
+
+- a **slots** group — one pip per active slot (colored by state) and a
+  ready count,
+- a **services** group — one pip per backing service and a ready count
+  (a single warn-toned "services unknown" pip appears if the health
+  check itself hasn't answered, rather than falsely reporting all-green),
+- an update chip when a new hal0 release is available,
+- a trailing tail of the most recent journal lines.
+
+Expanded, it becomes a two-tab pane: **journal** (the live event stream,
+filterable by source and searchable) and **downloads** (active/queued/
+completed/failed model pulls with cancel, retry, and clear controls).
+
+## Settings
+
+Settings groups its pages into four sections in the left rail. Several
+pages are the primary documentation surface for another guide — those get
+one line and a link here rather than a repeat.
+
+### GENERAL
+
+- **Overview** — the landing page: overall health status, per-service
+  health, live hardware/power counters, the `/v1` request rollup, and the
+  telemetry opt-in.
+- **Security** — auth posture only (never a key value): whether auth is
+  required, whether an admin key is set, and the tier; rotates the admin
+  or client key; shows the live route-exposure table. See
+  [Auth](/docs/operate/auth).
+- **Doctor** — runs and renders `hal0 doctor`'s typed diagnoses (id,
+  severity, evidence, next steps) over HTTP.
+
+### MODELS & INFERENCE
+
+- **Loaded Models**, **Model Defaults**, and **AI Capabilities** (TTS,
+  STT, embeddings, reranking, image generation, plus the NPU anchor) —
+  see [Choose models](/docs/guides/choose-models) for the catalogue and
+  per-model launch defaults, and
+  [Generate images](/docs/guides/generate-images) /
+  [Speech to text and text to speech](/docs/guides/voice-stt-tts) for
+  the capability slots.
+
+### SYSTEM
+
+- **Hardware & Runtimes** — read-only evidence: detected hardware,
+  available backends, and the runner-image registry per slot. See
+  [Manage slots](/docs/guides/manage-slots) and
+  [Manage runner images](/docs/guides/manage-runner-images) for what
+  actually controls what a slot runs on.
+- **Storage** — where hal0 reads and writes model files on disk. Covered
+  in detail below.
+- **Memory** — the memory engine, graph extraction, and reranker. See
+  [Enable memory](/docs/guides/enable-memory).
+- **Updates** — signed self-update plus version/license identity. See
+  [Update and roll back](/docs/guides/update-and-rollback).
+- **Advanced** — low-level dispatcher and activity-log tuning rendered
+  straight from the server's settings schema, plus a hal0-api restart
+  control.
+
+### INTEGRATIONS
+
+- **Secrets** — provider keys, pull-auth, and custom env vars. This is
+  **not** an encrypted store: values are persisted as plaintext
+  double-quoted `KEY="value"` lines in `/etc/hal0/api.env`, root-only at
+  mode `0600` — the same systemd `EnvironmentFile=` `hal0-api` reads at
+  start. Includes a dedicated `HF_TOKEN` field that applies live (no
+  restart) so a gated or large pull can authenticate right away. See
+  "Secrets" on [REST API index](/docs/reference/api/rest-api/) for the
+  write path.
+- **Agent Chat** — the `[brain_chat]` policy surface (kill switch, target
+  slot override, loop knobs). See [Brain](/docs/concepts/brain).
+
+## Settings ▸ Storage, in detail
+
+Storage holds one field: **Storage location**, an absolute directory that
+every model consumer — the pull engine, the registry, slots — resolves
+through. Alongside it:
+
+- **Current state** — a live probe of the effective path: whether it
+  exists, file count, bytes used, bytes free, and whether it's writable.
+- **Suggested locations** — clickable preset paths, each labeled with its
+  current state.
+- **Auto-scan on start** — whether hal0-api walks the storage path at
+  startup and registers any new files it finds.
+- **File extensions** — read-only; edit via `hal0 config edit`.
+
+### Changing the location: the migration flow
+
+If you change **Storage location** to a path that doesn't yet hold your
+existing model files, Saving doesn't move anything right away. hal0 first
+does a dry run and shows a confirmation dialog: it will move a specific
+number of files (with a total size) from the old path to the new one. If
+source and target are on the same filesystem the move is effectively
+instant; across filesystems it's a real copy and can take a while. Only
+after you confirm does hal0 actually touch disk.
+
+On confirm, hal0 moves the files first and persists the new path to
+`hal0.toml` second — deliberately in that order, so a failed move leaves
+your prior config and your files exactly where they were; you can safely
+re-run the move. Once the new path is saved, hal0 immediately rescans it
+and registers any files it finds, so newly-visible models show up in the
+registry without waiting for a restart.
+
+<Aside type="caution">
+Moving files does **not** touch already-running slots. A slot that has a
+model loaded keeps serving it from memory against the old path — nothing
+interrupts an in-flight request. What changes is the *next* time each
+slot's container restarts: only then does it observe the new storage
+path. The Storage location row carries an amber "requires restarting
+slots to take effect" badge for exactly this reason. If you want every
+slot serving from the new location immediately, restart them yourself
+afterward — from the Slots page, or with **Restart &lt;slot&gt;** in the
+command palette.
+</Aside>
+
+If a move partially fails, the files that already moved are **not**
+rolled back — the operator can re-run the same move (now effectively a
+no-op for what already succeeded) to finish it safely.

--- a/docs/guides/enable-memory.mdx
+++ b/docs/guides/enable-memory.mdx
@@ -1,11 +1,11 @@
 ---
 title: Enable memory
-description: hal0's memory subsystem is toggled with hal0 memory enable/disable — Hindsight-backed recall, optional graph extraction, and per-bank management.
+description: hal0's memory subsystem is toggled with hal0 memory enable/disable — Hindsight-backed recall, optional graph extraction, reranking, and per-bank management from the CLI or the dashboard.
 sidebar:
   order: 50
 ---
 
-import { Steps, Aside, Tabs, TabItem, Code } from '@astrojs/starlight/components';
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
 hal0's memory subsystem gives agents a persistent recall store —
 **Hindsight** — plus an optional knowledge-graph extraction layer. As of
@@ -15,10 +15,10 @@ variable — the old `HAL0_MEMORY_ENABLED` flag is gone.
 <Aside type="note">
 A fresh install turns memory on for you and stands up the local Hindsight
 daemon automatically. The steps below are for the cases the installer
-doesn't cover: re-enabling memory after you turned it off, or a manual
-install. Every downstream caller — the admin MCP tools, the
-`/api/memory/*` routes, the agent memory provider — degrades to a no-op
-or `503` when memory is off.
+doesn't cover: re-enabling memory after you turned it off, a manual
+install, or tuning the engine/graph/reranker after the fact. Every
+downstream caller — the MCP tools, the `/api/memory/*` routes, the agent
+memory provider — degrades to a no-op or `503` when memory is off.
 </Aside>
 
 ## Turn it on or off
@@ -31,11 +31,17 @@ hal0 memory disable
 
 Toggles `[memory].enabled` in `hal0.toml`; enabling requires a
 `hal0-api` restart to actually construct the memory provider.
+`hal0 memory status` also reports the retain pipeline's health once memory
+is on — whether writes are landing, waiting on a chat model to be loaded, or
+failing, plus the engine's own failed/pending/processing operation counts.
 
 When enabled, hal0 builds the memory provider from your config. The
 engine is **Hindsight**; if the Hindsight daemon is unreachable at
 startup, hal0 logs a warning and degrades to an in-memory PgVector
-fallback rather than failing startup.
+fallback rather than failing startup. hal0-api keeps re-probing in the
+background and swaps the durable engine back in on its own once Hindsight
+answers — no restart needed — but any writes accepted while degraded are
+gone; they were never on the durable side.
 
 <Aside type="caution">
 The PgVector fallback is **volatile** — every write is lost on restart.
@@ -46,20 +52,37 @@ Check `GET /api/memory/engine` — `"engine": "hindsight"` and
 </Aside>
 
 <Aside type="caution">
-`[memory].engine` accepts `hindsight` (default), `pgvector`, or `mem0`.
-The legacy `cognee` engine is **retired as of v1.0.0** and now fails
-config validation outright — migrate off it first (see
-[Migrate a legacy store](#migrate-a-legacy-store)) before updating past
-the version that dropped it.
+`[memory].engine` accepts `hindsight` (default), `pgvector`, or `mem0` at
+config validation time, but `mem0` **is not implemented** — selecting it
+just logs a warning and runs Hindsight anyway. The dashboard's engine
+picker only offers `hindsight`/`pgvector` for this reason. The legacy
+`cognee` engine is **retired as of v1.0.0** and fails config validation
+outright. There is no automated migration path off a Cognee-era store —
+Cognee has been dark since v0.4; `hal0 memory migrate unify` (below) folds
+Hindsight banks together and has nothing to do with Cognee.
 </Aside>
 
 ## One shared bank, or per-agent private banks
 
 `[memory].unified_bank` (default `true`) routes all memory into one
 shared Hindsight bank instead of splitting it per agent into private
-banks. This is a config-level policy decision, not something you toggle
-per request — see [MCP servers](/docs/guides/connect-mcp) for how
-`X-hal0-Private` interacts with it at write time.
+banks. When true, a private write still lands in `shared` but is tagged
+`visibility:private` + `agent:<id>` rather than forking a separate bank; set
+it `false` to restore real per-agent `private:<agent>` banks and
+cross-bank fan-out recall. This is a config-level policy decision, not
+something you toggle per request — see [MCP servers](/docs/guides/connect-mcp)
+for how `X-hal0-Private` interacts with it at write time.
+
+## The dashboard's Settings → Memory page
+
+Everything below this section is also available from the dashboard —
+`#settings/memory` — as three panels: **Engine**, **Memory graph
+extraction**, and **Reranker**. Engine and reranker changes save through the
+generic settings API; graph changes go through a dedicated endpoint (see
+below) because it validates the extraction slot against the live slot set
+and propagates the change to `hindsight-api` itself. Changing the engine
+needs a `hal0-api` restart to take effect; graph and reranker changes apply
+live.
 
 ## The graph-extraction gate
 
@@ -70,7 +93,10 @@ on a fresh install.
 Hindsight builds its graph natively from whatever local `llm` slot you
 point it at. That slot is `[memory.graph].extraction_slot` in
 `hal0.toml` (default `"utility"`); changing it repoints Hindsight's
-extraction LLM and restarts `hindsight-api` to apply it.
+extraction LLM and restarts `hindsight-api` to apply it. `[memory.graph].llm_timeout_s`
+(default `300`, 30–3600) sets how long Hindsight will wait on its own
+extraction/consolidation/reflect calls — raise it if a cold slot start
+regularly times out.
 
 ![Memory view showing live graph extraction status and counters](/screenshots/memory-view.png)
 *Live memory and graph-extraction dashboard in hal0.*
@@ -107,11 +133,53 @@ an unknown or non-llm slot before it ever reaches `hal0.toml`.
 hal0 memory graph disable
 ```
 
-Turns extraction off and cancels any in-flight build. Vector recall is
-unaffected either way — this gate only controls the graph layer.
+Turns off the *reporting and routing* gate only. On Hindsight (the only
+shipping engine) extraction runs inside the daemon itself and this flag is
+a hal0-side label — the daemon keeps extracting regardless, which is why
+`memory graph status` keeps reporting rising operation counters after a
+disable. Vector recall is unaffected either way.
 
 </TabItem>
 </Tabs>
+
+If extraction operations are failing (an unreachable or too-small
+extraction slot, for example), the dashboard's graph panel shows a "Retry N
+failed" button that requeues every failed extraction/consolidation
+operation once the underlying problem is fixed. The CLI equivalent is
+`hal0 memory ops retry --all-failed` (below), which covers the same
+operations from the terminal.
+
+<Aside type="note">
+A memory write is refused outright — not silently dropped — if the
+extraction slot's model can't clear an ~8192-token context-window floor
+(a conservative estimate of the extraction prompt's own footprint).
+Override the floor with `HAL0_MEMORY_EXTRACTION_FLOOR` on the hal0-api
+service if it's wrong for your engine. Chat is unaffected; only memory
+writes are gated on this check.
+</Aside>
+
+## Reranking
+
+Recall from more than one bank goes through a second-pass reranker before
+it's returned, configured under `[memory.embedding]`:
+
+```toml
+[memory.embedding]
+rerank_gateway_url = "http://127.0.0.1:8080"
+rerank_model = "builtin.jina-reranker-v1-tiny-en-q8"
+rerank_connect_timeout_s = 1.0
+rerank_read_timeout_s = 8.0
+```
+
+`rerank_model` must resolve to a model the `rerank` capability slot serves.
+The dashboard's Reranker panel gives you a picker instead of free text: the
+schema default labelled "builtin", every model the capabilities catalog
+tags for reranking (with its serving backend), and — if you've saved
+something outside both — that value labelled "(saved)" so you can see and
+move off it. A model id the gateway can't resolve doesn't error; it just
+makes every recall fall back to fused vector ordering, so pick from the
+list. The panel links to Settings → Capabilities, where the underlying
+`rerank` slot itself lives.
 
 ## Manage banks
 
@@ -119,40 +187,66 @@ unaffected either way — this gate only controls the graph layer.
 hal0 memory bank list
 hal0 memory bank stats <bank>
 hal0 memory bank profile get <bank>
-hal0 memory bank profile set <bank> <key> <value>
-hal0 memory bank export <bank>
-hal0 memory bank import <bank> <file>
-hal0 memory bank delete <bank>
-hal0 memory bank consolidate <bank>
+hal0 memory bank profile set <bank> --skepticism 4 --retain-mission "..."
+hal0 memory bank export <bank> [--out <file>]
+hal0 memory bank import <bank> --file <file> [--dry-run]
+hal0 memory bank delete <bank> --confirm <bank>
+hal0 memory bank consolidate <bank> [--scope <tag>]
 ```
 
-Deleting a whole bank requires an explicit confirmation that echoes the
-bank id back — a plain delete with no confirmation is rejected.
+Deleting a whole bank requires `--confirm <bank>` to exactly match the
+target bank id — the CLI refuses before the request even reaches the
+server if it doesn't, and the server enforces the same check independently.
+
+`bank profile set` splits its flags across two different upstream calls:
+`--skepticism`/`--literalism`/`--empathy` (1–5 disposition traits) go
+through a profile PUT; `--retain-mission`/`--observations-mission`/
+`--reflect-mission` go through a bank-config PATCH. Pass any combination —
+only the fields you name are changed.
 
 ## Async operations and mental models
 
 ```sh
-hal0 memory ops list           # in-flight/recent Hindsight ops: retain, consolidation, refresh
-hal0 memory ops retry <id>
-hal0 memory mm list            # mental models Hindsight has built
-hal0 memory mm refresh <id>
-hal0 memory mm history <id>
-hal0 memory recall             # ad-hoc recall from the CLI
+hal0 memory ops list [--bank <bank>] [--failed]
+hal0 memory ops retry --all-failed [--bank <bank>]
+hal0 memory ops retry --bank <bank> --id <operation_id>
+hal0 memory mm list <bank>
+hal0 memory mm refresh <bank> <model_id>
+hal0 memory mm history <bank> <model_id>
+hal0 memory recall <query> [--bank <bank>] [--tags ...] [--types ...]
 ```
 
-## Migrate a legacy store
+`ops list`/`ops retry --all-failed` fan out across every bank when `--bank`
+is omitted — Hindsight's operations API has no cross-bank listing endpoint,
+so hal0 merges the per-bank results itself. `ops retry --id` needs `--bank`
+too, since operation ids are bank-scoped. `mm` (mental model) commands
+always take the bank as the first argument. `hal0 memory recall` hits the
+same namespace-scoped recall path an agent uses at runtime (not the admin
+bank console) — use it to see exactly what an agent would get back for a
+query.
 
-If you previously ran the Cognee-backed memory store, or need to bring
-per-agent private banks together into the unified bank:
+## Fold banks together
 
 ```sh
-hal0 memory migrate unify
+hal0 memory migrate unify --source <bank> [--source <bank> ...] --target <bank> [--apply]
 ```
 
+Folds one or more source banks into a target bank (default target
+`shared`), tagging each migrated document with its provenance
+(`agent:<id>`, `visibility:private` for a former private bank, plus any
+`--add-tag` you pass). Default is `--dry-run` — it reports the plan
+(fact counts, tags to add) without writing anything; pass `--apply` to
+actually run it. Requires the running hindsight-api to advertise the
+document-transfer API (`features.document_export_api`/
+`document_import_api` on `/version`) — the command checks this and refuses
+loudly if it's missing rather than guessing. It never deletes the source
+banks; that's always a separate, explicit `hal0 memory bank delete <bank>
+--confirm <bank>`.
+
 <Aside type="caution">
-Check the command's own `--dry-run` support before running it against
-production data — a migration touching your durable recall store is
-worth previewing first.
+This is a bank-consolidation tool (private banks → one unified bank), not
+a Cognee migration path — there is no CLI command for migrating a
+Cognee-era store. See the engine note above.
 </Aside>
 
 ## Destructive ops are audited
@@ -164,6 +258,10 @@ wipe is attributable after the fact.
 
 ## Related
 
+- [Memory](/docs/concepts/memory) — what the subsystem is, namespaces,
+  fact types, directives, and mental models.
+- [Browse the Bank workspace](/docs/guides/memory-workspace) — the
+  dashboard's fact browser, filters, curation, and graph views.
 - [Run agents](/docs/guides/run-agents) — agents are the main consumer of
   the memory store.
 - [Connect MCP servers](/docs/guides/connect-mcp) — the `memory_*` tool

--- a/docs/guides/generate-images.mdx
+++ b/docs/guides/generate-images.mdx
@@ -35,7 +35,8 @@ hal0 capabilities set img img --model sdxl-turbo
 This is the same pattern as every other capability — set the child
 (`img`) under its parent (`img`), pointing at an installed image model.
 Pull a curated image checkpoint first with the standard model tooling —
-see [Choose models](/docs/guides/choose-models#embed-rerank-and-image-picks)
+see the Embed, rerank, and image picks section of
+[Choose models](/docs/guides/choose-models)
 — or bulk-fetch the curated set:
 
 ```sh

--- a/docs/guides/manage-runner-images.mdx
+++ b/docs/guides/manage-runner-images.mdx
@@ -1,0 +1,350 @@
+---
+title: Manage runner images
+description: Browse, pull, pin, and reason about the container images that back hal0's slots — the Runner Images catalogue under Slots, the Vulkan image gate, and what happens to a running slot when its image changes.
+sidebar:
+  order: 15
+---
+
+import { Steps, Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+
+A **runner image** is the container image a slot actually launches: the
+`podman` image that bundles `llama-server` (or FLM, Kokoro, Qwen3-TTS,
+Moonshine, ComfyUI) plus the GPU/CPU backend it was built against. hal0
+tracks the known runner images in a catalogue, and the dashboard's **Runner
+Images** page — a sub-page of **Slots** (`#slots/runner-images`) — is where
+you browse it, pull an image ahead of time, and set per-family defaults.
+
+## How a runner image relates to a slot
+
+A [slot](/docs/concepts/slots/) owns its own hardware placement: `device`,
+`binary`, and an optional `image_pin`. `binary` is a key into hal0's runner
+registry (`hal0.runners.RUNNER_IMAGES`) — the fixed set of runner families
+hal0 knows how to launch:
+
+| Runner key | Runtime | Device class | Backend |
+|---|---|---|---|
+| `rocmfpx` | llama-server | gpu | rocm |
+| `vulkanfpx` | llama-server | gpu | vulkan |
+| `cuda` | llama-server | gpu | cuda |
+| `cpu` | llama-server | cpu | — |
+| `flm` | flm (NPU) | npu | — |
+| `kokoro` | kokoro (TTS) | cpu | — |
+| `moonshine` | moonshine (STT) | cpu | — |
+| `qwen3tts` | qwen3tts (TTS) | gpu | rocm |
+| `comfyui` | comfyui (image gen) | img | — |
+
+`rocmfpx` and `vulkanfpx` resolve to the *same* image today — the shipped
+runner build is Vulkan-portable, so one image serves both GPU lanes on AMD.
+The two keys exist so a future split has somewhere to land, not because they
+differ right now.
+
+A slot with no `binary` set derives one from its `device`
+(`hal0.runners.runner_for_backend`) — this is the ordinary case. A
+**profile** never names an image: profiles are device-agnostic flag
+templates (see [Providers, profiles & devices](/docs/reference/providers-profiles-devices/)).
+The provider (`ContainerProvider`, `FLMProvider`, …) is what actually starts
+the process for whichever image resolution picks.
+
+Resolution order, from `hal0.providers.container._resolve_image_ref`:
+
+<Steps>
+1. `slot.image_pin` — a per-slot escape hatch (debug build, A/B test, pinned
+   rollback). A non-empty value is honored verbatim and never re-resolved.
+2. `[slots].default_images[<runner key>]` in `hal0.toml` — the operator's
+   per-family default, set from the Runner Images page's **Defaults strip**
+   or the **Set as … default** button.
+3. The release-baked default (`hal0.runners.RUNNER_IMAGES[key].image`),
+   further resolved through an `HAL0_TOOLBOX_IMAGE_<KEY>` environment
+   override or a release manifest digest pin, in that order.
+</Steps>
+
+## The Runner Images page
+
+Open **Slots → Runner Images**. The list is every catalogued image; the
+right-hand card shows the selected row's detail.
+
+**Defaults strip** (top of the list, when at least one family has a
+catalogued row): one line per runner family — its effective image:tag, and
+a `release default` or `override` chip. An `override` row gets a **clear**
+button that removes the `[slots].default_images` entry and falls back to
+the release default; the confirm dialog names the slots currently on that
+family's image, since they pick up the change on their next restart, not
+immediately.
+
+Each row in the list shows:
+
+- A download indicator (green when `local_path`/`downloaded_at` is set).
+- The catalogue id and `image:tag`.
+- Chips: `<family> default` (with `· override` when it's an operator
+  override), `newer: <tag>` when the registry has a tag ahead of the row's
+  headline, `ownership` (`owned`/`referenced`), `publish`
+  (`ci`/`external`/`manual`), and any `extra.features` chips (forward-compat
+  — today's `images.json` carries no `features` field, so this is usually
+  empty).
+- Size, and a `✓ downloaded` chip once pulled.
+
+The detail card adds digest, ownership, publish, `manifest_key`, and **in
+use by** — the slot names whose rendered unit (or, absent that, resolved
+config) currently launches this exact `image:tag`.
+
+### Sync now
+
+**Sync now** runs one discovery pass: it re-fetches
+`Hal0ai/hal0-runner-images`'s `images.json` for display metadata, and probes
+each entry's GHCR repo anonymously for its tag list, digest, and size. Rows
+also auto-refresh every 30 seconds without a manual sync, but a sync is the
+only way to pick up a brand-new tag or a metadata edit immediately. If
+`images.json` is unreachable, sync degrades to GHCR-only data for the images
+already catalogued and says so in the toast; a single package's probe
+failing never aborts the rest of the run.
+
+<Aside type="note">
+The catalogue only knows about GHCR repos that appear in `images.json`. An
+image published to GHCR but never added there — including, historically,
+hal0's own flagship combined image — will not appear until that file lists
+it. This is an external-repo edit, not something a sync run can fix on its
+own.
+</Aside>
+
+### How a tag is picked
+
+Every row has one **headline tag** (`image.tag`) and a newest-first
+`available_tags` list from the GHCR `tags/list` probe. The headline is
+either the tag `images.json` pins for that entry, or — when the entry is
+unpinned — the newest tag by `sort_tags_newest_first`: all-digit tags
+(date-stamps like `0826`) sorted numerically descending, then semver tags,
+then everything else in registry order.
+
+The card's **tag** dropdown lets you pick any tag in `available_tags` for
+display and for **Set as … default**, but the **Pull** button always pulls
+the row's headline tag — it is disabled with an explanatory tooltip if you've
+picked a different one in the dropdown. Pulling a specific non-headline tag
+isn't wired up in the dashboard; see "Pulling a specific tag" further down
+this page for the API-level workaround.
+
+### The defaults strip and #2043
+
+The Defaults strip, the tag picker, and Set-as-family-default all shipped
+together as the runner-image-catalogue v2 UI wave. What did **not** ship
+from that design: there is still no way to remove a catalogued or
+downloaded image from the dashboard or the API ("Removing an image" below),
+and per-tag pulling from the UI (above). If you're comparing this page
+against the catalogue v2 design doc, those two gaps are the difference
+between the design and what's shipped.
+
+## `image_status`: what a slot is actually running
+
+The Runner Images page's own `downloaded`/`local_path` fields describe the
+*catalogue* — what's on disk, independent of any slot. A **slot's**
+`image_status` (visible on `GET /api/slots`, and in the dashboard's slot
+detail) is a different, tri-plus-state answer to "is the image this slot
+would launch actually present":
+
+| Value | Meaning |
+|---|---|
+| `present` | The resolved image is on disk. |
+| `pulling` | A pull job for this image is in flight. |
+| `missing` | podman was asked and the image is confirmed absent. |
+| `not-configured` | The slot has no profile/image to check — not a fault. |
+| `unknown` | The probe could not be made at all. |
+
+`unknown` (added by #1968, with two remaining gaps closed by #1980) exists
+because `missing` used to be overloaded: before that work, *any* probe
+failure — the rootful `hal0-podman-ro` seam not answering, `sudo -n` being
+denied, the probe timing out — was reported as `missing`, indistinguishable
+from "podman was asked and said no." That collapse made `missing` on a
+`running`, healthy slot look like the smoking gun it's supposed to be, when
+it usually meant the probe seam itself was broken.
+
+If you see `image_status: "unknown"` on a slot:
+
+<Steps>
+1. Run `hal0 doctor` — it probes the `hal0-podman-ro` seam directly
+   (`check-slot-token`) and will name a missing or stale sudoers grant if
+   that's the cause.
+2. Check the hal0-api journal for a `slot_view.image_probe_failed` line —
+   it always logs the specific reason (seam denial, subprocess failure,
+   timeout) behind an `unknown`, even though the API payload itself carries
+   no reason field.
+3. Don't treat `unknown` as `missing`: retrying a pull on a slot that's
+   actually fine, just unprobeable, wastes bandwidth and doesn't fix the
+   seam.
+</Steps>
+
+## The Vulkan LLM lane's image gate
+
+On an AMD host, a `gpu-vulkan` llama.cpp slot is gated on its **resolved
+runner image**, not just on hardware presence. This is a narrower,
+newer check than the ROCm lane's `/dev/kfd` requirement, and it exists
+because of a specific, nasty failure mode:
+
+<Aside type="caution" title="Why the gate exists">
+The retired runner lineage (`ade07ba`) emitted invalid tokens on its Vulkan
+backend for every model, at full nominal speed, while HTTP 200, container
+health, and `hal0 doctor` all read green. #1923 retired the Vulkan LLM lane
+entirely over this and required `/dev/kfd` (ROCm) for every AMD GPU slot.
+#1973 re-enabled Vulkan, but only behind an explicit image allowlist — so
+the same silent-garbage failure can't recur on a new build until that build
+has been validated.
+</Aside>
+
+Membership in `hal0.config.schema.VULKAN_CAPABLE_IMAGE_REFS` is earned per
+exact image ref, not by "newer than the pin": the tags are git shortrefs and
+date stamps, not versions, and Vulkan correctness has not been monotonic
+across builds (an older tree passed where a newer one failed). As of this
+writing the set holds one ref, `ghcr.io/hal0ai/hal0-combined:0826`
+(`VULKAN_FIXED_IMAGE`) — check the constant in `src/hal0/config/schema.py`
+for the current membership, since new refs are added only after passing the
+validation matrix.
+
+A `gpu-vulkan` llama-server slot on an AMD host is refused at load if its
+resolved image isn't in that set — the error names the image and tells you
+to repin to `VULKAN_FIXED_IMAGE` or move the slot to `gpu-rocm`. This gate
+applies only to the llama.cpp runtime lane; ComfyUI and Qwen3-TTS's
+`gpu-vulkan` slots are actually ROCm images behind the picker's GPU row and
+are unaffected, and Kokoro/Moonshine never touch a GPU node at all. See
+[Manage slots → Switching a slot to the Vulkan lane](/docs/guides/manage-slots/)
+for the walkthrough (the `--hardware vulkan` CLI flag, the dashboard drawer
+equivalent, and the `HAL0_ALLOW_VULKAN_FALLBACK` escape hatch, which
+downgrades this refusal to a warning and has no supported use).
+
+## Pulling, updating, pinning, and removing an image
+
+<Aside type="note" title="No `hal0` CLI for runner images">
+There is currently no `hal0` CLI command for the runner-image catalogue —
+no `hal0 image pull`, no `hal0 registry runner-images …`. Everything below
+that isn't dashboard-only is a direct call to the local API
+(`http://localhost:8080`), which is also what the dashboard itself calls.
+</Aside>
+
+### Pulling an image
+
+<Tabs>
+<TabItem label="Dashboard">
+Select the row, then click **Pull** (or **Re-pull** if it's already
+downloaded). Progress streams into the **Runner image downloads** pane
+below the list — `layers_done`/`layers_total`, mirroring how model
+downloads report progress, since this is a whole OCI image pull via
+`podman pull`, not a single file.
+</TabItem>
+<TabItem label="API">
+```sh
+curl -X POST http://localhost:8080/api/runner-images/hal0ai%2Fhal0-toolbox-cpu/pull
+```
+
+Pulls the row's headline tag. Job state is keyed one-per-image: a second
+request for the same tag (or with no tag) while one is already in flight is
+idempotently handed the existing job rather than duplicated; a request for a
+*different* tag while one is in flight answers `409
+runner_image.pull_conflict`.
+</TabItem>
+</Tabs>
+
+#### Pulling a specific tag
+
+The pull route does accept `?tag=<tag>` for any tag in the row's
+`available_tags` — the dashboard just never sends it. If you need a
+non-headline tag pulled onto disk right now, call the API directly:
+
+```sh
+curl -X POST "http://localhost:8080/api/runner-images/hal0ai%2Fhal0-toolbox-cpu/pull?tag=v1.2.3"
+```
+
+An unknown tag 404s as `runner_image.tag_not_available`.
+
+### Setting a family default (updating what new/unpinned slots launch)
+
+<Tabs>
+<TabItem label="Dashboard">
+On the card, pick the tag you want (if not the headline), then **Set as
+`<family>` default**. The confirm dialog names every slot currently running
+that family's image — none of them restart immediately; they pick up the
+new default on their next (re)start. This writes
+`{"slots": {"default_images": {"<family>": "<image>:<tag>"}}}` through the
+existing settings deep-merge, i.e. `[slots].default_images.<family>` in
+`hal0.toml`.
+</TabItem>
+<TabItem label="API">
+```sh
+curl -X PUT http://localhost:8080/api/settings \
+  -H 'content-type: application/json' \
+  -d '{"slots": {"default_images": {"rocmfpx": "ghcr.io/hal0ai/hal0-combined:0826"}}}'
+```
+
+Send an explicit `null` value for the family to clear the override and fall
+back to the release default (the deep-merge has no key-delete idiom, so
+`null` is the documented clear signal) — an empty string is rejected.
+</TabItem>
+</Tabs>
+
+### Pinning a single slot
+
+A family default changes what *unpinned* slots in that family launch. To
+pin one slot to a specific image regardless of the family default, set that
+slot's `image_pin` — see
+[Manage slots](/docs/guides/manage-slots/) for the CLI/dashboard flow. A
+non-default pin is surfaced on the slot card so the drift is never hidden.
+
+### Removing an image
+
+There is no remove action — not in the dashboard, not in the API, and not
+in the catalogue v2 design. A downloaded runner image can only be removed
+by hand on the host, outside hal0's management surface:
+
+<Steps>
+1. Check the image's **in use by** field on its detail card (or `GET
+   /api/runner-images/<id>`) — don't remove an image a running slot still
+   references.
+2. Since slots run under rootful podman
+   (`/etc/containers/systemd`), remove it as root:
+   `sudo podman rmi <image>:<tag>`.
+3. hal0 will not notice the removal on its own; the row stays catalogued
+   (its `downloaded`/`local_path` fields go stale until the next successful
+   pull or a process that re-checks local state runs).
+</Steps>
+
+## What happens to a running slot when its image changes
+
+Nothing, immediately — and this is true whether the change comes from an
+operator override or a release upgrade. Every image-resolution write above
+is documented as applying "on the next (re)start," and that's not a
+simplification: no code path here restarts a slot for you.
+
+**Release upgrades.** `hal0 update` retags stale slot pins —
+`retag_stale_slot_images` rewrites any slot whose `image_pin` (or legacy
+`image`) is *exactly* a known former default to the new one — but it does
+not touch the running container, and it does not restart the unit. The new
+image applies (and is pulled by podman if absent) the next time that slot's
+unit starts, whether that's a manual restart, a crash-restart, or a reboot.
+An operator pin that isn't a known former default is never touched — that's
+the escape hatch working as intended, not a bug.
+
+<Aside type="caution" title="Known gap, not a design choice">
+`hal0 update` does not restart slots when a release rolls the runner
+image, so a slot can keep serving the build the release replaced
+indefinitely. Until that changes, **restart your slots after every `hal0
+update` that touches a runner image** (check the release notes, or just
+restart every GPU/LLM slot to be safe): `hal0 slot restart <name>` per slot,
+or the dashboard's restart control on each slot card. There is no
+"restart everything" single command today — restart the slots you care
+about individually.
+</Aside>
+
+**Operator defaults and per-slot pins.** Same story: setting a family
+default or a slot's `image_pin` writes config, it does not bounce anything.
+Watch a slot's `image_mismatch` field (or the dashboard's drift indicator)
+to see when the running container's actual image has diverged from what
+hal0 would now resolve — see
+[Manage slots → Config drift after an update](/docs/guides/manage-slots/)
+— and restart the slot once you're ready for the new image to take effect.
+
+## See also
+
+- [Slots](/docs/concepts/slots/) — the lifecycle state machine and the
+  hardware/model write boundary that `binary`/`image_pin` are part of.
+- [Manage slots](/docs/guides/manage-slots/) — creating/editing slots,
+  switching GPU lanes, and reading the config-drift warning.
+- [Providers, profiles & devices](/docs/reference/providers-profiles-devices/) —
+  how `binary`/`device` map to a runner, and why profiles carry no image.
+- [Hardware matrix](/docs/reference/hardware-matrix/) — device detection and
+  backend selection upstream of a slot's `device`.

--- a/docs/guides/manage-slots.mdx
+++ b/docs/guides/manage-slots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Manage slots
-description: Create, load, swap, restart, rename, edit, and delete inference slots with the hal0 CLI or the dashboard's inline pencil editor. Each slot is a podman container behind a systemd unit and the local API.
+description: Create, load, swap, restart, rename, edit, and delete inference slots with the hal0 CLI or the dashboard's slot edit drawer. Each slot is a podman container behind a systemd unit and the local API.
 sidebar:
   order: 10
 ---
@@ -35,10 +35,23 @@ hal0 slot capacity          # aggregate memory/port headroom across all slots
 
 `status` also prints a `WARN config drift: ...` line when the container's
 *actual* running launch flags no longer match what hal0 would render
-today — see [Config drift after an update](#config-drift-after-an-update).
+today — see Config drift after an update, below.
 
 ![Slot detail panel showing state, model, port, and on-disk TOML config as formatted JSON](/screenshots/slot-detail.png)
 *The slot detail panel combines live status with the persisted TOML config in a single view.*
+
+The dashboard's per-slot cards (Inference pane) carry a metric row —
+**tok/s**, **ttft**, and **mem** (resident memory in GB, from the slot's
+`mem_mb`) — plus a footer strip of chips: a **context** chip (`Nk ctx`,
+shown on a full-size card whenever `ctx_max` is a positive number — MiniCards
+never show it), an **image status** chip when
+hal0 could not read the container image store (label "image ?" — not a claim
+the image is missing, see [Slot lifecycle reference](/docs/reference/slot-lifecycle)),
+and a **crash-loop breaker** chip whenever a slot is backing off or parked
+after repeated load failures (see the same reference page). Drag a card's grip
+handle (or use the arrow keys on it) to reorder the grid — that ordering is a
+per-browser preference stored locally, not slot config, so it needs no Save
+step.
 
 <Aside type="note">
 `primary` and `chat` are retired slot/role names — neither is accepted as
@@ -77,8 +90,7 @@ hal0 slot create embed \
    Vulkan-validated runner image, or slot load refuses it by name. Either way
    the refusal is loud and immediate rather than a slot that serves nonsense.
    On Strix Halo the Vulkan lane currently *measures faster* than ROCm — see
-   [Switching a slot to the Vulkan lane](#switching-a-slot-to-the-vulkan-lane).
-   This sets the slot's
+   Switching a slot to the Vulkan lane, below. This sets the slot's
    `device` field directly (`vulkan → gpu-vulkan`, `rocm → gpu-rocm`,
    `cpu → cpu`) — as of v1.0, **the slot owns its hardware grid**
    (`device`, `n_gpu_layers`, `threads`, `binary`, `image_pin`), not the
@@ -98,15 +110,15 @@ hal0 slot create embed \
    speech-to-text). Nothing is inferred where hal0 has no engine for that
    pairing — a `tts` slot on a Vulkan device, for instance, keeps the CPU
    Kokoro runtime rather than being pinned to the ROCm-only Qwen3 image.
-   An `image` slot also infers nothing: pass `--profile comfyui`
-   explicitly (the shipped `img` slot already carries it). That inference
-   is what makes a capability
-   slot actually serve its endpoint — an `embedding` slot with no
-   `--embedding` flag loads to `ready` and returns HTTP 501 from
-   `/v1/embeddings`. An `llm` slot infers nothing: no mode flag is at
-   stake, so its tune stays the model's (or yours). Change a slot's
-   profile later with `hal0 slot edit <name> --profile <profile>` or the
-   slot drawer.
+   `image` → `comfyui`. Nothing is inferred where hal0 has no engine for
+   that pairing — a `tts` slot on a Vulkan device, for instance, keeps the
+   CPU Kokoro runtime rather than being pinned to the ROCm-only Qwen3
+   image. That inference is what makes a capability slot actually serve
+   its endpoint — an `embedding` slot with no `--embedding` flag loads to
+   `ready` and returns HTTP 501 from `/v1/embeddings`. An `llm` slot is
+   the one type that infers nothing: no mode flag is at stake, so its
+   tune stays the model's (or yours). Change a slot's profile later with
+   `hal0 slot edit <name> --profile <profile>` or the slot drawer.
 
 </Steps>
 
@@ -116,8 +128,11 @@ start it — follow with `hal0 slot load`.
 <Aside type="note" title="Pinning a GPU on multi-GPU hosts">
 Multi-GPU hosts can pin a slot to one card via the `gpu_index` key in the
 slot's TOML — there's no `--gpu-index` CLI flag and no dashboard field for
-it, so set it by editing `/etc/hal0/slots/<name>.toml` directly
-(`gpu_index = 1`), then `hal0 slot restart <name>`.
+it, so set it by editing the slot's TOML directly (`gpu_index = 1`), then
+`hal0 slot restart <name>`. The file is `/etc/hal0/slots/<name>.toml` on a
+box that's still name-keyed, or `/etc/hal0/slots/<id>.toml` (the slot's
+numeric id) after running `migrate-id-keying` — `ls /etc/hal0/slots/` shows
+which stem this box uses.
 </Aside>
 
 <Aside type="caution">
@@ -170,6 +185,14 @@ hal0 slot rename agent primary-llm
 The slot's internal id is stable across a rename — only the label
 changes, so references from stacks and activity history stay intact.
 
+<Aside type="caution">
+Rename requires the slot to be **offline** first (`hal0 slot unload <name>`) —
+the on-disk TOML and the systemd unit are still name-keyed, so renaming a
+running slot would orphan its unit. The API rejects a rename attempted while
+the slot is anything but offline. In the dashboard's slot drawer the Rename
+field is disabled with this same reason while the slot is up.
+</Aside>
+
 </TabItem>
 </Tabs>
 
@@ -218,10 +241,11 @@ baked in (port, hardware grid) take effect on the next `restart`.
 Capability slots created before v1.0 could land on disk with no `profile`
 key — they load to `ready` but return HTTP 501 from their own endpoint,
 because the profile is what carries llama-server's `--embedding` /
-`--reranking` mode flag. Check with
-`grep profile /etc/hal0/slots/<name>.toml`; repair with
-`hal0 slot edit <name> --profile embedding` (or `reranking`) followed by
-`hal0 slot restart <name>`. Newly created slots infer it automatically.
+`--reranking` mode flag. Check with `hal0 slot show <name>` (its on-disk
+TOML is included in the output, so you don't need to know whether this box
+keys slot files by name or by id); repair with `hal0 slot edit <name>
+--profile embedding` (or `reranking`) followed by `hal0 slot restart
+<name>`. Newly created slots infer it automatically.
 </Aside>
 
 ## Switching a slot to the Vulkan lane
@@ -278,21 +302,114 @@ for every model. There is no supported configuration in which it is the right
 answer.
 </Aside>
 
-## Dashboard: the inline model-edit pencil
+## Dashboard: the slot edit drawer
 
-Every slot card in the dashboard's **Slots** view carries a pencil icon
-next to its model control. Click it to open the docked **model drawer**
-directly for the slot's currently bound model — its launch flags, chat
-template, and capabilities, without leaving the slots view. The pencil is
-disabled when no model is bound yet.
+Click **Edit** on any slot card, or a slot's row in the SLOTS list, to open
+its drawer at `#slots/<name>`. It's the dashboard's equivalent of `hal0 slot
+edit`, plus the lifecycle controls, the runtime profile, and a live view of
+the resolved launch command.
+
+### Header: lifecycle toggles and the breaker chip
+
+Two toggles sit side by side in the header, applying instantly (their own
+`PUT`, independent of Save below):
+
+- **Auto-Load** — start this slot automatically at boot. Controls startup
+  only.
+- **Pinned** / **Unpinned** — once loaded, a pinned slot stays resident:
+  exempt from idle and memory-pressure eviction, and `unload`/`delete`
+  require `?force=true`. Pinning never starts a slot on its own — that's
+  Auto-Load's job.
+
+Next to the lifecycle state chip, the drawer shows the same **crash-loop
+breaker** chip the slot card does whenever the slot is backing off or parked
+after repeated load failures — see the [Slot lifecycle
+reference](/docs/reference/slot-lifecycle) for what triggers it.
+
+### Identity, runner, and image status (read-only)
+
+Two read-only strips show the slot's stable `id`, its `port` (assigned by
+PortAuthority), its lifecycle `state`, its resolved runner `binary`, its
+fixed `type` (set at creation — make a new slot for a different kind), and
+its container `image status`. The **Name** field next to them is always
+disabled — display only. A **Rename** button beside it opens a separate
+Rename dialog, which is the actual offline-gated control: while the slot is
+up, its input is disabled too and an inline notice explains that renaming
+re-templates `hal0-slot@<name>` and needs the unit stopped first — see the
+caution under Rename, earlier on this page.
+
+### Hardware
+
+Holds the fields v1.0 moved onto the slot itself — see [The hardware/model
+write boundary](/docs/concepts/slots) for why. **Device** appears only for
+GPU-class slots: it's the rocm/vulkan switch covered in Switching a slot to
+the Vulkan lane, above. **Runner Image** pins a specific container image
+(or is left to resolve from Runner Binary); **Runner Binary** picks which
+binary inside that image executes; **Threads** is the CPU thread count
+(`0` = runtime default); **NGL** is GPU layers to offload (`-1` = all).
+Every field here needs a restart to take effect.
+
+### Profile: same-device tuning, or a cross-device switch
+
+The **Profile** select lists profiles that fit the slot's current device
+first. A profile declaring a *different* backend is also offered, grouped
+under "Other backend — switches slot device" — picking one stages a device
+switch (and a restart) for the next Save, and Save blocks if the switch would
+strand the slot's currently bound model on a backend it can't run. A profile
+matching the bound model's own stamped preference shows as adopted from the
+model (swapping the model may change it); one you pick that diverges instead
+overlays its flags on top of the model's tune for this slot only, at launch.
+
+### Model: swap and the context ceiling
+
+The **Model** select swaps the slot's bound model — on a live container slot
+this cold-restarts it, and the drawer confirms before firing that restart.
+The pencil button beside it opens the bound model's own tune (launch flags,
+chat template, capabilities) docked to the left of the slot drawer, so your
+in-progress slot edits stay visible while you adjust the model. It's disabled
+when no model is bound yet, or when the bound id doesn't resolve to a
+registry row.
+
+**Context (ceiling)** sets `[model].context_size` — a hardware ceiling that
+clamps the model's own resolved context window down. The one exception is a
+model with no explicit `defaults.context_size` of its own: there, the
+ceiling replaces the dense-capped derived default rather than clamping it,
+so it can raise the effective window (still bounded by the model's native
+GGUF context) — see [Slots](/docs/concepts/slots) for the mechanics. Leave
+it unset to just follow the model.
+
+### Advanced: eviction priority and the resolved command
+
+Collapsed by default. **Eviction priority** (`0`–`100`, default `50`) applies
+instantly on blur — lower unloads first under memory pressure, with
+least-recently-used as the tie-break; pin the slot instead to exempt it
+entirely. Below it, **Resolved command** shows the actual `podman` argv hal0
+would launch right now, with per-flag source badges when the API supplies
+provenance — a way to confirm a hardware or profile change actually changed
+what will run before you restart.
+
+### Deleting a slot from the drawer
+
+The footer's **Delete slot** button states the real blast radius before you
+confirm: it removes the `hal0-slot@<name>.service` unit, releases the port
+back to PortAuthority, and deletes the slot's on-disk state directory under
+`/var/lib/hal0/slots/` (keyed by name, or by the slot's numeric id on a box
+that has run `migrate-id-keying`) — the bound model and its weights are
+explicitly untouched.
+
+### The model-edit pencil, outside the drawer
+
+Every slot card in the dashboard's **Slots** view also carries its own pencil
+icon next to its model control. Click it to open the model drawer directly
+for the slot's currently bound model, without opening the slot's own drawer
+first. Here the drawer is **not docked** — it opens in its normal
+flush-right position with its own dim scrim, unlike the docked instance the
+slot drawer opens (see "Model: swap and the context ceiling," above). The
+pencil is disabled when no model is bound yet.
 
 This is a separate action from the model dropdown on the same card, which
-swaps *which* model the slot runs — the pencil edits the *bound* model's
-own settings.
-
-The Edit Slot drawer has its own model-edit entry point too: opening it
-docks a second model drawer to the left of the slot drawer, so your
-in-progress slot edits stay visible while you tune the model.
+swaps *which* model the slot runs — the pencil edits the *bound* model's own
+settings.
 
 <Aside type="note" title="Editing raw flags in the dashboard">
 `[server].extra_args` on a slot is legacy TOML round-trip only as of
@@ -300,7 +417,7 @@ v1.0 — it's inert at launch. The live tuning surface for launch flags is
 the model's own `defaults.extra_args`, edited from the model drawer (see
 [Choose models](/docs/guides/choose-models)) — this is also where
 `[server].extra_args` writes are screened against the hardware/managed-flag
-denylist, see [Edit configuration](/docs/guides/configure#server-extra_args-is-screened-everywhere).
+denylist, see [Edit configuration](/docs/guides/configure).
 </Aside>
 
 ## Editing multiple slots at once: Stacks
@@ -339,13 +456,16 @@ hal0 slot delete scratch
 ```
 
 Stops the unit and removes the config. You'll be asked to confirm; pass
-`--force` / `-f` to skip the prompt.
+`--force` / `-f` to skip the prompt — for a seeded slot, `--force` also
+bypasses the delete protection described below.
 
 <Aside type="note">
-Seeded slots (`utility`, `embed`, `rerank`, `stt`, `tts`, `img`, `vision`,
-`agent`) are reserved and cannot be deleted — the API rejects the
-request. Clear the slot's default model instead to take it out of
-rotation.
+Seeded slots (`flm`, `tts`, `rerank`, `utility`, `img`, `agent`, `brain`,
+`qwen3tts`, `coder`, `embed`) are protected: deleting one without
+`--force` is rejected. `hal0 slot delete <name> --force` (or
+`DELETE /api/slots/{name}?force=true`) deletes a seeded slot anyway — but
+an install or update reconcile may re-seed it later. Clearing the slot's
+default model is the way to take it out of rotation without deleting it.
 </Aside>
 
 ## Stream logs
@@ -363,9 +483,13 @@ Logs come from the slot's `hal0-slot@<name>.service` journal.
 A handful of one-shot `hal0 slot migrate-*` commands exist for bringing
 older on-disk slot config forward through the v1.0 field-ownership
 changes: `migrate-id-keying`, `migrate-hw`, `migrate-caps`,
-`migrate-flags`, `migrate-enabled-removal`. `hal0 update` runs the ones a
-release needs automatically — you shouldn't need these by hand unless
-you're recovering a config that skipped a release.
+`migrate-flags`, `migrate-enabled-removal`. These are **manual, operator-run**
+migrations — `hal0 update` only *detects* which ones a box still needs and
+prints the command to run; it never applies one for you. `hal0 slot
+migrate-hw --apply` (and its siblings) also refuse to run while `hal0-api`
+or any `hal0-slot@*` unit is active, since rewriting slot TOML under a live
+runtime risks a split-brain config — stop hal0's services first, then run
+the reported command with `--apply`.
 
 ## Related
 

--- a/docs/guides/memory-workspace.mdx
+++ b/docs/guides/memory-workspace.mdx
@@ -1,0 +1,203 @@
+---
+title: Browse the Bank workspace
+description: The hal0 dashboard's memory v2 UI — the Overview tab's bank table and growth chart, and the Bank workspace's fact list, filters, curation, and graph views.
+sidebar:
+  order: 51
+---
+
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+
+Once [memory is enabled](/docs/guides/enable-memory), the dashboard's Memory
+view (`#memory`, reachable from the sidebar) gives you two tabs: **Overview**
+and **Bank**. This guide covers both — for what memory *is* (namespaces,
+fact types, directives, mental models), see [Memory](/docs/concepts/memory).
+
+<Aside type="note">
+Every card here fails soft with a "Memory engine unreachable" message and a
+Retry button rather than rendering an empty state, so a Hindsight outage
+never looks like an empty bank.
+</Aside>
+
+## Overview tab
+
+The landing view. A bank picker at the top drives a **Retained** growth
+chart — a stacked bar of world/experience/observation counts per day, with
+1d/7d/30d range tabs and a small triangle marker on any day a consolidation
+operation completed. Below it:
+
+- **Engine panel** — reachability, engine name/version, bank count (and how
+  many are empty), total facts across every bank, and — only while graph
+  extraction is off — lifetime build/error/in-flight counts (once
+  extraction is on, that same information moves into the embedded graph
+  panel instead, so it's never shown twice). When extraction is on, that
+  embedded panel also lists **Active tasks**: one row per bank with
+  in-flight work, a spinner, the operation type(s) (`retain`,
+  `consolidation`, ...) and how many are processing versus queued.
+- **Banks table** — one row per bank: name, a one-line description (or doc
+  count if there isn't one), the world/experience/observation counts on a
+  single line with a proportional bar underneath, total facts and links, and
+  an activity chip (`⟳ N working`, `N pending`, or `idle`). Click a row (or
+  its arrow button) to open that bank in the Bank workspace.
+
+A **+ New bank** button/form sits below the table.
+
+## Bank tab
+
+Selecting (or exploring into) a bank opens the **Bank workspace** — a bank
+identity bar on top, a filterable fact list or graph view on the left, and
+either a filter panel or a fact inspector on the right.
+
+### The bank bar
+
+Across the top: a bank picker, the bank's description, its
+world/experience/observation composition (bar + counts), total facts,
+total links, a 30-day activity spark, and an activity chip — `⟳ N working`,
+`N queued`, or `idle` (the Overview table's equivalent chip reads `N
+pending` for the same state, not `N queued`). `+ Add` opens the add-content
+modal (below); the small refresh icon next to it triggers **consolidate
+now** for this bank.
+
+Below that, two sub-tabs:
+
+<Tabs>
+<TabItem label="Reflect">
+
+A single-question box over this bank's memory, plus two example prompts
+("why is extraction lagging?", "what broke this week?"). While the answer
+is generating it shows "recalling · reranking · composing…"; the answer
+itself is grounded-in a count of facts, documents, and mental models it
+drew on. This calls `memory_reflect` under the hood, scoped to one bank —
+there's no cross-bank reflect.
+
+</TabItem>
+<TabItem label="Rules">
+
+Two columns: **directives** (each with an on/off toggle and a delete
+button — deleting one is destructive and gated for operator approval) and
+**mental models** (each showing a stale badge or its last-refreshed date,
+with a manual refresh button). Both have their own "+ New" button that
+opens the add-content modal on the matching tab.
+
+</TabItem>
+</Tabs>
+
+### Adding content
+
+The `+ Add` modal has four tabs:
+
+- **Fact** — free text, a type picker (`world` or `experience` only —
+  `observation` is derived, never operator-authored), and comma-separated
+  tags.
+- **Document** — lists existing documents in the bank with a **Reprocess**
+  button per document (re-runs extraction over it). There is currently no
+  document upload/ingest endpoint, so the drop-file/paste-URL area and the
+  **Ingest** button are inert placeholders — this tab is view-and-reprocess
+  only for now.
+- **Directive** — a rule text box and an active-immediately toggle.
+- **Mental model** — a name, a standing question, and a refresh-schedule
+  picker (on consolidation / daily / manual). Only the manual trigger
+  (`memory_mental_model_refresh`) is actually wired up server-side today —
+  the schedule choice isn't persisted or acted on.
+
+### Filters
+
+With no fact selected, the right-hand panel is the **Filters** card:
+
+- Free-text search.
+- Fact-type toggles (world/experience/observation) with live counts.
+- A "show invalidated" toggle — the only way to browse or revert a fact
+  that's been soft-invalidated (see Curating a fact below) once you've
+  navigated away from the moment you invalidated it.
+- A **when** density strip: a day-by-day histogram of the last 30 days you
+  can drag to select a date range, plus 24h/7d/30d preset buttons.
+- A **Tag map** — tag names as bubbles sized by usage count (auto-generated
+  UUID-shaped tags, like session/document ids, are filtered out of both the
+  bubble map and the quick-filter chip row below it, since they carry no
+  readable information). Click a bubble or a chip to filter by that tag.
+
+### List, focus, and web views
+
+A view switcher above the fact list toggles between three ways of looking
+at the current filter set:
+
+<Tabs>
+<TabItem label="List">
+
+The default. A **Sources** panel above the fact list shows the bank's
+source documents (id, fact count, ingest date) with a size picker
+(5/15/25/50); clicking a source focuses the list to just facts extracted
+from it. The fact list itself shows each fact's type dot, text, timestamp,
+tags, and a small per-link-type count badge; sort by newest or "most
+connected" (salience). Use ↑/↓ to move the selection and Esc to close the
+inspector. Pagination is exact — "showing X–Y of N matched" always matches
+what's rendered — except that the server only ranks/paginates within its
+first 2000-row slab, flagged in the UI when a filter set is large enough to
+hit it.
+
+</TabItem>
+<TabItem label="Focus">
+
+A radial "ego graph" centered on the selected fact, expandable by a depth
+slider (1–10, server-bounded so it never pulls the whole bank). Click any
+node to re-centre the graph on it. A legend at the bottom maps link colors
+to relationship names and fact-type colors to dots.
+
+</TabItem>
+<TabItem label="Web">
+
+A force-directed graph of the whole filtered bank, capped at 120 facts by
+salience (weighted degree — how connected a fact is) with a warning when
+the cap is active. Nodes cluster by tag; scroll to zoom, drag the canvas to
+pan, drag a node to pin it, click a node to inspect it, and use the **fit**
+button to reset the view. Lens buttons across the top toggle individual
+link types on/off — only the link types actually present in the loaded
+data get a button, so you never see a dead toggle for a relationship type
+this bank doesn't use.
+
+</TabItem>
+</Tabs>
+
+### The inspector
+
+Selecting a fact (in any view) replaces the Filters panel with the
+**Inspector**: the fact's type, its tags, full text, timestamp, unit id,
+linked entities, a salience score (weighted degree, or "—" if the fact
+falls outside the server's scored slab), and a compact depth-1
+neighbourhood graph.
+
+#### Curating a fact
+
+- **Curate** (world/experience only) opens an edit box — saving requires
+  the text to actually differ from the current text (an unchanged save is
+  rejected client-side rather than sent as an empty patch). This creates a
+  new revision; the original is kept.
+- **Invalidate** (world/experience only, and not already invalidated) is
+  reversible and **not** approval-gated: the fact stops being recalled or
+  injected into prompts but stays in the bank, with an optional reason. An
+  invalidated fact shows a banner with a one-click **Revert**.
+- **Delete** is permanent — removed from recall and the graph, with a
+  durable audit row (actor, target, outcome). Prefer Invalidate unless the
+  fact is genuinely wrong, not just currently unhelpful.
+- **History** only appears for `observation` facts (the history endpoint
+  404s for world/experience — hal0 doesn't offer the button where it can't
+  answer) and lists the fact's state-change events with timestamps and
+  reasons.
+
+`observation` facts show neither Curate nor Invalidate — the inspector
+explains why: "observations aren't curatable — derived patterns, not
+operator-editable." Delete still applies to any fact type.
+
+## Deep links
+
+The Bank workspace's URL hash carries state: `#memory/bank?bank=<id>&fact=<id>`
+(or `#agent/memory/bank?...` if you got here from the Agent tab — both
+forms are honoured). Sharing a link with both params opens straight to
+that bank with that fact selected in the inspector. The legacy `#memory/graph`
+and `#memory/tools` routes from the pre-v2 UI redirect here automatically.
+
+## Related
+
+- [Memory](/docs/concepts/memory) — namespaces, fact types, directives,
+  mental models, reranking, and graph extraction.
+- [Enable memory](/docs/guides/enable-memory) — turn memory on, and the CLI
+  equivalents of the engine/graph/reranker settings.

--- a/docs/guides/pull-and-register-models.mdx
+++ b/docs/guides/pull-and-register-models.mdx
@@ -75,16 +75,23 @@ If the bytes are already on the host — say you dropped a GGUF into the
 model store — register it without re-downloading:
 
 ```sh
-hal0 model add qwen3-4b-q4_k_m \
-  --path /path/to/qwen3-4b-instruct-q4_k_m.gguf \
+hal0 model add /path/to/qwen3-4b-instruct-q4_k_m.gguf \
+  --id qwen3-4b-q4_k_m \
   --name "Qwen3 4B Q4_K_M" \
   --license Apache-2.0
 ```
 
-`hal0 model add` reads the file's header to auto-detect id/capabilities/
-backends. The old `hal0 model register` name is a deprecated alias for
-the same command. The API also exposes a directory scan that registers
-every new file it finds:
+The path is the positional argument; `--id` is optional (omit it and the
+registry derives one). `hal0 model add` reads the file's header to
+auto-detect capabilities and backends — when the header doesn't carry
+enough signal (no `pooling_type`, say) it falls back to a filename guess
+and prints a confidence/warning line; fix a wrong guess with
+`PUT /api/models/{id}` (`{"capabilities": [...]}`). Pass `--overwrite` to
+replace an existing entry at the same id. The old `hal0 model register`
+name is a deprecated alias with the *old* argument order —
+`hal0 model register <id> --path <path> --name … --license …` — kept
+only for scripts that haven't moved to `model add` yet. The API also
+exposes a directory scan that registers every new file it finds:
 
 ```sh
 hal0 model scan
@@ -220,17 +227,27 @@ loading it.
 ## Restore a pre-registry backup
 
 ```sh
-hal0 model import-backup /path/to/backup [--dest /mnt/models] [--force]
+hal0 model import-backup /path/to/backup [--dest /var/lib/hal0/registry/registry.toml] [--force]
 ```
 
-Disaster-recovery import for a model store captured before hal0's
-registry existed — restores files and re-registers them.
+Disaster-recovery import for a v0.1.x model store backup — restores only
+`registry.toml` from the archive, then syncs its entries into the SQLite
+registry (`INSERT OR IGNORE`, so anything already present in SQLite is left
+alone). It does **not** restore model bytes, `capabilities.toml`, or
+per-slot TOML files — redo slot selection with `hal0 slot create` (or the
+bundle picker) after importing. `--dest` is the destination *registry.toml
+path*, not a model directory; it defaults to
+`/var/lib/hal0/registry/registry.toml` and exists mainly as a test/dev
+escape hatch. `--force` overwrites an existing `registry.toml` at that
+destination — without it, the command refuses to clobber one that may
+already hold current selections.
 
 ## The registry on disk
 
 Registry entries are metadata records — id, display name, path, size,
 SHA-256, capabilities, and the model's own launch defaults (including an
 optional preferred profile) — see
-[Choose models](/docs/guides/choose-models#launch-flags-now-live-on-the-model-not-the-slot).
+[Choose models](/docs/guides/choose-models), which covers how those launch
+defaults now live on the model instead of the slot.
 The registry is the source of truth the dispatcher resolves model ids
 against; the actual weights live in your configured model store.

--- a/docs/guides/run-agents.mdx
+++ b/docs/guides/run-agents.mdx
@@ -28,7 +28,7 @@ sudo hal0 agent install hermes
 ```
 
 Installing Hermes runs a three-step foreground pipeline: ensure the
-toolchain (Python ≥3.11, venv stdlib, pip/pipx), provision the managed
+toolchain (Python ≥3.12, venv stdlib, pip/pipx), provision the managed
 venv and register the agent, then enable and start the systemd unit
 (`hal0-agent@hermes`).
 
@@ -149,13 +149,19 @@ from a slot's runtime logs.
 
 ```sh
 hal0 agent reprovision hermes          # idempotent re-converge
-hal0 agent reprovision hermes --repair # force every phase
+hal0 agent reprovision hermes --repair # force every phase, rebuilding the venv
 hal0 agent upgrade hermes              # bump the version pin + repair
 hal0 agent upgrade hermes --to 0.15.3  # pin a specific version
 ```
 
 `reprovision` is a stable wrapper over the same state machine `install`
-runs. For finer control — skipping a phase, staging the agent wheel
+runs. Plain `reprovision` re-converges the agent, including its managed
+virtualenv, so it is the command to reach for when the agent is running
+but its MCP tools are missing. `--repair` forces every phase instead of
+converging: it rebuilds the venv, re-writes the persona seeds and
+re-renders the config.
+
+For finer control — skipping a phase, staging the agent wheel
 offline, or a dry run that doesn't persist the checkpoint — drop to the
 underlying command directly:
 
@@ -281,6 +287,40 @@ curl 'http://localhost:8080/api/agents/hermes/activity?limit=50'
 
 Each row carries `tool`, `args`, `gated`, `outcome`, `timestamp`, and the
 `client_id` the action was attributed to.
+
+## When the agent has no memory tools
+
+An otherwise healthy Hermes that answers chat but cannot recall anything
+usually has a broken MCP client rather than a broken memory service. There
+are two independent causes, and both are repaired automatically now.
+
+The first is the wiring: the `X-hal0-Private` header has to be a YAML
+string, and a version that wrote it unquoted left the client unable to
+connect. The second is the managed virtualenv itself. A venv that drifted
+off its vetted pin — no `mcp` package installed at all — used to survive
+every upgrade untouched, because nothing outside provisioning re-converges
+the venv and `hal0 update` never provisions. The symptom is a client that
+fails to import with `mcp.client.streamable_http is not available` while
+the config header reads correctly.
+
+`hal0 update` now checks both on every upgrade and repairs what it finds.
+Verification is a re-probe of the import, not pip's exit code, so a repair
+that silently produces an unusable venv is reported as a failure rather
+than a success. If a repair cannot run — no venv on the box, an
+unresolvable pip — the update logs the fault and the remedy and carries on
+rather than failing.
+
+`hal0-api` also probes this on every start, including crash-restarts, but
+that path only diagnoses: it will not run pip during the startup of a box
+that is already unhealthy. It logs the remedy, and the next real update
+performs the repair.
+
+To fix a box by hand:
+
+```sh
+hal0 agent reprovision hermes           # re-converges the venv; usually enough
+hal0 agent reprovision hermes --repair  # forces a full venv rebuild
+```
 
 ## Related
 

--- a/docs/guides/update-and-rollback.mdx
+++ b/docs/guides/update-and-rollback.mdx
@@ -17,9 +17,8 @@ itself.
 <Aside type="caution" title="Read this before your first v1.0 update">
 If you've hand-edited custom entries into `/etc/hal0/profiles.toml`, the
 first `hal0 update` that crosses the v1.0 schema boundary **wipes and
-reseeds that file**. Skip to
-[The profiles.toml reseed](#the-profilestoml-reseed-a-pre-v10-one-time-wipe)
-before you run it.
+reseeds that file**. Read "The profiles.toml reseed (a pre-v1.0 one-time
+wipe)", further down this page, before you run it.
 </Aside>
 
 ## Check for an update
@@ -92,6 +91,49 @@ hal0 update --channel preview
 
 ![The Settings → Updates panel showing current version, available update, and channel selector](/screenshots/settings-page.png)
 *Settings → Updates: current version, available release, and channel selector.*
+
+### How a channel resolves to a release
+
+A channel is resolved at check time. It is not a pointer file someone
+maintains by hand.
+
+The updater fetches `https://releases.hal0.dev/<channel>.json`. That host
+scans the project's GitHub releases newest-first and serves the manifest
+from the first release that publishes an asset of that name, together with
+its detached `<channel>.json.bundle` signature from the same release. A
+release therefore joins a channel by carrying that channel's manifest
+asset — nothing else promotes it.
+
+Which manifests a release carries follows from its tag:
+
+| Tag shape | Manifests published |
+| --- | --- |
+| `v1.2.3` | `stable.json` and `preview.json` |
+| `v1.2.3-rc.1`, `v1.2.3-alpha.1`, `v1.2.3-beta.1` | `preview.json` |
+| `v1.2.3-nightly.20260829120000` | `nightly.json` |
+
+The separator before the sequence number is a dot, and it is not optional.
+`v1.2.3-rc.1` parses; `v1.2.3-rc1` does not and the release tooling rejects
+it outright rather than publishing nothing quietly. A nightly tag carries a
+14-digit timestamp.
+
+A stable release also enters `preview`, so `preview` is never behind
+`stable`. The reverse does not hold: only a final tag publishes
+`stable.json`, so every preview and nightly cut afterwards pushes the
+current stable release further down the release list. That is why the
+channel host scans more than the first page of releases — a stable release
+that falls off page one must still resolve. If a channel looks stuck, check
+for a release cut without its manifest asset before suspecting the updater.
+
+<Aside type="note">
+The channel host is served by the website, not by this repository, so its
+scan depth is a property of that deployment rather than of the hal0 tree.
+</Aside>
+
+Set `HAL0_RELEASES_URL` to point the updater at a different endpoint. It
+wins over the default; when the override is an `http`/`https` URL and the
+channel is not `stable`, the channel is appended as a `?channel=`
+parameter instead of as a filename.
 
 ## How the atomic update works
 
@@ -185,7 +227,8 @@ Same destination, and it keeps you on the `hal0 update` flow described above.
   (`releases.hal0.dev`) serves manifests directly.
 
 Rolling back afterwards works normally — the 0.9.8 tree is kept, not deleted.
-See [Roll back](#roll-back), and note that config migrations are forward-only:
+See the "Roll back" section below, and note that config migrations are
+forward-only:
 a rolled-back 0.9.8 daemon reads a `hal0.toml` that 1.0 already migrated.
 
 ## The profiles.toml reseed (a pre-v1.0 one-time wipe)

--- a/docs/guides/voice-stt-tts.mdx
+++ b/docs/guides/voice-stt-tts.mdx
@@ -23,9 +23,14 @@ hal0 exposes two voice directions through OpenAI-compatible endpoints:
 
 Both are children of the **`voice`** capability: `voice.stt` maps to the
 `stt` slot and `voice.tts` maps to the `tts` slot. Both children are
-now device-keyed engine switches with the same shape — see
-[ADR-0001](/docs/adr/0001-moonshine-cpu-stt-reinstatement/) for why `stt`
-was redesigned to match `tts` here.
+now device-keyed engine switches with the same shape. Before this
+redesign, `voice.stt` could only ever run `backend=npu` — any host
+without the XDNA NPU had zero speech-to-text. Reinstating Moonshine as a
+CPU-side STT engine and keying `stt` on device the same way `tts`
+already was closed that gap (see ADR-0001, "Reinstate Moonshine as the
+CPU STT engine", `docs/adr/0001-moonshine-cpu-stt-reinstatement.md` in
+the repository — an internal design record, not published to these
+docs).
 
 ## Enable the voice capability
 
@@ -98,7 +103,8 @@ There is deliberately no GPU row — hal0 ships no GPU STT engine. This is a
 two-engine, two-device special case, not a general `provider` selector: if
 a second CPU (or GPU) STT engine ever lands, `device` alone stops being
 enough to disambiguate and `provider` must become a first-class part of
-capability selection (see [ADR-0001](/docs/adr/0001-moonshine-cpu-stt-reinstatement/)).
+capability selection — this future-work trigger is recorded in ADR-0001
+(`docs/adr/0001-moonshine-cpu-stt-reinstatement.md`, repo-only).
 
 ### The `voice.tts` engine switch
 
@@ -193,7 +199,7 @@ curl -X POST http://localhost:8080/v1/audio/speech \
 ```
 
 `model` is required. `voice`, `speed`, and `response_format` are
-optional — see [request defaults](#tts-request-defaults) below.
+optional — see TTS request defaults below.
 
 ### TTS request defaults
 

--- a/docs/hal0-install-migration-guide.html
+++ b/docs/hal0-install-migration-guide.html
@@ -662,7 +662,8 @@ hal0 slot list &amp;&amp; systemctl list-units <span class="str">'hal0-slot@*'</
     <li>The update path works end-to-end on real hosting: manifest fetch follows redirects, the privileged stage honours <code>HAL0_RELEASES_URL</code>, wrappers refresh on every activate.</li>
     <li>Id-keyed boxes are first-class in every lane (capability toggles, NPU trio, config writes).</li>
     <li>Memory surfaces tell the truth: real operations envelope, accurate bank-delete blast radius, per-agent stats scoping, ACL-aware pagination, extraction-slot changes actually reach the daemon.</li>
-    <li>Removed: the experimental standalone browser MCP server (never mounted; Hermes brings its own browser tooling) and the never-read <code>[brain_chat] tool_model</code> key.</li>
+    <li>Removed: the experimental standalone browser MCP server (never mounted; Hermes brings its own browser tooling).</li>
+    <li><code>[brain_chat] tool_model</code> is wired for real: rc.1 deleted the key because nothing read it, and it came back with an implementation behind it. Tool rounds run on <code>tool_model</code> (default <code>hal0/agent</code>) while chat stays on the brain slot; set it to <code>off</code>, <code>none</code> or <code>disabled</code> to route tool turns nowhere.</li>
   </ul>
 </section>
 

--- a/docs/operate/auth.mdx
+++ b/docs/operate/auth.mdx
@@ -16,15 +16,15 @@ tier is rejected before the handler runs.
 <Aside type="caution">
 **Auth ships off by default.** A fresh v1.0 install is trusted-LAN-open —
 every route responds to any caller that can reach the port — until an
-operator explicitly enables enforcement (see [Enabling
-auth](#enabling-auth)). This is a deliberate v1.0 decision: an earlier
+operator explicitly enables enforcement (see the Enabling auth section
+below). This is a deliberate v1.0 decision: an earlier
 auto-on-when-non-loopback design locked operators out of a dashboard that
 shipped no login UI. hal0 still doesn't terminate TLS or manage a user
-directory — for that, put a reverse proxy in front (see [TLS still needs a
-proxy](#tls-still-needs-a-proxy)). And if you installed the OpenWebUI
+directory — for that, put a reverse proxy in front (see the TLS still
+needs a proxy section below). And if you installed the OpenWebUI
 companion there is a **second** listener — a full chat UI on `:3001` that
-this auth model does not cover at all; see
-[The second listener](#the-second-listener-openwebui-on-3001).
+this auth model does not cover at all; see the second listener section
+below (OpenWebUI on `:3001`).
 </Aside>
 
 ## Tiers and credential resolution
@@ -284,7 +284,7 @@ server {
 </Tabs>
 
 If your proxy forwards `X-Forwarded-For`, set `HAL0_TRUST_FORWARDED_FOR=true`
-(see [Rate limiting](#rate-limiting)) once you've confirmed the proxy itself
+(see the Rate limiting section above) once you've confirmed the proxy itself
 strips any client-supplied value — otherwise treat hal0's own admin-key auth
 as the access control and skip proxy-level basic auth entirely.
 

--- a/docs/operate/sentry.mdx
+++ b/docs/operate/sentry.mdx
@@ -14,8 +14,8 @@ DSN, and sends nothing.
 
 <Aside type="caution" title="This sends data off your LAN">
 hal0 is otherwise a local-first appliance. Enabling Sentry means crash reports
-leave the box for a third-party service. Read [What gets sent](#what-gets-sent)
-before you enable it on anything holding real data.
+leave the box for a third-party service. Read the What gets sent section
+below before you enable it on anything holding real data.
 </Aside>
 
 ## Enable it on the backend

--- a/docs/operate/services.mdx
+++ b/docs/operate/services.mdx
@@ -1,6 +1,6 @@
 ---
 title: Services
-description: The two systemd units that make up the hal0 platform — hal0-api and hindsight-api. Unit contents, config files, ports, health checks, and how to start/stop/restart/inspect logs for each.
+description: "The two systemd units that make up the hal0 platform — hal0-api and hindsight-api — plus the four companion services the dashboard's Services page manages (OpenWebUI, ComfyUI, Hermes, Hindsight): unit contents, config files, health checks, lifecycle actions, and mDNS discovery."
 sidebar:
   order: 20
 ---
@@ -13,10 +13,13 @@ it delegates recall/extraction to. Both run as the unprivileged `hal0` system
 user and are managed with plain `systemctl`/`journalctl`.
 
 <Aside type="note">
-This page covers the two platform units. Per-model inference units
-(`hal0-slot@<name>.service`) and companion apps managed through the
-`/api/services` registry (OpenWebUI, ComfyUI, Hermes) each have their own
-lifecycle and aren't covered here.
+This page covers the two platform units by raw `systemctl` below, and —
+further down, in Companion services — the four services in the
+`/api/services` registry (OpenWebUI, ComfyUI, Hermes, Hindsight) that the
+dashboard's Services page controls. Per-model inference units
+(`hal0-slot@<name>.service`) have their own lifecycle; see
+[Manage slots](/docs/guides/manage-slots) and the
+[slot lifecycle reference](/docs/reference/slot-lifecycle).
 </Aside>
 
 ## hal0-api.service
@@ -114,6 +117,7 @@ Environment=HINDSIGHT_API_LLM_PROVIDER=openai
 Environment=HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:8080/v1
 Environment=HINDSIGHT_API_LLM_MODEL=hal0/utility
 Environment=HINDSIGHT_API_LLM_API_KEY=hal0-local-noauth
+EnvironmentFile=-/etc/hal0/hindsight-llm.env
 Environment=HINDSIGHT_API_LLM_TIMEOUT=300
 Environment=HINDSIGHT_API_SKIP_LLM_VERIFICATION=true
 
@@ -139,7 +143,12 @@ WantedBy=multi-user.target
   OpenAI-compatible endpoint (`HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:8080/v1`).
   hindsight-api is a consumer of hal0-api, not the reverse.
 - **No TOML config** — every setting is an inline `Environment=` line in the
-  unit itself. An optional operator drop-in,
+  unit itself, with one exception: `EnvironmentFile=-/etc/hal0/hindsight-llm.env`
+  (the leading `-` means "ignore if absent") overrides the inline
+  `HINDSIGHT_API_LLM_API_KEY=hal0-local-noauth` placeholder with the real
+  client key. `installer/install.sh` writes that file at install time from
+  `HAL0_CLIENT_KEY`/`HAL0_ADMIN_KEY` in `/etc/hal0/api.env`, and `hal0 auth
+  rotate` keeps it fresh afterward. An optional operator drop-in,
   `hindsight-api.service.d/extraction-model.conf`, overrides
   `HINDSIGHT_API_LLM_MODEL` and `HINDSIGHT_API_LLM_TIMEOUT` without editing the
   installer-owned unit (written by `hal0 memory graph enable --slot <name>` or
@@ -159,6 +168,13 @@ WantedBy=multi-user.target
 - **Data root** — embedded Postgres at `/var/lib/hal0/memory/hindsight/.pg0`,
   pinned via the unit's `HOME=` env (Hindsight has no dedicated data-dir
   variable of its own).
+
+### Config files it reads
+
+| File | Purpose |
+|---|---|
+| `/etc/hal0/hindsight-llm.env` | Optional `EnvironmentFile`, `-` prefixed (ignored if absent) — supplies the real `HINDSIGHT_API_LLM_API_KEY`, written by `installer/install.sh` and kept fresh by `hal0 auth rotate`. |
+| `hindsight-api.service.d/extraction-model.conf` | Optional systemd drop-in under `/etc/systemd/system` — overrides `HINDSIGHT_API_LLM_MODEL`/`HINDSIGHT_API_LLM_TIMEOUT`, written via `hal0 memory graph enable --slot <name>` or the Memory dashboard page. |
 
 ### Health endpoint
 
@@ -200,6 +216,113 @@ GET /api/logs/stream?unit=hal0-api&level=...     # SSE tail
 
 Swap `unit=hindsight-api` for the memory engine's logs. Both routes are
 admin-tier.
+
+## Companion services
+
+The dashboard's Services page manages four companion services from a single
+registry — `hal0.services.registry.SERVICES` in
+`src/hal0/services/registry.py`. One `ServiceDef` per service names its
+owning unit, its probe strategy, and which lifecycle verbs it permits:
+
+| Service | Purpose | Unit | Allowed actions |
+|---|---|---|---|
+| OpenWebUI | Chat UI companion (podman container, LAN `:3001`) | `hal0-openwebui.service` | start, stop, restart, enable, disable |
+| ComfyUI | Image generation engine (runs as the seeded `img` slot container, LAN `:8188`) | `hal0-slot@img.service` | start, restart (no stop) |
+| Hermes | Bundled agent + its own dashboard (loopback `:9119`) | `hal0-agent@hermes.service` | start, stop, restart, enable, disable |
+| Hindsight | Memory engine — this is the same unit documented above | `hindsight-api.service` | start, stop, restart, enable, disable |
+
+Hindsight's entry here isn't a second thing to learn: the Services page's
+buttons for it run through the identical `unit_action` → `hal0-systemctl`
+path already described in hindsight-api.service above.
+
+### Start, Stop, Restart
+
+The Services page renders one button per allowed action
+(`ui/src/dash/services.jsx:100-124`): Restart whenever it's allowed, Start
+when the unit isn't currently active, Stop only while it is. Clicking one
+calls `POST /api/services/{id}/action` with `{"action": "start"|"stop"|"restart"}`,
+which `hal0.services.systemd.unit_action()` runs against the unit — the
+same verb allow-list and `hal0-systemctl` wrapper described above for
+hal0-api and hindsight-api.
+
+Stop carries a browser confirmation — "Stop `<name>`? Clients using it will
+lose access until it is started again." — because stopping OpenWebUI,
+Hermes, or Hindsight takes down something other browsers or agents may be
+using right now. It's a client-side prompt only: it isn't enforced by the
+API, so a direct `POST` bypasses it. Restart shows no such prompt.
+
+ComfyUI has no Stop button at all — the registry grants it only `start`
+and `restart`. Its "start" is not a raw `systemctl start`: the route
+substitutes the GPU-arbiter switchover (`_comfyui_start`,
+`src/hal0/api/routes/services.py:187-208`, delegating to the same
+`comfyui_switchover` handler the FirstRun repair flow uses) so resident LLM
+slots get drained before the iGPU is handed to ComfyUI. Stopping is
+arbiter-managed too, per its card hint: "stop is GPU-arbiter managed —
+switch back to inference in the Image-Gen pane".
+
+The registry also allows `enable`/`disable` for OpenWebUI, Hermes, and
+Hindsight, but the Services page renders no buttons for those two verbs —
+only `POST /api/services/{id}/action` with `{"action": "enable"|"disable"}`
+reaches them.
+
+There's no `hal0 service` command group, and for OpenWebUI and Hermes
+specifically there's no CLI equivalent for start/stop/restart. `hal0 app
+list` and `hal0 agent list`/`hal0 agent status` show a service's systemd
+enabled/active state, but neither `hal0 app` nor `hal0 agent` has a
+start/stop/restart subcommand — for those two services, the dashboard
+buttons, or a direct `systemctl {start|stop|restart} <unit>` as root (same
+mechanism as the platform units above), are the only ways to drive these
+verbs today. ComfyUI is the exception: its unit is `hal0-slot@img.service`,
+the same seeded `img` slot the Slots page manages, so `hal0 slot restart
+img`, `hal0 slot load img`, and `hal0 slot unload img` reach it from the
+CLI.
+
+### Health
+
+Two endpoints report health, for different consumers:
+
+- `GET /api/services` — the Services page's own source. Every entry
+  carries `up` (bool), a probe-specific `detail` string, and the raw
+  systemd `unit_state` (`active_state`/`sub_state`/`unit_file_state`/`since`).
+  The page's status pill is green **up** when `up` is true, red **failed**
+  when `unit_state.active_state` is `"failed"`, grey **down** for any other
+  managed service, and a plain grey **—** for an unmanaged one
+  (`ui/src/dash/services.jsx:67`).
+- `GET /api/services/health` — an older, stable three-service summary
+  (OpenWebUI, ComfyUI, Hermes only — no Hindsight) that feeds the Overview
+  page's Services widget. It collapses the same probes into
+  `state: "up" | "stopped" | "down"`, splitting "not up" into a deliberate
+  `stopped` (unit `inactive` — comes back on demand) from `down` (unit
+  `failed`, or reachable-but-unhealthy).
+
+Each service is probed differently: OpenWebUI is a loopback
+`GET http://127.0.0.1:3001/health` (2xx = up); ComfyUI is its own
+`/system_stats` + `/queue` (reachable = up, with a live "N running / M
+queued" job count); Hermes and Hindsight both fall back to systemd
+`active_state == "active"`. Every probe is fail-soft by design — a probe or
+systemd failure degrades to `up=false` with an honest detail, never a
+fabricated "up" and never a 500. A service with no wired probe would report
+`detail: "unmonitored"`, though none of the four registered services hits
+that path today.
+
+### mDNS discovery toggle
+
+The DISCOVERY (mDNS) card above the service grid
+(`DiscoveryCard`, `ui/src/dash/services.jsx:200-241`, toggle button at
+`:214-219`) toggles `POST /api/services/mdns` with
+`{"advertise": true|false}`. Turning it on writes one avahi service-group
+file — `/etc/avahi/services/hal0-addon-<id>.service` — per service that is
+both mDNS-capable and LAN-published; today that's OpenWebUI and ComfyUI
+only (Hermes and Hindsight are loopback-only and carry no LAN port, so
+they're never mdns-capable). avahi-daemon inotify-watches that directory,
+so the announcement takes effect immediately — no reload, no unit restart.
+Turning it off removes every `hal0-addon-*.service` file.
+
+The toggle never touches `hal0.service`, the base dashboard announcement
+the installer writes separately — that's why "Dashboard announced as
+`<host>.local`" can be true even when the addon toggle is off. If
+avahi-daemon isn't active, the button is disabled and the card tells the
+operator to install/enable it or add a static hosts entry.
 
 ## See also
 

--- a/docs/reference/api/openai-compat.mdx
+++ b/docs/reference/api/openai-compat.mdx
@@ -14,8 +14,9 @@ authenticated `router` for everything else, plus a separate realtime WebSocket r
 <Aside type="caution">
 The `/v1/*` route module's own comment states auth was removed and the surface is open
 on the local network — this predates or is independent of the `[security].require_auth`
-/ `hal0 auth` machinery documented in [Config schema](/docs/reference/config-schema/#security)
-and [CLI](/docs/reference/cli/#hal0-auth--manage-hal0-api-authentication). Verify
+/ `hal0 auth` machinery documented in the `[security]` section of
+[Config schema](/docs/reference/config-schema/)
+and the `hal0 auth` section of [CLI](/docs/reference/cli/). Verify
 whether `require_auth` actually gates `/v1/*` routes, `/api/*` routes, or both before
 publishing an unqualified "auth is/isn't enforced" claim.
 </Aside>
@@ -26,14 +27,14 @@ publishing an unqualified "auth is/isn't enforced" claim.
 |---|---|---|
 | `/v1/models` | GET | Aggregated catalog. Hides non-text-modality models (image/tts/stt) by default — pass `?show_all=true` to see them. Supports `X-hal0-Model-Filter` header or `?owned_by=` query param to scope by owner (hal0 extension, not OpenAI-standard). |
 | `/v1/models/{model_id}` | GET | By-id lookup — bypasses the modality filter above. |
-| `/v1/chat/completions` | POST | See [request body deviations](#v1chatcompletions) below. |
+| `/v1/chat/completions` | POST | See the `/v1/chat/completions` entry under Request body deviations, below. |
 | `/v1/completions` | POST | Pure passthrough — no hal0-specific body handling at the route layer. |
 | `/v1/embeddings` | POST | Standard `{model, input}`. Requests that resolve to the NPU "embed" trio slot bypass the generic dispatcher and post directly to that slot's own `/v1/embeddings`. |
 | `/v1/rerankings` | POST | OpenAI-compat shape name. Rewritten to `/v1/rerank` on the outgoing leg for llama-server upstreams (llama-server only serves native `POST /rerank`). |
 | `/v1/rerank` | POST | Alias, for clients that already speak llama-server's native shape. |
-| `/v1/audio/transcriptions` | POST | multipart/form-data. `model` form field is **required** — 400 `request.missing_model` if absent. See [deviations](#v1audiotranscriptions) below. |
+| `/v1/audio/transcriptions` | POST | multipart/form-data. `model` form field is **required** — 400 `request.missing_model` if absent. See the `/v1/audio/transcriptions` entry under Request body deviations, below. |
 | `/v1/audio/speech` | POST | JSON body. `model` is **required** (400 `request.missing_model` if missing/blank) — a deliberate deviation from the dispatcher's usual default-model fallback. |
-| `/v1/images/generations` | POST | ComfyUI-backed. **Not** a passthrough — see [Images](#v1imagesgenerations) below. |
+| `/v1/images/generations` | POST | ComfyUI-backed. **Not** a passthrough — see the `/v1/images/generations` entry under Request body deviations, below. |
 | `/v1/realtime` | WebSocket | Separate module (`realtime.py`) — not covered in depth by this pass. |
 
 ### Not implemented

--- a/docs/reference/api/realtime.mdx
+++ b/docs/reference/api/realtime.mdx
@@ -1,0 +1,207 @@
+---
+title: Realtime API reference
+description: "WS /v1/realtime — hal0's OpenAI-Realtime-shaped voice WebSocket, what it implements versus not, and how it relates to the STT/TTS/chat routes and the voice stack. Verified against src/hal0/realtime/ and src/hal0/api/routes/realtime.py."
+sidebar:
+  order: 40
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+`WS /v1/realtime` is a WebSocket endpoint that speaks a subset of the OpenAI Realtime
+API's event protocol. It is a thin transport shell (`src/hal0/api/routes/realtime.py`,
+~100 lines) over an engine in `src/hal0/realtime/` (~1,100 lines: `session.py`'s turn
+state machine, `backends.py`'s STT/TTS/chat seams, `audio.py`'s pcm framing,
+`vad.py`'s voice-activity detector, and `events.py`'s event vocabulary). It is
+**enabled by default** (`[realtime].enabled = true`) and classified **CLIENT** tier in
+`src/hal0/security/exposure.py` — see [REST API index](/docs/reference/api/rest-api/)
+for what that means once `[security].require_auth` is on.
+
+<Aside type="caution">
+This is not an OpenAI Realtime API passthrough. hal0 implements its own engine that
+speaks a compatible-looking subset of the wire event vocabulary, but every "model" it
+talks to is a local hal0 slot reached over loopback HTTP — there is no upstream OpenAI
+connection anywhere in this path.
+</Aside>
+
+## What it is
+
+hal0's realtime engine ties together three things it already exposes as separate
+REST routes — speech-to-text, chat (or the hal0-brain steward), and text-to-speech —
+into one stateful WebSocket session, so a voice client doesn't have to orchestrate
+record → transcribe → chat → synthesize → play as four separate round trips. The
+session owns: connection state, an input-audio ring buffer, server-side voice-activity
+detection (turn boundaries), the STT/LLM/TTS pipeline for a turn, sentence-chunked
+audio output, cancellation, and barge-in.
+
+Relation to the rest of the API surface: the engine is deliberately fenced away from
+importing model/provider/slot internals directly. It reaches STT via
+`POST /v1/audio/transcriptions`, TTS via `POST /v1/audio/speech`, and chat via either
+`POST /v1/chat/completions` or `POST /api/brain/chat` — all as loopback HTTP calls to
+hal0's own already-documented endpoints (see
+[OpenAI-compatible API reference](/docs/reference/api/openai-compat/)). The base URL
+for these internal calls is `http://127.0.0.1:8080` by default, overridable via
+`HAL0_SELF_BASE_URL`. This means the realtime session's STT/TTS quality and latency
+are exactly whatever the `[realtime].stt_model` / `[realtime].tts_model` slots deliver
+through their normal REST contract — there is no separate, faster internal path.
+
+## Connecting and authenticating
+
+Connect to `ws://<host>:8080/v1/realtime?model=<model>` (or `wss://` behind TLS
+termination). `model` is an optional query parameter; if omitted, the session falls
+back to `[realtime].default_model`, and if that's also empty the session starts with
+an empty model string until a `session.update` event sets one.
+
+Authentication is forwarded, not renegotiated over the socket: the
+`AuthEnforcementMiddleware` gates the WebSocket upgrade itself (it classifies every
+request — HTTP, SSE, and WS — before a handler ever runs), and separately the session
+forwards a credential on its own outbound loopback calls to `/v1/chat/completions`,
+`/api/brain/chat`, etc., so those internal calls also pass the same enforcement when
+auth is on. That credential is resolved as: the `Authorization` header if the client
+sent one, otherwise synthesized as `Bearer <value>` from a `?api_key=` query
+parameter — the fallback exists because browser WebSocket clients cannot set
+arbitrary upgrade headers.
+
+The server always accepts the WebSocket upgrade, even when the endpoint is disabled.
+If `[realtime].enabled` is `false`, the server accepts the connection, immediately
+sends a typed `error` event (`code: "disabled"`), and closes with WS code `4404`. A
+client can't tell "disabled" from "wrong URL" purely from the handshake succeeding —
+it has to read the first frame.
+
+## Session lifecycle and event vocabulary
+
+On connect the server emits `session.created` with the current session object
+(`id`, `model`, `modalities: ["audio", "text"]`, `voice`, `instructions`,
+`turn_detection`, `tools`, `input_audio_format: "pcm16"`,
+`output_audio_format: "pcm16"`).
+
+**Client → server events the engine accepts** (`ACCEPTED_CLIENT_EVENTS` in
+`events.py`):
+
+| Event | Effect |
+|---|---|
+| `session.update` | Updates `model`, `voice`, `instructions`, `tools`, and/or `turn_detection` (only these fields are read — see "Not implemented" below). Replies with `session.updated`. |
+| `input_audio_buffer.append` | Appends base64 pcm16 audio to the input buffer; if `turn_detection` is `server_vad`, also feeds the VAD. |
+| `input_audio_buffer.commit` | Runs STT on the buffered audio, appends a `user` message, emits `conversation.item.input_audio_transcription.completed`, and starts a response. Errors `input_audio_buffer_commit_empty` if the buffer is empty. |
+| `response.create` | Starts a response turn from the current message history (no-op if one is already running). |
+| `response.cancel` | Cancels the in-flight response; emits `response.done` with `status: "cancelled"`, or acknowledges the same way if nothing was running. |
+| `conversation.item.create` | Injects an item into history: `type: "message"` (text) or `type: "function_call_output"` (a tool result for the plain LLM leg — see below). Accepted silently; the client must send `response.create` next. |
+
+**Client → server events the engine recognizes but does not implement**
+(`REJECTED_CLIENT_EVENTS`) — these get a typed `error` event
+(`code: "unsupported_event"`), never a silent drop or a closed socket:
+`input_audio_buffer.clear`, `conversation.item.delete`, `conversation.item.truncate`.
+
+Anything else — an unrecognized `type`, a non-JSON frame, or a JSON frame that isn't
+an object — also becomes a typed `error` event (`unknown_event`, or a parse-error
+message) rather than tearing down the connection.
+
+**Server → client events emitted** (`EMITTED_SERVER_EVENTS`): `session.created`,
+`session.updated`, `input_audio_buffer.speech_started`,
+`input_audio_buffer.speech_stopped`,
+`conversation.item.input_audio_transcription.completed`, `response.created`,
+`response.output_audio_transcript.delta`, `response.output_audio.delta`,
+`response.function_call_arguments.done`, `response.done`, `error`.
+
+## Turn detection and audio format
+
+Turn detection defaults to `server_vad` and is driven by `EnergyVAD`
+(`src/hal0/realtime/vad.py`) — a pure normalized-RMS energy threshold detector, not a
+machine-learning VAD (the shipped runtime has numpy but deliberately no
+onnxruntime/webrtcvad/silero, to avoid a heavyweight dependency and an unpullable
+multi-file model). It emits `speech_started` on voiced onset and `speech_stopped`
+after `[realtime].vad_silence_ms` of trailing silence, auto-committing the buffer and
+starting a response only if the segment carried at least `vad_min_speech_ms` of voiced
+audio — a cough or click below that floor is dropped, not treated as a turn.
+Disabling VAD is also accepted via `session.update`, but only as `turn_detection:
+null` or `turn_detection: {"type": "none"}` — the handler (`_on_session_update` in
+`session.py`) checks `td is None` and `isinstance(td, dict)` and nothing else. A
+bare string like `turn_detection: "none"` matches neither branch: it's silently
+dropped, the server still replies `session.updated` as if it took effect, and the
+session stays in `server_vad` — the same silent-drop trap this page warns about
+above for other `session.update` fields. In `none` mode the client must send
+`input_audio_buffer.commit` itself. Threshold/silence tuning can be set per-session
+through `session.update`'s `turn_detection.threshold` /
+`turn_detection.silence_duration_ms`, in addition to the `[realtime].vad_*` config
+defaults documented on [Config schema](/docs/reference/config-schema/) — note that
+`silence_duration_ms` is only honored when it's a JSON integer (`_reconfigure_vad`
+checks `isinstance(..., int)`); a float value is silently dropped too.
+
+Barge-in is implemented: if the VAD detects new speech onset while a response is
+still being spoken, the in-flight response is cancelled (`response.done`,
+`status: "cancelled"`) before the new turn proceeds.
+
+Audio is fixed at **mono, 16-bit signed little-endian PCM at 24 kHz** for both
+directions (`[realtime].sample_rate` is schema-constrained to 8000–48000 but the
+engine does no resampling on either leg — it assumes the configured rate end to end).
+Input arrives as base64 pcm16 in `input_audio_buffer.append`. Output is emitted as a
+sequence of `response.output_audio.delta` events, each carrying one base64 pcm16
+frame sliced to `[realtime].frame_ms` (default 20ms). There is no Opus, no G.711
+(`g711_ulaw`/`g711_alaw`), and no WebRTC transport — WebSocket with raw pcm16 frames
+is the only transport.
+
+## The two LLM legs
+
+The session's `model` field selects between two independent chat backends
+(`src/hal0/realtime/backends.py`):
+
+- **Plain leg** (any model other than the sentinel below) — streams
+  `POST /v1/chat/completions`, forwarding the session's `tools` array. Tool calls
+  surface to the client as `response.function_call_arguments.done` for **client-side**
+  execution; the client is expected to run the tool and reply with
+  `conversation.item.create` (`type: "function_call_output"`), then send
+  `response.create` again.
+- **Steward leg** (`model == "hal0-brain"`, the `STEWARD_MODEL` sentinel) — streams
+  `POST /api/brain/chat` and consumes its SSE frames (`token` → spoken text,
+  `approval_required` → a spoken notice, `error` → a typed `error` event). Tools run
+  **server-side** inside the steward; the client never sees
+  `response.function_call_arguments.done` on this leg. Because a gated steward tool
+  can otherwise block the brain's SSE stream for up to 300 seconds waiting on
+  operator approval, the session bounds that wait to `[realtime].approval_wait_s`
+  (default 20s): if the next chunk doesn't arrive in time, the session speaks
+  "I'm still waiting on that approval — I'll stop here. Approve it at the bell and
+  ask me again," and ends the turn rather than leaving the caller in silence.
+
+## What is NOT implemented (with evidence)
+
+- **`input_audio_buffer.clear`, `conversation.item.delete`, `conversation.item.truncate`**
+  — recognized as valid OpenAI Realtime event names but explicitly rejected with a
+  typed `unsupported_event` error (`REJECTED_CLIENT_EVENTS` in
+  `src/hal0/realtime/events.py`).
+- **Most `session.update` fields are silently ignored, not rejected.** The handler
+  (`_on_session_update` in `session.py`) only reads `model`, `voice`, `instructions`,
+  `tools`, and `turn_detection`. Sending OpenAI-standard fields like `modalities`,
+  `temperature`, `max_response_output_tokens`, or `input_audio_transcription` gets a
+  normal `session.updated` acknowledgment — the fields are simply dropped, with no
+  error to signal they weren't honored.
+- **No G.711 / Opus audio, no WebRTC transport** — `audio.py` hardcodes pcm16 mono at
+  a single configured sample rate; `input_audio_format`/`output_audio_format` in the
+  session object are always `"pcm16"`, never negotiated.
+- **No server-side tool execution on the plain leg** — only the steward leg
+  (`hal0-brain` model) executes tools server-side; the plain leg always hands
+  `tool_call` chunks back to the client (`backends.py`'s `_default_chat_plain`).
+- **No conversation-item retrieval/listing** — history is an internal, append-only
+  `self.messages` list per session with no read-back event; a client that wants to
+  know what's in history has to have tracked it itself.
+- **No multi-turn response streaming controls** — there's no `response.cancel`
+  target-selection (only "cancel whatever's running"), and only one response can be
+  in flight per session at a time; a redundant `response.create` while one is already
+  running is a silent no-op (not queued, not errored).
+
+## Relation to the voice stack
+
+This endpoint is the single integration point tying hal0's STT slot, chat/steward
+routing, and TTS slot into one live session — the same three pieces the dashboard's
+`/v1/audio/transcriptions` and `/v1/audio/speech` endpoints expose individually (see
+[OpenAI-compatible API reference](/docs/reference/api/openai-compat/)). Which actual
+model backs STT/TTS is controlled by `[realtime].stt_model` / `[realtime].tts_model`
+(default `tts_model` is `"kokoro"`; an empty `stt_model` falls back to the session's
+chat model) — configuration reference for the full `[realtime]` table lives on
+[Config schema](/docs/reference/config-schema/).
+
+<Aside type="note">
+Everything on this page was verified directly against `src/hal0/realtime/session.py`,
+`backends.py`, `audio.py`, `vad.py`, `events.py`, and
+`src/hal0/api/routes/realtime.py` in this tree. It was not possible to verify this
+against a running voice client in this pass — treat any claim about real-world
+latency or audio quality as unverified.
+</Aside>

--- a/docs/reference/api/rest-api.mdx
+++ b/docs/reference/api/rest-api.mdx
@@ -1,60 +1,196 @@
 ---
 title: REST API index
-description: Index of hal0's HTTP /api/* management surface, router group by router group — verified against src/hal0/api/routes and the tool-to-route map in src/hal0/mcp/admin.py.
+description: Index of hal0's HTTP /api/* management surface, router group by router group — verified against src/hal0/api/routes, src/hal0/api/__init__.py's mount list, and the auth classification table in src/hal0/security/exposure.py.
 sidebar:
   order: 100
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-hal0-api serves an OpenAI-compatible `/v1/*` inference surface plus an `/api/*`
+hal0-api serves an OpenAI-compatible `/v1/*` inference surface (see
+[OpenAI-compatible API reference](/docs/reference/api/openai-compat/)) plus an `/api/*`
 management surface that backs the dashboard and the `hal0-admin` MCP server. This page
-indexes the `/api/*` router groups that could be verified directly against source for
-this pass — for full request/response schemas for a given route, read the OpenAPI spec
-served live at `/api/openapi.json` (interactive docs at `/api/docs`).
+indexes every `/api/*` router group mounted in `src/hal0/api/__init__.py` — for full
+request/response schemas for a given route, read the OpenAPI spec served live at
+`/api/openapi.json` (interactive docs at `/api/docs`).
 
 <Aside type="caution">
 Unlike pre-1.0 docs may claim, auth is **not** unconditionally removed in this tree.
 `[security].require_auth` (overridable via `HAL0_REQUIRE_AUTH`) and the `hal0 auth`
 CLI group (`status`, `rotate`, `require`) are live — see
-[Config schema → [security]](/docs/reference/config-schema/#security) and
-[CLI → hal0 auth](/docs/reference/cli/#hal0-auth--manage-hal0-api-authentication).
+[Config schema](/docs/reference/config-schema/) (`[security]`) and
+[CLI](/docs/reference/cli/) (`hal0 auth`).
 Verify the current default (`require_auth` defaults to `null`, which resolves to off)
 before stating a blanket "no auth" or "auth required" claim.
 </Aside>
 
-## Router groups
+## Auth tiers
 
-| Prefix | Purpose |
-|---|---|
-| `/api/slots` | Slot lifecycle — list, create, delete, restart, model swap, resolved-argv provenance, metrics, capacity. See [Slot lifecycle](/docs/reference/slot-lifecycle/). |
-| `/api/models` | Model registry — list, pull, delete, inspect, scan, catalogue, update checks. See [Model roster & benchmarks](/docs/reference/model-roster-benchmark/). |
-| `/api/ports` | Port allocation view. |
-| `/api/stats/hardware` | Live hardware probe/stats. See [Hardware matrix](/docs/reference/hardware-matrix/). |
-| `/api/system-info` | Host system info. |
-| `/api/capabilities` | Capability-slot configuration (embed/rerank/stt/tts/vision child slots). |
-| `/api/providers` | Local provider entries (`providers.toml`). See [Providers, profiles & devices](/docs/reference/providers-profiles-devices/). |
-| `/api/upstreams` | Remote/cloud upstream entries (`upstreams.toml`), including credential write and connectivity test. |
-| `/api/stacks` | Stack bundles — list, create, apply, import/export, snapshot. |
-| `/api/profiles` | Backend-tuning profiles — list, create, update, import/export. |
-| `/api/settings` | Root config read/write/reload, JSON schema, apply-plan preview. |
-| `/api/settings/models/store` | Model store path get/set/migrate. |
-| `/api/benchmarks` | Benchmark queue, run status, control. See [Model roster & benchmarks](/docs/reference/model-roster-benchmark/#benchmarks). |
-| `/api/logs` | Secret-redacted log tail. |
-| `/api/status` | Version/build info. |
-| `/api/mcp` | MCP server lifecycle/introspection — **not** tool invocation. See [MCP tools → MCP server management REST API](/docs/reference/mcp-tools/#mcp-server-management-rest-api) for the full endpoint table. |
-| `/api/comfyui` | ComfyUI generation-engine status and image-gen slot control. |
-| `/api/install` | First-run wizard endpoints, including `GET /api/install/curated-models`. |
+Every route resolves to one of four classes in `src/hal0/security/exposure.py`
+(`hal0.security.exposure.classify`), evaluated first-match-wins against an explicit
+rule table:
 
-Every prefix in this table is backed by at least one route independently confirmed
-either directly in `src/hal0/api/routes/` or via the `hal0-admin` MCP tool-to-route
-map (`hal0.mcp.admin`) — see [MCP tools](/docs/reference/mcp-tools/) for the exact
-verb + path for every admin-tool-backed route.
+- **OPEN** — no auth ever. A deliberately tiny, enumerated allowlist (the `/v1/models`
+  probe, the Prometheus scrape, the two liveness checks, the dashboard bootstrap-urls
+  endpoint, the login/status/logout routes themselves, the static SPA shell — same
+  HTML/JS bundle for every visitor, no server data — and the Hermes
+  dashboard-plugin static asset proxy at
+  `/dashboard-plugins/{plugin_name}/{file_path}`).
+- **BOOTSTRAP** — open only until an admin key is configured (`/api/install/*`).
+- **CLIENT** — the `/v1/*` inference/writer surface plus a short list of genuinely
+  read-only introspection `GET`s.
+- **ADMIN** — everything else, including every mutating route and every route that can
+  return secrets or config. **Unclassified paths fall back to ADMIN** (deny-by-default).
+
+These classes only matter once `[security].require_auth` is actually on — while it's
+off the whole surface is trusted-LAN-open regardless of class. The table below states
+each group's class as enforced by `exposure.py`, not as a claim about the current
+default posture.
 
 <Aside type="note">
-This index was not able to verify the `/v1/*` OpenAI-compatible inference surface, the
-"slot as an OpenAI model" addressing scheme, or SSE streaming response shapes in this
-pass — those need a dedicated read of `src/hal0/api/routes/*` inference-serving code
-before publishing exact request/response schemas. Treat any such claims from prior
-(pre-v1.0) docs as unverified until then.
+`src/hal0/api/routes/events.py`, `activity.py`, and `journal.py` each carry a
+module docstring claiming "no auth dependency" / "no auth gate" for first-run UX
+reasons (the footer/journal/activity panels must render before any credential
+exists). `exposure.py`'s own module docstring names eight routes not spelled out
+in either explicit OPEN/CLIENT bucket list — `/api/status`, JSON `/api/metrics`,
+`/api/features`, `/api/logs`, `/api/events`, `/api/activity`, `/api/journal`, and
+the dashboard-plugin manifest — as an "UNSURE — please review" bucket that
+defaults to ADMIN except where a close analogy to an existing CLIENT bucket
+argued otherwise: `/api/status` and JSON `/api/metrics` were reasoned across to
+CLIENT (and `/api/features` GET separately resolves CLIENT via its own exact-match
+rule). That leaves `/api/logs`, `/api/events`, `/api/activity`, `/api/journal`,
+and the dashboard-plugin manifest as the UNSURE items that actually landed
+ADMIN. If `require_auth` is ever turned on, the events/activity/journal panels
+will 401 during first-run before a credential exists — contradicting the
+rationale their own route files state. Flagging this as a real discrepancy
+between route-level intent and the enforced classification, not a doc error to
+silently paper over.
+</Aside>
+
+## Router groups
+
+| Prefix | Auth | Purpose |
+|---|---|---|
+| `/api/auth` | Mixed | `login`/`status`/`logout` are OPEN (you can't require a cookie to obtain one); `require` (toggle enforcement) and `rotate` (mint a new admin/client key) are ADMIN; `exposure` (serialize this whole rule table) is ADMIN. |
+| `/api/secrets` | ADMIN | Operator-managed secrets store. See "Secrets" below — dedicated section, not just a table row. |
+| `/api/settings` | ADMIN | Root config read/write/reload, JSON schema, apply-plan preview. |
+| `/api/settings/models/store` | ADMIN | Model store path get/set/migrate (part of the `/api/settings` prefix). |
+| `/api/settings/proxmox` | ADMIN | Proxmox integration config (host/token) + live cluster status. See "Proxmox integration" below — no dedicated exposure rule; it inherits ADMIN from the generic `/api/settings` prefix. |
+| `/api/slots` | CLIENT (list) / ADMIN (else) | Slot lifecycle — list, create, delete, restart, model swap, resolved-argv provenance, metrics, capacity. See [Slot lifecycle](/docs/reference/slot-lifecycle/). |
+| `/api/models` | CLIENT (GET) / ADMIN (mutations) | Model registry — list, pull, delete, inspect, scan, catalogue, update checks. `GET /api/models/health` is registered by `hardware.router`, not `models.router` — it's mounted ahead of `/api/models` so the literal path wins over the `{model_id}` catch-all. See [Model roster & benchmarks](/docs/reference/model-roster-benchmark/). |
+| `/api/runner-images` | CLIENT (list/detail) / ADMIN (sync/pull) | Runner Image catalogue — discovery + pull-job orchestration for GHCR-hosted runner images. |
+| `/api/ports` | CLIENT (GET) / ADMIN (else) | Port allocation view. |
+| `/api/hardware` | CLIENT (GET) / ADMIN (`/probe`) | Hardware probe read + on-demand re-probe. |
+| `/api/stats/hardware` | CLIENT | Live hardware probe/stats. See [Hardware matrix](/docs/reference/hardware-matrix/). |
+| `/api/stats` (`/slots`, `/requests`, `/throughput/history`, `/power`) | CLIENT (GET) / ADMIN (else) | Dispatcher rollups, throughput history, power stats. |
+| `/api/status` | CLIENT | Version/build summary. |
+| `/api/health`, `/api/health/system` | OPEN | Shallow + deep liveness probes hit by the installer/systemd watchdog before any credential exists. |
+| `/api/doctor` | ADMIN | `GET /api/doctor` — the same report card `hal0 doctor verify --json` prints, aggregated in-process from health/urls/system/memory/services, over HTTP. Classified ADMIN (not CLIENT) because it re-surfaces detail from ADMIN-only subsystems. |
+| `/api/metrics` | CLIENT | JSON metrics snapshot. |
+| `/api/metrics/prometheus` | OPEN | Prometheus scrape target. |
+| `/api/features` | CLIENT (GET) | Feature-flag surface. `GET /api/features` is the only route `health.py` registers on this prefix — no mutating route is mounted, so `exposure.py`'s ADMIN-mutations rule is currently latent, not backing a real endpoint. The CLIENT rule is an exact match on `/api/features` only, so a hypothetical `GET /api/features/<sub>` would fall through to the prefix rule and resolve ADMIN. |
+| `/api/system-info`, `/api/system-stats` | CLIENT | Host system info / fleet metrics over the SQLite tables (OBS-1). |
+| `/api/capabilities` | ADMIN | Capability-slot configuration (embed/rerank/stt/tts/vision child slots). |
+| `/api/backends` | CLIENT (GET) / ADMIN (else) | Backend introspection (NPU/GPU-Vulkan/GPU-ROCm/CPU status) + NPU load/unload. |
+| `/api/npu` | CLIENT (GET) / ADMIN (else) | NPU trio swap-status for the "swap incoming" dashboard banner. |
+| `/api/providers` | ADMIN | Local provider entries (`providers.toml`). See [Providers, profiles & devices](/docs/reference/providers-profiles-devices/). |
+| `/api/upstreams` | ADMIN | Remote/cloud upstream entries (`upstreams.toml`), including credential write and connectivity test. Mounted on the same router as `/api/providers`. |
+| `/api/stacks` | ADMIN | Stack bundles — list, create, apply, import/export, snapshot. |
+| `/api/profiles` | CLIENT (GET) / ADMIN (mutations) | Backend-tuning profiles — list, create, update, import/export. |
+| `/api/benchmarks` | ADMIN | Benchmark queue, run status, control. See [Model roster & benchmarks](/docs/reference/model-roster-benchmark/). |
+| `/api/chat-templates` | ADMIN | Chat-template catalog — bundled + operator-added templates. |
+| `/api/logs` | ADMIN | Secret-redacted log tail. |
+| `/api/mcp` | ADMIN | MCP server lifecycle/introspection — **not** tool invocation. See [MCP tools](/docs/reference/mcp-tools/) for the full endpoint table. |
+| `/api/comfyui` | ADMIN | ComfyUI generation-engine status and image-gen slot control. |
+| `/api/install` | BOOTSTRAP | First-run wizard endpoints, including `GET /api/install/curated-models`. Open until an admin key is configured, then treated as ADMIN. |
+| `/api/memory` | ADMIN | Two routers share this prefix: the `[memory.graph]` gate/status, and the Hindsight engine admin surface (banks, graph, recall/reflect, mental models, directives, async operations). Every `DELETE` under this prefix is pinned ADMIN by an explicit rule independent of the generic one (issues #1024/#1302 — a prior unauthenticated bank-delete cascade-dropped ~632 live records); bank-scoped deletes additionally require a `?confirm=` echo + dry-run preview. |
+| `/api/board` | ADMIN | Operator Board — task/board CRUD, links, dispatch, `WS /api/board/events`, and the `POST /api/board/chat` orchestrator alias. Frozen FE↔BE contract (`ui/CONTRACTS.md` §4). |
+| `/api/brain` | ADMIN | `POST /api/brain/chat` (SSE) — the primary hal0-brain platform-steward chat surface. Drives the full admin tool surface (slot mutations, model pulls, board writes), hence ADMIN. `/api/board/chat` is a thin alias into the same engine. |
+| `/api/updates` | ADMIN | Self-update: release-manifest check, prepare/commit/apply/rollback, channel get/set, post-update slot-drift report + restart. |
+| `/api/events` | ADMIN | Dashboard footer event feed — backfill + `GET /api/events/stream` (SSE). See the auth-tier note above. |
+| `/api/activity` | ADMIN | Durable audit surface (SQLite-backed) — the slots-page ActivityLog's source of truth, with `/export` (csv/json) and `/stream` (SSE). See the auth-tier note above. |
+| `/api/journal` | ADMIN | Unified journal panel — flattens `/api/events` into one envelope for the dashboard journal view. See the auth-tier note above. |
+| `/api/images` | ADMIN | Cache for PNGs written by `POST /v1/images/generations`. ADMIN because a cached-image URL could otherwise leak a prompt via filename. |
+| `/api/agents` | ADMIN | Bundled-agent lifecycle (install/uninstall/list/status), personas, service restart, memory stats, and the chat-proxy WS/REST shim to the Hermes dashboard process. |
+| `/api/agent/approvals` | ADMIN | Gated-tool approval inbox — every method (GET list, POST approve/deny, GET `/events` SSE) is ADMIN; `exposure.py`'s rule on this prefix carries no method filter, and the route module itself (`approvals.py`) declares no `Depends` — enforcement is entirely middleware-side. |
+| `/api/user` | ADMIN | Dashboard layout persistence (single-operator LAN device — one layout file per install). |
+| `/api/config` | Mixed | `GET /api/config/urls` (dashboard bootstrap hostnames) is OPEN; the rest of this prefix is ADMIN (may hold config-derived secrets). |
+| `/api/meta` | CLIENT (GET) / ADMIN (else) | `GET /api/meta/enums` — the canonical device/backend/capability vocabulary from `hal0.model_meta`. |
+| `/api/hf` | CLIENT (GET) / ADMIN (else) | HuggingFace Hub search proxy backing the dashboard's "Search HF" button. |
+| `/api/services` | ADMIN | `services_health.router` (`GET /api/services/health`, 3-service overview) and `services_routes.router` (full per-service detail + lifecycle actions + mDNS) share this prefix. |
+| `/api/dashboard/plugins` | ADMIN | Hermes dashboard-plugin manifest (kanban plugin discovery for `<AgentView>`). |
+| `/api/openrouter` | ADMIN | OpenRouter OAuth callback scaffold — only mounted when `HAL0_OPENROUTER_OAUTH_ENABLED` is truthy; 501 placeholder otherwise absent from the route table entirely. |
+
+Every prefix above is backed by at least one route confirmed directly against
+`src/hal0/api/routes/` and the mount list in `src/hal0/api/__init__.py`. This brings
+documented coverage to every `/api/*` prefix currently mounted (previously 18 of
+roughly 43). `WS /v1/realtime` is documented separately — see
+[Realtime API reference](/docs/reference/api/realtime/).
+
+## Secrets (`/api/secrets`)
+
+Backs the dashboard's Settings → Secrets panel. Persists to `/etc/hal0/api.env` — the
+same systemd `EnvironmentFile=` the provider-credential writer targets — via the
+shared atomic, mode-0600 writer in `hal0.api._env_store`. A successful write also
+updates the running process's `os.environ` so the new value is observable without a
+restart; the persisted file is the source of truth across restarts. ADMIN-gated
+(whole prefix, `exposure.py` line-item `secrets`).
+
+| Method | Path | Status | Notes |
+|---|---|---|---|
+| GET | `/api/secrets` | 200 | Lists secret **names** only — `{"secrets": [{name, set, masked, updated_at, protected}]}`. `masked` is always the constant `"••••••••"`; a value is never returned by any endpoint, logged, or echoed in an error body. |
+| POST | `/api/secrets/{name}` | 204 | Set/overwrite. Body `{"value": "..."}`. Accepted alongside PUT because the shipped dashboard hook POSTs. |
+| PUT | `/api/secrets/{name}` | 204 | Set/overwrite — the documented-contract verb; identical handler to POST. |
+| DELETE | `/api/secrets/{name}` | 204 | Idempotent — 204 even if the name was never set. |
+
+Validation, enforced server-side (not just in the UI, since this route is reachable
+by anyone who can reach the API):
+
+- **Name grammar**: `^[A-Z][A-Z0-9_]{0,63}$` — ALL_CAPS, leading letter, ≤64 chars.
+  A non-conforming name is `400 secret.name_invalid`.
+- **Protected prefix**: any name starting with `HAL0_` is hal0's own service
+  configuration and auth surface (written by the installer, `hal0.toml` derivation,
+  and `hal0 auth rotate`) — it is listed by GET (with `protected: true`, so an
+  operator can see what the service is configured with) but every mutation against
+  it is refused with `403 secret.protected`, including a DELETE of a name that isn't
+  even currently set (so the response doesn't leak which `HAL0_*` keys exist on the
+  box). Deleting `HAL0_ADMIN_KEY` would disarm every future login and deleting
+  `HAL0_PORT`/`HAL0_UI_DIST` would break the service on next restart — this is the
+  control introduced after #1450.
+- **Value grammar**: non-empty and printable (`str.isprintable()`). Control
+  characters — including the higher-codepoint line separators `U+0085`/`U+2028`/
+  `U+2029`, not just the ASCII C0 set — are rejected as `400 secret.value_invalid`,
+  because `api.env` is an unauthenticated-at-the-filesystem-level, LAN-writable
+  systemd `EnvironmentFile`: an injected line separator could otherwise smuggle a
+  second `KEY=value` pair into the file on round-trip.
+
+Every set/delete emits a structured `hal0.audit` log line and a footer journal event
+carrying the secret **name** only, never the value.
+
+## Proxmox integration (`/api/settings/proxmox`)
+
+Lets an operator configure the optional Proxmox API token the dashboard's "Proxmox
+host" hardware panel uses (`hal0.hardware.pve`). Persisted to `/etc/hal0/proxmox.json`
+— a separate file from `hal0.toml`, mounted as a sibling under `/api/settings` purely
+for the dashboard's Settings-panel grouping. There is **no dedicated exposure.py rule**
+for this path — it inherits ADMIN from the generic `/api/settings` prefix rule, the
+same as every other settings sub-route.
+
+| Method | Path | Notes |
+|---|---|---|
+| GET | `/api/settings/proxmox` | Returns `{configured, host, port, user, token_name, verify_ssl, token_value_set, status}` — the token **value** is never included; `token_value_set` is a boolean instead. `status` is a live `pve_status()` cluster snapshot fetched on every call. |
+| PUT | `/api/settings/proxmox` | Body: `{host, port?, user, token_name, token_value?, verify_ssl?}`. `token_value` is optional on edit — if omitted and a config already exists on disk, the existing token is preserved so an operator can flip `verify_ssl` or change the host without re-entering the secret. If omitted with **no** existing config, the write is rejected `400 proxmox.token_required`. |
+| DELETE | `/api/settings/proxmox` | Removes the config file entirely — returns to "not configured". |
+| POST | `/api/settings/proxmox/test` | Body: same shape as PUT but `token_value` is **required** (there's no "test the saved config" path that can omit it — that's what GET's live `status` field already covers). Validates a candidate connection without writing anything to disk. |
+
+`port` defaults to `8006` and is constrained `1-65535`; `verify_ssl` defaults to
+`false`. Both request bodies are `extra: "forbid"` pydantic models — an unrecognized
+field is a validation error, not a silently-dropped key.
+
+<Aside type="note">
+This page could not verify the `/v1/*` OpenAI-compatible inference surface in depth —
+see [OpenAI-compatible API reference](/docs/reference/api/openai-compat/),
+[Streaming reference](/docs/reference/api/streaming/), and
+[Realtime API reference](/docs/reference/api/realtime/) for those, verified in
+separate passes.
 </Aside>

--- a/docs/reference/api/slot-as-model.mdx
+++ b/docs/reference/api/slot-as-model.mdx
@@ -8,8 +8,8 @@ sidebar:
 import { Aside } from '@astrojs/starlight/components';
 
 hal0's dispatcher resolves the `model` field of an OpenAI-compatible request primarily
-by **model id**, not by slot name — see
-[OpenAI-compatible API → Model → slot resolution](/docs/reference/api/openai-compat/#model--slot-resolution)
+by **model id**, not by slot name — see the Model → slot resolution
+section of [OpenAI-compatible API](/docs/reference/api/openai-compat/)
 for the full 5-step resolution order. Direct slot-name addressing exists, but only as
 the last-resort fallback in that chain (`SLOT_ALIASES` direct lookup) — described in
 source as "operator muscle memory," for requesting a slot literally by name.

--- a/docs/reference/api/streaming.mdx
+++ b/docs/reference/api/streaming.mdx
@@ -29,7 +29,7 @@ hal0's streaming forward path in the dispatcher (`hal0.dispatcher.router`).
 
 <Aside type="caution">
 `[dispatcher].direct_read_timeout_s` (default `300.0`, range `30.0-600.0` — see
-[Config schema](/docs/reference/config-schema/#dispatcher)) sets the HTTP client's
+the `[dispatcher]` section of [Config schema](/docs/reference/config-schema/)) sets the HTTP client's
 `read` timeout, which httpx applies to **every** body read — streaming included.
 While the stall guard is active, streaming requests therefore disable it
 per-request so the guard owns the *body* bound and a stall always produces the

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -101,7 +101,7 @@ already matches).
 On a v1.0 update, the profile catalog is reset once (gated on a schema-version
 watermark) — custom profiles are backed up and the seed catalog is reapplied.
 `hal0 update` prints a convergence report before applying. See
-[Config schema](/docs/reference/config-schema/#profilestoml) and the update guide for
+[Config schema](/docs/reference/config-schema/) and the update guide for
 what gets backed up and how to recover a custom profile afterward.
 </Aside>
 
@@ -120,8 +120,8 @@ Enums: `--type` = `llm|embedding|reranking|transcription|tts|image`; `--provider
 | `slot rename <name> <new_name>` | `name`, `new_name` | — |
 | `slot swap <name>` | `name` | `--model`/`-m` (required), `--no-persist` |
 | `slot logs <name>` | `name` | `--follow`/`-f`, `--lines`/`-n` (default 200, 1-5000) |
-| `slot create <name>` | `name` | `--type`/`-t` (default `llm`), `--provider` (default `llama-server`), `--hardware` (default: auto-detect), `--backend`/`-b` (hidden, deprecated alias for `--provider`), `--model`/`-m` (required), `--port`/`-p` (default: auto-assign, 1024-65535), `--ctx-size` (default `4096`, min `128`) |
-| `slot edit <name>` | `name` | `--model`/`-m`, `--port`/`-p`, `--ctx-size`, `--provider`, `--hardware`, `--backend`/`-b` (hidden, deprecated) |
+| `slot create <name>` | `name` | `--type`/`-t` (default `llm`), `--provider` (default `llama-server`), `--hardware` (default: auto-detect), `--backend`/`-b` (hidden, deprecated alias for `--provider`), `--model`/`-m` (required), `--port`/`-p` (default: auto-assign, 1024-65535), `--ctx-size` (default `4096`, min `128`), `--profile` (default: inferred from `--type`/`--hardware`) |
+| `slot edit <name>` | `name` | `--model`/`-m`, `--port`/`-p`, `--ctx-size`, `--provider`, `--hardware`, `--profile`, `--backend`/`-b` (hidden, deprecated) |
 | `slot delete <name>` | `name` | `--force`/`-f` |
 | `slot add <name>` | `name` | hidden, deprecated alias for `slot create` |
 | `slot remove <name>` | `name` | hidden, deprecated alias for `slot delete` |
@@ -156,7 +156,7 @@ selected with `--hardware`, and stored on the slot as `device` (`gpu-rocm`, `gpu
 | `model scan` | — | — |
 | `model add <path>` | `path` | `--id` (default `""`), `--name`, `--license` (default `""`), `--overwrite` |
 | `model store [path]` | optional `path` | `--migrate` |
-| `model run <ref>` | `ref` | `--slot`/`-s` (default `""`), `--timeout` (default: the derived slot-load budget from `hal0.slot_lifecycle_budget`, `622` at time of writing — see [slot lifecycle timeouts](#slot-lifecycle-timeouts)) |
+| `model run <ref>` | `ref` | `--slot`/`-s` (default `""`), `--timeout` (default: the derived slot-load budget from `hal0.slot_lifecycle_budget`, `622` at time of writing — see "Slot lifecycle timeouts" below) |
 | `model import-backup <path>` | `path` (required) | `--force`/`-f`, `--dest` (default `/var/lib/hal0/registry/registry.toml`) |
 
 ## `hal0 memory` — manage hal0 memory (Hindsight engine)
@@ -238,8 +238,17 @@ Bare `hal0 doctor` (no subcommand) runs `installer/lib/preflight.sh`:
 | `doctor models` | `--fix`, `--force`/`-f`, `--json` |
 | `doctor migrations` | `--json` |
 | `doctor profiles` | `--json` |
+| `doctor ports` | `--fix` (delete stale netavark DNAT rules found by the audit; privileged) |
 | `doctor all` | `--json` |
 | `doctor bundle` | `--out`, `--no-rocm-smi`, `--include-logs` (default `auto`; `auto\|yes\|no`) |
+
+`doctor all` rolls up every read-only check into one report. Each row has a stable id
+(`Check.key`) used in `--json` output and cross-referenced elsewhere in the docs: `api`,
+`dns`, `runners`, `capabilities`, `memory`, `openwebui`, `hermes`, `auth`, `models`,
+`migrations`, `ui-dist`, `ports`, `port_dnat`, `netns`, `hal0_target`, `secret-modes`,
+`agent-uid`, `stt-weights`, `seams`, `mcp_mounts`, `hermes_mcp_auth`,
+`hermes_anchor_window`, `hindsight_llm_auth`. There is no standalone `hal0 doctor seams`
+command — `seams` is one of these roll-up rows, surfaced by `hal0 doctor all`.
 
 ## `hal0 upstream` — manage upstream LLM providers
 
@@ -255,12 +264,19 @@ disambiguation.
 | `upstream list` | — | `--json` |
 | `upstream advertise <name> <state>` | `name`, `state` (`on\|off`) | — |
 | `upstream show <name>` | `name` | `--json` |
-| `upstream create <name>` | `name` | `--catalog`/`-c`, `--url`/`--base-url`, `--auth-style` (`bearer\|anthropic\|google_query\|header\|none`), `--auth-header`, `--auth-env`, `--timeout`, `--api-key`/`-k`, `--advertise-models`/`--hide-models` (default advertise), `--enabled`/`--disabled` (default enabled) |
-| `upstream update <name>` | `name` | same as `create` (partial update) plus `--model` (repeatable), `--include` (repeatable), `--exclude` (repeatable), `--clear-filters` |
+| `upstream create <name>` | `name` | `--catalog`/`-c`, `--url`/`--base-url`, `--auth-style` (`bearer\|anthropic\|header\|none`), `--auth-header`, `--auth-env`, `--timeout`, `--api-key`/`-k`, `--advertise-models`/`--hide-models` (default advertise), `--enabled`/`--disabled` (default enabled) |
+| `upstream update <name>` | `name` | partial update — `--url`/`--base-url`, `--auth-style` (`bearer\|anthropic\|header\|none`), `--auth-header`, `--auth-env`, `--timeout`, `--advertise-models`/`--hide-models`, `--enabled`/`--disabled`, `--model` (repeatable), `--include` (repeatable), `--exclude` (repeatable), `--clear-filters`. No `--catalog`/`--api-key` — use `upstream credentials set` to rotate the key. |
 | `upstream delete <name>` | `name` | `--force`/`-f` |
 | `upstream test <name>` | `name` | — |
 | `upstream credentials set <name>` | `name` | `--key` (required, prompts securely if omitted), `--env-var` |
 | `upstream set-credentials <name>` | `name` | hidden, deprecated alias for `upstream credentials set` |
+
+<Aside type="note">
+`google_query` is a retired `--auth-style`. The valid values are `bearer`, `anthropic`,
+`header`, and `none` — that's what the CLI's own `--help` lists. An existing upstream
+config with `auth_style = "google_query"` still loads: it's coerced to `bearer` on read
+(with a one-time retirement warning) rather than failing.
+</Aside>
 
 ## `hal0 capabilities` — capability-slot configuration
 
@@ -280,7 +296,7 @@ disambiguation.
 
 | Command | Args | Flags |
 |---|---|---|
-| `agent install <name>` | `name` (e.g. `hermes`) | `--switch`, `--gateway`/`--no-gateway` (default gateway), `--reset-personas` |
+| `agent install <name>` | `name` (e.g. `hermes`) | `--switch`, `--gateway`/`--no-gateway` (default gateway), `--reset-personas`, `--terminal-tool`/`--no-terminal-tool` (default: off on a fresh install, preserved on an existing box) |
 | `agent uninstall <name>` | `name` | `--keep-memory`, `--force`/`-f` |
 | `agent list` | — | `--json` |
 | `agent peers` | — | — |

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -24,7 +24,7 @@ below) — see [Environment variables](/docs/reference/env-vars/) for the full l
 
 | File | Format | Purpose |
 |---|---|---|
-| `/etc/hal0/hal0.toml` | TOML | Main config — `[meta]`, `[slots]`, `[dispatcher]`, `[telemetry]`, `[models]`, `[memory]`, `[activity]`, `[brain_chat]`, `[security]`, `[realtime]`. |
+| `/etc/hal0/hal0.toml` | TOML | Main config — `[meta]`, `[slots]`, `[dispatcher]`, `[telemetry]`, `[models]`, `[memory]`, `[activity]`, `[brain_chat]`, `[security]`, `[realtime]`, `[metrics]` (the last is read independently of the rest — see below). |
 | `/etc/hal0/slots/<name>.toml` | TOML | One file per slot. |
 | `/etc/hal0/providers.toml` | TOML | Local cloud-provider API entries (`[[provider]]`). |
 | `/etc/hal0/upstreams.toml` | TOML | Remote/cloud LLM upstream entries (`[[upstream]]`). |
@@ -62,6 +62,7 @@ Root model `Hal0Config`, `extra="allow"`.
 | `preload_evict_headroom_mb` | int | `1024` | `>= 0` |
 | `publish_host` | str | `"127.0.0.1"` | non-empty, no whitespace/`:`/`/` |
 | `network_mode` | str | `""` | must be `""` or `"host"` |
+| `default_images` | dict[str,str] | `{}` | keys must be a known `RUNNER_IMAGES` family (e.g. `rocmfpx`, `vulkanfpx`, `cuda`, `cpu`, `flm`, `kokoro`, `moonshine`, `qwen3tts`, `comfyui`); values must be non-empty image refs; sending `null` for a family clears its override |
 
 ### `[dispatcher]`
 
@@ -106,7 +107,7 @@ clock: a healthy long generation on slow hardware that outlives it is also cut.
 | `roots` | list[str] | `[models_dir()]` = `["/var/lib/hal0/models"]` | each entry non-empty and absolute |
 | `auto_scan_on_start` | bool | `true` | — |
 | `file_extensions` | list[str] | `[".gguf", ".safetensors"]` | — |
-| `pull_root` | str | `"/var/lib/hal0/models"` | **deprecated**; absolute or empty |
+| `pull_root` | str | `"/var/lib/hal0/models"` | **deprecated**; must be non-empty and absolute |
 | `store` | str | `""` | absolute if set, else empty |
 | `flm_store` | str | `""` | absolute if set (NPU/FLM model store) |
 
@@ -156,7 +157,15 @@ override: `HAL0_FLM_MODELS_DIR`.
 |---|---|---|---|
 | `enabled` | bool | `true` | — |
 | `retention_days` | int | `30` | `>= 1` |
-| `max_rows` | int \| null | `50000` | `>= 100`; `null` disables the cap |
+| `max_rows` | int \| null | `50000` | `>= 100`; in memory, `null` disables the cap |
+
+`max_rows` is unrepresentable as `null` in TOML (`tomli_w` raises on it), so
+the on-disk spelling of "unlimited" is `0`, not the bare key omitted or set to
+an unwritable null. A load-time validator maps on-disk `0` to `None` in
+memory; the reverse holds on save — an in-memory `None` is written back out
+as `0` (`0` is otherwise unreachable as a real cap, since it sits below the
+`>= 100` floor). Write `max_rows = 0` to disable the cap; anything you read
+back as `null` from the API is the same state (#1665).
 
 ### `[brain_chat]`
 
@@ -169,11 +178,19 @@ override: `HAL0_FLM_MODELS_DIR`.
 | `model` | str | `""` | empty → persona default |
 | `max_rounds` | int | `8` | `1-100` |
 | `completion_timeout_s` | float | `300.0` | `> 0` |
+| `tool_model` | str | `"hal0/agent"` | see below |
+
+`tool_model` is the model a brain turn reroutes to when it needs a tool the
+chat model's runner cannot serve natively. It is a live routing knob, not a
+dead key.
 
 <Aside type="caution">
-`brain_chat.tool_model` was removed from the schema on the v1.0 branch (`#1453`) —
-current source has zero references to it. If you see it in an old config, it's a dead
-key that gets silently stripped on load. Do not document it as a live field.
+An empty `tool_model` is **not** how you switch tool routing off. An explicit
+`tool_model = ""` in `hal0.toml` is indistinguishable on disk from never having
+set the key, but pydantic treats it as an override of the `"hal0/agent"`
+default — which would leave tool turns with no target, silently. hal0 therefore
+coerces an empty value back to the default and logs a warning. To genuinely
+disable rerouting, say so out loud: `off`, `none` or `disabled`.
 </Aside>
 
 ### `[security]`
@@ -205,6 +222,39 @@ key that gets silently stripped on load. Do not document it as a live field.
 | `approval_wait_s` | float | `20.0` | `> 0, <= 300.0` |
 | `max_buffer_seconds` | float | `30.0` | `> 0, <= 600.0` |
 
+### `[metrics]`
+
+<Aside type="caution">
+`[metrics]` is read straight out of `hal0.toml` by its own small
+`MetricsSettings` dataclass (`hal0.metrics.config`) — it is **not** a field
+on `Hal0Config` and does not appear anywhere in the root-model tree this
+page otherwise describes. Only the *file read* is guarded: a missing or
+unparseable `hal0.toml` (`OSError` or a TOML parse error) is caught and
+treated as an empty table, so every key falls back to its default. There
+is no `extra="forbid"`/pydantic validation on the table itself, so a
+present, correctly-typed value is used as-is with no range checking. But
+an individual key's type is **not** guarded — a wrong-typed value such as
+`sample_interval_s = "fast"` raises `ValueError`/`TypeError` straight out
+of the loader and into `MetricsService` construction, which can block API
+startup.
+</Aside>
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `enabled` | bool | `true` | Master on/off. When `false`, every background metrics task (sampler, aggregator, retention sweep) stays unconstructed rather than running disabled. |
+| `sample_interval_s` | float | `5.0` | Sampling cadence. |
+| `aggregate_interval_s` | float | `3600.0` | Rollup/aggregation cadence. |
+| `retention_interval_s` | float | `21600.0` (6h) | How often the retention sweep runs. |
+| `retention_request_days` | int | `7` | Retention window for raw request-level rows. |
+| `retention_slot_sample_days` | int | `3` | Retention window for slot sample rows. |
+| `retention_rollup_days` | int | `90` | Retention window for aggregated rollup rows. |
+| `queue_maxsize` | int | `1024` | Bounded queue depth for the async metrics writer. |
+| `write_batch_size` | int | `64` | Rows drained per `BEGIN IMMEDIATE` transaction. |
+
+Each key also has a `HAL0_METRICS_*` environment variable that overrides it
+(precedence: env var > `[metrics]` TOML table > default) — see
+[Environment variables](/docs/reference/env-vars/) for that list.
+
 ## `slots/<name>.toml`
 
 Root model `SlotConfig`, `extra="allow"`. Both a legacy nested `[slot]` table and flat
@@ -219,6 +269,7 @@ top-level scalars are accepted on load and normalized.
 | `gpu_index` | int \| null | `null` | — | `>= 0` |
 | `n_gpu_layers` | int | `-1` | — | `-1` = all, `0` = CPU-only |
 | `threads` | int | `0` | — | `>= 0`; `0` = unset |
+| `metrics` | bool | `true` | — | emits `--metrics`, enabling llama-server's loopback-only `/metrics` endpoint; without it `/metrics` 501s and hal0's tok/s and request-count collection can never populate (#1810) |
 | `binary` | str | `""` | — | key into `RUNNER_IMAGES` |
 | `image_pin` | str \| null | `null` | — | escape-hatch image ref override |
 | `provider` | str | `"llama-server"` | — | one of `llama-server, flm, moonshine, kokoro, qwen3tts, comfyui`; **deprecated**, legacy label only — all slots run as podman containers now |
@@ -243,11 +294,11 @@ top-level scalars are accepted on load and normalized.
 There is **no `enabled` field** — a non-empty `model.default` is the activation signal.
 Boot start is separate and explicit (`autoload`); a retired `lru` key is still accepted
 but ignored, with a one-time deprecation warning. See
-[Slot lifecycle → Activation](/docs/reference/slot-lifecycle/#activation).
+[Slot lifecycle](/docs/reference/slot-lifecycle/) for the activation model.
 
 `output_sanity` (bool, default `true`) is accepted here too, though it is not a typed
-field: `false` exempts this one slot from the
-[output-sanity gate](/docs/reference/slot-lifecycle/#output-sanity-gate).
+field: `false` exempts this one slot from the output-sanity gate — see
+[Slot lifecycle](/docs/reference/slot-lifecycle/).
 
 <Aside type="note">
 A legacy `backend` key on a slot is silently promoted to `device` and dropped on load
@@ -330,7 +381,7 @@ Root model `UpstreamsConfig`, `extra="allow"`: `upstream: list[UpstreamEntry]`
 | `name` | str | — | **required** | non-empty |
 | `kind` | str | `"remote"` | — | `slot` or `remote` |
 | `url` | str | — | **required** | non-empty |
-| `auth_style` | str | `"bearer"` | — | `bearer, anthropic, google_query, header, none` |
+| `auth_style` | str | `"bearer"` | — | `bearer, anthropic, header, none` |
 | `auth_header` | str | `""` | — | required if `auth_style = "header"` |
 | `auth_value_env` | str | `""` | — | — |
 | `timeout_seconds` | float | `300.0` | — | `> 0.0` |
@@ -339,6 +390,14 @@ Root model `UpstreamsConfig`, `extra="allow"`: `upstream: list[UpstreamEntry]`
 | `advertise_models` | bool | `true` | — | — |
 | `enabled` | bool | `true` | — | — |
 | `model_filters` | table \| null | `null` | — | see below |
+| `hal0_peer` | bool \| null | `null` | — | `null` auto-derives from the URL host: private/loopback hosts are treated as another hal0's dashboard API (pollable for hardware/slot metrics), public hosts never are. Set `true` to opt a public-hostname hal0 peer in. |
+
+`google_query` was a fifth `auth_style` value with no implementation behind
+it — Google AI Studio calls dispatched unauthenticated while the UI showed
+"key set" (#1513). It is retired from the accepted set; an on-disk
+`auth_style = "google_query"` still loads without error, coerced on read to
+`"bearer"` (the style the endpoint it points at actually accepts), with a
+warning logged.
 
 ### `[[upstream]].model_filters`
 

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -1,6 +1,6 @@
 ---
 title: Environment variables reference
-description: "Every environment variable hal0 reads, its default, and what it controls — verified by grepping os.environ/os.getenv across src/hal0 in the v1.0 tree."
+description: "Every environment variable hal0 reads, its default, and what it controls — verified by grepping os.environ/os.getenv across src/hal0 and installer/ in the v1.0 tree."
 sidebar:
   order: 30
 ---
@@ -20,7 +20,77 @@ by name at a specific call site. Most have a hardcoded fallback if unset.
 | `HAL0_PREFLIGHT_SH` | unset (auto-discovered) | Explicit override path to `preflight.sh`. |
 | `HAL0_FORCE` | unset | `HAL0_FORCE=1` skips the `hal0 uninstall --purge` confirmation prompt. |
 | `HAL0_ALLOW_ROOT` | unset (false) | `1`/`true`/`yes` allows the `hal0-agent` shim to run as root. |
-| `HAL0_AGENTS_CONF_DIR` | `/etc/hal0/agents` | — |
+| `HAL0_AGENTS_CONF_DIR` | `/etc/hal0/agents` | Directory of per-agent TOML files (`<id>.toml`) the `hal0-agent` shim reads for invocation overrides — type, home, venv, bin, port, host, `serve_args`. |
+
+## Bootstrap (one-line installer)
+
+The `curl -fsSL https://hal0.dev/install.sh | sudo bash` path is `installer/bootstrap.sh`
+(mirrored to `hal0-web:public/install.sh`). It resolves and verifies a release before
+handing off to `install.sh`.
+
+| Variable | Default | Controls |
+|---|---|---|
+| `HAL0_CHANNEL` | `stable` | Release channel to install: `stable`, `preview`, or `nightly`. Also gates which manifest-signer identity bootstrap will accept. |
+| `HAL0_RELEASES_URL` | unset → `https://releases.hal0.dev/<channel>.json` | Full URL to a `hal0.releases.v1` manifest, overriding the channel default. |
+| `HAL0_BOOTSTRAP_KEEP_TMP` | unset | `1` leaves the downloaded/verified work directory in place on exit instead of deleting it — for inspecting the unpacked tree. |
+
+<Aside type="note">
+`HAL0_RELEASES_URL` is also read at update time by `src/hal0/updater/updater.py`
+(`releases_url()`), with a different append rule there: when the override looks
+URL-shaped (`http://`/`https://`) and the requested channel is not `stable`, the
+channel is appended as a `?channel=` query parameter rather than as part of the
+path. A `file://` or bare-path override is always used verbatim. There is no
+`HAL0_UPDATE_SKIP_COSIGN` (or any other) bypass for `cosign verify-blob` on an
+update — verification is unconditional in the current updater, on every channel.
+</Aside>
+
+## Install-time overrides
+
+Read by `installer/install.sh`. Most exist as documented escape hatches for
+non-interactive/CI installs or unusual hardware; a handful also map to the same
+skip an operator can reach later via `hal0 app install <name>` / `hal0 agent install
+hermes` (see the comment on each).
+
+| Variable | Default | Controls |
+|---|---|---|
+| `HAL0_NONINTERACTIVE` | unset | `1` disables every TTY prompt, including the Hermes terminal-tool consent and the CPU-only confirm — both then take their safe default (off / declined) unless separately forced. |
+| `HAL0_ALLOW_CPU_ONLY` | unset (`0`) | `1` proceeds with a CPU-only install (`device = "cpu"` on seeded slots) when no usable GPU lane is detected, instead of failing or prompting. |
+| `HAL0_SKIP_HERMES` | unset (`0`) | `1` skips Hermes provisioning at install time. Deferred install: `hal0 agent install hermes`. |
+| `HAL0_SKIP_OPENWEBUI` | unset (`0`) | `1` skips enabling the bundled OpenWebUI chat UI at install time. Deferred install: `hal0 app install openwebui`. |
+| `HAL0_SKIP_HINDSIGHT` | unset (`0`) | `1` skips standing up the Hindsight memory engine (interpreter resolution and the `hindsight-api` unit) entirely. |
+| `HAL0_HINDSIGHT_PYTHON` | unset (auto-resolved 3.11–3.13) | Pins the interpreter used for the Hindsight venv — needed when the default `python3` is 3.14+ (litellm's `requires-python` gate rejects it) and no compatible one can be auto-installed. |
+| `HAL0_SKIP_SETUP` | unset (`0`) | `1` skips first-run seeding (`hal0 setup --auto`) — no sentinel/wiring, no capability-slot scaffolding, no brain or agent model offer. |
+| `HAL0_NO_PROBE` | unset | Alias for `HAL0_SKIP_SETUP=1` at the hardware-probe step specifically; also re-exported across the sudo re-exec so a re-launched root install keeps the answer. |
+| `HAL0_SKIP_BRAIN_MODEL` | unset (`0`) | `1` skips the brain-model pull offer. |
+| `HAL0_BRAIN_MODEL` | unset (hardware-derived pick) | Forces a specific curated model id for the brain-model pull instead of deriving one from detected hardware. |
+| `HAL0_PULL_AGENT_MODEL` | unset (TTY-prompted) | `1` opts into the (optional, bigger) agent tool-caller model pull non-interactively; `0` forces the skip even on a terminal. |
+| `HAL0_AGENT_MODEL` | unset (hardware-derived pick) | Forces a specific curated model id for the agent-model pull instead of the hardware-derived ladder rung. |
+| `HAL0_SKIP_COMFYUI` | unset (`0`) | `1` skips the ComfyUI model-share setup step. |
+| `HAL0_MODELS_DIR` | unset (TTY-prompted, else `<var_lib>/models`) | Pull destination for `hal0 model pull` and the dashboard's pull buttons, written to `hal0.toml` as `[models].store`. Same as `--models-dir`. |
+| `HAL0_PYTHON` | unset → `python3` | Interpreter install.sh uses to build hal0's own venv. Also the fallback the preflight interpreter checks use when `HAL0_PY` (below) is unset. |
+| `HAL0_RESET_PROFILES` | unset (TTY-prompted only when it would lose operator profiles) | `1` pre-approves a profile-catalog reset non-interactively. |
+| `HAL0_OWUI_TRUSTED_EMAIL_HEADER` | unset | Name of a header an upstream reverse proxy injects with the authenticated user's email. Setting it flips OpenWebUI's `WEBUI_AUTH` on and wires `WEBUI_AUTH_TRUSTED_EMAIL_HEADER` to it — perimeter auth in front of OpenWebUI, since it has no auth of its own on a LAN-default hal0 install. |
+| `HAL0_INSTALL_SKIP_VERIFY` | unset (`0`) | `1` allows `install.sh` to run as root against a release tree that is neither a git checkout nor already verified by bootstrap.sh (i.e. no cosign check happened). Off by default; running unverified code as root is the exact thing this gate exists to refuse. |
+| `HAL0_NO_QR` | unset | Set (any value) to skip rendering the dashboard-URL QR code at the end of a headless install. |
+| `HAL0_TOOLBOX_IMAGE_VULKAN`, `_ROCM`, `_FLM`, `_COMFYUI`, `_KOKORO`, `_MOONSHINE`, `_QWEN3TTS` | unset (release manifest's digest pin, else the bundled default image) | Optional per-backend container image ref overrides, one per runner. Highest-precedence tier of `resolve_runner_image`'s three-tier lookup (env → manifest digest pin → bundled default); shared by every provider that pulls a toolbox image (llama-server's GPU-hardware-gated runners, FLM, ComfyUI, Kokoro, Moonshine, Qwen3-TTS). |
+| `HAL0_SKIP_FLM_SHA` | unset (`0`) | The FLM `.deb`'s pinned SHA-256 is checked before install; if the pin is still the all-zeroes placeholder (never looked up), install.sh normally warns and skips the FLM install rather than trust an unverified download. `HAL0_SKIP_FLM_SHA=1` accepts that placeholder and proceeds anyway — an explicit trust trade-off the operator opts into, not a routine flag. Does not bypass a real SHA-256 *mismatch*, which always refuses the install. |
+
+## Doctor & preflight
+
+Shared by `hal0 doctor` and the install-time preflight checks in
+`installer/lib/preflight.sh`.
+
+| Variable | Default | Controls |
+|---|---|---|
+| `HAL0_PY` | unset → `HAL0_PYTHON`, else `python3` | Interpreter `preflight_python` (existence + `>=3.12` version check) and the venv-selection helpers resolve to. Takes precedence over `HAL0_PYTHON`, documented in the Install-time overrides section above. |
+| `HAL0_DOCTOR_PORTS` | `"8080 3001"` | Space-separated TCP ports the port-collision check probes. Also settable via `hal0 doctor --ports`. |
+| `HAL0_DOCTOR_PORTS_SOFT` | `0` | `1` downgrades a port-in-use finding to a warning instead of a failure. `hal0 doctor` (the post-install self-check) always sets this itself, since hal0's own `hal0-api`/`hal0-openwebui` units legitimately hold those ports on a healthy box. |
+| `HAL0_DISK_MIN_GB` | `20` | Minimum free space (GB) `preflight_disk` requires, when called with no explicit threshold. |
+| `HAL0_DISK_TARGET` | `/var/lib` | Directory `preflight_disk` checks free space on, when called with no explicit target. |
+| `HAL0_MODELS_DISK_MIN_GB` | `20` | Same check, scoped to the resolved models directory during install. |
+| `HAL0_CONTAINER_DISK_MIN_GB` | `20` | Same check, scoped to the container/podman graph root during install. |
+| `HAL0_CONTAINER_SMOKE_IMAGE` | `quay.io/podman/hello` | Image the container-runtime smoke test pulls and runs. Override for air-gapped installs pointing at a mirrored registry. |
+| `HAL0_NET_PROBE_URL` | `https://github.com` | URL the one-shot connectivity preflight probes with `curl -I`. Soft check (warns, never blocks) — useful to point at a reachable host behind a restrictive proxy/firewall. |
 
 ## Model / storage
 
@@ -37,21 +107,23 @@ by name at a specific call site. Most have a hardcoded fallback if unset.
 | `HAL0_BIND_HOST` | `0.0.0.0` | API bind host. Also read by `hal0 serve --host`. |
 | `HAL0_HOSTNAME` | `socket.gethostname()` | Canonical hostname override — feeds the dashboard URLs, the WS-origin allowlist, and the mDNS announcement. At install time (`HAL0_HOSTNAME=jarvis sudo -E bash install.sh` — the env path only; `network.hostname` in the answer file is consumed by the separate `hal0 setup --answers` process and does **not** reach the installer's avahi sync yet, a known follow-up) the installer also pins avahi's announced name via `host-name=` under `[server]` in `/etc/avahi/avahi-daemon.conf`, so `http://jarvis.local:8080` resolves on the LAN without renaming the box (no `hostnamectl`). Re-running with a different name updates the announcement; running without one withdraws only the installer-managed line and reverts to the machine hostname. Caveat: if an operator had hand-written their own `host-name=` before pinning, the pin replaces it (with a warning) and a later no-override run does not restore it. Wrinkle: a renamed box stops answering to the `hal0.local` alias (avahi cannot cleanly publish CNAMEs) — the alias stays in the origin allowlist, which is harmless. |
 | `HAL0_PUBLIC_URL` | unset | Public URL announced by the installer/mDNS. |
-| `HAL0_LAN_IPS` | `""` | — |
+| `HAL0_LAN_IPS` | `""` | Comma/space-separated list of the box's LAN IPv4 addresses, short-circuiting auto-detection. The installer feeds it `hostname -I` output — Python's own resolver is unreliable inside some containers. |
 | `HAL0_SELF_BASE_URL` | `http://127.0.0.1:8080` | Self-referential base URL used by the realtime backend and internal API calls. |
 | `HAL0_UI_DIST` | `""` (built-in dist dir) | Override the served UI static-asset directory. |
 | `HAL0_REQUIRE_AUTH` | unset | Overrides `[security].require_auth` — wins over the persisted config value. |
 | `HAL0_TRUST_FORWARDED_FOR` | unset | Overrides `[security].trust_forwarded_for` — wins over the persisted config value. |
+| `HAL0_LOGIN_RATELIMIT_MAX` | `10` | Max login attempts per window before the sliding-window rate limiter cuts an IP off. Budget is deliberately loose enough for a fat-fingered operator to retry a few times a minute while capping an automated key-guessing loop at this many tries/minute/IP. |
+| `HAL0_LOGIN_RATELIMIT_WINDOW_S` | `60` | Window (seconds) `HAL0_LOGIN_RATELIMIT_MAX` is measured over. |
 | `HAL0_ALLOWED_ORIGINS` | `""` (falls back to a built-in default set) | Comma-separated CORS allowlist for the agent chat WebSocket. |
-| `HAL0_MCP_ALLOWED_HOSTS` | `""` | — |
-| `HAL0_MCP_ALLOWED_ORIGINS` | `""` | — |
+| `HAL0_MCP_ALLOWED_HOSTS` | `""` (localhost only) | Comma-separated `host` / `host:port` / `host:*` values added to the `/mcp/*` mount's Host-header allowlist (DNS-rebinding protection). The single value `*` disables that protection entirely. |
+| `HAL0_MCP_ALLOWED_ORIGINS` | `""` (derived from `HAL0_MCP_ALLOWED_HOSTS`) | Comma-separated browser Origins allowed to call `/mcp/*`. When unset, `http`/`https` origins are derived from each host in `HAL0_MCP_ALLOWED_HOSTS`. |
 | `HAL0_ADMIN_KEY` | minted on rotation, else read from `api.env` | Admin bearer key for `/api/*`. See `hal0 auth`. |
 | `HAL0_CLIENT_KEY` | minted on rotation, else read from `api.env` | Client bearer key. |
 | `HAL0_OPENROUTER_OAUTH_ENABLED` | unset (disabled) | `1`/`true` enables OpenRouter OAuth. |
-| `HAL0_COMFYUI_PUBLIC_URL` | `""` | — |
-| `HAL0_OPENWEBUI_PUBLIC_URL` | `""` | — |
-| `HAL0_OPENWEBUI_PROBE_URL` | `""` | — |
-| `HAL0_HERMES_PUBLIC_URL` | `""` | — |
+| `HAL0_COMFYUI_PUBLIC_URL` | `""` (falls back to `http://<request-host>:8188`) | Public URL the dashboard uses to open ComfyUI. Set in `/etc/hal0/api.env` when ComfyUI sits behind a reverse proxy with its own HTTPS hostname — otherwise an HTTPS dashboard opening a bare `http://` link is blocked as mixed content. |
+| `HAL0_OPENWEBUI_PUBLIC_URL` | `""` (falls back to `http://<host>:3001`) | Public URL the dashboard advertises for OpenWebUI. Needed for a reverse-proxy deploy: OpenWebUI emits root-absolute asset URLs, so it needs its own (sub)domain, not a path prefix. |
+| `HAL0_OPENWEBUI_PROBE_URL` | `""` → `http://127.0.0.1:3001/health` | Loopback health-check URL for OpenWebUI, independent of the browser-facing public URL. Override for tests or a non-default deployment. |
+| `HAL0_HERMES_PUBLIC_URL` | `""` | Public URL the dashboard advertises for the Hermes agent dashboard. Hermes binds loopback-only (`127.0.0.1:9119`), so — unlike OpenWebUI — there is no host:port fallback; on a stock install the dashboard shows the health row without a link until this is set. |
 | `HAL0_API_URL` | `http://127.0.0.1:8080` (CLI client default) | Base URL the CLI uses to reach `hal0-api`. |
 
 <Aside type="caution">
@@ -65,38 +137,75 @@ rely on the default rather than setting it explicitly, verify which code path ap
 
 | Variable | Default | Controls |
 |---|---|---|
-| `HAL0_SLOT_OUTPUT_SANITY` | unset (gate ON) | `0`/`false`/`no`/`off` disables the [output-sanity gate](/docs/reference/slot-lifecycle/#output-sanity-gate) box-wide, so a `type = "llm"` slot reaches `READY` on the health probe alone. Per-slot equivalent: `output_sanity = false` in the slot TOML. |
+| `HAL0_SLOT_OUTPUT_SANITY` | unset (gate ON) | `0`/`false`/`no`/`off` disables the [output-sanity gate](/docs/reference/slot-lifecycle/) box-wide, so a `type = "llm"` slot reaches `READY` on the health probe alone. Per-slot equivalent: `output_sanity = false` in the slot TOML. |
+
+## Metrics
+
+The OBS-1 metrics core (`src/hal0/metrics/config.py`) is a standalone reader — it
+is not part of the root `Hal0Config` model, so these env vars are the primary way
+to tune it (alongside the optional `[metrics]` table in `hal0.toml`; env wins).
+See [Config schema](/docs/reference/config-schema/) for the `[metrics]` TOML table.
+
+| Variable | Default | Controls |
+|---|---|---|
+| `HAL0_METRICS_ENABLED` | `true` | Master on/off. When `false`, every background task (sampler, aggregator, retention) stays unconstructed — near-zero overhead, not a disabled poll loop. |
+| `HAL0_METRICS_SAMPLE_INTERVAL_S` | `5.0` | Seconds between metric samples. |
+| `HAL0_METRICS_AGGREGATE_INTERVAL_S` | `3600.0` | Seconds between rollup aggregation passes. |
+| `HAL0_METRICS_RETENTION_INTERVAL_S` | `21600.0` (6h) | Seconds between retention sweeps. |
+| `HAL0_METRICS_RETENTION_REQUEST_DAYS` | `7` | Days of raw per-request rows kept before pruning. |
+| `HAL0_METRICS_RETENTION_SLOT_SAMPLE_DAYS` | `3` | Days of raw slot-sample rows kept before pruning. |
+| `HAL0_METRICS_RETENTION_ROLLUP_DAYS` | `90` | Days of aggregated rollup rows kept before pruning. |
+| `HAL0_METRICS_QUEUE_MAXSIZE` | `1024` | Bounded depth of the async metrics-writer queue. |
+| `HAL0_METRICS_WRITE_BATCH_SIZE` | `64` | Rows drained per `BEGIN IMMEDIATE` write transaction. |
 
 ## Hermes agent
 
 | Variable | Default | Controls |
 |---|---|---|
 | `HAL0_HERMES_RUNTIME_JSON` | `/var/lib/hal0/.hermes/runtime.json` | Hermes runtime info file (embed token etc). |
-| `HAL0_HERMES_HOST` | `127.0.0.1` | — |
-| `HAL0_HERMES_PORT` | `9119` | — |
-| `HAL0_HERMES_PYTHON` | unset (auto-discovered interpreter) | — |
-| `HAL0_HERMES_LIVE_RESOLVE` | `"1"` | — |
-| `HAL0_HERMES_TERMINAL` | unset (→ terminal tool OFF) | Opt the agent into a terminal tool at provisioning time. `1` enables it, `0` disables it. With it on, Hermes can run shell commands as the `hal0` user, which is root-equivalent on this box. A non-interactive install never enables it; see [Run agents](/guides/run-agents/#hermes-terminal-tool-off-by-default). |
+| `HAL0_HERMES_HOST` | `127.0.0.1` | Host the chat proxy dials to reach Hermes' own API. |
+| `HAL0_HERMES_PORT` | `9119` | Port the chat proxy dials to reach Hermes' own API. |
+| `HAL0_HERMES_PYTHON` | unset (auto-discovered interpreter) | Pins the interpreter used to run/re-provision the Hermes venv. |
+| `HAL0_HERMES_LIVE_RESOLVE` | `"1"` | `0` opts out of live model-discovery (Hermes' picker polling hal0-api's `/v1/models`) back into single-backend pinning. |
+| `HAL0_HERMES_TERMINAL` | unset (→ terminal tool OFF) | Opt the agent into a terminal tool at provisioning time. `1` enables it, `0` disables it. With it on, Hermes can run shell commands as the `hal0` user, which is root-equivalent on this box. A non-interactive install never enables it; see [Run agents](/docs/guides/run-agents/). |
 | `HAL0_HERMES_OFFLINE` | unset | Set programmatically by `hal0 agent bootstrap --offline`. |
-| `HAL0_AGENTENV` | `/usr/lib/hal0/bin/hal0-agentenv` | — |
-| `HAL0_SYSTEMCTL` | `/usr/lib/hal0/bin/hal0-systemctl` | — |
-| `HAL0_INFERENCE_BASE` | `http://127.0.0.1:8080` | — |
+| `HAL0_AGENTENV` | `/usr/lib/hal0/bin/hal0-agentenv` | Privileged-seam binary hal0-api (running unprivileged) delegates to for writing root:root agent secret/env files. Env-overridable for tests, not a normal operator knob. |
+| `HAL0_SYSTEMCTL` | `/usr/lib/hal0/bin/hal0-systemctl` | Privileged-seam binary hal0-api delegates to for the systemd writes/reloads it cannot do unprivileged. Env-overridable for tests, not a normal operator knob. |
+| `HAL0_INFERENCE_BASE` | `http://127.0.0.1:8080` | Base URL the Hermes provisioner records as hal0's inference endpoint. |
 | `HAL0_AGENT_SECRET_PATH` | `/var/lib/hal0/agents/secret.bin` | HMAC session-cookie secret for the agent chat proxy. |
-| `HAL0_AGENT_ID` | varies by call site (`"hermes"` in board/manifest-proxy code, a module constant elsewhere) | — |
+| `HAL0_AGENT_ID` | `"hermes"` everywhere (default constant + per-call-site fallback) | Identity a plugin/proxy presents as (`X-hal0-Agent` header to Hindsight, board/manifest-proxy routing target, the hal0-provider plugin's own id). Written into the shim's child env by `hal0-agent`; per-request overrides exist above it in some paths. |
 | `HERMES_HOME` | `~/.hermes` | — |
-| `HERMES_SESSION_TOKEN` | unset | — |
-| `HERMES_DASHBOARD_BASE_URL` | module-local default constant (grep `board/hermes_executor.py` for the exact literal) | — |
+| `HERMES_SESSION_TOKEN` | unset (harvested live from the dashboard HTML) | Pins a Hermes session bearer explicitly instead of the per-process token the client otherwise scrapes from the dashboard on each start. Mainly for tests or a non-standard deploy. |
+| `HERMES_DASHBOARD_BASE_URL` | `http://127.0.0.1:9119` | Upstream base URL for the Kanban-board plugin proxy (`/api/plugins/kanban/*` + its `/events` WS) and the manifest proxy — both loopback-only by design. |
 
 ## Hindsight memory
 
 | Variable | Default | Controls |
 |---|---|---|
-| `HAL0_MEMORY_BASE` | module-local default constant | Base URL for the memory-plugin client. |
-| `HAL0_MEMORY_DEFAULT_VISIBILITY` | module-local default constant | — |
-| `HAL0_MEMORY_SPOOL` | unset | — |
+| `HAL0_MEMORY_BASE` | `http://127.0.0.1:8080` | Base URL the Hermes memory plugin uses to reach hal0's memory API (precedence: ctor arg → this env var → `memory.hal0.base_url` in the plugin's own config). |
+| `HAL0_MEMORY_DEFAULT_VISIBILITY` | `shared` | Default visibility for explicit durable writes (`hal0_memory_add`) when the caller doesn't pass one. Raw turn/lifecycle captures are always `private` regardless of this. |
+| `HAL0_MEMORY_SPOOL` | unset | Directory for the memory plugin's retry spool (writes that failed to reach Hindsight get queued here instead of dropped). |
+| `HAL0_MEMORY_REFLECT_TIMEOUT_S` | `900` | Timeout (seconds) for the Hindsight `reflect` call. |
+| `HAL0_MEMORY_REPROBE_INTERVAL_S` | `30` | Minimum interval (seconds) between the API's re-probes of a previously-unreachable Hindsight engine. |
 | `HAL0_HINDSIGHT_URL` | `http://127.0.0.1:9177` | Hindsight engine base URL. |
-| `HAL0_HINDSIGHT_PROBE_TIMEOUT_S` | — | Probe timeout for the Hindsight health check. |
+| `HAL0_HINDSIGHT_PROBE_TIMEOUT_S` | `2.0` | Timeout for the Hindsight reachability health check. |
 | `HINDSIGHT_API_TENANT_API_KEY` | `hal0-local-noauth` | — |
+
+## Observability (Sentry)
+
+Optional error/trace reporting (`src/hal0/observability/sentry.py`). hal0 phones
+home to nobody by default: Sentry stays fully inert — no SDK import, no network
+egress — until a DSN is configured. Requires `pip install 'hal0ai[sentry]'` (or
+`uv pip install sentry-sdk`) in addition to setting the DSN.
+
+| Variable | Default | Controls |
+|---|---|---|
+| `HAL0_SENTRY_DSN` | unset (off) | The DSN. This is the **only** switch — there is no separate enable flag to drift out of sync with it. Falls back to the SDK-conventional `SENTRY_DSN` if unset. |
+| `HAL0_SENTRY_ENVIRONMENT` | `development` | Sentry "environment" tag. Deliberately not `production`, so a copied-around DSN doesn't silently pollute a production stream. |
+| `HAL0_SENTRY_SERVER_NAME` | `socket.gethostname()` | Overrides the reported hostname. |
+| `HAL0_SENTRY_TRACES_SAMPLE_RATE` | `0.0` | Float in `[0, 1]`. Transaction tracing is opt-in per install — sampling every transaction on a box serving long-lived streaming requests is expensive. |
+| `HAL0_SENTRY_PROFILES_SAMPLE_RATE` | `0.0` | Float in `[0, 1]`. Same rationale as traces. |
+| `HAL0_SENTRY_DEBUG` | unset (off) | `1`/`true`/`yes` prints the SDK's own transport logging — for diagnosing "why did my event not arrive". |
 
 ## Providers / external services
 
@@ -114,10 +223,12 @@ rely on the default rather than setting it explicitly, verify which code path ap
 | `HAL0_FLM_HOME` | `/var/lib/hal0` | — |
 | `HAL0_FLM_USER` | `hal0` | — |
 | `HAL0_FLM_BINARY` | `{native_flm_root}/bin/flm` | — |
-| `HAL0_QWEN3TTS_CACHE` | module-local default constant | — |
-| `HAL0_AVAHI_SERVICES_DIR` | `""` | — |
-| `HAL0_HOST_RAM_GB` | `""` (auto-probe) | — |
-| `HAL0_BUNDLES_DIR` | `""` | — |
+| `HAL0_QWEN3TTS_CACHE` | `/var/lib/hal0/qwen3tts-cache` | Host cache dir bind-mounted at `/cache` for the Qwen3-TTS (ROCm) provider. |
+| `HAL0_PROVIDER_BASE` | `http://127.0.0.1:8080/v1` | Base URL the Hermes `provider_hal0` plugin uses for hal0's own OpenAI-compatible endpoint. |
+| `HAL0_AVAHI_SERVICES_DIR` | `""` (standard avahi services dir) | Overrides the mDNS service-file directory. Documented as a test/non-standard-init override, not a routine operator knob. |
+| `HAL0_HOST_RAM_GB` | unset (auto-probed from `/proc/meminfo`) | Forces the detected unified-RAM figure used for bundle-tier eligibility, so an operator on a too-small box can pick a larger bundle anyway. Documented escape hatch for the (deferred, see note below) bundle-tier picker — no separate "force install" flag exists. |
+| `HAL0_BUNDLES_DIR` | unset (production manifest dir, else in-tree fallback) | Overrides the bundle-manifest root the (deferred) bundle-tier picker reads. A test hook per its own docstring, not a normal operator knob. |
+| `HAL0_ALLOW_VULKAN_FALLBACK` | unset | `1`/`true`/`yes` is an escape hatch for the ROCm device-node requirement on AMD GPU lanes (#1888). Set it only when you knowingly want a lane whose output may be invalid — there is no supported configuration where this is the right answer; it exists so a box can be inspected, not run. It cannot conjure a missing device node: it applies only to the correctness gates (missing `/dev/kfd`, an unvalidated runner-image Vulkan backend), never to a missing render node. |
 
 ## Activity / metrics / bench
 
@@ -127,6 +238,7 @@ rely on the default rather than setting it explicitly, verify which code path ap
 | `HAL0_BENCH_SUITE_DIR` | unset | — |
 | `HAL0_BENCH_API` | module-local default constant | — |
 | `HAL0_BENCH_STATE` | `/var/lib/hal0-bench` (`$HAL0_HOME/var-lib/hal0-bench` under HAL0_HOME) | — |
+| `HAL0_BENCH_TELEMETRY_ROOT` | module-local default root | Overrides where `hal0 bench` writes its telemetry tree. |
 | `HAL0_BENCH_HOST`, `HAL0_BENCH_PLATFORM`, `HAL0_BENCH_GPU`, `HAL0_BENCH_HAL0_VERSION` | probed values | Override the identity fields `hal0 bench` records with a run. |
 
 ## Misc
@@ -135,6 +247,7 @@ rely on the default rather than setting it explicitly, verify which code path ap
 |---|---|---|
 | `HAL0_SETUP_TIMEOUT_SECS` | `300.0` | Timeout for `hal0 setup`'s non-interactive install steps. |
 | `HAL0_FORCE_INTERACTIVE` | unset | Forces `hal0 setup` into interactive mode even in a non-TTY. |
+| `HAL0_LOG_LEVEL` | code default `WARNING`; the installer's `/etc/hal0/api.env` pins it to `info` | structlog level filter, applied by the CLI's root callback before every command runs — including `hal0 serve`, so it governs `hal0-api.service`'s own log verbosity too, since the unit's `ExecStart` is `hal0 serve`. |
 | `NO_COLOR`, `HAL0_PLAIN` | unset | Disable ANSI color / force ASCII-only output. |
 | `EDITOR`, `VISUAL` | `vi` | Editor used by `hal0 config edit`. |
 | `NOTIFY_SOCKET` | inherited from systemd | sd_notify socket — not hal0-specific. |
@@ -143,4 +256,14 @@ rely on the default rather than setting it explicitly, verify which code path ap
 `.bundle-chosen`-related bundle-tier env vars (`HAL0_HOST_RAM_GB`, `HAL0_BUNDLES_DIR`)
 back a bundle picker that is explicitly unwired/deferred past v1.0 — don't imply it's
 an active operator-facing flow.
+</Aside>
+
+<Aside type="note">
+Excluded from this page: env vars that exist purely as test seams (explicitly
+labelled as such in their own source comments — e.g. the `HAL0_GPU_*_OVERRIDE`
+family and `HAL0_SCHEMA_PY_OVERRIDE` in `installer/lib/preflight.sh`, `HAL0_RUNAS_TEST_UID`,
+`HAL0_APPARMOR_CONF`), and internal wiring one process sets for a child it spawns
+rather than something an operator sets from outside (`HAL0_*_REQUIRED`/`HAL0_*_AUTOINSTALL`
+flags `install.sh` passes into `preflight.sh`'s own functions, `HAL0_MCP_PROBE_URL`/
+`HAL0_MCP_PROBE_HEADERS`, the per-slot `HAL0_SLOT` injected into container envs).
 </Aside>

--- a/docs/reference/hardware-matrix.mdx
+++ b/docs/reference/hardware-matrix.mdx
@@ -27,8 +27,8 @@ subprocess/sysfs-based and never raises.
 | GPU (AMD) | DRM sysfs scan of `/sys/class/drm/card*/device/mem_info_vram_total`. |
 | Hostname | `/proc/sys/kernel/hostname`. |
 
-The result is validated against the `HardwareInfo` schema — see
-[Config schema → hardware.json](/docs/reference/config-schema/#hardwarejson) for the
+The result is validated against the `HardwareInfo` schema — see the
+`hardware.json` section of [Config schema](/docs/reference/config-schema/) for the
 full field list, including `unified_memory_mb` (the true UMA pool — use this, not
 `ram_mb + vram_mb`, on unified-memory systems like Strix Halo) and `platform`
 (`strix-halo`, `wsl2`, `proxmox-kvm`, `kvm`, `lxc`, `bare-metal-*`, `unknown`).
@@ -100,8 +100,8 @@ maturity, not speed:
 
 **The seeded default is an open question, revisited at GA against a broader
 matrix.** If your workload is plain prefill/decode on Strix Halo, switching is
-a defensible thing to do today — see
-[Switching a slot to the Vulkan lane](/docs/guides/manage-slots#switching-a-slot-to-the-vulkan-lane).
+a defensible thing to do today — see the "Switching a slot to the Vulkan
+lane" section of [Manage slots](/docs/guides/manage-slots).
 
 VRAM budget (`_vram_budget_gb()`): AMD UMA → half of the unified pool; discrete GPU →
 `vram_mb`; CPU-only → half of `ram_available_mb`.

--- a/docs/reference/model-roster-benchmark.mdx
+++ b/docs/reference/model-roster-benchmark.mdx
@@ -37,7 +37,8 @@ hand-registered outside that layout).
 <Aside type="note">
 As of the v1.0 slot/hardware-ownership rework, the **model**, not the slot, owns
 tuning knobs like `context_size` and MTP. A slot's `[model].context_size` is now a
-ceiling only — see [Config schema](/docs/reference/config-schema/#model-nested-under-a-slot).
+ceiling only — see the "Model nested under a slot" section of
+[Config schema](/docs/reference/config-schema/).
 </Aside>
 
 ## Curated catalogue
@@ -69,7 +70,9 @@ Moonshine's resolution is decided (it doesn't wait on the curated-schema redesig
 weights are operator-staged under the model store rather than registry-pulled, and
 both slot spawn and `hal0 doctor` preflight the staged path, failing loudly and by
 name (`slot.weights_missing`) instead of starting a container that 500s on first
-request. See [ADR-0001](/docs/adr/0001-moonshine-cpu-stt-reinstatement/).
+request. This is recorded in ADR-0001, "Reinstate Moonshine as the CPU STT engine"
+(`docs/adr/0001-moonshine-cpu-stt-reinstatement.md` in the repository — an internal
+design record, not published to these docs).
 </Aside>
 
 ## Hardware-driven recommendation
@@ -134,6 +137,73 @@ hal0 bench plan|run|status|worker|results|history|reindex|devices|publish|eval|b
 (drives `llama-bench`/`llama-server`), `bench/store.py` (JSONL/db layer),
 `bench/publish.py` (pushes results to the dashboard), `bench/suites.py`,
 `bench/regress.py`.
+
+### Dashboard pane
+
+The dashboard's **Benchmarks** page (`#benchmarks`, a top-level nav
+destination — `ui/src/dash/Benchmarks.tsx`) is a UI over the same
+`/var/lib/hal0-bench` store the CLI reads and writes, via `GET/POST
+/api/benchmarks/*`. The API process never drives the GPU itself — it only
+queues and reads; `hal0 bench worker` is what drains the queue, same as a
+run started from the CLI.
+
+The page has four tabs:
+
+- **Roster** — every registry model (blessed and pulled) as one row:
+  `decode`/`prefill`/`acc` throughput, capability and spec/kv chips, size,
+  last run, and run count. Expanding a row loads that model's lane×depth
+  matrix, a history sparkline across every recorded sweep, and its recent
+  run chips.
+- **Runs** — run records newest-first, each expandable into a full-detail
+  drawer: identity chips, the per-repetition measurement table, telemetry,
+  and artifact links.
+- **Evals** — the agentic-eval leaderboard (model × task scores).
+- **Run Queue** — worker control and the queue. A dot next to the tab
+  label reflects `hal0-bench-worker`'s own heartbeat (written every poll
+  tick), distinguishing "armed but idle" from "worker not reporting" —
+  not just whether the queue is turned on.
+
+#### Starting a run
+
+From **Run Queue**, an operator queues work one of two ways:
+
+- **Queue suite** — pick one of the suites the staleness planner
+  considered (by default `roster`, `smoke`, `lane-matrix` — the three
+  seeded under `installer/bench/suites/`, or whatever
+  `/etc/hal0/bench/suites/*.toml` defines) and click **Queue suite**. Each
+  suite in the dropdown shows its stale-cell count, from the same planner
+  `hal0 bench plan` runs.
+- **Queue model** — pick a single roster model, then choose one of five
+  ad-hoc benches from the **Queue model** menu: **Vulkan Bench** (pp+tg on
+  the `vulkan_radv` lane), **ROCm Bench** (pp+tg on the `rocm` lane),
+  **Comparison of Both** (both lanes), **Tool Bench** (the agentic
+  tool-calling eval against the live endpoint), or **Tune Bench** (a
+  5-config flag-tuning grid — batch/ubatch size, flash attention, KV
+  quantization — restricted to the planner's flag whitelist).
+
+Either action posts to the queue; nothing runs until the worker is armed.
+**Start**/**Pause**/**Stop** control `hal0-bench-worker`; Pause and Stop
+take effect between cells, since a sweep can't be interrupted mid-run. The
+**exclusive** checkbox is the same GPU-exclusivity gate as the CLI's
+`--exclusive` — checked by default, it stops competing slots so the
+numbers are clean.
+
+The plan panel alongside the queue lists every stale cell (model, suite,
+lane, kind, depth, priority, exclusive, and why it's stale — never
+measured vs. aged out): the same computation behind `hal0 bench plan`.
+
+#### Results
+
+Everything the dashboard shows comes from the same store the CLI's
+`results`/`history`/`publish`/`bundle` verbs read: `records.jsonl`
+(append-only, schema-2 records) plus the `bench.db` SQLite index rebuilt
+from it, both under `/var/lib/hal0-bench` (`$HAL0_BENCH_STATE`, or
+`$HAL0_HOME/var-lib/hal0-bench` in a dev/sandboxed install). A run queued
+from the dashboard lands in the same queue `hal0 bench worker` drains
+whether started from the CLI or the UI — there is one queue and one
+result store, not a separate dashboard-only pipeline. Sharing a
+dashboard-produced run still goes through `hal0 bench bundle`/`upload` as
+described below — the dashboard has no upload action of its own.
 
 ### Sharing results
 

--- a/docs/reference/paths-and-files.mdx
+++ b/docs/reference/paths-and-files.mdx
@@ -111,17 +111,28 @@ hal0 uses a generic sibling-lock pattern (`hal0.config.locking.file_lock()`):
 ## Temp file prefixes (atomic-write pattern)
 
 hal0 writes config and state files via `tempfile.mkstemp` in the same directory,
-`fsync`, then `os.replace` — so readers never see a torn write. Recognizable prefixes:
+`fsync`, then `os.replace` — so readers never see a torn write. Recognizable prefixes;
+every one of these is transient — created, then either unlinked or renamed away,
+never left on disk as a final artifact:
 
 | Prefix | Used by |
 |---|---|
-| `.hal0-writeprobe-{pid}` | Write-permission probe. |
-| `.hal0-managed` | Marker stamped in a claimed `HERMES_HOME`/agent data dir — gates the unmanaged-directory refusal. |
+| `.hal0-writeprobe-{pid}` | Write-permission probe (`hal0.agents.hermes_provision.path_is_writable`) — `touch`ed then immediately unlinked in the same call, to test whether an ancestor directory is actually writable (not just `os.access`-writable, which lies under SELinux/ACLs/NFS root-squash). Never renamed into place. |
 | `.hal0-gpu-arbiter-*.tmp` | GPU arbiter state. |
 | `.hal0-state-*.tmp` | Slot state / ID-keying migration. |
 | `.hal0-stack-state-*.tmp` | Stack state. |
 | `.hal0-env-*.tmp` | Atomic env-file writer (`config/env.py`). |
-| `.hal0-build-stamp` | UI prebuild content-hash stamp under the served dist dir. |
+
+## Persistent markers
+
+These are *not* temp files — each is written once and left in place as the
+final artifact, checked again on a later run. Don't confuse them with the
+atomic-write temp files above.
+
+| Marker | Used by |
+|---|---|
+| `.hal0-managed` | Stamped into a claimed `HERMES_HOME`/agent data dir the moment hal0 takes ownership of it (`hal0.agents.hermes_provision`). It persists for the life of the install: `hal0 agent uninstall` `rmtree`s an agent home only when this marker is present, refusing to touch a directory (e.g. a user's pre-existing `~/.hermes`) that lacks it — see `_safe_to_remove_data_dir` at `src/hal0/agents/manager.py:507` (called from `manager.py:466`). |
+| `.hal0-build-stamp` | Content hash of the `ui/` source tree, written under the served UI dist dir (`${UI_DIST}/.hal0-build-stamp`) right after a successful `npm run build` (`installer/install.sh:1109`). Persists across installs — the installer diffs it against the current tree hash on the next run and skips the rebuild only on an exact match. |
 
 ## Portable export envelope formats
 

--- a/docs/reference/providers-profiles-devices.mdx
+++ b/docs/reference/providers-profiles-devices.mdx
@@ -28,10 +28,16 @@ process. Concrete implementations:
 
 Every `Provider` is stateless — no per-slot mutable state lives on the instance.
 Abstract methods: `build_env()`, `start_cmd()`, `health()`, `infer()`,
-`container_spec()`. Every slot dispatches through `ContainerProvider`, which builds a
-`RuntimeLaunchPlan` (frozen dataclass: image, command/argv, env, typed mounts with
-read-only/SELinux flags, devices, cap_add, security_opt, port, network_mode,
-extra_args, optional health check) fed to a single Quadlet renderer.
+`container_spec()`. `_spec_provider_for` dispatches each slot to its family
+provider by `runtime_family` — FLM, Kokoro, Qwen3TTS, Moonshine, ComfyUI each
+build their own `RuntimeLaunchPlan` (frozen dataclass: image, command/argv,
+env, typed mounts with read-only/SELinux flags, devices, cap_add,
+security_opt, port, network_mode, extra_args, optional health check); only
+plain llama-server slots fall through to `ContainerProvider.container_spec`.
+Every plan, whichever provider built it, still lands on the same single
+Quadlet renderer, and `ContainerProvider` owns the container lifecycle
+(start/stop/health) for all of them regardless of which provider built the
+plan.
 
 `SlotConfig.provider` (the string field on a slot) is **deprecated** — every slot runs
 as a podman container now, and this field is a legacy label round-tripped for
@@ -51,7 +57,7 @@ user config lives in `/etc/hal0/upstreams.toml`.
 | `openai` | `https://api.openai.com/v1` | `bearer` | cloud | chat, embed, vision, tools, tts, stt |
 | `anthropic` | `https://api.anthropic.com/v1` | `anthropic` (`x-api-key` + `anthropic-version` header) | cloud | chat, vision, tools |
 | `openrouter` | — | — | cloud | — |
-| `google_ai_studio` | — | — | cloud | — |
+| `google_ai_studio` | `https://generativelanguage.googleapis.com/v1beta/openai` | `bearer` | cloud | chat, vision |
 | `deepseek` | — | — | cloud | — |
 | `minimax` | — | — | cloud | — |
 | `ollama` | `http://localhost:11434/v1` | `none` | local | — |
@@ -59,11 +65,11 @@ user config lives in `/etc/hal0/upstreams.toml`.
 <Aside type="note">
 `anthropic`'s catalog entry speaks the native `/v1/messages` shape only — it needs a
 proxy for OpenAI-shape compatibility. Auth styles overall: `bearer, anthropic,
-google_query, header, none`.
+header, none`.
 </Aside>
 
 Persisted config is a `ProviderEntry` per upstream (see
-[Config schema → providers.toml](/docs/reference/config-schema/#providerstoml)):
+[Config schema → providers.toml](/docs/reference/config-schema/)):
 `catalog_id`, `name`/`base_url` overrides, `auth_value_env` (the **name** of an
 environment variable, never the key itself — the actual secret lives in `api.env`),
 `enabled`, `models`.
@@ -73,7 +79,7 @@ environment variable, never the key itself — the actual secret lives in `api.e
 `upstreams.toml`/`UpstreamEntry` are a **separate schema** from `providers.toml`/
 `ProviderEntry` above — both represent "remote provider" concepts but are distinct
 tables with distinct fields (`UpstreamEntry` adds `kind`, `warmup_strategy`,
-`model_filters`; see [Config schema](/docs/reference/config-schema/#upstreamstoml)).
+`model_filters`; see [Config schema](/docs/reference/config-schema/)).
 Verify which one a given feature actually reads before documenting behavior.
 </Aside>
 
@@ -93,14 +99,12 @@ runtime image reference.
 | `intent` | Dashboard card headline. |
 | `quant` | Display chip only — the runtime reads quant from the model, not the profile. |
 
-<Aside type="caution">
-On the v1.0 branch (Stream C, `fix/profile-tuning-only` — reviewed PASS, not yet
-merged to `main` at time of writing), `device_class`/`backend` are being rewritten to
-**inert match-only fit hints**. The slot's own `device` field (see the device
-taxonomy below) becomes the single authoritative hardware fact; the profile hints are
-retained on-disk only because published `.hal0profile.json` export artifacts carry
-them and their checksums cover the field. Verify this has landed on `main` before
-treating it as unqualified current behavior.
+<Aside type="note">
+As of v1.0, `device_class`/`backend` are **inert match-only fit hints**. The
+slot's own `device` field (see the device taxonomy below) is the single
+authoritative hardware fact; the profile hints are retained on-disk only
+because published `.hal0profile.json` export artifacts carry them and their
+checksums cover the field.
 </Aside>
 
 Profiles carry **no `image` field** — image resolution is slot-owned
@@ -120,16 +124,48 @@ name and `device_class`, not by sniffing an image string), `supported_slot_types
 `used_by` (slot names referencing the profile), and static `tps`/`rtf` numbers from the
 bench table.
 
-The seeded `moonshine` profile (device `cpu`) is the STT sibling of the seeded `kokoro`
+The seeded `moonshine` profile sets no `device_class` at all (neither does the
+seeded `kokoro` profile) — both are classified into their runtime family by
+name, not by device. It's the STT sibling of the seeded `kokoro`
 profile: `runtime_family = "moonshine"`, `supported_slot_types = ("transcription",)`,
 image `ghcr.io/hal0ai/hal0-toolbox-moonshine:v1` (resolved via `RUNNER_IMAGES["moonshine"]`,
 digest pinned in `manifest.json`), and self-managed (operator-staged) weights — see
-[Voice: STT and TTS](/docs/guides/voice-stt-tts/) and
-[ADR-0001](/docs/adr/0001-moonshine-cpu-stt-reinstatement/).
+[Voice: STT and TTS](/docs/guides/voice-stt-tts/) and ADR-0001, "Reinstate
+Moonshine as the CPU STT engine" (`docs/adr/0001-moonshine-cpu-stt-reinstatement.md`
+in the repository, not published to these docs).
+
+## Runner images
+
+`hal0.runners.RUNNER_IMAGES` is the code registry of runner keys hal0 can
+launch — `rocmfpx`, `vulkanfpx`, `cuda`, `cpu` (all `llama-server`), plus one
+key per single-purpose runtime: `flm`, `kokoro`, `moonshine`, `qwen3tts`,
+`comfyui`. Each entry pairs a runner key with a bundled default image ref, a
+`runtime_family`, a `device_class` (`gpu`/`cpu`/`npu`/`img`), and an optional
+`backend` (`rocm`/`vulkan`/`cuda`) — this is the registry `SlotConfig.binary`
+indexes into, and the single place every provider now resolves its launch
+image from (`hal0.runners.resolve_runner_image`), replacing what used to be
+three separate, inconsistent image-resolution chains.
+
+A slot's `binary` field selects a runner key directly; left empty, it derives
+one from the slot's `device` via `hal0.runners.runner_for_backend`. Either
+way, the slot's actual launch image is resolved through
+`hal0.providers.container._resolve_image_ref`: `slot.image_pin` (a per-slot
+escape hatch) outranks `[slots].default_images[<runner key>]` (an operator's
+per-family override, settable from the dashboard), which outranks the
+registry's release-baked default (itself resolvable through an
+`HAL0_TOOLBOX_IMAGE_<KEY>` env override or a release manifest digest pin).
+`rocmfpx` and `vulkanfpx` resolve to the same image today — the shipped
+runner build is Vulkan-portable — so the two keys exist for a future split,
+not because they differ now.
+
+See [Manage runner images](/docs/guides/manage-runner-images/) for the
+catalogue page (Slots → Runner Images), the Vulkan lane's image gate, and
+what pulling/pinning/updating an image does and does not do to a running
+slot.
 
 ## Device taxonomy
 
-See [Hardware matrix](/docs/reference/hardware-matrix/#canonical-device-taxonomy) for
+See [Hardware matrix](/docs/reference/hardware-matrix/) for
 the full table. In short: `hal0.model_meta.CANONICAL_DEVICES` is the single source of
 truth for the 5 valid device ids (`gpu-rocm`, `gpu-vulkan`, `gpu-cuda`, `cpu`, `npu`),
 consumed by `SlotConfig.device`, a profile's (now inert) `device_class`, and every

--- a/docs/reference/slot-lifecycle.mdx
+++ b/docs/reference/slot-lifecycle.mdx
@@ -80,15 +80,25 @@ Each is an HTTP-status-bearing error under the `slot.*` namespace:
 | `SlotNotReady` | 503 | — |
 | `SlotSpawnFailed` | 500 | — |
 | `SlotHealthFailed` | 503 | — |
-| `SlotOutputSanityFailed` | 500 | The server is healthy but its output is not language — see [Output-sanity gate](#output-sanity-gate). |
-| `SlotCrashLooping` | 503 | Reload blocked during exponential backoff, or after too many consecutive failures. Carries `retry_after_s`. |
+| `SlotOutputSanityFailed` | 500 | The server is healthy but its output is not language — see Output-sanity gate below. |
+| `SlotCrashLooping` | 503 | Reload blocked during exponential backoff, or after too many consecutive failures — see Crash-loop breaker below. Carries `retry_after_s`. |
 | `SlotTerminateTimeout` | 504 | Stop didn't return in time — the request unblocks anyway. |
 | `SlotConfigError` | 400 | — |
-| `NpuExclusivityViolation` | 409 | Only one `device=npu, type=llm, enabled=true` slot is allowed at a time (AMD XDNA hardware context limit). |
+| `NpuExclusivityViolation` | 409 | Only one `device=npu, type=llm` slot with a bound model is allowed at a time (AMD XDNA hardware context limit). |
 | `SlotPinned` | 409 | A pinned slot needs `?force=true` to unload or delete. |
 
 Health-probe resolution on timeout: unresolved health checks resolve to `WARMING`, not
 `ERROR` — an ambiguous outcome is treated as "still loading," not "failed."
+
+<Aside type="note" title="Client-side lifecycle timeouts">
+The CLI and the MCP admin bridge derive their read timeout for `load` / `unload`
+/ `restart` / `swap` from the server's own worst-case budget
+(`hal0.slot_lifecycle_budget`) rather than a fixed number — a load charges the
+health poll, the output-sanity gate's CPU-lane budget, and up to three
+in-series eviction unloads, all with a 1.15x overhead margin. A restart or swap
+charges both an unload and a load. This is why a slow (e.g. CPU-only) box's
+load can legitimately take several minutes before a client gives up.
+</Aside>
 
 ## Output-sanity gate
 
@@ -131,11 +141,59 @@ Escape hatches, both default-ON:
 | Whole box | `HAL0_SLOT_OUTPUT_SANITY=0` in the api environment |
 | One slot | `output_sanity = false` in the slot TOML, or via `PUT /api/slots/{name}/config` |
 
+## Crash-loop breaker
+
+A slot in `ERROR` is freely re-loadable, but not at request cadence. `SlotManager`
+tracks consecutive load failures per slot (`hal0.slots.manager`) and throttles
+further `load()` calls through three states:
+
+| State | When | Next retry |
+|---|---|---|
+| `backoff` | 1–4 consecutive failures | Exponential: `min(5s * 2^(failures-1), 300s)` |
+| `parked` | 5 or more consecutive failures | `min(300s * 2^(failures-5), 3600s)` — loads are refused outright |
+| `half-open` | The current backoff or parked cooldown has elapsed | One trial load runs; success closes the breaker, a failed trial re-parks it at the next cooldown step |
+
+A load the breaker refuses raises `SlotCrashLooping` (503, see above) with **no**
+state transition — no `STARTING` event, no journal row, no `systemctl` call — and
+carries `retry_after_s` for the response's `Retry-After` header. Any operator
+action (a manual load, a restart, or a config edit) resets the breaker
+immediately, independent of the cooldown clock; a load that converges healthy
+clears it too.
+
+The manager stamps the live view onto every slot snapshot as
+`metadata.breaker = {state, failures, retry_after_s}` while the breaker is
+non-closed, and omits the key entirely once it's closed — so the field's
+presence is the render signal. The dashboard shows this as a chip on both the
+slot card and the Edit-slot drawer's state strip: amber "retry in Ns" while
+backing off, red "parked · N failures" once parked, and a neutral "trial
+pending" during the half-open window.
+
+## Container image status
+
+`image_status` on a slot snapshot is one of `present`, `pulling`, `missing`,
+`unknown`, or `not-configured` (`hal0.slot_view.image_status_for`). Only
+`unknown` renders a dashboard chip: it means hal0 could not read the container
+image store at all — the rootful `hal0-podman-ro` seam returned an error, the
+sudoers grant is absent, or the read probe timed out — which is a different
+claim from `missing` (podman was asked and said the image isn't there).
+`present` and `not-configured` are the quiet, correct states, and `pulling`
+already has its own progress bar. Seeing the "image ?" chip is the cue to run
+`hal0 doctor all` and check the `seams` row — there is no standalone
+`hal0 doctor seams` command.
+
+A slot or its container that was stopped cleanly no longer paints as `crashed`
+on either the slot card or the dashboard's slot list — only a unit that
+actually failed (`state = "error"` or a `crashed` container status) gets the
+red treatment; a graceful stop renders the same neutral "stopped" state as any
+other offline slot.
+
 ## Persistence
 
 `SlotStateRecord` (`name`, `state`, `model_id`, `port`, `updated_at`, `message`,
 `extra`) is written atomically (tempfile + `fsync` + `os.replace`) to
-`/var/lib/hal0/slots/<name>/state.json`, so SSE readers never observe a torn write.
+`/var/lib/hal0/slots/<stem>/state.json`, where `<stem>` is the slot's name
+(or, after `migrate-id-keying`, its stable numeric id — see
+`hal0.slots.layout`), so SSE readers never observe a torn write.
 
 ## Self-managed providers
 
@@ -183,13 +241,13 @@ previously were not.
 
 ## The v1.0 write-boundary guard
 
-<Aside type="caution">
-New in v1.0 (Stream F, `fix/write-boundary-enforcement` — reviewed PASS, not yet
-merged to `main` at time of writing). Before this change, `stacks/apply.py` and
-`SlotManager.create()` could both write slot TOML in-process **without** ever routing
-through the HTTP-layer's model-owned-key guard or the `[server].extra_args`
-hardware-flag screen — a real bypass of the model/slot key-ownership split described in
-[Config schema](/docs/reference/config-schema/#model-nested-under-a-slot).
+<Aside type="note">
+New in v1.0 (Stream F, `fix/write-boundary-enforcement`). Before this change,
+`stacks/apply.py` and `SlotManager.create()` could both write slot TOML
+in-process **without** ever routing through the HTTP-layer's model-owned-key
+guard or the `[server].extra_args` hardware-flag screen — a real bypass of the
+model/slot key-ownership split described in the [Config schema](/docs/reference/config-schema)
+reference.
 </Aside>
 
 `guard_slot_write_payload` (`hal0.slots.config_write`) is now the single shared
@@ -199,5 +257,5 @@ and `SlotManager` alike. It partitions model-owned vs. slot-owned keys and scree
 silently write a key the model is supposed to own. `PATCH /slots/{name}/defaults`
 correctly reports model-owned keys as such after this change.
 
-For the CLI surface that drives slot lifecycle transitions directly, see
-[CLI reference → hal0 slot](/docs/reference/cli/#hal0-slot--manage-inference-slots).
+For the CLI surface that drives slot lifecycle transitions directly, see the
+[CLI reference](/docs/reference/cli), `hal0 slot`.

--- a/installer/README.md
+++ b/installer/README.md
@@ -56,7 +56,7 @@ supported everywhere).
 8. **Systemd units** — writes `hal0-api.service`, `hal0.target`, `hal0-openwebui.service`, the podman↔Docker forward-reconciliation unit, and the `hal0-agent@.service` template (+ hermes drop-in, session-state hook, and the `hal0-systemctl` / `hal0-agentenv` / `hal0-benchctl` sudo seams with their sudoers grants), then `systemctl daemon-reload`. Units are written here; `hal0-api` and `hal0-openwebui` aren't enabled/started until the "Service start" step below. Per-slot `hal0-slot@<name>.service` units are managed by hal0 itself when slots are loaded.
 9. **Container slot seeds** — copies `installer/etc-hal0/slots/{flm,tts,rerank,utility,img,agent,brain,qwen3tts,coder,embed}.toml` into `/etc/hal0/slots/` (never overwriting operator edits, and honoring a `hal0 slot delete` tombstone). Each slot gates on its own runtime validation at load time.
 10. **Hardware probe** — runs `hal0 setup --auto --no-pull --no-extensions` (first-run seeding): scaffolds capability-slot structure with no model picks, writes `/etc/hal0/hardware.json`, and prints the detected backends. Skipped by `HAL0_SKIP_SETUP=1` or `HAL0_NO_PROBE=1`.
-11. **Steward + agent models** — unconditionally pulls a hardware-matched brain model (~1-2 GB) and binds it to the `brain` slot, so the dashboard's steward chat works out of the box — the brain models are native tool-callers on the shipped runner, so tool calls work too. `HAL0_SKIP_BRAIN_MODEL=1` skips the pull; `HAL0_BRAIN_MODEL=<id>` forces a specific curated quant. Then, only on an interactive terminal, an **opt-in** offer for a larger agent model (15-31 GB, exact size printed first, default **No**, skipped entirely on non-interactive installs) — it becomes the bigger tool-caller behind the `[brain_chat] tool_model` fallback (default `hal0/agent`); `HAL0_PULL_AGENT_MODEL=1` opts in unattended, `=0` force-skips even on a TTY, `HAL0_AGENT_MODEL=<id>` picks a specific rung. Both pulls are fail-soft — a decline or failure never fails the install.
+11. **Steward + agent models** — unconditionally pulls the curated brain model and binds it to the `brain` slot, so the dashboard's steward chat works out of the box — the brain models are native tool-callers on the shipped runner, so tool calls work too. Since rc.10 the default is hardware-blind: `lfm2.5-2.6b` (LiquidAI LFM2.5-2.6B-Q8_0, ~2.87 GB, 131k context) is plain Q8_0 GGUF that the FPX runner and stock llama.cpp both load, and the install step discloses the download size first. `HAL0_SKIP_BRAIN_MODEL=1` skips the pull; `HAL0_BRAIN_MODEL=<id>` forces a specific curated quant — mind that the `hal0-brain-sft` Q8/Q4 builds carry custom GGML tensor type ids and are **ROCmFPX-runner only**, so forcing one onto a CPU box crash-loops the slot. Then, only on an interactive terminal, an **opt-in** offer for a larger agent model (15-31 GB, exact size printed first, default **No**, skipped entirely on non-interactive installs) — it becomes the bigger tool-caller behind the `[brain_chat] tool_model` fallback (default `hal0/agent`); `HAL0_PULL_AGENT_MODEL=1` opts in unattended, `=0` force-skips even on a TTY, `HAL0_AGENT_MODEL=<id>` picks a specific rung. Both pulls are fail-soft — a decline or failure never fails the install.
 12. **NPU prerequisites (FastFlowLM)** — on apt hosts, installs `libxrt-npu2` (best-effort, from the lemonade-team PPA) and the per-distro, SHA-256-pinned FastFlowLM `.deb` (`ubuntu24.04`/`ubuntu25.10`/`ubuntu26.04`/`debian13`); `apt-get install ./deb` then resolves that release's own ffmpeg/boost/fftw dependencies from the host's own repos — no hardcoded library list. FastFlowLM ships Debian/Ubuntu `.deb`s only upstream, so on non-apt distros (Fedora, Arch, openSUSE…) this step is skipped with an honest message naming the distro — GPU/CPU paths are unaffected; the NPU/FLM trio waits on a manual FastFlowLM install. All fail-soft: a GPU-only host still installs fine.
 13. **ComfyUI model share** — creates the `models`/`output`/`input`/`user`/`custom_nodes` share directories the `img` slot container bind-mounts, and seeds custom nodes + `extra_model_paths.yaml` (never overwriting an existing copy). Skip with `HAL0_SKIP_COMFYUI=1`; a squashed/read-only mount here warns rather than aborts.
 14. **Bundle picker manifests** — copies the five first-run bundle manifests (hal0-Lite / hal0-Default / hal0-Pro / hal0-Max + LMX-Omni-52B-Halo) into `/var/lib/hal0/models/collections/omni/`, so the dashboard's bundle picker works from a packaged install and not just a source checkout.
@@ -176,22 +176,44 @@ Two ways to resolve this, depending on what you're trying to do:
 
 The installer prints the same warning block at the end of every `--dev` run as a reminder.
 
-## ROCmFP4 + MTP (container profiles)
+## ROCmFP4 + MTP
 
-FP4 GGUFs with a baked-in multi-token-prediction (MTP) head are served
-by the `rocm-7.2.4-rocmfp4-server` toolbox image — the fork
-`llama-server` that loads the FP4 quant types is **inside the
-container**, no host-side build or binary wiring required. Two seed
-profiles use it (see `/etc/hal0/profiles.toml`):
+FP4 GGUFs with a baked-in multi-token-prediction (MTP) head are served by the
+**ROCmFPX runner image** (`hal0.config.schema.DEFAULT_ROCMFPX_IMAGE`) — the
+fork `llama-server` that loads the FP4 quant types is **inside the
+container**, no host-side build or binary wiring required. The old
+`--rocmfp4` installer flag and host-side fork binary are gone.
 
-- `rocm` — A3B MoE models (~52.8 tok/s gen, 131k ctx).
-- `rocm-mtp` — dense chat with MTP (`mtp = true`, ~2× non-MTP).
+Two things compose to launch a slot, and neither is the other:
 
-Point a slot at one of them (`profile = "rocm-mtp"`) or let
-the device default pick it (`device = "gpu-rocm"` resolves to
-`rocm`). gfx1151 (Strix Halo) + ROCm hosts only; non-eligible
-hosts should stay on `vulkan`. The old `--rocmfp4` installer flag
-and host-side fork binary are gone.
+- The **runner** is slot-owned — `slot.image_pin or RUNNER_IMAGES[slot.binary]`
+  (`hal0.runners`). `rocmfpx` and `vulkanfpx` both resolve to the FPX image
+  and both declare `RunnerSupports(mtp=True)`; `cuda` and `cpu` do not
+  support MTP drafting.
+- The **profile** is a device-agnostic tune template — a flag bundle, nothing
+  more. Profiles no longer carry an image. The generic chat seeds are `chat`,
+  `chat-long-context`, `dense` and `moe`, with family-specific variants
+  (`chadrock-dense`, `chadrock-moe`) for models that need their own kv-cache
+  or sampler policy.
+
+**MTP is a model property, not a profile tune.** `profile.mtp` in
+`profiles.toml` is informational only and is not consulted at launch
+(`providers.container._effective_mtp`). Precedence: an explicit
+`ModelDefaults.mtp` tri-state wins in either direction; `None` falls back to
+the registry `mtp` tag; and the runner must support drafting either way. When
+MTP resolves on, `MTP_FLAG_BUNDLE` (`--spec-type draft-mtp` and its
+`--spec-draft-*` defaults) is appended after the profile flags, and a model
+can override any of those from its own `defaults.extra_args`.
+
+The seed profile catalog is **virtual** — it lives in code (`SEED_PROFILES`,
+sourced from `hal0/config/data/seed_profiles.toml`) and is overlaid on every
+load, so a re-tuned seed reaches every install on upgrade instead of being
+frozen by a stale on-disk copy. `/etc/hal0/profiles.toml` is for operator
+profiles only; seeds are immutable and are cloned under a new name to
+customize.
+
+FP4 is gfx1151 (Strix Halo) + ROCm territory; non-eligible hosts run the same
+FPX image through the `vulkanfpx` runner.
 
 ## Uninstall
 


### PR DESCRIPTION
## Why

The published docs had not been reviewed against the code as a whole before a
release. This does that pass: adds the surfaces that shipped without
documentation, corrects what the code contradicts, and repairs links that were
silently dead on the forum.

Every claim here was verified against source. Where a doc and the code
disagreed, the code won and the doc changed.

## What was missing

Five new pages. The largest gap was **hal0-brain**, which is a first-class part
of the product with no page of its own — a reader had to infer it from mentions
scattered across six other files. Also `guides/manage-runner-images.mdx`,
`guides/memory-workspace.mdx`, `guides/dashboard-and-settings.mdx` (the
dashboard chrome and Settings tour were named nowhere), and
`reference/api/realtime.mdx`.

Expanded: `[metrics]` (nine tunables, invisible because the table loads outside
the root config model), `rest-api.mdx` from 18 route prefixes to ~43 each with
its `exposure.py` auth tier, `env-vars.mdx` from ~70 to ~130 variables, and the
companion services whose lifecycle buttons ship in the dashboard while
`operate/services.mdx` explicitly scoped them out.

## What was wrong

The review found more wrong-doc than missing-doc, which is the more dangerous
kind. A sample, all verified:

- Seeded-slot lists named `stt` and `vision` — neither exists — and omitted
  `flm`, `brain`, `qwen3tts`, `coder` (`static_seeds.py:39`).
- Seeded slots were documented as undeletable. `?force=true` deletes them.
- `concepts/memory.mdx` had the memory default backwards: `[memory].enabled`
  defaults to `true` (`schema.py:2783`) and nothing writes the key, so an
  upgraded box comes up with memory **on**, not off.
- `config-schema.mdx` asserted `brain_chat.tool_model` had been removed and
  instructed writers not to document it. It is live at `schema.py:3128` and is
  the whole tool-routing mechanism.
- A documented `--private` flag and a `hal0 slot get` verb do not exist.
- `hal0 upstream update --api-key` does not exist; rotation is
  `hal0 upstream credentials set --key`.
- Preview tags were documented as `v1.2.3-rc1`. `policy.py:26` requires the dot,
  so every shape listed would have been rejected outright.
- `dashboard-and-settings.mdx` said secrets are "encrypted at rest". They are
  plaintext mode-0600 in `api.env`.

## Dead links

All 32 fragment links across the corpus are gone.

Discourse does not emit raw heading slugs as anchors — it emits
`p-<post-id>-<heading-slug>-<n>`. Verified against live topic 38, which renders
`p-40-create-a-slot-2` and friends, with zero `id` attributes on headings. The
sync passes fragments through unchanged (`links.py:173`), so every one of them
landed on the right page at the wrong place, with no broken-link signal
anywhere. Tracked for a real fix in #2111.

## SECURITY.md

Two corrections. The supported-versions section still said hal0 is pre-1.0. More
importantly, the bundled-agent section said Hermes ships provisioned with
`terminal.backend = local` — stale since #1882. The terminal tool has been
off by default and opt-in for several releases, so the page was pointing
operators at the wrong knob for a root-equivalent capability.

## Product bugs

Filed rather than documented around, per the house pattern: #2105, #2106, #2107,
#2108, #2109, #2110, #2111, #2112. Two are worth a look before GA — #2110 (the
Secrets page's false encryption claim) and #2109 (three routes whose docstrings
and enforced auth tier disagree, so their panels would 401 during the first-run
scenario the docstrings exist to protect).

## Verification

`tests/ -k "changelog or release_notes or docs"` — **164 passed**, run on real
hardware against this tree.

That run earned its keep: it caught two publish-breakers that six independent
review passes missed. `services.mdx` had an unquoted `: ` in its YAML
description, and a line in `brain.mdx` wrapped onto the word "import", which
the sync transform reads as a stray ESM statement. Both would have failed the
docs-sync job after merge.

Also verified corpus-wide: zero fragment links, zero broken internal links
across 50 pages, no Starlight component used without an import, no
`sidebar.order` collisions.

## Method

Nine parallel writers scoped to non-overlapping files, six independent Opus
reviewers verifying against source rather than against the prose, then fix lanes
applying only what the review substantiated. Reviewers caught real errors in the
writers' output; fixers twice caught errors in the reviewers' findings and said
so instead of applying them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
