### PR TITLE
fix(installer): allocate subuid/subgid for hal0 so rootless image pulls work

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -724,6 +724,50 @@ else
         usermod -aG "${KFD_GROUPS}" hal0
         info "added hal0 to groups: ${KFD_GROUPS}"
     fi
+
+    # Rootless-podman uid/gid ranges. `useradd --system` never allocates
+    # /etc/subuid + /etc/subgid entries, so the hal0 user's rootless podman
+    # ran in a single-uid namespace: any image layer carrying files owned by
+    # a non-root uid died at unpack ("potentially insufficient UIDs or GIDs
+    # available in user namespace", podman exit 125). Slot units pull as
+    # root and never hit it — which is why the gap stayed invisible until
+    # the dashboard's runner-image pull (runs as the hal0 service user) grew
+    # a Pull button. Idempotent: skipped once BOTH files carry a hal0 range.
+    # The start is placed after every range any user already claims so a
+    # pre-existing allocation (e.g. an operator's own account) is never
+    # overlapped.
+    # HAL0_SUBUID_JUST_ALLOCATED gates the deferred `podman system migrate`
+    # near "doctor perms --fix --force" below — VAR_DIR (hal0's $HOME) is
+    # still root:root here (the P3-perms chown to hal0:hal0 2775 hasn't run
+    # yet), so a migrate attempted from THIS block can't even create hal0's
+    # rootless storage dir under $HOME and would always hit the warn() path,
+    # fresh install or not.
+    HAL0_SUBUID_JUST_ALLOCATED=0
+    if ! grep -q '^hal0:' /etc/subuid 2>/dev/null \
+        || ! grep -q '^hal0:' /etc/subgid 2>/dev/null; then
+        SUB_START=100000
+        SUB_COUNT=65536
+        for _subfile in /etc/subuid /etc/subgid; do
+            [[ -f "${_subfile}" ]] || continue
+            while IFS=: read -r _sub_user _sub_first _sub_n; do
+                [[ -n "${_sub_first:-}" && -n "${_sub_n:-}" ]] || continue
+                _sub_end=$(( _sub_first + _sub_n ))
+                (( _sub_end > SUB_START )) && SUB_START=${_sub_end}
+            done < "${_subfile}"
+        done
+        if usermod --add-subuids "${SUB_START}-$(( SUB_START + SUB_COUNT - 1 ))" \
+                --add-subgids "${SUB_START}-$(( SUB_START + SUB_COUNT - 1 ))" \
+                hal0 2>/dev/null; then
+            info "allocated rootless uid/gid range ${SUB_START}:${SUB_COUNT} for hal0"
+        else
+            # shadow-utils too old for --add-subuids: append the entries
+            # directly — same format usermod writes.
+            echo "hal0:${SUB_START}:${SUB_COUNT}" >> /etc/subuid
+            echo "hal0:${SUB_START}:${SUB_COUNT}" >> /etc/subgid
+            info "allocated rootless uid/gid range ${SUB_START}:${SUB_COUNT} for hal0 (direct append)"
+        fi
+        HAL0_SUBUID_JUST_ALLOCATED=1
+    fi
 fi
 
 ui_step "Filesystem layout"
@@ -3127,6 +3171,25 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
     else
         warn "'${HAL0_BIN} doctor perms --fix' reported drift/errors — re-run 'sudo ${HAL0_BIN} doctor perms --fix' after install"
     fi
+fi
+
+# Rootless-podman storage migrate (issue #2119), deferred to HERE — not the
+# "System user" step that allocated the subuid/subgid range above. VAR_DIR
+# only just became hal0:hal0 2775 in the doctor-perms step immediately
+# above; run this any earlier and hal0 can't even create its rootless
+# storage dir under $HOME yet (still root:root at that point), so the
+# migrate would fail on every install — fresh or upgrade — for a reason
+# that has nothing to do with the subuid mapping it's meant to validate.
+# An EXISTING install already initialized hal0's podman storage under the
+# old single-uid mapping; without this one-time migrate the next rootless
+# operation fails with "user namespace changed". A fresh install has no
+# storage yet and migrate is a cheap no-op. Gated on a fresh allocation
+# just having happened (HAL0_SUBUID_JUST_ALLOCATED) so a re-run of
+# install.sh against an already-converged box doesn't redo it every time.
+if [[ "${DEV_MODE}" -eq 0 && "${HAL0_SUBUID_JUST_ALLOCATED:-0}" -eq 1 ]] \
+    && command -v podman >/dev/null 2>&1; then
+    runuser -u hal0 -- podman system migrate >/dev/null 2>&1 \
+        || warn "podman system migrate (as hal0) failed — run it once as the hal0 user before the first dashboard image pull"
 fi
 
 # ── Post-install smoke probes (#2066) ──────────────────────────────────────

--- a/tests/installer/test_subuid_allocation.py
+++ b/tests/installer/test_subuid_allocation.py
@@ -45,9 +45,7 @@ class TestSubuidAllocation:
         assert re.search(r"grep -q '\^hal0:' /etc/subuid", install_sh_text)
         assert re.search(r"grep -q '\^hal0:' /etc/subgid", install_sh_text)
 
-    def test_range_start_respects_existing_allocations(
-        self, install_sh_text: str
-    ) -> None:
+    def test_range_start_respects_existing_allocations(self, install_sh_text: str) -> None:
         """The chosen start must be computed from every range already present
         in both files, not hardcoded — overlapping another user's range makes
         two accounts share host uids, which is exactly what the namespace is
@@ -56,9 +54,7 @@ class TestSubuidAllocation:
         assert "/etc/subuid /etc/subgid" in block
         assert re.search(r"_sub_end > SUB_START", block)
 
-    def test_fallback_append_matches_usermod_format(
-        self, install_sh_text: str
-    ) -> None:
+    def test_fallback_append_matches_usermod_format(self, install_sh_text: str) -> None:
         """shadow-utils without --add-subuids: the direct append must write
         the exact ``user:start:count`` triple usermod would."""
         assert re.search(
@@ -70,20 +66,14 @@ class TestSubuidAllocation:
             install_sh_text,
         )
 
-    def test_storage_migrate_runs_for_existing_installs(
-        self, install_sh_text: str
-    ) -> None:
+    def test_storage_migrate_runs_for_existing_installs(self, install_sh_text: str) -> None:
         """An already-initialized single-uid podman store errors on the next
         operation after the mapping changes; the installer must run the
         one-time ``podman system migrate`` as hal0 (warn-only — a fresh
         install has no storage and must not fail the platform gate)."""
-        assert re.search(
-            r"runuser -u hal0 -- podman system migrate", install_sh_text
-        )
+        assert re.search(r"runuser -u hal0 -- podman system migrate", install_sh_text)
 
-    def test_allocation_happens_in_the_system_user_step(
-        self, install_sh_text: str
-    ) -> None:
+    def test_allocation_happens_in_the_system_user_step(self, install_sh_text: str) -> None:
         """The range belongs with user creation (before any hal0-user podman
         touch), not bolted on after service start."""
         user_step = install_sh_text.index('ui_step "System user"')

--- a/tests/installer/test_subuid_allocation.py
+++ b/tests/installer/test_subuid_allocation.py
@@ -1,0 +1,92 @@
+"""Rootless-podman subuid/subgid allocation for the hal0 service user.
+
+``useradd --system`` never allocates ``/etc/subuid`` + ``/etc/subgid``
+ranges, so every install shipped a hal0 user whose rootless podman ran in a
+single-uid namespace. Any image layer carrying files owned by a non-root
+uid then died at unpack — ``potentially insufficient UIDs or GIDs available
+in user namespace`` / ``lchown ...: invalid argument``, podman exit 125.
+Slot units pull through ROOT podman and never hit it, which kept the gap
+invisible until the dashboard's runner-image Pull button (which pulls as
+the hal0 service user) shipped: first observed live on lxc105, where both
+the comfyui and rocmfpx-combined dashboard pulls failed identically while
+the same tags sat happily in the root store.
+
+Static-text assertions against ``installer/install.sh``, same technique as
+``test_platform_gate_hardening.py`` — actually exercising useradd/usermod
+needs root, which the black-box harness owns.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
+
+
+@pytest.fixture(scope="module")
+def install_sh_text() -> str:
+    assert _INSTALL_SH.exists(), f"missing {_INSTALL_SH}"
+    return _INSTALL_SH.read_text(encoding="utf-8")
+
+
+class TestSubuidAllocation:
+    def test_allocation_block_present(self, install_sh_text: str) -> None:
+        assert "--add-subuids" in install_sh_text
+        assert "--add-subgids" in install_sh_text
+
+    def test_idempotence_guards_on_both_files(self, install_sh_text: str) -> None:
+        """The block must be skipped only when BOTH files already carry a
+        hal0 range — a subuid-only half-allocation still breaks unpack on the
+        gid side."""
+        assert re.search(r"grep -q '\^hal0:' /etc/subuid", install_sh_text)
+        assert re.search(r"grep -q '\^hal0:' /etc/subgid", install_sh_text)
+
+    def test_range_start_respects_existing_allocations(
+        self, install_sh_text: str
+    ) -> None:
+        """The chosen start must be computed from every range already present
+        in both files, not hardcoded — overlapping another user's range makes
+        two accounts share host uids, which is exactly what the namespace is
+        supposed to prevent."""
+        block = install_sh_text[install_sh_text.index("--add-subuids") - 2000 :]
+        assert "/etc/subuid /etc/subgid" in block
+        assert re.search(r"_sub_end > SUB_START", block)
+
+    def test_fallback_append_matches_usermod_format(
+        self, install_sh_text: str
+    ) -> None:
+        """shadow-utils without --add-subuids: the direct append must write
+        the exact ``user:start:count`` triple usermod would."""
+        assert re.search(
+            r'echo "hal0:\$\{SUB_START\}:\$\{SUB_COUNT\}" >> /etc/subuid',
+            install_sh_text,
+        )
+        assert re.search(
+            r'echo "hal0:\$\{SUB_START\}:\$\{SUB_COUNT\}" >> /etc/subgid',
+            install_sh_text,
+        )
+
+    def test_storage_migrate_runs_for_existing_installs(
+        self, install_sh_text: str
+    ) -> None:
+        """An already-initialized single-uid podman store errors on the next
+        operation after the mapping changes; the installer must run the
+        one-time ``podman system migrate`` as hal0 (warn-only — a fresh
+        install has no storage and must not fail the platform gate)."""
+        assert re.search(
+            r"runuser -u hal0 -- podman system migrate", install_sh_text
+        )
+
+    def test_allocation_happens_in_the_system_user_step(
+        self, install_sh_text: str
+    ) -> None:
+        """The range belongs with user creation (before any hal0-user podman
+        touch), not bolted on after service start."""
+        user_step = install_sh_text.index('ui_step "System user"')
+        fs_step = install_sh_text.index('ui_step "Filesystem layout"')
+        alloc = install_sh_text.index("--add-subuids")
+        assert user_step < alloc < fs_step


### PR DESCRIPTION
## What

The installer's "System user" step now allocates a rootless-podman subordinate uid/gid range for the `hal0` service user, because `useradd --system` never does — leaving `/etc/subuid`/`/etc/subgid` empty and every dashboard runner-image pull failing at layer unpack with podman exit 125 (`potentially insufficient UIDs or GIDs available in user namespace … lchown: invalid argument`).

## Why it was invisible

Slot units pull through **root** podman (separate image store); only the dashboard's Pull button pulls as the hal0 service user through rootless podman. Both dashboard pulls ever attempted on lxc105 (comfyui on Aug 5, rocmfpx-combined:0826 on Aug 29) failed identically.

## How

- 65536-wide range, start computed past every range any user already claims in either file (never overlaps a pre-existing allocation)
- `usermod --add-subuids/--add-subgids`, with a direct-append fallback for shadow-utils without those flags (same `user:start:count` format)
- one-time `runuser -u hal0 -- podman system migrate` so EXISTING installs whose store was initialized single-uid converge on their next upgrade (warn-only: fresh installs have no store and must not fail the platform gate)
- idempotent: skipped once both files carry a `hal0:` range

## Verification

- Live remediation of exactly this recipe on lxc105: after `usermod --add-subuids 100000-165535 --add-subgids 100000-165535 hal0` + `podman system migrate`, the previously failing `rocmfpx-combined:0826` dashboard pull completed and the `combined-upstream:0829` pull ran clean
- `bash -n installer/install.sh` clean
- `tests/installer/test_subuid_allocation.py` — 6 static-text assertions (same technique as `test_platform_gate_hardening.py`): allocation present, both-files idempotence guard, collision-free start computation, fallback format, migrate for existing installs, ordering inside the System-user step — 6/6 green

Closes #2119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfrTQYNegDmrAguRhQemSm