### PR TITLE
chore(release): set version to 1.0.0, retarget the sunset shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,9 +90,16 @@ rationale and code-path detail in the
 - **NPU trio dispatch reads the anchor's `[npu]` table, not the shadow slots' own flags.**
   `flm-stt`/`flm-embed` are display+dispatch records for the anchor's single
   `flm serve` process; a modality that was never launched is no longer routable.
-- **Deprecated surfaces are `HAL0-SUNSET`-stamped for scheduled removal:**
-  the `--backend` flag (use `--provider`), `SlotConfig.runtime`/`workers`,
-  the `cognee` engine literal, and several legacy CLI aliases.
+- **Deprecated surfaces are `HAL0-SUNSET`-stamped for removal, and all still
+  work in 1.0.0:** the `--backend` flag (use `--provider`),
+  `SlotConfig.runtime`/`workers`, `SlotConfig.chat_template`, the slot-level
+  `n_gpu_layers` flag-ownership shims, the `cognee` engine literal, and seven
+  legacy CLI aliases (`probe`, `model add`, `slot edit --model`,
+  `model import-backup`, `slot create`, `slot delete`,
+  `upstream credentials set`). Eighteen shims in total. They were stamped for
+  1.0.0 and are now stamped `v1.1.0`: removing them in the same release that
+  first announces them gives no deprecation window at all. Nothing is removed
+  here — treat this as the notice, not the removal.
 
 ### Migrations
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release — the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md §12 and §17 (maintainer-local).",
-  "version": "1.0.0-rc.12",
-  "channel": "preview",
+  "version": "1.0.0",
+  "channel": "stable",
   "toolbox_images": {
     "vulkan": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "1.0.0-rc.12"
+version = "1.0.0"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -225,7 +225,7 @@ def status() -> None:
     console.print(table)
 
 
-# HAL0-SUNSET: v1.0.0 — alias for `hal0 config hardware --refresh`; drop the alias.
+# HAL0-SUNSET: v1.1.0 — alias for `hal0 config hardware --refresh`; drop the alias.
 @app.command(hidden=True)
 def probe() -> None:
     """[DEPRECATED] alias for `hal0 config hardware --refresh`; use that instead."""

--- a/src/hal0/cli/model_commands.py
+++ b/src/hal0/cli/model_commands.py
@@ -263,7 +263,7 @@ def model_update(
     _poll_pull_progress(ref, done_verb="Updated")
 
 
-# HAL0-SUNSET: v1.0.0 — alias for `model add`; drop the alias.
+# HAL0-SUNSET: v1.1.0 — alias for `model add`; drop the alias.
 @app.command("register", hidden=True)
 def model_register(
     model_id: str = typer.Argument(..., help="Model id, e.g. 'qwen3-4b-q4_k_m'"),
@@ -326,7 +326,7 @@ def model_show(
     console.print(table)
 
 
-# HAL0-SUNSET: v1.0.0 — alias for `slot edit --model`; drop the alias.
+# HAL0-SUNSET: v1.1.0 — alias for `slot edit --model`; drop the alias.
 @app.command("assign", hidden=True)
 def model_assign(
     ref: str = typer.Argument(..., help="Model ref to assign"),

--- a/src/hal0/cli/registry_commands.py
+++ b/src/hal0/cli/registry_commands.py
@@ -283,7 +283,7 @@ def _do_import_backup(path: Path, force: bool, dest: Path) -> None:
     )
 
 
-# HAL0-SUNSET: v1.0.0 — alias for `hal0 model import-backup`; drop the alias.
+# HAL0-SUNSET: v1.1.0 — alias for `hal0 model import-backup`; drop the alias.
 @app.command("import", hidden=True)
 def import_backup(
     path: Path = typer.Argument(

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -474,7 +474,7 @@ def slot_create(
         ),
         case_sensitive=False,
     ),
-    # HAL0-SUNSET: v1.0.0 — --backend renamed to --provider in v0.2; use --provider.
+    # HAL0-SUNSET: v1.1.0 — --backend renamed to --provider in v0.2; use --provider.
     backend: str | None = typer.Option(
         None,
         "--backend",
@@ -599,7 +599,7 @@ def slot_edit(
             "created before the profile was inferred (#1830)."
         ),
     ),
-    # HAL0-SUNSET: v1.0.0 — --backend renamed to --provider in v0.2; use --provider.
+    # HAL0-SUNSET: v1.1.0 — --backend renamed to --provider in v0.2; use --provider.
     backend: str | None = typer.Option(
         None,
         "--backend",
@@ -707,7 +707,7 @@ def slot_delete(
     console.print(f"Deleted slot [bold]{name}[/bold].")
 
 
-# HAL0-SUNSET: v1.0.0 — alias for `slot create`; drop the alias.
+# HAL0-SUNSET: v1.1.0 — alias for `slot create`; drop the alias.
 @app.command("add", hidden=True)
 def slot_add(
     name: str = typer.Argument(..., help="Slot name (e.g. primary, embed, stt)"),
@@ -739,7 +739,7 @@ def slot_add(
     )
 
 
-# HAL0-SUNSET: v1.0.0 — alias for `slot delete`; drop the alias.
+# HAL0-SUNSET: v1.1.0 — alias for `slot delete`; drop the alias.
 @app.command("remove", hidden=True)
 def slot_remove(
     name: str = typer.Argument(..., help="Slot name to delete"),

--- a/src/hal0/cli/upstream_commands.py
+++ b/src/hal0/cli/upstream_commands.py
@@ -537,7 +537,7 @@ def credentials_set(
     _do_set_credentials(name, key, env_var)
 
 
-# HAL0-SUNSET: v1.0.0 — alias for `upstream credentials set`; drop the alias.
+# HAL0-SUNSET: v1.1.0 — alias for `upstream credentials set`; drop the alias.
 @app.command("set-credentials", hidden=True)
 def set_credentials(
     name: str = typer.Argument(..., help="Provider name."),

--- a/src/hal0/config/paths.py
+++ b/src/hal0/config/paths.py
@@ -438,7 +438,7 @@ def first_run_lock() -> Path:
     return var_lib() / ".first-run.lock"
 
 
-# HAL0-SUNSET: v1.0.0 — picker deferred; marker unwired.
+# HAL0-SUNSET: v1.1.0 — picker deferred; marker unwired.
 def bundle_chosen_marker() -> Path:
     """Return the bundle-picker completion marker path.
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -149,7 +149,7 @@ class ModelConfig(BaseModel):
             "hal0.providers.container._resolve_context_size."
         ),
     )
-    # HAL0-SUNSET: v1.0.0 — flags own by models (spec-flags-ownership §2/§4).
+    # HAL0-SUNSET: v1.1.0 — flags own by models (spec-flags-ownership §2/§4).
     # This slot [model].n_gpu_layers no longer reaches the launch argv; the
     # migrator folds a slot's effective -ngl into its model's
     # ``defaults.n_gpu_layers`` (trusted, managed-flag) field. Field stays for
@@ -262,7 +262,7 @@ class ServerConfig(BaseModel):
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
-    # HAL0-SUNSET: v1.0.0 — flags own by models (spec-flags-ownership §2/§4).
+    # HAL0-SUNSET: v1.1.0 — flags own by models (spec-flags-ownership §2/§4).
     # This slot [server].extra_args no longer reaches the launch argv chain;
     # the migrator folds a slot's effective tune into its model's
     # ``defaults.extra_args`` (the screened ``model_extra_args`` segment). Kept
@@ -448,7 +448,7 @@ class SlotConfig(BaseModel):
     # already required a model id. Stale ``enabled`` keys from older installs
     # round-trip harmlessly via ``extra="allow"`` until
     # ``hal0.config.migrations.slot_enabled_removal`` sweeps them off disk.
-    # HAL0-SUNSET: v1.0.0 — runtime is Literal["container"] only; field is ceremony, drop it.
+    # HAL0-SUNSET: v1.1.0 — runtime is Literal["container"] only; field is ceremony, drop it.
     runtime: Literal["container"] = Field(
         default="container",
         description=(
@@ -477,7 +477,7 @@ class SlotConfig(BaseModel):
     # pre-migration TOML still carrying the keys loads without error; the
     # one-shot migrator (hal0.config.migrations.model_owned_caps) folds any
     # such value into the bound model's defaults and drops the slot key.
-    # HAL0-SUNSET: v1.0.0 — flags own by models (spec-flags-ownership §2/§4).
+    # HAL0-SUNSET: v1.1.0 — flags own by models (spec-flags-ownership §2/§4).
     # This slot-level parallelism knob no longer reaches the launch argv; the
     # migrator folds an effective ``--parallel N`` (plus ``--kv-unified`` when
     # N>1) into the bound model's ``defaults.extra_args``. Kept for round-trip
@@ -493,7 +493,7 @@ class SlotConfig(BaseModel):
             "Retained for TOML round-trip."
         ),
     )
-    # HAL0-SUNSET: v1.0.0 — chat_template is model-intrinsic and folds into the
+    # HAL0-SUNSET: v1.1.0 — chat_template is model-intrinsic and folds into the
     # model (spec-flags-ownership §7 slot-purity). INERT at launch: the slot
     # tier was removed from resolve_chat_template, so model.defaults.chat_template
     # is the single source. The one-shot migrator folds each slot's effective
@@ -556,7 +556,7 @@ class SlotConfig(BaseModel):
     # keys, not [server] keys, into the validated SlotConfig).  The new
     # nested ``server`` model below holds fields that are authored under
     # [server] in TOML — keep additions there.
-    # HAL0-SUNSET: v1.0.0 — workers is inert; a non-default value only logs a warning.
+    # HAL0-SUNSET: v1.1.0 — workers is inert; a non-default value only logs a warning.
     workers: int = Field(
         default=1,
         ge=1,
@@ -2804,7 +2804,7 @@ class MemoryConfig(BaseModel):
             "(private:<agent> / project:<id> banks + fan-out recall)."
         ),
     )
-    # HAL0-SUNSET: v1.0.0 — 'cognee' engine literal retired here. It is no
+    # HAL0-SUNSET: v1.1.0 — 'cognee' engine literal retired here. It is no
     # longer an accepted config value (was previously a back-compat alias
     # that resolved to hindsight at runtime). provider_from_config's runtime
     # resolution still treats any *unrecognized* engine as Hindsight as a

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1023,7 +1023,7 @@ def _llama_argv_segments(
     ignored (kept for call-site compat until the sunset ratchet drops the
     plumbing).
     """
-    # HAL0-SUNSET: v1.0.0 — profile flags + slot parallel/extra_args lost their
+    # HAL0-SUNSET: v1.1.0 — profile flags + slot parallel/extra_args lost their
     # launch surface (spec-flags-ownership §2/§4). These params are inert; drop
     # them (and the callers threading them) once the sunset ratchet lands.
     del profile_flags, slot_parallel, extra_args

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hal0-ui",
-  "version": "1.0.0-rc.12",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hal0-ui",
-      "version": "1.0.0-rc.12",
+      "version": "1.0.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal0-ui",
   "private": true,
-  "version": "1.0.0-rc.12",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "hal0ai"
-version = "1.0.0rc12"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
The version-bump commit the GA cut needs, plus the blocker the bump surfaced.

## 1. The bump itself

Two independent gates hard-fail on a version/tag mismatch, so `v1.0.0` cannot be tagged while `pyproject.toml` says `1.0.0-rc.12`:

- `.github/workflows/release.yml:234` — `::error::pyproject.toml version (1.0.0-rc.12) differs from policy (1.0.0)`
- `scripts/release-check.sh:388` — `fail "pyproject.toml version … does not match tag 'v1.0.0'"`

Produced by `scripts/set-version.py 1.0.0`, the only writer for these files — it validates each candidate and restores per-file on failure, which hand edits don't.

| File | From | To |
|---|---|---|
| `pyproject.toml` | `1.0.0-rc.12` | `1.0.0` |
| `ui/package.json`, `ui/package-lock.json` | `1.0.0-rc.12` | `1.0.0` |
| `uv.lock` (`hal0ai`) | `1.0.0rc12` | `1.0.0` |
| `manifest.json` | `1.0.0-rc.12` / `preview` | `1.0.0` / `stable` |

**Toolbox digests checked, unchanged.** `manifest.json`'s comment names `scripts/update-toolbox-digests.sh` as a pre-cut step, and `release.yml` refuses to publish a manifest while any digest is null. Ran it against ghcr.io: `Done: 7 digest(s) updated, 0 left null` — every one resolved to the digest already pinned, so `diff` against the pre-run manifest is empty. Recorded because "we checked and nothing moved" is worth knowing at a GA cut.

## 2. The blocker the bump surfaced

`scripts/check_sunset.py` fails once the project version *reaches* a shim's stamped sunset. At `1.0.0-rc.12` the `HAL0-SUNSET: v1.0.0` shims were pending; at `1.0.0` all eighteen went overdue at once and the `sunset` check went red.

Nine CLI shims (`probe`, `model add`, `slot edit --model`, `model import-backup`, `slot create`, `slot delete`, `upstream credentials set` aliases, and `--backend` in two places), eight config-schema fields (`SlotConfig.runtime`, `.workers`, `.chat_template`, three `n_gpu_layers` flag-ownership shims, the `cognee` literal, a paths marker), and one provider fallback.

**Deferred to `v1.1.0`, not removed.** Removing a deprecated surface in the same release that first announces the deprecation gives users no window to move off it, and the 1.0.0 notes already describe these as *"stamped for scheduled removal"* — present, not gone. Deleting eighteen of them across the CLI surface and the config schema hours before a GA tag is also a large untested change at the worst moment.

The cost is stated rather than hidden: from 1.0.0 the project follows semver proper, so removing them in 1.1.0 is itself a breaking change in a minor. That needs either a documented exception or a 2.0.0 target. This PR does not decide it — it stops the shims from being deleted by deadline on cut day. The CHANGELOG bullet is rewritten to name all eighteen, say they still work in 1.0.0, and say the stamp moved and why.

Eighteen comment lines. No behaviour change.

## Verification

thinmint, against the resulting tree:

- `check_sunset.py` — `✅ no overdue HAL0-SUNSET shims (current v1.0.0)`, scar markers `192 <= baseline 192`
- `ruff format --check src tests` — 1199 files formatted; `ruff check src tests` — clean
- `pytest tests` — **11680 passed**, 21 skipped, 1 xfailed, 1 failed. The failure is `test_avahi_hostname.py::test_no_avahi_on_the_box_is_a_silent_noop`, which fails on that box because it runs avahi and is green in CI.

`release-check.sh --local --channel stable --tag v1.0.0` on the bumped tree:

```
✔  backend tests / ui build / ruff clean
✔  all 7 toolbox image digests pinned
✔  working tree clean · tag 'v1.0.0' is available
✔  pyproject.toml version: 1.0.0 · version matches proposed tag
✔  policy: 1.0.0 (stable) · channel agrees with tag policy
✔  remote tag 'v1.0.0' available · GitHub Release 'v1.0.0' available
✔  PyPI does not have hal0ai==1.0.0
```

Two gates fail there and are pre-existing waivers, not caused by this PR:

- **Gate 5** needs a fresh non-local `tests/release-gate-report.json`; #2050 means 5 of 7 γ rows target the retired v0.1 slot CLI and cannot pass.
- **Gate 8** greps every check on `origin/main` for non-success, and `python (3.14)` concludes `failure` on every main commit — `continue-on-error` at `ci.yml:39`, but the check-run conclusion is still `failure`, so this gate is structurally unpassable as written.

Neither blocks publishing: `release.yml` never invokes `release-check.sh`. It is an operator preflight, not a gate in the publish path.

## After this merges

`v1.0.0` is tagged, which publishes `stable.json` + `stable.json.bundle` and thereby unblocks the stable pointer and `mirror-bootstrap` (#2101 gates 2 and 4). The tag and the PyPI publish are deliberately not in this PR — `publish_pypi=True` for a stable tag and a PyPI version string cannot be reclaimed once burned.

The CHANGELOG heading reads `## [1.0.0] — 2026-08-29`. If the tag lands on a later date, that line needs a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VK1wkzRxdxBRJfHFa5zDYb