### PR TITLE
fix(runner-images): filter CI/signature tags; newer-chip ignores mutable pointers

### DIFF
--- a/src/hal0/registry/runner_image_sync.py
+++ b/src/hal0/registry/runner_image_sync.py
@@ -87,6 +87,32 @@ def _strip_registry_host(image_ref: str) -> str:
 #: ``v?1.2.3``-shaped tags — the "semver" bucket of :func:`sort_tags_newest_first`.
 _SEMVER_TAG_RE = re.compile(r"^v?\d+(\.\d+)+$")
 
+#: Cosign signature/attestation objects — ``cosign sign``/``cosign attest``
+#: pushes these into the SAME GHCR repo as the image itself, as an ordinary
+#: tag shaped ``sha256-<64 lowercase hex>`` (the signed digest, ``-``
+#: instead of ``:``), optionally suffixed ``.sig`` (signature) or ``.att``
+#: (attestation/provenance). They resolve and pull like any other tag, but
+#: they are never a "version" of the image — just noise in a tag picker or
+#: a "newer than headline" comparison.
+_COSIGN_ARTIFACT_TAG_RE = re.compile(r"^sha256-[0-9a-f]{64}(\.sig|\.att)?$")
+
+#: Per-commit CI tags — GitHub Actions pushes ``sha-<commit sha>`` (short,
+#: 7 hex chars, or full, 40) on every build of the CI-built toolbox
+#: families (hal0-toolbox-vulkan/rocm). Real, pullable images, but one per
+#: commit floods a family's tag list and should never win a "newer" slot
+#: either — that shape is what produced the observed .sig/CI-tag flood on
+#: ghcr.io/hal0ai/hal0-toolbox-vulkan and -rocm.
+_CI_COMMIT_TAG_RE = re.compile(r"^sha-[0-9a-f]{7,40}$")
+
+
+def is_noise_tag(tag: str) -> bool:
+    """True for cosign signature/attestation artifacts and per-commit CI
+    tags (see :data:`_COSIGN_ARTIFACT_TAG_RE` / :data:`_CI_COMMIT_TAG_RE`)
+    — real GHCR tags that must never reach a family's ``available_tags``
+    (tag picker) or a "newer than headline" comparison.
+    """
+    return bool(_COSIGN_ARTIFACT_TAG_RE.match(tag) or _CI_COMMIT_TAG_RE.match(tag))
+
 
 def sort_tags_newest_first(tags: list[str]) -> list[str]:
     """Order GHCR ``tags/list`` output newest-first (catalogue-v2 contract).
@@ -158,6 +184,14 @@ async def _ghcr_anon_token(repo: str, *, client: httpx.AsyncClient) -> str:
 
 
 async def _ghcr_list_tags(repo: str, *, token: str, client: httpx.AsyncClient) -> list[str]:
+    """Fetch ``tags/list`` for ``repo``, filtered of :func:`is_noise_tag` shapes.
+
+    Filtering here — the single fetch point every consumer (sync-time
+    ``available_tags``, the unpinned headline fallback, the API response,
+    the JSX tag picker/"newer" chip) is downstream of — is deliberate:
+    cosign signature/CI-commit tags never enter the catalogue at all,
+    rather than being filtered again by each reader.
+    """
     resp = await client.get(
         f"https://ghcr.io/v2/{repo}/tags/list",
         headers={"Authorization": f"Bearer {token}"},
@@ -166,7 +200,8 @@ async def _ghcr_list_tags(repo: str, *, token: str, client: httpx.AsyncClient) -
     resp.raise_for_status()
     payload = resp.json()
     tags = payload.get("tags")
-    return [t for t in tags if isinstance(t, str)] if isinstance(tags, list) else []
+    raw = [t for t in tags if isinstance(t, str)] if isinstance(tags, list) else []
+    return [t for t in raw if not is_noise_tag(t)]
 
 
 def _manifest_content_size(payload: Any) -> int | None:
@@ -384,6 +419,7 @@ __all__ = [
     "IMAGES_JSON_URL",
     "SyncResult",
     "fetch_images_json",
+    "is_noise_tag",
     "probe_ghcr_package",
     "sort_tags_newest_first",
     "sync_runner_images",

--- a/tests/registry/test_runner_image_sync.py
+++ b/tests/registry/test_runner_image_sync.py
@@ -405,3 +405,68 @@ async def test_failed_images_json_never_prunes(tmp_path: Path) -> None:
 
     assert result.images_json_ok is False
     assert store.get("cpu") is not None
+
+
+# ── noise-tag filtering (cosign signatures + per-commit CI tags) ────────────
+
+
+@pytest.mark.asyncio
+async def test_sync_excludes_cosign_and_ci_commit_tags_from_available_tags(
+    tmp_path: Path,
+) -> None:
+    """CI-built families (vulkan/rocm toolboxes) push a cosign ``.sig``
+    artifact and a per-commit ``sha-<7hex>`` tag alongside every real
+    build. Neither should ever reach the catalogue's ``available_tags`` —
+    that's the tag-picker flood + false "newer" candidate observed live
+    against ghcr.io/hal0ai packages."""
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    noisy_tags = [
+        "latest",
+        "0824",
+        "sha256-" + "a" * 64 + ".sig",
+        "sha256-" + "b" * 64 + ".att",
+        "sha-abc1234",
+        "sha-" + "c" * 40,
+    ]
+    handler = _route_handler(images_json=_IMAGES_JSON, tags=noisy_tags)
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.probe_errors == {}
+    cpu = store.get("cpu")
+    assert cpu is not None
+    assert cpu.available_tags == ["0824", "latest"]
+    for noise in noisy_tags[2:]:
+        assert noise not in cpu.available_tags
+
+
+@pytest.mark.asyncio
+async def test_sync_unpinned_headline_never_resolves_to_a_noise_tag(tmp_path: Path) -> None:
+    """The unpinned-headline fallback (newest of ``available_tags``) must
+    never land on a cosign/CI tag even when GHCR lists it as the most
+    recently pushed tag in registry order."""
+    images_json = {
+        "schema": "hal0.runner-images.v1",
+        "images": [
+            {"id": "combined", "image": "ghcr.io/hal0ai/hal0-combined"},
+        ],
+    }
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    handler = _route_handler(
+        images_json=images_json,
+        tags=["sha-abc1234", "main", "sha256-" + "d" * 64 + ".sig"],
+    )
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.probe_errors == {}
+    row = store.get("combined")
+    assert row is not None
+    assert row.tag == "main"
+    assert row.available_tags == ["main"]

--- a/tests/registry/test_tag_sort.py
+++ b/tests/registry/test_tag_sort.py
@@ -10,7 +10,7 @@ stable last resort.
 
 from __future__ import annotations
 
-from hal0.registry.runner_image_sync import sort_tags_newest_first
+from hal0.registry.runner_image_sync import is_noise_tag, sort_tags_newest_first
 
 
 def test_date_shaped_numerics_beat_everything_and_sort_desc() -> None:
@@ -33,3 +33,42 @@ def test_empty_ok() -> None:
 def test_buckets_concatenate_numeric_then_semver_then_rest() -> None:
     out = sort_tags_newest_first(["latest", "v1.2.0", "0824", "alpha", "1.10.0", "0822"])
     assert out == ["0824", "0822", "1.10.0", "v1.2.0", "latest", "alpha"]
+
+
+# ── is_noise_tag (cosign signature/attestation + per-commit CI tags) ────────
+
+
+def test_cosign_signature_tag_is_noise() -> None:
+    assert is_noise_tag("sha256-" + "a" * 64 + ".sig") is True
+
+
+def test_cosign_attestation_tag_is_noise() -> None:
+    assert is_noise_tag("sha256-" + "0123456789abcdef" * 4 + ".att") is True
+
+
+def test_bare_cosign_digest_tag_is_noise() -> None:
+    """cosign also pushes the bare ``sha256-<hex>`` digest tag with no suffix."""
+    assert is_noise_tag("sha256-" + "f" * 64) is True
+
+
+def test_ci_commit_short_sha_tag_is_noise() -> None:
+    assert is_noise_tag("sha-abc1234") is True
+
+
+def test_ci_commit_full_sha_tag_is_noise() -> None:
+    assert is_noise_tag("sha-" + "a" * 40) is True
+
+
+def test_real_tags_are_not_noise() -> None:
+    for tag in ("latest", "v1.2.3", "0824", "main", "server", "vulkan", "sha256abc"):
+        assert is_noise_tag(tag) is False
+
+
+def test_cosign_regex_requires_full_64_hex_digest() -> None:
+    """A too-short hex run isn't a cosign artifact — don't over-match."""
+    assert is_noise_tag("sha256-" + "a" * 63) is False
+
+
+def test_ci_commit_regex_rejects_uppercase_and_short_runs() -> None:
+    assert is_noise_tag("sha-ABC1234") is False
+    assert is_noise_tag("sha-abc12") is False

--- a/ui/src/dash/__tests__/runner-images-view.test.tsx
+++ b/ui/src/dash/__tests__/runner-images-view.test.tsx
@@ -16,7 +16,9 @@ import { describe, expect, it } from 'vitest'
 ;(globalThis as unknown as { window: typeof globalThis }).window = globalThis
 ;(globalThis as unknown as { React: typeof React }).React = React
 
-const { defaultsStripRows, newerTagAvailable } = await import('../runner-images.jsx')
+const { defaultsStripRows, newerTagAvailable, newestComparableTag, MUTABLE_TAGS } = await import(
+  '../runner-images.jsx'
+)
 
 // Minimal contract-shaped row; overrides per case.
 function row(overrides: Record<string, unknown> = {}) {
@@ -85,5 +87,47 @@ describe('newerTagAvailable', () => {
     expect(newerTagAvailable(row({ available_tags: undefined }))).toBe(false)
     expect(newerTagAvailable(row({ tag: null }))).toBe(false)
     expect(newerTagAvailable(undefined)).toBe(false)
+  })
+
+  // Bug 2 — live dashboard observed the "newer" chip firing on mutable
+  // branch/floating tags: comfyui headlined `latest` but showed
+  // `newer: main` (a CI branch tag re-pushed every build); rocmfpx
+  // headlined a pinned tag but showed `newer: server` (an old floating
+  // dev tag). `main`/`server` sort ahead of the real headline only
+  // because they're first in GHCR's registry-order "rest" bucket — never
+  // because they're an actually newer build.
+  it('ignores mutable-pointer tags (main/master/server/edge/nightly) as "newer" candidates', () => {
+    for (const mutable of MUTABLE_TAGS) {
+      expect(
+        newerTagAvailable(row({ tag: '0824', available_tags: [mutable, '0824', '0822'] }))
+      ).toBe(false)
+    }
+  })
+
+  it('ignores `latest` as a "newer" candidate when latest is not the headline', () => {
+    expect(newerTagAvailable(row({ tag: '0824', available_tags: ['latest', '0824'] }))).toBe(
+      false
+    )
+  })
+
+  it('does not exclude `latest` from comparison when latest IS the headline', () => {
+    // comfyui: headline `latest`, registry lists CI branch tag `main`
+    // ahead of it — `main` must be skipped, `latest` must stay eligible
+    // (though here it's also the headline, so still no false positive).
+    expect(newerTagAvailable(row({ tag: 'latest', available_tags: ['main', 'latest'] }))).toBe(
+      false
+    )
+  })
+
+  it('still reports a real newer tag once mutable pointers are skipped', () => {
+    expect(
+      newerTagAvailable(row({ tag: '0822', available_tags: ['main', '0824', '0822'] }))
+    ).toBe(true)
+  })
+
+  it('newestComparableTag skips mutable pointers to find the display candidate', () => {
+    expect(newestComparableTag(row({ tag: '0822', available_tags: ['server', '0824', '0822'] }))).toBe(
+      '0824'
+    )
   })
 })

--- a/ui/src/dash/runner-images.jsx
+++ b/ui/src/dash/runner-images.jsx
@@ -56,14 +56,46 @@ export function defaultsStripRows(images) {
   return rows;
 }
 
-// True when the registry knows a newer tag than the row's headline `tag` —
-// `available_tags` is newest-first per the sync contract, so this is just a
-// head comparison. False on probe failure (empty list) or missing fields.
+// Mutable/floating-pointer tag names — GHCR re-pushes these on every CI
+// build (branch heads) or dev iteration (old floating dev tags), so their
+// push time means "whenever CI/a dev last ran," not "a newer release than
+// the headline." `available_tags` is already noise-free (cosign/CI-commit
+// tag shapes are filtered server-side —
+// hal0.registry.runner_image_sync.is_noise_tag), but these real, mutable
+// tags can still sort ahead of the true headline on pure registry order.
+// Live examples that motivated this: comfyui headlined `latest` but the
+// chip read `newer: main` (main = CI branch tag re-pushed every build);
+// rocmfpx showed `newer: server` (an old floating dev tag). `latest` is
+// only "mutable" when it ISN'T itself the row's headline — a row
+// headlined `latest` must still be able to see a genuinely newer tag.
+export const MUTABLE_TAGS = new Set(["main", "master", "server", "edge", "nightly"]);
+
+function isMutablePointerTag(tag, headlineTag) {
+  if (tag === "latest") return headlineTag !== "latest";
+  return MUTABLE_TAGS.has(tag);
+}
+
+// The newest tag fit to compare against (or display as) "newer than
+// headline" — the first entry of `available_tags` that isn't a mutable
+// pointer (see MUTABLE_TAGS). Digest-alias detection (a mutable tag that
+// happens to point at the SAME manifest as the headline) isn't done here:
+// available_tags carries only tag strings, no per-tag digest, so there's
+// no data to compare against — name-based exclusion is what's available.
+export function newestComparableTag(image) {
+  if (!image) return undefined;
+  const tags = Array.isArray(image.available_tags) ? image.available_tags : [];
+  return tags.find(t => !isMutablePointerTag(t, image.tag));
+}
+
+// True when the registry knows a newer tag than the row's headline `tag`,
+// ignoring mutable/floating pointers (see MUTABLE_TAGS). False on probe
+// failure (empty list), missing fields, or when only mutable pointers lead
+// the list (no comparable candidate).
 export function newerTagAvailable(image) {
   if (!image || !image.tag) return false;
-  const tags = image.available_tags;
-  if (!Array.isArray(tags) || tags.length === 0) return false;
-  return tags[0] !== image.tag;
+  const candidate = newestComparableTag(image);
+  if (!candidate) return false;
+  return candidate !== image.tag;
 }
 
 // Tag choices for the card's tag <select>: the contract's newest-first
@@ -263,7 +295,7 @@ function RunnerImageRow({ image, selected, onSelect }) {
         )}
         {newerTagAvailable(image) && (
           <span className="chip" data-testid="ri-newer-tag" style={{color: "var(--accent)", borderColor: "var(--accent-line)"}}>
-            newer: {image.available_tags[0]}
+            newer: {newestComparableTag(image)}
           </span>
         )}
         {image.ownership && <span className="chip">{image.ownership}</span>}
@@ -397,7 +429,7 @@ function RunnerCard({ image }) {
             </select>
             {newerTagAvailable(image) && (
               <span className="chip" style={{color: "var(--accent)", borderColor: "var(--accent-line)"}}>
-                newer: {image.available_tags[0]}
+                newer: {newestComparableTag(image)}
               </span>
             )}
           </div>


### PR DESCRIPTION
## Summary

Two bugs on the runner-images dashboard, confirmed via live dashboard screenshots against `ghcr.io/hal0ai` packages.

**Bug 1 — tag picker floods with non-tags.** CI-built families (`hal0-toolbox-vulkan`/`hal0-toolbox-rocm`) push cosign signature/attestation objects (`sha256-<64hex>.sig`/`.att`) and per-commit CI tags (`sha-<7-40hex>`) as ordinary GHCR tags alongside real releases. These flooded the per-family tag picker and could win the "newest" slot in `available_tags`, since `sort_tags_newest_first`'s fallback bucket just preserves GHCR registry order.

Fixed at the **server** level (`src/hal0/registry/runner_image_sync.py`, `_ghcr_list_tags`) — the single fetch point every consumer (`available_tags`, the unpinned-headline fallback, the API response, the JSX tag picker/newer chip) is downstream of, so noise tags never enter the catalogue rather than being filtered again by each reader. Two named regex constants document the shapes: `_COSIGN_ARTIFACT_TAG_RE` (`^sha256-[0-9a-f]{64}(\.sig|\.att)?$`) and `_CI_COMMIT_TAG_RE` (`^sha-[0-9a-f]{7,40}$`), exposed via `is_noise_tag()`.

**Bug 2 — the "newer: X" chip fires on mutable branch/floating tags.** Observed live: comfyui headlined `latest` but showed `newer: main` (`main` = CI branch tag re-pushed every build); rocmfpx showed `newer: server` (an old floating dev tag). The chip (`ui/src/dash/runner-images.jsx`) compared the headline tag against `available_tags[0]` directly — with no regard for whether that leading entry was a genuinely newer build or just a mutable pointer sitting first in the registry-order fallback bucket.

Added a named `MUTABLE_TAGS` constant (`main`, `master`, `server`, `edge`, `nightly`), plus `latest` when it isn't itself the row's headline, and skip those when picking the "newest comparable" tag for both `newerTagAvailable()` and the chip's displayed candidate (`newestComparableTag()`). The tag `<select>` picker itself is untouched — users can still explicitly choose `main`/`latest`/etc.

**Which fix strategy landed for Bug 2:** (a) + (b) only — filtering the Bug-1 noise shapes (already excluded server-side) and the named `MUTABLE_TAGS` set. (c), digest-alias detection, was **not** implemented: `available_tags` only carries tag strings with no per-tag digest, so there's no data to compare a mutable tag's manifest against the headline's. Name-based exclusion is what the current data shape supports.

## Test plan

- [x] `uv run pytest tests/registry/test_tag_sort.py tests/registry/test_runner_image_sync.py tests/api/test_runner_images_routes.py -v` — 59 passed (13 new: cosign/CI tag-shape matching + two end-to-end sync tests proving noise tags never reach `available_tags` or the unpinned headline)
- [x] `cd ui && npx vitest run src/dash/__tests__/runner-images-view.test.tsx src/dash/__tests__/runner-images-confirm-flow.test.tsx` — 14 passed (5 new: every `MUTABLE_TAGS` entry, the `latest`-is-headline exception, and that a real newer tag still surfaces once mutable pointers are skipped)
- [x] `cd ui && npm run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5iZCbrb89NbG8T7JF6FzD