### PR TITLE
feat(registry): admit the promptforge mode envs (#1891 gate evidence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,10 @@ full detail in the
 
 ### Added
 
+- PromptForge mode envs live: `SPECIALTY_KINDS["promptforge"].mode_env` now
+  carries the card's four validated values (non-IU4/no-ngram profile), so
+  accelerated launches synthesize the full gated env. Admitted by the #1891
+  ct150 gate (2026-08-30).
 - PromptForge runner digest pin: the #1891 ct150 gate passed (2026-08-30),
   so `manifest.json.toolbox_images.promptforge` now ships the gate-validated
   digest and the promptforge runner's `manifest_key` resolves it. Optional

--- a/src/hal0/registry/specialty.py
+++ b/src/hal0/registry/specialty.py
@@ -71,8 +71,21 @@ SPECIALTY_KINDS: dict[str, SpecialtyKind] = {
                 required=False,
             ),
         ),
-        # Card's mode envs ride here once validated on ct150; empty until then.
-        mode_env={},
+        # Card-verbatim mode envs, admitted by the #1891 ct150 gate
+        # (2026-08-30; report at
+        # /mnt/mintdev/artifacts/hal0-promptforge-gate-report-2026-08-30.md,
+        # results on #1946). These exact four values ran the whole gate:
+        # temp-0 Paris probe green, HumanEval+ 0.939/0.909 with the card's
+        # disclosed task-130 regression reproducing precisely, MTP depth-4 at
+        # ~86% draft acceptance (+75% decode vs MTP-off). The non-IU4 /
+        # no-ngram qualified profile — the IU4/ngram env family stays out by
+        # design (the card qualifies only this combination).
+        mode_env={
+            "PROMPTFORGE_MODE": "m2048_fused_tail1476",
+            "PROMPTFORGE_ENABLE_SMALLM_W8": "1",
+            "PROMPTFORGE_MTP_OUTPUT_K8": "1",
+            "PROMPTFORGE_MTP_OUTPUT_K8_VALIDATE": "0",
+        },
         degraded_ok=True,
         default_ctx=262_144,
         argv_profile="promptforge",

--- a/tests/registry/test_specialty.py
+++ b/tests/registry/test_specialty.py
@@ -101,3 +101,34 @@ class TestKindForRole:
     def test_maps_role_back_to_kind(self):
         assert kind_for_role("promptforge_ffn").key == "promptforge"
         assert kind_for_role("mmproj") is None
+
+
+class TestModeEnv:
+    """The card's mode envs, admitted by the #1891 ct150 gate (2026-08-30).
+
+    These four values ran the entire gate — Paris probe, the HumanEval+
+    panel, and the MTP acceptance runs — exactly as recorded in the gate
+    report; the values are card-verbatim and must never drift from it.
+    """
+
+    def test_promptforge_mode_env_is_the_gated_card_set(self):
+        kind = SPECIALTY_KINDS["promptforge"]
+        assert dict(kind.mode_env) == {
+            "PROMPTFORGE_MODE": "m2048_fused_tail1476",
+            "PROMPTFORGE_ENABLE_SMALLM_W8": "1",
+            "PROMPTFORGE_MTP_OUTPUT_K8": "1",
+            "PROMPTFORGE_MTP_OUTPUT_K8_VALIDATE": "0",
+        }
+
+    def test_mode_env_rides_along_in_specialty_env_for(self):
+        from hal0.registry.specialty import specialty_env_for
+
+        env = specialty_env_for(
+            {
+                "specialty": "promptforge",
+                "companions": {"promptforge_ffn": "/models/x-FFN.pfs"},
+            }
+        )
+        assert env["PROMPTFORGE_SIDECAR"] == "/models/x-FFN.pfs"
+        assert env["PROMPTFORGE_MODE"] == "m2048_fused_tail1476"
+        assert env["PROMPTFORGE_MTP_OUTPUT_K8_VALIDATE"] == "0"


### PR DESCRIPTION
Stacked on #2132 (shows its commit until that merges; will rebase after).

The four card-verbatim mode envs enter `SPECIALTY_KINDS["promptforge"].mode_env`, now that the ct150 gate validated them on real silicon (2026-08-30 — report at `/mnt/mintdev/artifacts/hal0-promptforge-gate-report-2026-08-30.md`, results on #1946):

```
PROMPTFORGE_MODE=m2048_fused_tail1476
PROMPTFORGE_ENABLE_SMALLM_W8=1
PROMPTFORGE_MTP_OUTPUT_K8=1
PROMPTFORGE_MTP_OUTPUT_K8_VALIDATE=0
```

These exact values ran the whole gate: Paris green, HumanEval+ 0.939/0.909 (task-130 regression reproduces exactly as the card discloses), MTP depth-4 ~86% acceptance, +75% decode vs MTP-off. Accelerated launches synthesize the full gated env through the existing `specialty_env_for` path — no consumer changes. IU4/ngram family stays out (card qualifies only non-IU4/no-ngram).

TDD: 2 red tests first (exact env set + ride-along through `specialty_env_for`); tests/registry + specialty guard + ctx surfaces green (499 passed).

Closes #1946 post-gate item 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCyXUDGyH3gfUPBMdYMa4W