### PR TITLE
release: cut 1.0.0 — rename the CHANGELOG heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ breaking/migrations as callouts — from the cosign-verified tarball, before
 applying. Add those subsections to a version's section to surface them; see
 `scripts/gen_release_notes.py`.
 
-## [Unreleased]
+## [1.0.0] — 2026-08-29
 
 The first stable release. hal0 stops being a box you configure and starts
 being a box that is already configured: the whole platform is reachable by


### PR DESCRIPTION
**Merge this on the day v1.0.0 is tagged, and not before. Update the date in the heading if that day is not 2026-08-29.**

Stacked on #2114 — that PR must land first, because it replaces the paragraph that sits under this heading. Renaming the heading is what makes that paragraph render; doing the rename without it publishes "no `v1.0.0` tag exists" as the headline text of the 1.0.0 release. Details and the reproduction are in #2114.

One line changes:

```diff
-## [Unreleased]
+## [1.0.0] — 2026-08-29
```

That line is the entire release cut on the product-repo side. Nothing else in either repo hardcodes a version.

## What it flips

**`gen_release_notes.py` can find a section for the tag.** It calls `hal0.release.notes.extract_changelog_section(raw, "v1.0.0")`, which looks for `## [1.0.0]`. Against the current file that returns `""`, and the release tarball ships a commit-log fallback with an empty `release.json` — so `hal0 update` would offer a 1.0.0 upgrade with no highlights, no breaking list and no migrations. Verified after the rename:

```
section chars: 23821
first line: The first stable release. hal0 stops being a box you configure and starts
{'highlights': 5, 'breaking': 9, 'migrations': 7}
```

**hal0.dev resolves 1.0.0.** The site derives every version it displays from this file; `parseChangelog` filters `## [Unreleased]` out entirely, so today it resolves latest = 1.0.0-rc.12. Verified after the rename, against the real `hal0-web/src/lib/changelog.js`:

```
latest: 1.0.0 | date: 2026-08-29 | stable: true | gaPreview: false
latestStable: 1.0.0
latestPrerelease: 1.0.0-rc.12
intro html: <p>The first stable release. hal0 stops being a box you configure and starts being
a box that is already configured: …
```

`gaPreview: false` is the one to check — it is the guard that would otherwise flag a stable block sitting above a newer prerelease of the same base version and keep it from being presented as shipped.

## Sequence

1. Merge #2114.
2. Merge this, adjusting the date if the tag is not landing today.
3. Tag `v1.0.0`.
4. In hal0-web: `npm run sync:changelog`, commit `src/data/changelog.md`, deploy.

Step 4 is not optional. The committed `src/data/changelog.md` is a build *fallback*, not a cache — `sync-changelog.mjs` swallows fetch failures by design and keeps whatever is committed. At last check it was 431,979 bytes against 437,143 in this repo, missing `### Audience` and `### Operator migrations`. A GA-day build with a flaky GitHub would silently ship rc-only notes and an rc version number in the hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VK1wkzRxdxBRJfHFa5zDYb
