### PR TITLE
feat(runners): ship the promptforge manifest digest pin (#1891 gate passed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,10 @@ full detail in the
 
 ### Added
 
+- PromptForge runner digest pin: the #1891 ct150 gate passed (2026-08-30),
+  so `manifest.json.toolbox_images.promptforge` now ships the gate-validated
+  digest and the promptforge runner's `manifest_key` resolves it. Optional
+  runner only — the AMD default (`DEFAULT_ROCMFPX_IMAGE`) is untouched.
 - Bench: opt-in `promptforge` lane (`--backends promptforge`) — benches the
   HIP-only PromptForge runner image at its own `/opt/promptforge/bin/
   llama-bench`. Never part of a default sweep: the image serves one model

--- a/manifest.json
+++ b/manifest.json
@@ -40,6 +40,11 @@
       "tag": "ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1",
       "digest": "sha256:748774babc8bd9b83da4c437d09311bbcbd279f0328d1a9f5b419e70ca2a036c",
       "_notes": "Qwen3-TTS-12Hz-1.7B-CustomVoice multilingual GPU TTS (ROCm); OpenAI-compat /v1/audio/speech. Digest pinned from the CI push via .github/workflows/toolbox.yml; refresh with scripts/update-toolbox-digests.sh."
+    },
+    "promptforge": {
+      "tag": "ghcr.io/hal0ai/hal0-promptforge:v2.3-qwen38",
+      "digest": "sha256:370af6e9717e8c96742198a4b920888e6a248d447e21e3432de4d2c913703aea",
+      "_notes": "PromptForge/ActiveFPX runner (HIP-only, GGML_VULKAN=OFF) for jcbtc Qwen3.8 CIRU distributions — OPTIONAL runner, never the AMD default. Digest is the exact image the #1891 ct150 gate validated 2026-08-30 (Paris + HumanEval+ 0.939/0.909 + MTP depth-4 ~86% acceptance; report in /mnt/mintdev/artifacts/). Tracked recipe: packaging/runner/promptforge/. Same digest pinned in Hal0ai/hal0-runner-images images.json."
     }
   },
   "_legacy_toolboxes": {

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1032,18 +1032,20 @@ DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-combined:0826"
 #: ``DEFAULT_PROMPTFORGE_IMAGE`` — the PromptForge-flavor runner (HIP-only
 #: build of ciru-ai/ROCmFPX v2.3 + the card's runtime patch; GGML_VULKAN=OFF,
 #: so it can never be the same image as DEFAULT_ROCMFPX_IMAGE — see #1946
-#: item 4 and spec 2026-08-29). Candidate tag until the ct150 validation
-#: gate (#1891) passes; the pin only moves operator-gated.
+#: item 4 and spec 2026-08-29).
 #:
-#: DELIBERATELY ABSENT from ``manifest.json``'s ``toolbox_images`` (fix wave,
-#: I3): the image isn't built yet, so the entry could only carry
-#: ``"digest": null`` — which is exactly what ``scripts/release-check.sh``
-#: step 4 hard-fails on ("manifest.json has unpinned toolbox image(s)"), and
-#: it buys nothing: ``manifest_image_ref()`` with a null digest falls through
-#: to the tag, which is byte-identical to this constant, so
-#: ``resolve_runner_image`` resolves the same string either way. The manifest
-#: entry gets ADDED, with a real digest, at the #1891 ct150 gate — the
-#: sequencing the spec's own image-build workstream already specifies.
+#: GATE PASSED: the #1891 ct150 validation ran 2026-08-30 (report at
+#: /mnt/mintdev/artifacts/hal0-promptforge-gate-report-2026-08-30.md,
+#: results on #1946) — Paris probe, HumanEval+ 0.939/0.909 with the card's
+#: disclosed task-130 regression reproducing exactly, MTP depth-4 at ~86%
+#: acceptance (+75% decode vs MTP-off). ``manifest.json``'s
+#: ``toolbox_images.promptforge`` now carries the gate-validated digest
+#: (sha256:370af6e9…) and the promptforge Runner's ``manifest_key`` points
+#: at it, so installs resolve the digest pin; this tag constant is the
+#: bundled fallback and stays in lockstep with the manifest entry (pinned by
+#: tests/runners/test_registry.py). promptforge is an OPTIONAL runner by
+#: operator decision — never the AMD default; DEFAULT_ROCMFPX_IMAGE above
+#: is untouched by any of this.
 DEFAULT_PROMPTFORGE_IMAGE = "ghcr.io/hal0ai/hal0-promptforge:v2.3-qwen38"
 
 #: Historical DEFAULT_ROCMFPX_IMAGE values (and their pre-consolidation

--- a/src/hal0/runners/__init__.py
+++ b/src/hal0/runners/__init__.py
@@ -39,7 +39,9 @@ carry ``manifest_key=None`` (env override still applies; the manifest tier
 is simply skipped, exactly matching the OLD :func:`resolve_default_image`
 behaviour, which never consulted the manifest either). ``flm`` / ``kokoro``
 / ``qwen3tts`` / ``comfyui`` DO have real, correctly-corresponding manifest
-keys and are wired accordingly.
+keys and are wired accordingly — and ``promptforge`` joined them once the
+#1891 ct150 gate passed (2026-08-30): its manifest entry was created fresh
+for this image lineage, so the wrong-lineage trap above does not apply.
 """
 
 from __future__ import annotations
@@ -151,12 +153,16 @@ RUNNER_IMAGES: dict[str, Runner] = {
         RunnerSupports(mtp=True, jinja=True, mmproj=True, specialties=("promptforge",)),
         "gpu",
         "rocm",
-        # manifest_key=None until the CANDIDATE image passes the #1891 gate
-        # and actually ships in manifest.json's toolbox_images — same
-        # doctrine as rocmfpx/vulkanfpx above: a key pointing at a manifest
-        # entry that doesn't exist yet would either fail the registry test
-        # or, worse, silently pin to whatever lands under that key later.
-        None,
+        # Real key as of the #1891 ct150 gate PASS (2026-08-30, report at
+        # /mnt/mintdev/artifacts/hal0-promptforge-gate-report-2026-08-30.md):
+        # manifest.json's toolbox_images.promptforge now exists and carries
+        # the exact digest the gate validated, so — unlike rocmfpx/vulkanfpx,
+        # whose manifest keys would resolve a DIFFERENT lineage (module
+        # docstring) — this key points at the same image this Runner's
+        # bundled tag names. promptforge remains an OPTIONAL runner either
+        # way (operator decision on #1946): a slot gets this image only by
+        # selecting this runner; nothing here touches the AMD default.
+        "promptforge",
         supported_backends=("rocm",),  # HIP-only build: deliberately NOT
         # vulkan — the existing (device, BINARY) fit-check refuses a
         # gpu-vulkan pairing with no new code.

--- a/tests/runners/test_registry.py
+++ b/tests/runners/test_registry.py
@@ -145,3 +145,18 @@ def test_rocm_and_vulkan_fpx_share_supported_backends() -> None:
     device — not BINARY — disambiguates (spec-hw-slot-ownership §2/§4)."""
     assert RUNNER_IMAGES["rocmfpx"].supported_backends == ("rocm", "vulkan")
     assert RUNNER_IMAGES["vulkanfpx"].supported_backends == ("rocm", "vulkan")
+
+
+def test_promptforge_shipped_pin_matches_the_gate_digest() -> None:
+    """The shipped manifest entry IS the #1891 gate evidence made durable:
+    tag must stay in lockstep with DEFAULT_PROMPTFORGE_IMAGE, and the digest
+    must be the exact image the ct150 gate validated (report
+    2026-08-30, hal0-runner-images images.json pins the same digest)."""
+    from hal0.config.schema import DEFAULT_PROMPTFORGE_IMAGE
+
+    manifest = json.loads((_REPO_ROOT / "manifest.json").read_text(encoding="utf-8"))
+    entry = manifest["toolbox_images"]["promptforge"]
+    assert entry["tag"] == DEFAULT_PROMPTFORGE_IMAGE
+    assert entry["digest"] == (
+        "sha256:370af6e9717e8c96742198a4b920888e6a248d447e21e3432de4d2c913703aea"
+    )

--- a/tests/runners/test_resolve_image.py
+++ b/tests/runners/test_resolve_image.py
@@ -124,3 +124,24 @@ def test_manifest_tier_applies_to_every_manifest_backed_runner(
     )
     resolved = resolve_runner_image(runner)
     assert resolved.endswith(f"@{digest}")
+
+
+def test_promptforge_manifest_digest_pin_resolves(tmp_hal0_home: str) -> None:
+    """Post-#1891: promptforge carries a REAL manifest_key (unlike
+    rocmfpx/vulkanfpx, whose manifest keys would point at the wrong lineage —
+    see the module docstring). A shipped manifest entry must therefore win
+    over the bundled tag default."""
+    runner = get_runner("promptforge")
+    assert runner.manifest_key == "promptforge"
+    _write_manifest(
+        tmp_hal0_home,
+        {
+            "toolbox_images": {
+                "promptforge": {
+                    "tag": "ghcr.io/hal0ai/hal0-promptforge:v2.3-qwen38",
+                    "digest": "sha256:" + "c" * 64,
+                }
+            }
+        },
+    )
+    assert resolve_runner_image(runner) == f"ghcr.io/hal0ai/hal0-promptforge@sha256:{'c' * 64}"

--- a/tests/runners/test_specialty_runner.py
+++ b/tests/runners/test_specialty_runner.py
@@ -8,10 +8,10 @@ def test_promptforge_runner_registered():
     assert r.backend == "rocm"
     assert r.supported_backends == ("rocm",)  # HIP-only: no vulkan
     assert r.format_arch == "gguf"
-    # None until the CANDIDATE image passes the #1891 gate and ships in
-    # manifest.json's toolbox_images (test_registry enforces that a set key
-    # actually exists there).
-    assert r.manifest_key is None
+    # Real key since the #1891 ct150 gate passed (2026-08-30): the image
+    # ships in manifest.json's toolbox_images with the gate-validated digest
+    # (test_registry enforces both existence and the exact digest).
+    assert r.manifest_key == "promptforge"
     assert r.supports.specialties == ("promptforge",)
     assert r.supports.mtp is True
 


### PR DESCRIPTION
The ct150 gate passed 2026-08-30 (report: `/mnt/mintdev/artifacts/hal0-promptforge-gate-report-2026-08-30.md`, results on #1946): Paris probe green, HumanEval+ 0.939/0.909 (card's disclosed task-130 regression reproduces exactly — fingerprint match), MTP depth-4 ~86% acceptance (+75% decode vs MTP-off).

**What ships:**
- `manifest.json.toolbox_images.promptforge` with the gate-validated digest `sha256:370af6e9…` (same digest hal0-runner-images images.json pins) — re-added exactly as the original fix-wave note specified (real digest, at the gate).
- promptforge Runner `manifest_key="promptforge"` — installs resolve the digest pin; the schema tag constant stays the bundled fallback.
- `test_registry` pins tag/digest lockstep (exact digest asserted); resolve-path test added; stale pre-gate comments updated.

**Not a default change:** promptforge remains an OPTIONAL runner (operator decision on #1946) — `DEFAULT_ROCMFPX_IMAGE` and all default resolution untouched. Verified: tests/runners + tests/release + tests/config + tests/registry green (1397 passed), ruff clean.

Closes #1946 post-gate items 1+2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCyXUDGyH3gfUPBMdYMa4W