### PR TITLE
feat(runner): upstream llama.cpp image variant for qwen4exp

### DIFF
--- a/packaging/runner/rocmfpx/build.sh
+++ b/packaging/runner/rocmfpx/build.sh
@@ -164,6 +164,13 @@ cp -a "${SRC}"/build/bin/. "${STAGE}/bin/"
 find "${SRC}/build" -name '*.so*' -exec cp -P {} "${STAGE}/bin/" \;
 cp "${HERE}/entrypoint.sh" "${STAGE}/hal0-runner-entrypoint.sh"
 
+# Which recipe DIRECTORY produced the image. This script is shared by symlink
+# (packaging/runner/upstream/build.sh -> ../rocmfpx/build.sh, #2118) between
+# more than one recipe, so this must come from $HERE rather than being spelled
+# out as a literal "rocmfpx" string — a literal would mislabel every image the
+# OTHER recipe builds while looking correct in isolation.
+RECIPE_DIR="packaging/runner/$(basename "$HERE")"
+
 # Which REVISION of this recipe built the image. Filenames alone cannot answer
 # that: the patch files are mutable in-tree under stable names, so an older
 # image labelled `0001-….patch` cannot be traced back to the bytes it was built
@@ -209,7 +216,7 @@ LABEL org.opencontainers.image.source="${REPO}" \\
       org.opencontainers.image.revision="${REF}" \\
       org.opencontainers.image.base.name="${BASE}" \\
       org.opencontainers.image.base.digest="${BASE_DIGEST}" \\
-      dev.hal0.runner.recipe="packaging/runner/rocmfpx" \\
+      dev.hal0.runner.recipe="${RECIPE_DIR}" \\
       dev.hal0.recipe.revision="${RECIPE_REV}" \\
       dev.hal0.runner.base="${BASE_REF}" \\
       dev.hal0.runner.patches="$(IFS=,; echo "${PATCHES[*]}")" \\

--- a/packaging/runner/upstream/build.sh
+++ b/packaging/runner/upstream/build.sh
@@ -1,0 +1,1 @@
+../rocmfpx/build.sh

--- a/packaging/runner/upstream/entrypoint.sh
+++ b/packaging/runner/upstream/entrypoint.sh
@@ -1,0 +1,1 @@
+../rocmfpx/entrypoint.sh

--- a/packaging/runner/upstream/manifest.toml
+++ b/packaging/runner/upstream/manifest.toml
@@ -1,0 +1,100 @@
+# Provenance for the UPSTREAM runner image variant (qwen4exp unblock).
+#
+# WHY THIS EXISTS: Qwen3.8-Flash-Next ships the `qwen4exp` architecture,
+# merged into ggml-org/llama.cpp on 2026-08-27 (#27742) with correctness
+# fixes on 2026-08-28 (#27880). The default runner (../rocmfpx) builds from
+# charlie12345/ROCmFPX, whose HEAD (c49ebdbd, 2026-08-22) predates that
+# merge and carries zero qwen4exp support. Porting a week of upstream into
+# the diverged fork is exactly the #1888-shaped risk; building a second
+# image from pristine upstream is not.
+#
+# WHAT THIS IS NOT: a replacement for ../rocmfpx. That recipe's image stays
+# `DEFAULT_ROCMFPX_IMAGE` and keeps serving every existing slot. This image
+# is wired to a slot ONLY via the per-slot `image_pin` escape hatch
+# (providers/container.py — pin outranks BINARY/registry resolution), so
+# nothing resolves to it by default and nothing can drift onto it.
+#
+# FEATURE DELTA vs ../rocmfpx (:0826), stated so nobody re-derives it:
+#   PRESERVED by sharing build.sh + entrypoint.sh (symlinks in this dir):
+#     * combined HIP+Vulkan in one image (same cmake flags, same builder)
+#     * hal0-runner entrypoint: device-less GPU preflight (#1936) and
+#       load-death -> exit 64 translation (#2037)
+#     * /opt/rocmfpx/bin layout, LD_LIBRARY_PATH, HSA_OVERRIDE_GFX_VERSION,
+#       GGML_HIP_ENABLE_UNIFIED_MEMORY, provenance labels
+#     * same pinned base digest => same ROCm 7.2.4 toolchain lineage
+#   GAINED:  qwen4exp (Qwen3.8-Flash-Next) + all upstream fixes since Aug 22
+#   ABSENT — deliberately, and why that is safe:
+#     * ROCmFPX/ROCmI4/IU4 quant formats: only the FPX-family GGUFs need
+#       them (hal0-brain-sft-*-rocmfpx, chadrock/qwopus ROCmFP4). Those
+#       models must never be launched on this image; the pairing rule below
+#       is the guard.
+#     * 0001/0002 minicpm5 pretokenizer + tool-call parser and
+#       0004 lfm2.5 response-format grammar: brain-family models only;
+#       they keep running on :0826.
+#     * 0003 vulkan-shaders-serialize-glslc: build-host workaround for a
+#       glslc race in the FORK's older vulkan-shaders-gen; upstream gained
+#       its own serialization long since. If the build ever hits a glslc
+#       race, port the patch — do not pre-apply it to a tree it no longer
+#       matches.
+#
+# PAIRING RULE (the one operational invariant this file can only document,
+# not enforce): `image_pin` to this image travels WITH the model swap. Pin
+# it when a qwen4exp model lands on the slot; CLEAR the pin when the slot
+# swaps back to an FPX-family model, or the load fails on the missing quant
+# format. RUNNER_IMAGES/RunnerSupports gating for arch families is the real
+# fix and belongs in the ML-5 flag-resolution lane, not here.
+
+[image]
+#: NOT DEFAULT_ROCMFPX_IMAGE and must never become it — see header.
+tag = "ghcr.io/hal0ai/hal0-combined-upstream:0829"
+
+[base]
+#: Same base, same digest, same rationale as ../rocmfpx/manifest.toml —
+#: the digest pin freezes the entire ROCm toolchain both stages build
+#: against. Re-resolved nothing: byte-identical to the :0826 lineage so the
+#: only variable between the two images is [source].
+image = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"
+digest = "sha256:4f5418c1b1e39e5ad9bbadfd2e8381c6b8a70e9b03f667179a7233c6f681462a"
+rocm_version = "7.2.4"
+upstream_family = "https://github.com/kyuz0/amd-strix-halo-toolboxes"
+upstream_ref = "unknown — inherited finding, see ../rocmfpx/manifest.toml"
+dnf_packages_pinned = false
+
+[source]
+#: Pristine ggml-org master, NOT a fork. Pinned to the exact commit the
+#: 2026-08-29 kyuz0 vulkan-radv toolbox build (llama.cpp build 10687)
+#: shipped and was binary-verified against on lxc105: `strings libllama`
+#: shows qwen4exp AND qwen35/qwen35moe, so this ref demonstrably loads both
+#: the new model and everything the fork-independent fleet runs.
+#: Contains #27742 (qwen4exp, merged 2026-08-27) and #27880 (correctness
+#: fixes, merged 2026-08-28).
+repo = "https://github.com/ggml-org/llama.cpp.git"
+ref = "c841aeeb8bb2fe417038dadfa9b007cf1a9ef950"
+ref_description = "opencl: use a better matmul path on two Adreno GPU generations (#27640)"
+#: Upstream vendors ggml in-tree at this ref, same as the fork; no
+#: submodule pointer hides a second unpinned input.
+submodules = false
+
+[build]
+#: Identical flag set to ../rocmfpx — that identity IS the preservation
+#: claim for the combined HIP+Vulkan property. If upstream has renamed or
+#: dropped a flag since the fork diverged, the cmake configure fails loudly
+#: on the build host; resolve by updating the flag HERE with a note, never
+#: by silently dropping a backend.
+gpu_arch = "gfx1151"
+cmake_flags = [
+    "-DGGML_HIP=ON",
+    "-DGGML_HIP_ROCWMMA_FATTN=OFF",
+    "-DGGML_HIP_FORCE_MMQ=ON",
+    "-DGGML_VULKAN=ON",
+    "-DGGML_CUDA=OFF",
+    "-DCMAKE_HIP_ARCHITECTURES=gfx1151",
+    "-DGPU_TARGETS=gfx1151",
+    "-DLLAMA_BUILD_SERVER=ON",
+    "-DLLAMA_BUILD_WEBUI=OFF",
+    "-DLLAMA_USE_PREBUILT_WEBUI=OFF",
+]
+
+#: No patches — the whole point of this variant. The fork patches target
+#: fork-only gaps (see FEATURE DELTA above); an empty series here is a
+#: statement, not an omission.

--- a/tests/packaging/test_upstream_recipe.py
+++ b/tests/packaging/test_upstream_recipe.py
@@ -1,0 +1,91 @@
+"""The upstream runner variant must ADD qwen4exp without LOSING anything.
+
+The variant exists because Qwen3.8-Flash-Next's `qwen4exp` architecture
+landed upstream (ggml-org/llama.cpp #27742, 2026-08-27) after the fork the
+default runner builds from last synced (charlie12345/ROCmFPX @ c49ebdbd,
+2026-08-22). The safe shape is a SECOND image from pristine upstream, pinned
+to a slot via `image_pin` — never a replacement of the default.
+
+Every preservation claim the variant's manifest makes is held here as an
+executable assertion against the rocmfpx recipe it claims to mirror:
+same base digest, same cmake flag set, shared build script and entrypoint.
+If either recipe drifts, the diff shows up as a red test naming the exact
+property lost — not as a slot that stops loading three weeks later.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from hal0.config.schema import DEFAULT_ROCMFPX_IMAGE
+
+RUNNER = Path(__file__).resolve().parents[2] / "packaging" / "runner"
+UPSTREAM = RUNNER / "upstream"
+ROCMFPX = RUNNER / "rocmfpx"
+
+MANIFEST = tomllib.loads((UPSTREAM / "manifest.toml").read_text(encoding="utf-8"))
+ROCMFPX_MANIFEST = tomllib.loads(
+    (ROCMFPX / "manifest.toml").read_text(encoding="utf-8")
+)
+
+
+def test_the_variant_is_not_the_shipped_default() -> None:
+    """The whole safety story: the default pin keeps the fork build with the
+    FPX quant formats and the minicpm5/lfm2.5 patches. If this tag ever equals
+    DEFAULT_ROCMFPX_IMAGE, the variant silently replaced the default and every
+    FPX-family model loses its runtime."""
+    assert MANIFEST["image"]["tag"] != DEFAULT_ROCMFPX_IMAGE
+    assert MANIFEST["image"]["tag"] != ROCMFPX_MANIFEST["image"]["tag"]
+
+
+def test_the_source_is_pristine_upstream_not_a_fork() -> None:
+    assert MANIFEST["source"]["repo"] == "https://github.com/ggml-org/llama.cpp.git"
+
+
+def test_the_source_ref_is_pinned_not_a_branch() -> None:
+    ref = MANIFEST["source"]["ref"]
+    assert ref not in ("main", "master", "HEAD"), ref
+    assert len(ref) == 40, f"pin the full 40-char sha, got {ref!r}"
+    assert all(c in "0123456789abcdef" for c in ref.lower()), ref
+
+
+def test_the_base_digest_is_byte_identical_to_the_default_recipe() -> None:
+    """Same base digest => same ROCm toolchain lineage in both images. The
+    variant's only intended variable is [source]; a base drift would mean two
+    toolchains on one box with one recipe claiming otherwise."""
+    assert MANIFEST["base"]["digest"] == ROCMFPX_MANIFEST["base"]["digest"]
+    assert MANIFEST["base"]["image"] == ROCMFPX_MANIFEST["base"]["image"]
+    assert (
+        MANIFEST["base"]["rocm_version"] == ROCMFPX_MANIFEST["base"]["rocm_version"]
+    )
+
+
+def test_the_cmake_flags_preserve_combined_hip_plus_vulkan() -> None:
+    """Flag-set identity IS the preservation claim for the combined image
+    property (both the rocmfpx and vulkanfpx lanes run one tag). Comparing as
+    sets against the default recipe means a flag dropped from either manifest
+    names itself in the diff."""
+    assert set(MANIFEST["build"]["cmake_flags"]) == set(
+        ROCMFPX_MANIFEST["build"]["cmake_flags"]
+    )
+    assert MANIFEST["build"]["gpu_arch"] == ROCMFPX_MANIFEST["build"]["gpu_arch"]
+
+
+def test_build_script_and_entrypoint_are_shared_not_copied() -> None:
+    """A copy drifts; a symlink cannot. The entrypoint carries the #1936 GPU
+    preflight and the #2037 exit-64 load-death translation — supervision
+    features the slot manager depends on regardless of which llama.cpp is
+    inside."""
+    for name in ("build.sh", "entrypoint.sh"):
+        link = UPSTREAM / name
+        assert link.is_symlink(), f"{name} must be a symlink into ../rocmfpx"
+        assert link.resolve() == (ROCMFPX / name).resolve()
+
+
+def test_the_patch_series_is_deliberately_empty() -> None:
+    """The fork patches target fork-only gaps (minicpm5, lfm2.5, the fork's
+    glslc race). Applying them to a tree they no longer match is how ports go
+    wrong; an entry appearing here deserves a review, not an auto-apply."""
+    assert not MANIFEST.get("patches"), "variant declares patches — see manifest header"
+    assert not list((UPSTREAM / "patches").glob("*.patch"))

--- a/tests/packaging/test_upstream_recipe.py
+++ b/tests/packaging/test_upstream_recipe.py
@@ -25,9 +25,7 @@ UPSTREAM = RUNNER / "upstream"
 ROCMFPX = RUNNER / "rocmfpx"
 
 MANIFEST = tomllib.loads((UPSTREAM / "manifest.toml").read_text(encoding="utf-8"))
-ROCMFPX_MANIFEST = tomllib.loads(
-    (ROCMFPX / "manifest.toml").read_text(encoding="utf-8")
-)
+ROCMFPX_MANIFEST = tomllib.loads((ROCMFPX / "manifest.toml").read_text(encoding="utf-8"))
 
 
 def test_the_variant_is_not_the_shipped_default() -> None:
@@ -56,9 +54,7 @@ def test_the_base_digest_is_byte_identical_to_the_default_recipe() -> None:
     toolchains on one box with one recipe claiming otherwise."""
     assert MANIFEST["base"]["digest"] == ROCMFPX_MANIFEST["base"]["digest"]
     assert MANIFEST["base"]["image"] == ROCMFPX_MANIFEST["base"]["image"]
-    assert (
-        MANIFEST["base"]["rocm_version"] == ROCMFPX_MANIFEST["base"]["rocm_version"]
-    )
+    assert MANIFEST["base"]["rocm_version"] == ROCMFPX_MANIFEST["base"]["rocm_version"]
 
 
 def test_the_cmake_flags_preserve_combined_hip_plus_vulkan() -> None:
@@ -66,9 +62,7 @@ def test_the_cmake_flags_preserve_combined_hip_plus_vulkan() -> None:
     property (both the rocmfpx and vulkanfpx lanes run one tag). Comparing as
     sets against the default recipe means a flag dropped from either manifest
     names itself in the diff."""
-    assert set(MANIFEST["build"]["cmake_flags"]) == set(
-        ROCMFPX_MANIFEST["build"]["cmake_flags"]
-    )
+    assert set(MANIFEST["build"]["cmake_flags"]) == set(ROCMFPX_MANIFEST["build"]["cmake_flags"])
     assert MANIFEST["build"]["gpu_arch"] == ROCMFPX_MANIFEST["build"]["gpu_arch"]
 
 


### PR DESCRIPTION
Sibling recipe producing `ghcr.io/hal0ai/hal0-combined-upstream:0829` — pristine `ggml-org/llama.cpp @ c841aeeb8` (carries qwen4exp #27742 + correctness fixes #27880) on the byte-identical base digest and cmake flag set of the default rocmfpx recipe, with `build.sh`/`entrypoint.sh` shared via symlinks so the #1936 GPU preflight and #2037 exit-64 supervision cannot drift. No patches on purpose: the fork's series targets fork-only gaps.

The default image, `DEFAULT_ROCMFPX_IMAGE`, and every existing slot are untouched — the variant is reached only through a slot's `image_pin`. `tests/packaging/test_upstream_recipe.py` (7 assertions) makes each preservation claim executable: variant tag ≠ shipped default, base/flags identity with the rocmfpx manifest, shared-symlink build script and entrypoint, deliberately empty patch series.

Context and retirement plan: #2118. Single-image port was measured and declined: cherry-picking qwen4exp onto the fork conflicts in 14 files / 38 hunks with structural kv-cache API drift.

Image is built (devops box, llama.cpp build 10687), pushed, catalogued (`combined-upstream` in Hal0ai/hal0-runner-images @ `bde62f9c`), and pull-verified end-to-end on lxc105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfrTQYNegDmrAguRhQemSm