### PR TITLE
feat(runner-images): privileged pull + disk-reclaim delete (v3 phase 4, D1a/D2)

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -336,15 +336,18 @@ config with `auth_style = "google_query"` still loads: it's coerced to `bearer` 
 
 ## `hal0 runner-images` — manage the runner-image catalogue
 
-Talks to the runner-image store/sync/pull service layer directly (not the
-API), so `ls` keeps working even when `hal0-api` is down. `rm` is
-deliberately absent pending a delete-story spec.
+Talks to the runner-image store/sync/pull/rm service layer directly (not
+the API), so `ls` keeps working even when `hal0-api` is down. `rm` mirrors
+`DELETE /api/runner-images/{id}/tags/{tag}`'s guard order, but cannot see
+a dashboard pull job's in-memory state — a concurrently running `hal0-api`
+pull of the same tag can race it.
 
 | Command | Args | Flags |
 |---|---|---|
 | `runner-images ls` | — | — |
 | `runner-images sync` | — | — |
 | `runner-images pull <id>` | `id` (catalogue id) | `--tag` (default: the row's headline tag) |
+| `runner-images rm <id>` | `id` (catalogue id) | `--tag` (required) |
 
 ## `hal0 profile` — inspect launch-flag profiles
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2003,6 +2003,44 @@ PYEOF
             warn "${PODMAN_RO_SUDOERS_SRC} not found — podman introspection sudoers grant not installed"
         fi
     fi
+
+    # Privileged seam #7 (runner-images v3, D1(a)/D2): hal0-podman-rw covers
+    # the FIRST write surface into ROOT's podman store — image-pull (the
+    # manifest gate materializing a verified recipe) and image-rm (evicting a
+    # stale/failed image) — against the SAME rootful store hal0-podman-ro
+    # reports on and slots actually launch from, NOT hal0-api's own rootless
+    # store. Separate and independently revocable from the read-only seam
+    # above: narrow + hardcoded (no shell, no wildcards, no operator-supplied
+    # podman flags), and `image-rm` never passes `-f`. Both argument-taking
+    # verbs validate their image ref root-side against the same closed regex
+    # hal0-podman-ro uses before podman is ever invoked. See the wrapper
+    # source for the full argument doctrine.
+    PODMAN_RW_SRC="${REPO_ROOT}/installer/wrappers/hal0-podman-rw"
+    if [[ -f "${PODMAN_RW_SRC}" ]]; then
+        install -d "${LIB_DIR}/bin"
+        install -m 0755 "${PODMAN_RW_SRC}" "${LIB_DIR}/bin/hal0-podman-rw"
+        info "wrote ${LIB_DIR}/bin/hal0-podman-rw"
+    else
+        warn "${PODMAN_RW_SRC} not found — podman write seam helper not installed"
+    fi
+
+    # sudoers grant for the podman write seam. Real installs only;
+    # visudo-validate before activating so a malformed drop-in can never wedge
+    # sudo for the box.
+    if [[ "${DEV_MODE}" -eq 0 ]]; then
+        PODMAN_RW_SUDOERS_SRC="${REPO_ROOT}/packaging/sudoers/hal0-podman-rw"
+        PODMAN_RW_SUDOERS_DST="/etc/sudoers.d/hal0-podman-rw"
+        if [[ -f "${PODMAN_RW_SUDOERS_SRC}" ]]; then
+            if visudo -cf "${PODMAN_RW_SUDOERS_SRC}" >/dev/null 2>&1; then
+                install -m 0440 "${PODMAN_RW_SUDOERS_SRC}" "${PODMAN_RW_SUDOERS_DST}"
+                info "wrote ${PODMAN_RW_SUDOERS_DST}"
+            else
+                warn "${PODMAN_RW_SUDOERS_SRC} failed visudo check — podman write sudoers grant not installed"
+            fi
+        else
+            warn "${PODMAN_RW_SUDOERS_SRC} not found — podman write sudoers grant not installed"
+        fi
+    fi
 else
     warn "${AGENT_UNIT_SRC} not found — hal0-agent@ template not installed"
 fi

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1461,9 +1461,8 @@ resolve_node() {
 # podman-ro/podman-rw are optional. install.sh used to install each
 # best-effort — a `visudo -cf` failure produced only a mid-log warn and the
 # run still printed its success box — and NOTHING verified the result
-# afterwards, so a box where that warn
-# fired reported all-green from every surface while every slot start failed
-# undiagnosably.
+# afterwards, so a box where that warn fired reported all-green from every
+# surface while every slot start failed undiagnosably.
 #
 # DELIBERATELY NOT IN preflight_all: preflight runs BEFORE the seams are
 # installed, where asserting them would fail every fresh install. This is a

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1457,10 +1457,11 @@ resolve_node() {
 #
 # Every privileged op hal0 performs post-P3-perms goes through a narrow
 # `sudo -n /usr/lib/hal0/bin/hal0-*` wrapper: slot lifecycle (hal0-systemctl)
-# and self-update (hal0-update) are load-bearing; agentenv/benchctl/podman-ro
-# are optional. install.sh used to install each best-effort — a `visudo -cf`
-# failure produced only a mid-log warn and the run still printed its success
-# box — and NOTHING verified the result afterwards, so a box where that warn
+# and self-update (hal0-update) are load-bearing; agentenv/benchctl/
+# podman-ro/podman-rw are optional. install.sh used to install each
+# best-effort — a `visudo -cf` failure produced only a mid-log warn and the
+# run still printed its success box — and NOTHING verified the result
+# afterwards, so a box where that warn
 # fired reported all-green from every surface while every slot start failed
 # undiagnosably.
 #
@@ -1470,7 +1471,7 @@ resolve_node() {
 # down, and `hal0 doctor all` carries the same predicate in Python
 # (src/hal0/system/seam_check.py). Keep the two inventories in lock-step.
 HAL0_REQUIRED_SEAMS=("hal0-systemctl" "hal0-update")
-HAL0_OPTIONAL_SEAMS=("hal0-agentenv" "hal0-benchctl" "hal0-podman-ro")
+HAL0_OPTIONAL_SEAMS=("hal0-agentenv" "hal0-benchctl" "hal0-podman-ro" "hal0-podman-rw")
 
 # Probe verbs that are provably side-effect-free (`help` prints usage,
 # `check` only proves the interpreter loads). Seams absent from this map are
@@ -1487,6 +1488,12 @@ _hal0_seam_probe() {
         # side-effect-free (validates, prints the name it would build, never
         # calls podman). Keep in lock-step with src/hal0/system/seam_check.py.
         hal0-podman-ro) printf 'check-slot-token hal0probe\n' ;;
+        # runner-images v3: the podman WRITE seam. `check-image-ref` is its
+        # side-effect-free validator probe (never touches podman), same
+        # shape as podman-ro's `check-slot-token` — presence alone would let
+        # a stale wrapper missing image-pull/image-rm probe green. Keep in
+        # lock-step with src/hal0/system/seam_check.py.
+        hal0-podman-rw) printf 'check-image-ref hal0probe\n' ;;
         *)              return 1 ;;
     esac
 }

--- a/installer/uninstall.sh
+++ b/installer/uninstall.sh
@@ -435,6 +435,10 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
     # here (r5-sync-assessment §6.3): a root sudoers grant for a
     # re-creatable principal left behind on every uninstall.
     rm_path "/etc/sudoers.d/hal0-podman-ro"
+    # runner-images v3 (D1(a)/D2): hal0-podman-rw (the podman WRITE seam,
+    # install.sh's PODMAN_RW_SUDOERS_DST) — same shape as hal0-podman-ro
+    # above, swept here from day one rather than repeating the O12 gap.
+    rm_path "/etc/sudoers.d/hal0-podman-rw"
     # hal0.bench units (timer + scheduled session + run-queue worker). The
     # result store /var/lib/hal0-bench is data, kept unless --purge.
     systemctl disable --now hal0-bench.timer hal0-bench-worker.service >/dev/null 2>&1 || true

--- a/installer/wrappers/hal0-podman-ro
+++ b/installer/wrappers/hal0-podman-ro
@@ -45,6 +45,9 @@
 # src/hal0/providers/podman_introspect.py, which mirrors every regex below so
 # the unprivileged side fails fast instead of burning a sudo round-trip.
 #
+# Write verbs (`image-pull`, `image-rm`) live in the separate hal0-podman-rw
+# wrapper under its own independently revocable sudoers grant — never here.
+#
 # EXIT-CODE CONTRACT. The read verbs distinguish "podman answered, and the
 # answer is negative" from "the seam itself is unusable", because the caller
 # must fall back to its rootless read only in the second case:

--- a/installer/wrappers/hal0-podman-rw
+++ b/installer/wrappers/hal0-podman-rw
@@ -1,0 +1,201 @@
+#!/bin/bash
+# hal0-podman-rw — privileged seam for WRITING the rootful podman store
+# (runner-images v3, D1(a)/D2).
+#
+# Background: slots run ROOTFUL podman (Quadlet units under
+# /etc/containers/systemd/, root's image store — written via the
+# hal0-systemctl write-quadlet seam). hal0-api runs as the unprivileged
+# `hal0` system user, so any podman call it issues DIRECTLY hits its own
+# rootless store — a different store than the one slots actually launch
+# from. hal0-podman-ro (#1889) exists so hal0-api can at least READ the
+# rootful store; it deliberately never wires up rm/run/build/exec/pull,
+# because a read seam widened to writes would let a single grant both see
+# and mutate the store slots depend on with no separate audit trail.
+#
+# This wrapper is the FIRST write surface. runner-images v3 needs hal0-api to
+# be able to actually PULL a recipe's image into root's store (D1(a): the
+# manifest gate must be able to materialize what it verified) and to REMOVE
+# a stale/failed one (D2: eviction), both against the SAME rootful store the
+# read seam already reports on and slots already launch from — a rootless
+# pull/rm from hal0-api would populate or evict the wrong store entirely,
+# the mirror-image of the #1889 bug hal0-podman-ro exists to avoid.
+# hal0-podman-ro STAYS READ-ONLY: this grant is separate, narrower (two
+# verbs only), and independently revocable.
+#
+# ARGUMENT DOCTRINE — identical boundary to hal0-podman-ro. A caller-supplied
+# value may reach podman's argv ONLY as a single positional operand that has
+# been validated on the ROOT side of the boundary against a closed regex,
+# for a verb whose podman subcommand and flags are literals written here:
+#
+#   * every podman invocation is a hardcoded exec/argv array — no shell, no
+#     eval, no word splitting, no wildcards, no operator-supplied flags;
+#   * both verbs take an image REFERENCE, matched against the OCI ref
+#     grammar (optional host[:port]/, path segments with single ._-
+#     separators, optional :tag, optional @sha256:<64 hex>) and length-capped
+#     — byte-identical to hal0-podman-ro's IMAGE_REF_RE, so a ref this
+#     wrapper accepts is exactly one the read seam would also report on;
+#   * `image-rm` never passes `-f`: a caller can only remove an image that is
+#     NOT in use, never force-evict one out from under a running slot.
+#
+# EXIT-CODE CONTRACT (extends hal0-podman-ro's with one NEW code):
+#
+#   * rc 0   — the verb completed and produced a DEFINITIVE, on-purpose
+#              answer. `image-rm` printed `removed` (rc 0 from `podman rmi`)
+#              or `missing` (podman rc 1, no such image — a real negative
+#              answer, not an error). `image-pull` execs podman directly, so
+#              rc 0 here means podman's own pull actually succeeded (see the
+#              exec note below).
+#   * rc 64  — this wrapper rejected the argument (validation) or the verb.
+#              Always occurs BEFORE podman is even located.
+#   * rc 65  — podman is not installed / not executable here. Also always
+#              before podman is invoked.
+#   * rc 66  — podman ran but FAILED operationally for a reason other than
+#              "no such image" or "image in use" (store corruption, lock
+#              contention, permission error, …). NOT a negative answer.
+#   * rc 67  — NEW. `image-rm` only: podman rmi refused because the image is
+#              IN USE by a container (its rc 2). Distinct from rc 66 so a
+#              caller can tell "this image is still needed" apart from "the
+#              store itself is broken" — conflating the two would either
+#              retry a doomed rmi forever (66) or silently give up on an
+#              image that is actually fine to remove once its container
+#              stops (treating it as a hard failure).
+#
+# `image-pull` is `exec`'d, not captured through run_podman: pull progress is
+# long-running and streams multiple lines to stdout/stderr as layers land,
+# and the caller (hal0-api) wants that streamed raw rather than buffered
+# behind a single subprocess.run() — and podman's own exit code should pass
+# straight through as this wrapper's exit code with no translation, since a
+# pull failure has no "negative answer" reading the way `image exists`/`rmi`
+# do (see hal0-podman-ro's contract for that distinction). Validation and the
+# podman-present check still happen BEFORE the exec, so rc 64/65 are always
+# reachable even though nothing after the exec is.
+#
+# See src/hal0/providers/podman_introspect.py, which mirrors IMAGE_REF_RE so
+# the unprivileged side fails fast instead of burning a sudo round-trip.
+
+set -euo pipefail
+
+# LOCALE PIN — load-bearing for the validator below, not a tidiness nit.
+# bash's `[[ =~ ]]` bracket expressions use the CURRENT locale's collation, so
+# under a UTF-8 locale `[A-Za-z0-9]` matches accented letters: `alpiné` would
+# be accepted here while the Python mirror rejects it — the wrapper LOOSER
+# than its mirror, the dangerous direction. This is reachable in production
+# because sudo's default `env_keep` passes LANG/LC_* straight through from
+# the calling process. Pinning to C makes every character class below mean
+# exactly the ASCII bytes it spells, in any caller's environment. Set before
+# any validator can run. (Same finding as hal0-podman-ro's; security review
+# of #1889.)
+export LC_ALL=C
+
+PODMAN=/usr/bin/podman
+
+die() { echo "hal0-podman-rw: $1" >&2; exit 64; }
+
+# ── argument validator (root side of the privilege boundary) ───────────────
+#
+# Byte-identical to hal0-podman-ro's IMAGE_REF_RE: a ref this wrapper accepts
+# is exactly one the read seam would also report on, and a ref the read seam
+# rejects can never reach a write either. Duplicated rather than sourced —
+# each wrapper must stand alone as its own privileged binary with no runtime
+# dependency on a sibling file's presence or content.
+#
+# An OCI image reference: [host[:port]/]path[/path...][:tag][@sha256:<hex>].
+# The separator set is the distribution-reference grammar's, verbatim:
+#   separator := "." | "_" | "__" | "-"+
+_REF_SEP='(__|[._]|-+)'
+# A registry host is a dotted/dashed name OR a bracketed IPv6 literal
+# ([2001:db8::1]:5000/...), which the reference grammar permits. The bracket
+# body is hex-and-colons only, so it still cannot carry a path, whitespace, a
+# metacharacter or a second word.
+_REF_IPV6='\[[0-9A-Fa-f:]{2,45}\]'
+_REF_HOST="([A-Za-z0-9]+(([.]|-+)[A-Za-z0-9]+)*|${_REF_IPV6})(:[0-9]{1,5})?"
+_REF_PATH="[A-Za-z0-9]+(${_REF_SEP}[A-Za-z0-9]+)*(/[A-Za-z0-9]+(${_REF_SEP}[A-Za-z0-9]+)*)*"
+_REF_TAG='(:[A-Za-z0-9_][A-Za-z0-9._-]{0,127})?'
+_REF_DIGEST='(@sha256:[0-9a-f]{64})?'
+IMAGE_REF_RE="^(${_REF_HOST}/)?${_REF_PATH}${_REF_TAG}${_REF_DIGEST}\$"
+
+validate_image_ref() {   # arg: image reference
+  local ref="${1-}"
+  [[ -n "$ref" ]] || die "missing image ref"
+  # Length cap first: a pathological input should never be handed to the
+  # regex engine, and no real ref approaches this.
+  (( ${#ref} <= 512 )) || die "image ref too long (${#ref} > 512)"
+  [[ "$ref" =~ $IMAGE_REF_RE ]] || die "bad image ref: $ref"
+}
+
+require_podman() {
+  [[ -x "$PODMAN" ]] || { echo "hal0-podman-rw: podman not found at $PODMAN" >&2; exit 65; }
+}
+
+# An operational podman failure — distinct from a negative answer or the
+# in-use case. See the exit-code contract in the header.
+podman_failed() { echo "hal0-podman-rw: $1 (rc=$2)" >&2; exit 66; }
+
+# Run podman, tolerating a non-zero rc (the caller inspects PODMAN_RC itself
+# to distinguish a negative answer from an operational failure). Sets
+# PODMAN_RC/PODMAN_OUT. stderr is dropped: podman emits benign device
+# warnings under LXC.
+run_podman() {
+  PODMAN_OUT=""
+  PODMAN_RC=0
+  PODMAN_OUT="$("$PODMAN" "$@" 2>/dev/null)" || PODMAN_RC=$?
+}
+
+cmd="${1:-help}"; shift || true
+
+case "$cmd" in
+  image-pull)              # arg: image ref -> streams podman pull, exec'd
+    [[ $# -eq 1 ]] || die "image-pull takes exactly one argument"
+    validate_image_ref "$1"
+    require_podman
+    # exec deliberate: progress lines stream raw to the caller and podman's
+    # own exit code passes through unmodified. Validation and the podman
+    # presence check above are the only things standing between argv and
+    # podman, and both already ran.
+    exec "$PODMAN" pull "$1"
+    ;;
+
+  image-rm)                # arg: image ref -> "removed" | "missing"
+    [[ $# -eq 1 ]] || die "image-rm takes exactly one argument"
+    validate_image_ref "$1"
+    require_podman
+    # NEVER -f: a caller can remove an image that is not in use, never
+    # force-evict one out from under a running slot.
+    run_podman rmi -- "$1"
+    case "$PODMAN_RC" in
+      0) echo removed ;;
+      1) echo missing ;;   # no such image — a real negative answer
+      2) exit 67 ;;        # image in use by a container
+      *) podman_failed "podman rmi failed" "$PODMAN_RC" ;;
+    esac
+    ;;
+
+  check-image-ref)         # arg: image ref — side-effect-free validator probe
+    # Exists so the validation regex can be exercised by the test suite (and
+    # by an operator debugging a rejection) without podman, without root and
+    # without a provisioned box. Never touches podman. Mirrors
+    # hal0-podman-ro's verb of the same name.
+    [[ $# -eq 1 ]] || die "check-image-ref takes exactly one argument"
+    validate_image_ref "$1"
+    printf '%s\n' "$1"
+    ;;
+
+  help|"")
+    cat <<EOF
+usage: hal0-podman-rw <command> <ref>
+  image-pull <ref>    podman pull <ref>, exec'd (progress streams raw; podman's
+                       own exit code passes through unmodified)
+  image-rm <ref>       podman rmi -- <ref> (never -f); "removed" | "missing"
+  check-image-ref <ref>   validate an image ref only (no podman call)
+
+exit codes:
+  0    verb completed with a definitive answer (or a successful pull)
+  64   validation/verb rejected (before podman is located)
+  65   podman not found (before podman is invoked)
+  66   podman ran but failed operationally
+  67   image-rm only: image is in use by a container (podman rmi rc 2)
+EOF
+    ;;
+
+  *) die "bad cmd: $cmd" ;;
+esac

--- a/installer/wrappers/hal0-podman-rw
+++ b/installer/wrappers/hal0-podman-rw
@@ -52,13 +52,20 @@
 #   * rc 66  — podman ran but FAILED operationally for a reason other than
 #              "no such image" or "image in use" (store corruption, lock
 #              contention, permission error, …). NOT a negative answer.
-#   * rc 67  — NEW. `image-rm` only: podman rmi refused because the image is
-#              IN USE by a container (its rc 2). Distinct from rc 66 so a
-#              caller can tell "this image is still needed" apart from "the
-#              store itself is broken" — conflating the two would either
-#              retry a doomed rmi forever (66) or silently give up on an
-#              image that is actually fine to remove once its container
-#              stops (treating it as a hard failure).
+#   * rc 67  — NEW. `image-rm` only: podman rmi refused (its rc 2) because
+#              the image is IN USE BY A CONTAINER, OR HAS CHILD IMAGES —
+#              podman's own rc 2 covers both, and this wrapper does not (and
+#              cannot, without a second podman call) tell them apart. Do NOT
+#              read 67 as "container-only, safe to retry once the container
+#              stops": a child-image refusal will not resolve on its own and
+#              retrying is pointless until the caller removes the child
+#              first. Distinct from rc 66 so a caller can tell "podman
+#              declined this specific removal for a structural reason" apart
+#              from "the store itself is broken" — conflating the two would
+#              either retry a doomed rmi forever (66) or silently give up on
+#              an image that is actually fine to remove once the blocker
+#              (container or child image) is gone (treating it as a hard
+#              failure).
 #
 # `image-pull` is `exec`'d, not captured through run_podman: pull progress is
 # long-running and streams multiple lines to stdout/stderr as layers land,
@@ -151,8 +158,11 @@ case "$cmd" in
     # exec deliberate: progress lines stream raw to the caller and podman's
     # own exit code passes through unmodified. Validation and the podman
     # presence check above are the only things standing between argv and
-    # podman, and both already ran.
-    exec "$PODMAN" pull "$1"
+    # podman, and both already ran. `--` end-of-options separator matches
+    # every other podman call in this file (defense-in-depth: the regex
+    # already forbids a leading '-', but this keeps the invocation
+    # unconditionally safe even if that ever changed).
+    exec "$PODMAN" pull -- "$1"
     ;;
 
   image-rm)                # arg: image ref -> "removed" | "missing"
@@ -165,7 +175,9 @@ case "$cmd" in
     case "$PODMAN_RC" in
       0) echo removed ;;
       1) echo missing ;;   # no such image — a real negative answer
-      2) exit 67 ;;        # image in use by a container
+      2) exit 67 ;;        # refused: in use by a container, OR has child
+                           # images (podman rmi's rc 2 covers both; not
+                           # distinguishable here — see header contract)
       *) podman_failed "podman rmi failed" "$PODMAN_RC" ;;
     esac
     ;;
@@ -193,7 +205,9 @@ exit codes:
   64   validation/verb rejected (before podman is located)
   65   podman not found (before podman is invoked)
   66   podman ran but failed operationally
-  67   image-rm only: image is in use by a container (podman rmi rc 2)
+  67   image-rm only: refused — image is in use by a container, or has
+       child images (podman rmi rc 2 covers both; not "container-only,
+       safe to retry later")
 EOF
     ;;
 

--- a/packaging/sudoers/hal0-podman-rw
+++ b/packaging/sudoers/hal0-podman-rw
@@ -1,0 +1,45 @@
+# hal0 — privileged seam grant for WRITING the rootful podman store
+# (runner-images v3, D1(a)/D2). This is the FIRST write surface for podman:
+# hal0-podman-ro (packaging/sudoers/hal0-podman-ro) is read-only by design
+# and stays that way — this is a separate, narrower, independently
+# revocable grant, not a widening of it.
+#
+# Slots run ROOTFUL podman (Quadlet units under /etc/containers/systemd/,
+# root's image store). hal0-api runs as the unprivileged `hal0` system user,
+# so a bare podman pull/rmi issued FROM hal0-api would populate or evict its
+# OWN rootless store — a different store from the one slots actually launch
+# from, the mirror-image of the #1889 bug the read seam exists to avoid.
+# D1(a) needs hal0-api to be able to materialize a manifest-verified image
+# into that SAME rootful store; D2 needs it to be able to evict a stale one.
+# This wrapper delegates exactly those two write ops to
+# /usr/lib/hal0/bin/hal0-podman-rw, which is the entire privileged write
+# surface: `image-pull <ref>` and `image-rm <ref>`, plus one side-effect-free
+# validator probe (`check-image-ref`). Every podman subcommand and flag is a
+# literal in the wrapper; no shell is ever evaluated, and `image-rm` never
+# passes `-f`. Both argument-taking verbs accept exactly ONE positional
+# operand, validated ROOT-side against the same closed image-ref regex
+# hal0-podman-ro uses, before podman is ever invoked. rm/run/build/exec other
+# than the two verbs above are never exposed; nothing here can start a
+# container, attach a volume, or touch anything but the image store.
+#
+# Install (as root):
+#   install -m 0755 -o root -g root hal0-podman-rw /usr/lib/hal0/bin/hal0-podman-rw
+#   install -m 0440 -o root -g root hal0-podman-rw /etc/sudoers.d/hal0-podman-rw
+#   visudo -cf /etc/sudoers.d/hal0-podman-rw
+#
+# Keep this grant pinned to the helper binary; a broader grant would let the
+# API run arbitrary root commands. Note the grant deliberately does NOT
+# enumerate argv (a bare command path in sudoers permits any arguments): the
+# wrapper itself is the control surface, exactly as for hal0-podman-ro and
+# hal0-systemctl's write-quadlet verb. Constraining argv in sudoers instead
+# would be a second, silently-drifting copy of the verb list, and sudoers
+# wildcards are a well-known footgun. Every new verb is gated by a ROOT-side
+# validator in the wrapper, same as the read seam.
+# Revoke with: rm /etc/sudoers.d/hal0-podman-rw
+#
+# Revoking this grant alone (leaving hal0-podman-ro installed) returns hal0
+# to read-only introspection of the rootful store with no ability to pull or
+# remove images from it — the intended fallback posture if the write seam
+# ever needs to be pulled without disturbing the read seam.
+
+hal0 ALL=(root) NOPASSWD: /usr/lib/hal0/bin/hal0-podman-rw

--- a/src/hal0/api/routes/runner_images.py
+++ b/src/hal0/api/routes/runner_images.py
@@ -675,9 +675,19 @@ async def delete_runner_image_tag(image_id: str, tag: str, request: Request) -> 
       2. 404 ``runner_image.tag_not_found`` — id known, but ``tag`` is
          neither the headline tag, a ``runner_image_tag`` fact, nor an
          ``available_tags`` entry.
-      3. 409 ``runner_image.tag_in_use`` — application-level guard naming
+      3. 409 ``runner_image.pull_in_progress`` — a pull job for this id is
+         ``queued``/``running`` and targets this tag (or has no tag at
+         all — an older untagged job record, which always pulls the
+         headline). Fix round 1 (#2106): a pull racing this DELETE could
+         otherwise complete AFTER ``store.remove_tag`` and re-stamp
+         ``local_path``/``downloaded_at`` via ``set_local_state``, leaving
+         the row ``downloaded=True`` with zero tag rows. Mirrors
+         ``RunnerPullConflict``'s discipline (``runner_pull.py``): an
+         in-flight mutation on the same id wins, the caller is told to
+         cancel first rather than racing silently.
+      4. 409 ``runner_image.tag_in_use`` — application-level guard naming
          the slot(s) responsible (see :func:`_tag_in_use_by`).
-      4. ``podman_mutate.remove_image`` — the seam-level guard, a second
+      5. ``podman_mutate.remove_image`` — the seam-level guard, a second
          independent barrier: outcome ``"in-use"`` (podman rc 67) also 409s
          the same code but names no slots (the app-level guard above didn't
          catch it, e.g. an unmanaged container holding the image);
@@ -708,6 +718,15 @@ async def delete_runner_image_tag(image_id: str, tag: str, request: Request) -> 
             f"tag {tag!r} not catalogued for {image_id!r}",
             details={"image_id": image_id, "tag": tag},
             code="runner_image.tag_not_found",
+        )
+
+    jobs: dict[str, RunnerPullJob] = request.app.state.runner_image_pull_jobs
+    job = jobs.get(image_id)
+    if job is not None and job.state in ("queued", "running") and job.tag in (tag, None):
+        raise Conflict(
+            f"a pull for {image_id!r} tag {tag!r} is in progress; cancel it first",
+            details={"image_id": image_id, "tag": tag},
+            code="runner_image.pull_in_progress",
         )
 
     ref = f"{image.image}:{tag}"
@@ -741,7 +760,19 @@ async def delete_runner_image_tag(image_id: str, tag: str, request: Request) -> 
         # "removed" or "missing": the seam agrees the bytes are gone (or
         # already were) — update the catalogue to match.
         old_local_path = image.local_path
-        store.remove_tag(image_id, tag)
+        catalogue_removed = store.remove_tag(image_id, tag)
+        rec.after = {"outcome": outcome, "catalogue_removed": catalogue_removed}
+        if not catalogue_removed:
+            # The seam agrees the bytes are gone, but the catalogue had no
+            # matching tag row to delete — a desync worth a log line (the
+            # 200 response is still honest: the bytes really are gone/
+            # already-absent, this just flags the catalogue disagreeing).
+            log.warning(
+                "runner_image.rm_catalogue_desync image_id=%s tag=%s outcome=%s",
+                image_id,
+                tag,
+                outcome,
+            )
         if old_local_path:
             updated = store.get(image_id)
             if updated is None or updated.local_path is None:

--- a/src/hal0/api/routes/runner_images.py
+++ b/src/hal0/api/routes/runner_images.py
@@ -11,14 +11,17 @@ converter rather than a plain string segment.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
-from hal0.api.middleware.error_codes import BadRequest, NotFound
+from hal0.api.middleware.error_codes import BadRequest, Conflict, Hal0Error, NotFound
 from hal0.providers.podman_introspect import LocalImagesDigests, images_digests, is_valid_image_ref
 from hal0.registry import runner_pull_jobs as _pull_jobs
 from hal0.registry.runner_image import RunnerImage, RunnerImageTag
@@ -28,6 +31,21 @@ from hal0.registry.runner_pull import RunnerPullJob
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+class RunnerImageRmUnavailable(Hal0Error):
+    """502 — ``podman_mutate.remove_image``'s write seam couldn't answer.
+
+    ``details["reason"]`` carries the ``SeamUnanswered`` reason (e.g.
+    ``"grant-denied"``, ``"podman-absent"``, ``"not-service-user"``). The
+    catalogue row is deliberately left untouched on this outcome: an
+    unanswered seam call is not the same as "removal failed", and faking a
+    delete would desync the catalogue from the real podman store — honesty
+    over a fake delete, same discipline as the pull side's fail-soft reads.
+    """
+
+    code = "runner_image.rm_unavailable"
+    status = 502
 
 
 def _image_to_dict(image: RunnerImage) -> dict[str, Any]:
@@ -376,6 +394,49 @@ def _slot_image_usage() -> dict[str, str]:
     return usage
 
 
+def _tag_in_use_by(image: RunnerImage, tag: str, slot_usage: Mapping[str, str]) -> list[str]:
+    """Slot names whose launched ref guards the ``(image, tag)`` about to be
+    deleted — the DELETE tag route's application-level in-use guard.
+
+    Deliberately simpler than ``enrich_row``/``_families_payload``'s
+    catalogue-wide digest reconciliation (that's for display; this is a
+    safety gate that must stay cheap and easy to reason about). Covers two
+    matches only:
+
+      1. Exact ref match — the slot's launched ref is literally
+         ``image:tag``.
+      2. Same-row digest match — the tag being deleted has a known digest
+         (from THIS row's own ``tags``, the ``runner_image_tag`` facts) and
+         some slot is pinned to a DIFFERENT tag of the same image repo whose
+         digest (again, from this row's own ``tags``) is identical — i.e.
+         two tag names that are secretly the same bytes (a re-tag) both
+         guard the shared image.
+
+    NOT covered: a slot ref pinned by digest (``repo@sha256:...``) is never
+    unpacked here — it can only ever match case 1, and never will (that ref
+    shape has no ``:tag`` suffix to equal). Accepted gap: digest-pinned
+    slots are rare (manifest-tier defaults only) and
+    ``podman_mutate.remove_image``'s seam-level rc-67 "in-use" outcome is
+    the real backstop that stops bytes a running container actually holds
+    from being removed regardless of what this application-level guard
+    missed.
+    """
+    ref = f"{image.image}:{tag}"
+    tag_digest = next((t.digest for t in image.tags if t.tag == tag), None)
+    hits: set[str] = set()
+    prefix = f"{image.image}:"
+    for name, usage_ref in slot_usage.items():
+        if usage_ref == ref:
+            hits.add(name)
+        elif tag_digest and usage_ref.startswith(prefix):
+            other_digest = next(
+                (t.digest for t in image.tags if t.tag == usage_ref[len(prefix) :]), None
+            )
+            if other_digest and other_digest == tag_digest:
+                hits.add(name)
+    return sorted(hits)
+
+
 async def _restart_slot(name: str, request: Request) -> None:
     """Restart one slot via the exact same service call the per-slot
     ``POST /api/slots/{name}/restart`` button makes today.
@@ -594,6 +655,104 @@ async def pull_runner_image_cancel(image_id: str, request: Request) -> dict[str,
     """Request cancellation of an in-flight runner-image pull."""
     jobs: dict[str, RunnerPullJob] = request.app.state.runner_image_pull_jobs
     return _pull_jobs.cancel(image_id, jobs)
+
+
+@router.delete("/{image_id:path}/tags/{tag}")
+async def delete_runner_image_tag(image_id: str, tag: str, request: Request) -> dict[str, Any]:
+    """Delete one catalogued tag and reclaim its bytes from the local store.
+
+    Grouped here with the other explicit-suffix routes (ahead of the
+    ``/{image_id:path}`` GET catch-all below) for readability, matching the
+    file's convention — but unlike the GET suffix routes, ordering here
+    isn't load-bearing: Starlette matches on (path, METHOD) together, so a
+    DELETE request never falls into a GET-only route no matter where this
+    is declared. ``test_delete_tag_route_ordering`` in
+    ``tests/api/test_runner_images_routes.py`` pins that both directions
+    (GET-single-image, DELETE-tag) resolve to the right handler.
+
+    Guards, in order:
+      1. 404 ``runner_image.not_found`` — unknown id.
+      2. 404 ``runner_image.tag_not_found`` — id known, but ``tag`` is
+         neither the headline tag, a ``runner_image_tag`` fact, nor an
+         ``available_tags`` entry.
+      3. 409 ``runner_image.tag_in_use`` — application-level guard naming
+         the slot(s) responsible (see :func:`_tag_in_use_by`).
+      4. ``podman_mutate.remove_image`` — the seam-level guard, a second
+         independent barrier: outcome ``"in-use"`` (podman rc 67) also 409s
+         the same code but names no slots (the app-level guard above didn't
+         catch it, e.g. an unmanaged container holding the image);
+         ``"unknown"`` (seam absent/denied/erroring) is 502
+         ``runner_image.rm_unavailable`` with the seam's reason, catalogue
+         left untouched (no fake delete); ``"removed"``/``"missing"``
+         update the catalogue via ``store.remove_tag`` and respond 200.
+
+    Audited the same way ``restart-affected`` is: ``record_action`` with
+    category ``"runner_image"``, action ``"runner_image.rm"``, target the
+    ``image:tag`` ref — a raised 409/502 inside the block is recorded
+    ``outcome="error"`` and re-raised (``hal0.activity.audit_action``'s
+    confirmation guarantee), so the audit trail is honest either way.
+    """
+    store = request.app.state.runner_image_registry
+    image = store.get(image_id)
+    if image is None:
+        raise NotFound(
+            f"runner image {image_id!r} not in catalogue",
+            details={"image_id": image_id},
+            code="runner_image.not_found",
+        )
+    tag_known = (
+        tag == image.tag or any(t.tag == tag for t in image.tags) or tag in image.available_tags
+    )
+    if not tag_known:
+        raise NotFound(
+            f"tag {tag!r} not catalogued for {image_id!r}",
+            details={"image_id": image_id, "tag": tag},
+            code="runner_image.tag_not_found",
+        )
+
+    ref = f"{image.image}:{tag}"
+    in_use_slots = _tag_in_use_by(image, tag, _slot_image_usage())
+    if in_use_slots:
+        raise Conflict(
+            f"runner image tag {ref!r} is in use",
+            details={"image_id": image_id, "tag": tag, "slots": in_use_slots},
+            code="runner_image.tag_in_use",
+        )
+
+    from hal0.api._audit import record_action
+    from hal0.providers import podman_mutate
+
+    async with record_action(
+        request, category="runner_image", action="runner_image.rm", target=ref
+    ) as rec:
+        outcome, reason = await asyncio.to_thread(podman_mutate.remove_image, ref)
+        rec.after = {"outcome": outcome}
+        if outcome == "in-use":
+            raise Conflict(
+                f"runner image tag {ref!r} is in use by a container or has child images",
+                details={"image_id": image_id, "tag": tag},
+                code="runner_image.tag_in_use",
+            )
+        if outcome == "unknown":
+            raise RunnerImageRmUnavailable(
+                f"image removal seam unavailable ({reason})",
+                details={"image_id": image_id, "tag": tag, "reason": reason},
+            )
+        # "removed" or "missing": the seam agrees the bytes are gone (or
+        # already were) — update the catalogue to match.
+        old_local_path = image.local_path
+        store.remove_tag(image_id, tag)
+        if old_local_path:
+            updated = store.get(image_id)
+            if updated is None or updated.local_path is None:
+                # remove_tag cleared the marker (or the row is gone
+                # entirely) — unlink the now-orphaned marker file.
+                # Fail-soft: a filesystem hiccup here must not turn an
+                # already-successful removal into a 500.
+                with contextlib.suppress(OSError):
+                    Path(old_local_path).unlink(missing_ok=True)
+
+    return {"removed": outcome == "removed", "outcome": outcome}
 
 
 @router.get("/{image_id:path}")

--- a/src/hal0/cli/runner_image_commands.py
+++ b/src/hal0/cli/runner_image_commands.py
@@ -287,7 +287,14 @@ def rm(
         )
         raise typer.Exit(1)
     if outcome == "unknown":
-        console.print(f"[red]✗[/red]  image removal seam unavailable ({reason}).")
+        if reason == "not-service-user":
+            console.print(
+                f"[red]✗[/red]  image removal seam unavailable ({reason}): this shell is "
+                "neither the hal0 service account nor root. Run this as "
+                "`sudo -u hal0 hal0 runner-images rm ...`, or as root."
+            )
+        else:
+            console.print(f"[red]✗[/red]  image removal seam unavailable ({reason}).")
         raise typer.Exit(1)
 
     # "removed" or "missing": the seam agrees the bytes are gone (or already

--- a/src/hal0/cli/runner_image_commands.py
+++ b/src/hal0/cli/runner_image_commands.py
@@ -14,12 +14,16 @@ groups use (e.g. ``hal0 registry``): ``ls`` must keep working even when
 service calls the API route handlers do, so behaviour (tag validation,
 store writes) is identical either way.
 
-``rm`` is deliberately absent — the delete story is still open (spec D2).
+``rm`` mirrors ``DELETE /api/runner-images/{id}/tags/{tag}`` (spec D2):
+same store, same seam, same guard order — see the ``rm`` command below for
+the one guard the CLI cannot offer (pull-in-progress).
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
+from pathlib import Path
 from typing import Any
 
 import typer
@@ -203,6 +207,107 @@ def pull(
         console.print("[yellow]![/yellow]  pull cancelled.")
         raise typer.Exit(1)
     console.print(f"[green]✓[/green]  pulled {image_ref} -> {job.local_path}")
+
+
+@app.command("rm")
+def rm(
+    image_id: str = typer.Argument(..., help="Catalogue id, e.g. hal0ai/hal0-toolbox-cpu."),
+    tag: str = typer.Option(
+        ...,
+        "--tag",
+        help="Tag to remove (required — no whole-image delete in this phase).",
+    ),
+) -> None:
+    """Delete one catalogued tag and reclaim its bytes from the local store.
+
+    Mirrors ``DELETE /api/runner-images/{id}/tags/{tag}``'s guard order
+    exactly (``hal0.api.routes.runner_images.delete_runner_image_tag``):
+
+      1. unknown id / unknown tag -> exit 1.
+      2. application-level "which slot launches this ref" guard -> exit 1,
+         naming the slot(s). Reuses the route's own
+         ``_slot_image_usage``/``_tag_in_use_by`` helpers directly rather
+         than re-deriving the same slot-config read here — both are pure,
+         request-independent functions (no ``request.app.state`` access),
+         so importing them costs nothing and keeps the guard's semantics
+         defined in exactly one place instead of two copies that could
+         drift.
+      3. ``podman_mutate.remove_image`` — the same seam-level guard the API
+         route calls: ``"in-use"`` (podman rc 67) -> exit 1;
+         ``"unknown"`` (seam absent/denied/erroring) -> exit 1 with the
+         seam's reason, catalogue left untouched (no fake delete).
+      4. ``"removed"``/``"missing"`` -> ``store.remove_tag`` updates the
+         catalogue (and unlinks the orphaned local-path marker, same as
+         the route) -> exit 0.
+
+    NOT guarded here: a concurrently in-flight ``hal0-api`` dashboard pull
+    for this same id/tag. The API route's pull-in-progress check reads
+    ``request.app.state.runner_image_pull_jobs`` — a live server process's
+    in-memory job table this standalone CLI invocation has no way to see.
+    An operator running this while the dashboard is mid-pull of the same
+    tag can race it; the printed note below is the honest posture rather
+    than a guard that doesn't actually exist.
+    """
+    from hal0.api.routes.runner_images import _slot_image_usage, _tag_in_use_by
+    from hal0.providers import podman_mutate
+
+    store = RunnerImageStore()
+    entry = store.get(image_id)
+    if entry is None:
+        console.print(
+            f"[red]✗[/red]  runner image {image_id!r} not in catalogue — "
+            "run `hal0 runner-images sync` first."
+        )
+        raise typer.Exit(1)
+
+    tag_known = (
+        tag == entry.tag or any(t.tag == tag for t in entry.tags) or tag in entry.available_tags
+    )
+    if not tag_known:
+        console.print(f"[red]✗[/red]  tag {tag!r} not catalogued for {image_id!r}.")
+        raise typer.Exit(1)
+
+    console.print(
+        "[dim]note: a concurrently running hal0-api dashboard pull for this "
+        "image/tag can race this delete — the CLI has no view of its job table.[/dim]"
+    )
+
+    ref = f"{entry.image}:{tag}"
+    in_use_slots = _tag_in_use_by(entry, tag, _slot_image_usage())
+    if in_use_slots:
+        console.print(
+            f"[red]✗[/red]  runner image tag {ref!r} is in use by: {', '.join(in_use_slots)}"
+        )
+        raise typer.Exit(1)
+
+    outcome, reason = podman_mutate.remove_image(ref)
+    if outcome == "in-use":
+        console.print(
+            f"[red]✗[/red]  runner image tag {ref!r} is in use by a container or has child images."
+        )
+        raise typer.Exit(1)
+    if outcome == "unknown":
+        console.print(f"[red]✗[/red]  image removal seam unavailable ({reason}).")
+        raise typer.Exit(1)
+
+    # "removed" or "missing": the seam agrees the bytes are gone (or already
+    # were) — update the catalogue to match, same as the API route.
+    old_local_path = entry.local_path
+    catalogue_removed = store.remove_tag(image_id, tag)
+    if not catalogue_removed:
+        console.print(
+            f"[yellow]![/yellow]  catalogue had no matching tag row for {ref!r} (already desynced)."
+        )
+    if old_local_path:
+        updated = store.get(image_id)
+        if updated is None or updated.local_path is None:
+            with contextlib.suppress(OSError):
+                Path(old_local_path).unlink(missing_ok=True)
+
+    if outcome == "removed":
+        console.print(f"[green]✓[/green]  removed {ref}")
+    else:  # "missing"
+        console.print(f"[green]✓[/green]  {ref} was not on disk — catalogue entry cleared")
 
 
 __all__ = ["app"]

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -3136,7 +3136,26 @@ class ContainerProvider(Provider):
         shared with the rootful pull path
         (:func:`hal0.providers.podman_mutate.pull_image_stream_rootful`) so both
         report identical event shapes regardless of which store they target.
+
+        Routing (#2119, runner-images v3 D1a): the rootful ``hal0-podman-rw``
+        seam is the PRIMARY path on an installed box — slots launch from
+        ROOT's podman store, so a dashboard-triggered pull that landed in
+        hal0-api's own rootless store was invisible to every slot that tried
+        to use it. When :func:`hal0.providers.podman_mutate.rw_seam_available`
+        says the seam is usable from here, this delegates wholesale to
+        :func:`hal0.providers.podman_mutate.pull_image_stream_rootful` (same
+        event shapes, so callers need no changes). The rootless path below is
+        unchanged and remains the path for dev/CI and any box without the
+        grant installed, where there is no seam to route through and the
+        operator's own store IS the one slots use.
         """
+        from hal0.providers import podman_mutate
+
+        if podman_mutate.rw_seam_available():
+            async for event in podman_mutate.pull_image_stream_rootful(image):
+                yield event
+            return
+
         import asyncio as _asyncio
 
         try:

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -3152,8 +3152,19 @@ class ContainerProvider(Provider):
         from hal0.providers import podman_mutate
 
         if podman_mutate.rw_seam_available():
-            async for event in podman_mutate.pull_image_stream_rootful(image):
-                yield event
+            # ``async with contextlib.aclosing(...)`` (not a bare ``async for``)
+            # is load-bearing: a bare ``async for ... yield`` never forwards
+            # this generator's own ``GeneratorExit``/``.aclose()`` to the inner
+            # one, so a dashboard cancel (``runner_pull.run_runner_pull`` calls
+            # ``agen.aclose()``) would return without killing the ROOT-owned
+            # ``sudo hal0-podman-rw image-pull`` subprocess — it keeps pulling
+            # until GC eventually (maybe) finalizes the inner generator.
+            # ``aclosing`` guarantees the inner generator's ``.aclose()`` (and
+            # therefore its ``finally: proc.kill()``) runs before this
+            # generator's own close completes, on every exit path.
+            async with contextlib.aclosing(podman_mutate.pull_image_stream_rootful(image)) as inner:
+                async for event in inner:
+                    yield event
             return
 
         import asyncio as _asyncio

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -86,6 +86,7 @@ from hal0.providers._gpu import (
     runtime_lane_for_provider,
 )
 from hal0.providers.base import HealthCheck, Mount, Provider, RuntimeLaunchPlan
+from hal0.providers.podman_mutate import PullLineParser
 from hal0.slot_lifecycle_budget import HEALTH_TIMEOUT_S
 from hal0.slots.activation import autoload_enabled
 from hal0.slots.argv import ResolvedArgv, resolve_argv
@@ -3131,11 +3132,10 @@ class ContainerProvider(Provider):
             {"state": "completed"}
             {"state": "failed",   "error": "<message>"}
 
-        Layer counting heuristic (docker non-TTY output):
-          - Each ``Pulling fs layer`` / ``Waiting`` / ``Verifying Checksum`` /
-            ``Already exists`` lines indicate a discovered layer (M increments).
-          - Each ``Pull complete`` / ``Download complete`` line indicates a
-            finished layer (N increments, capped at M).
+        Layer counting heuristic lives in :class:`hal0.providers.podman_mutate.PullLineParser`,
+        shared with the rootful pull path
+        (:func:`hal0.providers.podman_mutate.pull_image_stream_rootful`) so both
+        report identical event shapes regardless of which store they target.
         """
         import asyncio as _asyncio
 
@@ -3153,8 +3153,7 @@ class ContainerProvider(Provider):
             stderr=_asyncio.subprocess.STDOUT,
         )
 
-        total_layers = 0
-        done_layers = 0
+        parser = PullLineParser()
 
         try:
             assert proc.stdout is not None
@@ -3162,30 +3161,7 @@ class ContainerProvider(Provider):
                 line = raw.decode("utf-8", errors="replace").rstrip()
                 if not line:
                     continue
-                # Discover new layers.
-                if any(
-                    kw in line
-                    for kw in (
-                        "Pulling fs layer",
-                        "Waiting",
-                        "Verifying Checksum",
-                        "Already exists",
-                    )
-                ):
-                    total_layers += 1
-                # Count finished layers.
-                if (
-                    "Pull complete" in line
-                    or "Download complete" in line
-                    or "Already exists" in line
-                ):
-                    done_layers = min(done_layers + 1, max(total_layers, 1))
-                yield {
-                    "state": "pulling",
-                    "layer": done_layers,
-                    "total_layers": total_layers,
-                    "line": line,
-                }
+                yield parser.feed(line)
         except Exception as exc:
             yield {"state": "failed", "error": str(exc)}
             return
@@ -3195,7 +3171,11 @@ class ContainerProvider(Provider):
 
         exit_code = await proc.wait()
         if exit_code == 0:
-            yield {"state": "completed", "layer": done_layers, "total_layers": total_layers}
+            yield {
+                "state": "completed",
+                "layer": parser.done_layers,
+                "total_layers": parser.total_layers,
+            }
         else:
             yield {"state": "failed", "error": f"pull exited with code {exit_code}"}
 

--- a/src/hal0/providers/podman_mutate.py
+++ b/src/hal0/providers/podman_mutate.py
@@ -1,0 +1,274 @@
+"""podman_mutate — the WRITE-side twin of :mod:`hal0.providers.podman_introspect`
+(runner-images v3, D1(a)/D2).
+
+``podman_introspect`` routes reads through the ``hal0-podman-ro`` seam so
+hal0-api (running as the unprivileged ``hal0`` service user) can see the
+ROOTFUL podman store slots actually launch from. This module is the mirror
+for WRITES against that same store, through the separate, narrower
+``hal0-podman-rw`` seam (``installer/wrappers/hal0-podman-rw`` +
+``packaging/sudoers/hal0-podman-rw``) — two verbs only, independently
+revocable from the read grant:
+
+    from hal0.providers import podman_mutate
+
+    async for event in podman_mutate.pull_image_stream_rootful(image):
+        ...
+
+    outcome, reason = podman_mutate.remove_image(image)
+
+Same gating idiom as ``podman_introspect``/``hal0.system.seam.SystemCtlSeam``:
+the seam is only ever ATTEMPTED when this process is literally the ``hal0``
+service account (:func:`hal0.system.seam.is_hal0_service_user`) — a dev
+shell, CI runner or unit test is almost always non-root too, but none of
+those have the seam installed, so a bare "attempt sudo" would make every such
+process try (and noisily fail) a grant that doesn't exist there.
+
+Both entry points validate the image reference on THIS side first
+(:func:`hal0.providers.podman_introspect.is_valid_image_ref`, byte-identical
+to the wrapper's own validator) so a bad ref fails fast and readably instead
+of burning a sudo round-trip for an rc 64 the wrapper would reject anyway —
+and, for :func:`remove_image`, so a caller can never even reach ``sudo`` with
+an unvalidated operand.
+
+``remove_image``'s exit-code mapping extends ``podman_introspect._RC_REASON``
+with rc 67 (see the wrapper's EXIT-CODE CONTRACT): unlike every other
+non-zero rc, 67 is a DEFINITIVE answer ("refused: in use by a container, or
+has child images"), not an unanswered question, so it maps to the
+``"in-use"`` outcome rather than into the ``SeamUnanswered`` reason
+vocabulary.
+
+``pull_image_stream_rootful`` shares its line-progress heuristic with
+:meth:`hal0.providers.container.ContainerProvider.pull_image_stream` (the
+rootless pull path) via :class:`PullLineParser` below, so both pull paths
+report byte-identical event shapes to callers regardless of which store they
+targeted. The parser lives here rather than in ``container.py`` because
+``container.py`` already imports from this package's ``podman_introspect``
+sibling with no cycle back the other way, so ``container.py`` importing this
+module too costs nothing new; keeping the parser out of ``container.py``
+(a large, heavy module) also means a caller who only wants the pure
+line→event logic — this module, or a future rootful test double — never
+pulls in podman-run/quadlet/GPU machinery to get it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import subprocess
+from collections.abc import AsyncIterator, Callable
+from pathlib import Path
+from typing import Any, Literal
+
+from hal0.providers.podman_introspect import SeamUnanswered, is_valid_image_ref
+from hal0.system.seam import is_hal0_service_user
+
+#: Installed path of the write seam (D1(a)/D2). See
+#: installer/wrappers/hal0-podman-rw + packaging/sudoers/hal0-podman-rw.
+RW_SEAM_BIN = "/usr/lib/hal0/bin/hal0-podman-rw"
+
+#: Wrapper/sudo exit code -> :data:`SeamUnanswered`, for the codes that are
+#: genuinely "the question went unanswered" (as opposed to rc 67, a real
+#: answer). Byte-identical to ``podman_introspect._RC_REASON`` — kept as its
+#: own copy rather than imported so this module's exit-code contract stands
+#: on its own the same way the wrapper documents standing alone as its own
+#: privileged binary; ``tests/providers/test_podman_mutate.py`` and
+#: ``tests/providers/test_podman_introspect.py`` both pin their respective
+#: wrapper's documented contract, so a drift between the two wrappers would
+#: surface as a test failure here, not a silent divergence.
+_RC_REASON: dict[int, SeamUnanswered] = {
+    1: "grant-denied",
+    64: "invalid-argument",
+    65: "podman-absent",
+    66: "podman-failed",
+}
+
+#: Outcome of a guarded ``image-rm``. ``"unknown"`` pairs with a
+#: :data:`SeamUnanswered` reason (see :func:`remove_image`); the other three
+#: are definitive answers from the seam and carry no reason.
+RemoveOutcome = Literal["removed", "missing", "in-use", "unknown"]
+
+_RunFn = Callable[..., "subprocess.CompletedProcess[str]"]
+
+
+class PullLineParser:
+    """Turns raw ``podman pull`` progress lines into ``"pulling"`` events.
+
+    Shared by :meth:`hal0.providers.container.ContainerProvider.pull_image_stream`
+    (rootless pull) and :func:`pull_image_stream_rootful` (rootful pull, via
+    the ``hal0-podman-rw`` seam) so both report identical progress shapes.
+
+    Layer-counting heuristic, unchanged from the pre-extraction logic
+    (docker/podman non-TTY pull output):
+      - Each ``Pulling fs layer`` / ``Waiting`` / ``Verifying Checksum`` /
+        ``Already exists`` line discovers a new layer (``total_layers`` +=1).
+      - Each ``Pull complete`` / ``Download complete`` / ``Already exists``
+        line finishes a layer (``done_layers`` +=1, capped at
+        ``max(total_layers, 1)``).
+
+    Callers are expected to skip blank lines themselves before calling
+    :meth:`feed` — a blank line carries no signal and both pull paths already
+    filter it out of the raw stream before this ever sees it.
+    """
+
+    def __init__(self) -> None:
+        self.total_layers = 0
+        self.done_layers = 0
+
+    def feed(self, line: str) -> dict[str, Any]:
+        """Update layer counters from one non-empty output line, return its event."""
+        if any(
+            kw in line
+            for kw in (
+                "Pulling fs layer",
+                "Waiting",
+                "Verifying Checksum",
+                "Already exists",
+            )
+        ):
+            self.total_layers += 1
+        if "Pull complete" in line or "Download complete" in line or "Already exists" in line:
+            self.done_layers = min(self.done_layers + 1, max(self.total_layers, 1))
+        return {
+            "state": "pulling",
+            "layer": self.done_layers,
+            "total_layers": self.total_layers,
+            "line": line,
+        }
+
+
+def rw_seam_available(*, is_hal0_user: Callable[[], bool] = is_hal0_service_user) -> bool:
+    """Is the write seam usable from here, cheaply?
+
+    Service-account gate (same idiom as every other seam in this package)
+    AND the binary actually exists on disk. Deliberately does NOT probe
+    ``sudo -n`` itself — that costs a subprocess round-trip and the grant can
+    still be denied even when the binary is present (mid-upgrade race,
+    sudoers not yet installed); this is a cheap upfront check for callers
+    that want to skip offering a rootful action at all, not a guarantee the
+    seam will actually answer.
+    """
+    return is_hal0_user() and Path(RW_SEAM_BIN).is_file()
+
+
+async def pull_image_stream_rootful(image: str) -> AsyncIterator[dict[str, Any]]:
+    """Async generator: ``hal0-podman-rw image-pull <image>``, streamed.
+
+    Mirrors :meth:`hal0.providers.container.ContainerProvider.pull_image_stream`
+    exactly (same event shapes, via the shared :class:`PullLineParser`) but
+    execs the write seam instead of a bare ``podman pull``, so progress lands
+    in ROOT's store — the one slots actually launch from — rather than
+    hal0-api's own rootless store.
+
+    Yields::
+
+        {"state": "pulling",   "layer": N, "total_layers": M, "line": "<raw line>"}
+        {"state": "completed", "layer": N, "total_layers": M}
+        {"state": "failed",    "error": "<message>"}
+
+    A bad image reference is rejected HERE, before any subprocess is
+    spawned — no ``sudo`` round-trip is spent on a ref the wrapper would
+    reject anyway.
+    """
+    if not is_valid_image_ref(image):
+        yield {"state": "failed", "error": f"invalid image reference: {image}"}
+        return
+
+    proc = await asyncio.create_subprocess_exec(
+        "sudo",
+        "-n",
+        RW_SEAM_BIN,
+        "image-pull",
+        image,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+
+    parser = PullLineParser()
+
+    try:
+        assert proc.stdout is not None
+        async for raw in proc.stdout:
+            line = raw.decode("utf-8", errors="replace").rstrip()
+            if not line:
+                continue
+            yield parser.feed(line)
+    except Exception as exc:
+        yield {"state": "failed", "error": str(exc)}
+        return
+    finally:
+        with contextlib.suppress(ProcessLookupError, OSError):
+            proc.kill()
+
+    exit_code = await proc.wait()
+    if exit_code == 0:
+        yield {
+            "state": "completed",
+            "layer": parser.done_layers,
+            "total_layers": parser.total_layers,
+        }
+    else:
+        yield {"state": "failed", "error": f"pull exited with code {exit_code}"}
+
+
+def remove_image(
+    image: str,
+    *,
+    run: _RunFn = subprocess.run,
+    is_hal0_user: Callable[[], bool] = is_hal0_service_user,
+    timeout: float = 60.0,
+) -> tuple[RemoveOutcome, str | None]:
+    """Guarded ``hal0-podman-rw image-rm <image>`` — never force-removes.
+
+    Returns ``(outcome, reason)``; ``reason`` is set if and only if
+    ``outcome == "unknown"`` (same tri-state discipline as
+    :class:`hal0.providers.podman_introspect.ImageProbe`):
+
+      * ``("removed", None)``   — rc 0, wrapper printed ``removed``.
+      * ``("missing", None)``   — rc 0, wrapper printed ``missing`` (no such
+        image — a real negative answer, not a failure).
+      * ``("in-use", None)``    — rc 67: podman refused because the image is
+        in use by a container, or has child images (podman's rc 2 covers
+        both; the wrapper does not distinguish them, so neither do we).
+      * ``("unknown", reason)`` — every other case: a bad ref rejected before
+        any subprocess ran (``"invalid-argument"``), this process is not the
+        ``hal0`` service account (``"not-service-user"``), ``sudo -n`` denied
+        (``"grant-denied"``), the wrapper's rc 64/65/66
+        (``"invalid-argument"``/``"podman-absent"``/``"podman-failed"``), or
+        the call raising / an rc or stdout the contract does not define
+        (``"seam-error"``).
+    """
+    if not is_valid_image_ref(image):
+        return ("unknown", "invalid-argument")
+    if not is_hal0_user():
+        return ("unknown", "not-service-user")
+    try:
+        proc = run(
+            ["sudo", "-n", RW_SEAM_BIN, "image-rm", image],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ("unknown", "seam-error")
+    if proc.returncode == 0:
+        stdout = proc.stdout.strip()
+        if stdout == "removed":
+            return ("removed", None)
+        if stdout == "missing":
+            return ("missing", None)
+        # rc 0 with a word the contract does not define: the wrapper and
+        # this mirror have drifted.
+        return ("unknown", "seam-error")
+    if proc.returncode == 67:
+        return ("in-use", None)
+    return ("unknown", _RC_REASON.get(proc.returncode, "seam-error"))
+
+
+__all__ = [
+    "RW_SEAM_BIN",
+    "PullLineParser",
+    "RemoveOutcome",
+    "pull_image_stream_rootful",
+    "remove_image",
+    "rw_seam_available",
+]

--- a/src/hal0/providers/podman_mutate.py
+++ b/src/hal0/providers/podman_mutate.py
@@ -37,6 +37,13 @@ has child images"), not an unanswered question, so it maps to the
 ``"in-use"`` outcome rather than into the ``SeamUnanswered`` reason
 vocabulary.
 
+``remove_image`` also has a root fallback: a caller that is not the
+``hal0`` service account but IS ``os.geteuid() == 0`` skips the seam
+(there is nothing to gain from ``sudo``ing to a user you already are) and
+runs ``podman rmi`` directly against root's own store — the same
+rootful/rootless fallback philosophy ``podman_introspect.images`` already
+uses on the read side.
+
 ``pull_image_stream_rootful`` shares its line-progress heuristic with
 :meth:`hal0.providers.container.ContainerProvider.pull_image_stream` (the
 rootless pull path) via :class:`PullLineParser` below, so both pull paths
@@ -54,6 +61,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
+import shutil
 import subprocess
 from collections.abc import AsyncIterator, Callable
 from pathlib import Path
@@ -184,6 +193,7 @@ async def pull_image_stream_rootful(image: str) -> AsyncIterator[dict[str, Any]]
     )
 
     parser = PullLineParser()
+    clean_eof = False
 
     try:
         assert proc.stdout is not None
@@ -192,12 +202,30 @@ async def pull_image_stream_rootful(image: str) -> AsyncIterator[dict[str, Any]]
             if not line:
                 continue
             yield parser.feed(line)
+        clean_eof = True
     except Exception as exc:
         yield {"state": "failed", "error": str(exc)}
         return
     finally:
-        with contextlib.suppress(ProcessLookupError, OSError):
-            proc.kill()
+        # Only signal the child on an ABNORMAL exit from the loop above
+        # (the consumer stopped iterating early / the generator was
+        # cancelled) — never on a clean EOF, where the pull already
+        # finished and `proc.wait()` below just reaps the exit code.
+        #
+        # SIGTERM, not SIGKILL: `proc` here is `sudo`, not `podman` itself
+        # (see the `create_subprocess_exec` call above). sudo relays
+        # catchable signals like SIGTERM to the child it launched, so
+        # podman gets a chance to unwind (or at least exit) cleanly.
+        # SIGKILL cannot be caught or relayed by sudo, so a `.kill()` here
+        # would leave the root-owned `podman pull` orphaned, running to
+        # completion (or failure) with nobody watching — and, on the
+        # clean-EOF path specifically, killing sudo in the gap between the
+        # stdout pipe closing and `proc.wait()` running turns a fully
+        # successful pull into a reported `{"state": "failed", "error":
+        # "pull exited with code -9"}`.
+        if not clean_eof:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                proc.terminate()
 
     exit_code = await proc.wait()
     if exit_code == 0:
@@ -215,6 +243,7 @@ def remove_image(
     *,
     run: _RunFn = subprocess.run,
     is_hal0_user: Callable[[], bool] = is_hal0_service_user,
+    which: Callable[[str], str | None] | None = None,
     timeout: float = 60.0,
 ) -> tuple[RemoveOutcome, str | None]:
     """Guarded ``hal0-podman-rw image-rm <image>`` — never force-removes.
@@ -231,16 +260,57 @@ def remove_image(
         both; the wrapper does not distinguish them, so neither do we).
       * ``("unknown", reason)`` — every other case: a bad ref rejected before
         any subprocess ran (``"invalid-argument"``), this process is not the
-        ``hal0`` service account (``"not-service-user"``), ``sudo -n`` denied
-        (``"grant-denied"``), the wrapper's rc 64/65/66
+        ``hal0`` service account and not root (``"not-service-user"``),
+        ``sudo -n`` denied (``"grant-denied"``), the wrapper's rc 64/65/66
         (``"invalid-argument"``/``"podman-absent"``/``"podman-failed"``), or
         the call raising / an rc or stdout the contract does not define
         (``"seam-error"``).
+
+    Root fallback: when ``is_hal0_user()`` is False but this process is
+    already root (``os.geteuid() == 0`` — an admin at a root prompt, or
+    ``sudo -u hal0 hal0 runner-images rm ...`` run as ``sudo -i`` instead),
+    the seam is skipped but root's OWN podman IS the rootful store, so no
+    ``sudo`` round-trip is needed to reach it — mirrors the read-side
+    rootful/rootless fallback philosophy in
+    :func:`hal0.providers.podman_introspect.images` (root's own podman
+    answers just as authoritatively as the seam would). In that case this
+    runs ``podman rmi -- <ref>`` directly, no ``sudo``, no ``-f``:
+
+      * rc 0 -> ``("removed", None)``
+      * rc 1 -> ``("missing", None)``
+      * rc 2 -> ``("in-use", None)``
+      * any other rc, or a raise -> ``("unknown", "podman-failed")``
+      * ``podman`` absent from ``PATH`` -> ``("unknown", "podman-absent")``
+
+    A non-root, non-service-user caller still gets exactly
+    ``("unknown", "not-service-user")`` — the fallback is root-only, never a
+    way for an arbitrary unprivileged caller to bypass the seam.
     """
     if not is_valid_image_ref(image):
         return ("unknown", "invalid-argument")
     if not is_hal0_user():
-        return ("unknown", "not-service-user")
+        if os.geteuid() != 0:
+            return ("unknown", "not-service-user")
+        which_fn = which or shutil.which
+        podman = which_fn("podman")
+        if podman is None:
+            return ("unknown", "podman-absent")
+        try:
+            proc = run(
+                [podman, "rmi", "--", image],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ("unknown", "podman-failed")
+        if proc.returncode == 0:
+            return ("removed", None)
+        if proc.returncode == 1:
+            return ("missing", None)
+        if proc.returncode == 2:
+            return ("in-use", None)
+        return ("unknown", "podman-failed")
     try:
         proc = run(
             ["sudo", "-n", RW_SEAM_BIN, "image-rm", image],

--- a/src/hal0/registry/runner_image_store.py
+++ b/src/hal0/registry/runner_image_store.py
@@ -325,6 +325,12 @@ class RunnerImageStore:
             leaves the marker untouched — deleting one tag must not erase
             proof that a sibling tag is still downloaded.
 
+        Deliberate non-fix: deleting the row's own HEADLINE tag (``image.tag``)
+        does not update that scalar column — ``row.tag`` is left pointing at
+        a now-untagged value until the next sync rewrites it. Self-heals on
+        the next successful sync pass; not fixed here to keep this method a
+        single, narrow concern (the tag-row/available-tags/marker triple).
+
         Notifies ``on_change`` only when a row was actually deleted.
         """
         with self._connect() as conn:

--- a/src/hal0/registry/runner_image_store.py
+++ b/src/hal0/registry/runner_image_store.py
@@ -60,6 +60,24 @@ def _row_to_runner_image(row: sqlite3.Row) -> RunnerImage:
     )
 
 
+def _marker_matches_ref(local_path: str, ref: str) -> bool:
+    """Best-effort: does the marker JSON at ``local_path`` record ``ref``?
+
+    ``local_path`` is expected to be a ``hal0.registry.runner_pull.write_local_marker``
+    file (``{"image_id": ..., "image": "<ref pulled>", "pulled_at": ...}``),
+    but this is read directly (rather than importing that module, which
+    itself imports :class:`RunnerImageStore` — a cycle) and fail-soft on
+    anything else: a missing file, non-JSON content, or an unexpected shape
+    all answer False rather than raising, so a store mutation is never
+    blocked by a stale or foreign ``local_path`` value.
+    """
+    try:
+        data = json.loads(Path(local_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and data.get("image") == ref
+
+
 def _runner_image_to_row(image: RunnerImage, *, discovered_at: str | None = None) -> dict[str, Any]:
     now = datetime.now(UTC).isoformat()
     row: dict[str, Any] = {k: getattr(image, k) for k in _SCALAR_FIELDS if k != "discovered_at"}
@@ -286,6 +304,71 @@ class RunnerImageStore:
                     ],
                 )
         self._notify_change()
+
+    def remove_tag(self, image_id: str, tag: str) -> bool:
+        """Delete one ``(image_id, tag)`` row from ``runner_image_tag``.
+
+        One transaction. Returns False (nothing committed) if the row
+        didn't exist — a caller can't tell an already-absent tag from a
+        freshly-deleted one otherwise. When a row IS deleted:
+
+          * ``tag`` is pruned from the parent row's ``available_tags``
+            list, if present there (the images.json-sourced string list,
+            tracked separately from the ``runner_image_tag`` digest facts
+            this method deletes from).
+          * The parent row's ``local_path``/``downloaded_at`` (pull
+            provenance) are cleared when EITHER no ``runner_image_tag``
+            rows remain for this id, OR the marker file at ``local_path``
+            (fail-soft JSON read, see :func:`_marker_matches_ref`) recorded
+            pulling exactly the removed ``<image>:<tag>``. Any other case
+            (the marker belongs to a different, still-catalogued tag)
+            leaves the marker untouched — deleting one tag must not erase
+            proof that a sibling tag is still downloaded.
+
+        Notifies ``on_change`` only when a row was actually deleted.
+        """
+        with self._connect() as conn:
+            self._ensure_migrated(conn)
+            with tx(conn):
+                cur = conn.execute(
+                    "DELETE FROM runner_image_tag WHERE image_id = ? AND tag = ?",
+                    (image_id, tag),
+                )
+                if cur.rowcount == 0:
+                    return False
+                image_row = conn.execute(
+                    "SELECT image, available_tags_json, local_path FROM runner_image WHERE id = ?",
+                    (image_id,),
+                ).fetchone()
+                if image_row is not None:
+                    available = (
+                        json.loads(image_row["available_tags_json"])
+                        if image_row["available_tags_json"]
+                        else []
+                    )
+                    if tag in available:
+                        pruned = [t for t in available if t != tag]
+                        conn.execute(
+                            "UPDATE runner_image SET available_tags_json = ? WHERE id = ?",
+                            (json.dumps(pruned) if pruned else None, image_id),
+                        )
+                    local_path = image_row["local_path"]
+                    remaining = conn.execute(
+                        "SELECT COUNT(*) FROM runner_image_tag WHERE image_id = ?",
+                        (image_id,),
+                    ).fetchone()[0]
+                    clear_marker = bool(local_path) and (
+                        remaining == 0
+                        or _marker_matches_ref(local_path, f"{image_row['image']}:{tag}")
+                    )
+                    if clear_marker:
+                        conn.execute(
+                            "UPDATE runner_image SET local_path = NULL, downloaded_at = NULL, "
+                            "updated_at = ? WHERE id = ?",
+                            (datetime.now(UTC).isoformat(), image_id),
+                        )
+        self._notify_change()
+        return True
 
     def reload(self) -> None:
         """No-op — kept for interface symmetry with SqliteModelRegistry."""

--- a/src/hal0/registry/runner_pull.py
+++ b/src/hal0/registry/runner_pull.py
@@ -7,7 +7,11 @@ pulls a whole OCI container image via the existing
 ``hal0.providers.container.ContainerProvider.pull_image_stream`` layer-progress
 generator (``podman pull`` subprocess, one layer-progress dict per output
 line) rather than streaming a single HTTP file, so progress here is tracked
-in *layers* (``layers_done``/``layers_total``) instead of bytes. The
+in *layers* (``layers_done``/``layers_total``) instead of bytes.
+``pull_image_stream`` itself now routes through the rootful ``hal0-podman-rw``
+seam when available (runner-images v3 D1a, #2119) so a dashboard-triggered
+pull lands in the store slots actually launch from; the event shapes are
+identical either way, so nothing here changes. The
 job-state machine (queued → running → {completed, failed, cancelled}),
 persisted-snapshot format, and SSE-facing ``as_dict()`` shape otherwise
 mirror :class:`hal0.registry.pull.PullJob` closely so the orchestration

--- a/src/hal0/system/seam_check.py
+++ b/src/hal0/system/seam_check.py
@@ -3,10 +3,11 @@
 Every privileged operation hal0 performs post-P3-perms goes through one of a
 handful of narrow ``sudo -n /usr/lib/hal0/bin/hal0-*`` wrappers: slot lifecycle
 (``hal0-systemctl``), self-update (``hal0-update``), agent env files
-(``hal0-agentenv``), the benchmark harness (``hal0-benchctl``) and read-only
-podman introspection (``hal0-podman-ro``). ``install.sh`` installs each
-best-effort — a ``visudo -cf`` failure, or a missing source file, produced only
-a mid-log ``warn`` and the install still printed its success box.
+(``hal0-agentenv``), the benchmark harness (``hal0-benchctl``), read-only
+podman introspection (``hal0-podman-ro``), and the podman write surface
+(``hal0-podman-rw``). ``install.sh`` installs each best-effort — a
+``visudo -cf`` failure, or a missing source file, produced only a mid-log
+``warn`` and the install still printed its success box.
 
 Nothing verified the result afterwards. ``preflight_all`` never touched sudoers,
 ``doctor verify`` composes only live-API rows, and ``doctor all``'s extra rows
@@ -32,9 +33,10 @@ Three independent facts per seam:
   doesn't exist).
 
 The grant probe only runs for seams that expose a genuinely side-effect-free
-verb. ``hal0-systemctl help`` and ``hal0-update check`` do; the other three are
-presence-checked only, which is stated in the row detail rather than silently
-implied.
+verb. ``hal0-systemctl help``, ``hal0-update check``, ``hal0-podman-ro
+check-slot-token`` and ``hal0-podman-rw check-image-ref`` do; the remaining
+seams are presence-checked only, which is stated in the row detail rather
+than silently implied.
 """
 
 from __future__ import annotations
@@ -108,6 +110,19 @@ SEAMS: tuple[SeamSpec, ...] = (
         probe=("check-slot-token", "hal0probe"),
         required=False,
         role="podman image introspection (slot image_status / actual_image)",
+    ),
+    # runner-images v3 (D1(a)/D2): the FIRST write surface for the rootful
+    # podman store — image-pull / image-rm — separate and independently
+    # revocable from the read-only seam above. `check-image-ref` is the
+    # side-effect-free validator probe (never touches podman), mirroring
+    # `check-slot-token` on hal0-podman-ro: presence-checking alone would let
+    # a stale pre-write-seam wrapper (there was none, but the pattern still
+    # applies to any future narrowing) probe green with neither verb wired.
+    SeamSpec(
+        "hal0-podman-rw",
+        probe=("check-image-ref", "hal0probe"),
+        required=False,
+        role="podman image write (manifest-gated pull / stale-image eviction)",
     ),
 )
 

--- a/tests/api/test_runner_images_routes.py
+++ b/tests/api/test_runner_images_routes.py
@@ -1146,3 +1146,299 @@ class TestCanonicalFamilyFold:
         body = isolated_client.get("/api/runner-images").json()
         rocm = next(f for f in body["families"] if f["family"] == "rocmfpx")
         assert rocm["effective_ref"] == "ghcr.io/x/a:canonical"
+
+
+# ── DELETE /{image_id:path}/tags/{tag} — disk reclaim (D2, #2106) ───────────
+
+
+class TestDeleteRunnerImageTag:
+    IMAGE_ID = "hal0ai/hal0-combined"
+
+    def _seed(self, client: TestClient, **overrides) -> None:
+        from hal0.registry.runner_image import RunnerImage, RunnerImageTag
+
+        store = client.app.state.runner_image_registry
+        kw = {"available_tags": ["0826", "0824"], **overrides}
+        store.upsert(
+            RunnerImage(id=self.IMAGE_ID, image="ghcr.io/hal0ai/hal0-combined", tag="0826", **kw)
+        )
+        store.set_tags(
+            self.IMAGE_ID,
+            [
+                RunnerImageTag(tag="0826", digest="sha256:" + "a" * 64),
+                RunnerImageTag(tag="0824", digest="sha256:" + "b" * 64),
+            ],
+        )
+
+    def _fake_remove_image(self, monkeypatch: pytest.MonkeyPatch, outcome: str, reason=None):
+        calls: list[str] = []
+
+        def _fake(ref: str):
+            calls.append(ref)
+            return (outcome, reason)
+
+        monkeypatch.setattr("hal0.providers.podman_mutate.remove_image", _fake)
+        return calls
+
+    # ── 404s ─────────────────────────────────────────────────────────────
+
+    def test_unknown_image_404s(self, client: TestClient) -> None:
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 404
+        assert resp.json()["error"]["code"] == "runner_image.not_found"
+
+    def test_unknown_tag_404s(self, client: TestClient) -> None:
+        self._seed(client)
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/9999")
+        assert resp.status_code == 404
+        err = resp.json()["error"]
+        assert err["code"] == "runner_image.tag_not_found"
+        assert err["details"] == {"image_id": self.IMAGE_ID, "tag": "9999"}
+
+    # ── in-use guards ────────────────────────────────────────────────────
+
+    def test_app_level_guard_409_names_slot_on_exact_ref_match(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._seed(client)
+        monkeypatch.setattr(
+            "hal0.api.routes.runner_images._slot_image_usage",
+            lambda: {"brain": "ghcr.io/hal0ai/hal0-combined:0824"},
+        )
+
+        def _boom(ref: str):
+            raise AssertionError("seam must not be reached when app-level guard fires")
+
+        monkeypatch.setattr("hal0.providers.podman_mutate.remove_image", _boom)
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 409
+        err = resp.json()["error"]
+        assert err["code"] == "runner_image.tag_in_use"
+        assert err["details"]["slots"] == ["brain"]
+
+    def test_app_level_guard_409_names_slot_on_digest_sibling_match(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Deleting the headline 0826 while a slot is pinned to 0824 — a
+        DIFFERENT tag of the same repo that (per the seeded digests) shares
+        0826's digest — is caught even though the ref strings differ."""
+        self._seed(client)
+        from hal0.registry.runner_image import RunnerImageTag
+
+        client.app.state.runner_image_registry.set_tags(
+            self.IMAGE_ID,
+            [
+                RunnerImageTag(tag="0826", digest="sha256:" + "a" * 64),
+                RunnerImageTag(tag="0824", digest="sha256:" + "a" * 64),  # same digest as 0826
+            ],
+        )
+        monkeypatch.setattr(
+            "hal0.api.routes.runner_images._slot_image_usage",
+            lambda: {"agent": "ghcr.io/hal0ai/hal0-combined:0824"},
+        )
+
+        def _boom(ref: str):
+            raise AssertionError("seam must not be reached when app-level guard fires")
+
+        monkeypatch.setattr("hal0.providers.podman_mutate.remove_image", _boom)
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0826")
+        assert resp.status_code == 409
+        assert resp.json()["error"]["details"]["slots"] == ["agent"]
+
+    def test_seam_level_in_use_409_names_no_slots(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The app-level guard didn't catch anything (no slot config
+        matches), but the seam itself refuses (rc 67) — still 409, but
+        ``slots`` is absent/empty since no slot was implicated."""
+        self._seed(client)
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        self._fake_remove_image(monkeypatch, "in-use")
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 409
+        err = resp.json()["error"]
+        assert err["code"] == "runner_image.tag_in_use"
+        assert not err["details"].get("slots")
+
+        # catalogue untouched
+        detail = client.get(f"/api/runner-images/{self.IMAGE_ID}").json()
+        assert any(t["tag"] == "0824" for t in detail["tags"])
+
+    # ── seam-unavailable ─────────────────────────────────────────────────
+
+    def test_seam_unavailable_502_catalogue_untouched(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._seed(client)
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        self._fake_remove_image(monkeypatch, "unknown", "grant-denied")
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 502
+        err = resp.json()["error"]
+        assert err["code"] == "runner_image.rm_unavailable"
+        assert err["details"]["reason"] == "grant-denied"
+
+        detail = client.get(f"/api/runner-images/{self.IMAGE_ID}").json()
+        assert any(t["tag"] == "0824" for t in detail["tags"])
+        assert "0824" in detail["available_tags"]
+
+    # ── happy paths ──────────────────────────────────────────────────────
+
+    def test_removed_outcome_drops_the_tag_row(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._seed(client)
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        calls = self._fake_remove_image(monkeypatch, "removed")
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 200
+        assert resp.json() == {"removed": True, "outcome": "removed"}
+        assert calls == ["ghcr.io/hal0ai/hal0-combined:0824"]
+
+        detail = client.get(f"/api/runner-images/{self.IMAGE_ID}").json()
+        assert all(t["tag"] != "0824" for t in detail["tags"])
+        assert detail["available_tags"] == ["0826"]
+
+    def test_missing_outcome_also_drops_the_tag_row(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """podman already had no such image (a previous manual rm, e.g.) —
+        still an honest, successful reconciliation, not an error."""
+        self._seed(client)
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        self._fake_remove_image(monkeypatch, "missing")
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 200
+        assert resp.json() == {"removed": False, "outcome": "missing"}
+
+        detail = client.get(f"/api/runner-images/{self.IMAGE_ID}").json()
+        assert all(t["tag"] != "0824" for t in detail["tags"])
+
+    def test_headline_tag_deletable_even_without_available_tags_entry(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The headline ``tag`` column is always a valid delete target, even
+        if (unusually) it isn't also listed in available_tags."""
+        from hal0.registry.runner_image import RunnerImage, RunnerImageTag
+
+        store = client.app.state.runner_image_registry
+        store.upsert(RunnerImage(id="solo", image="ghcr.io/x/solo", tag="only"))
+        store.set_tags("solo", [RunnerImageTag(tag="only")])
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        self._fake_remove_image(monkeypatch, "removed")
+
+        resp = client.delete("/api/runner-images/solo/tags/only")
+        assert resp.status_code == 200
+        assert resp.json()["removed"] is True
+
+    def test_marker_unlinked_on_disk_when_last_tag_removed(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        from hal0.registry.runner_image import RunnerImage, RunnerImageTag
+
+        marker = tmp_path / "marker.json"
+        marker.write_text('{"image_id": "solo", "image": "ghcr.io/x/solo:only"}')
+
+        store = client.app.state.runner_image_registry
+        store.upsert(RunnerImage(id="solo", image="ghcr.io/x/solo", tag="only"))
+        store.set_tags("solo", [RunnerImageTag(tag="only")])
+        store.set_local_state("solo", local_path=str(marker), downloaded_at="t")
+        assert marker.exists()
+
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        self._fake_remove_image(monkeypatch, "removed")
+
+        resp = client.delete("/api/runner-images/solo/tags/only")
+        assert resp.status_code == 200
+        assert not marker.exists()
+
+        detail = client.get("/api/runner-images/solo").json()
+        assert detail["downloaded"] is False
+
+    def test_marker_left_alone_when_sibling_tag_survives(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        marker = tmp_path / "marker.json"
+        marker.write_text(
+            f'{{"image_id": "{self.IMAGE_ID}", "image": "ghcr.io/hal0ai/hal0-combined:0826"}}'
+        )
+        self._seed(client)
+        client.app.state.runner_image_registry.set_local_state(
+            self.IMAGE_ID, local_path=str(marker), downloaded_at="t"
+        )
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        self._fake_remove_image(monkeypatch, "removed")
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 200
+        assert marker.exists()  # still the marker for the surviving 0826 tag
+
+    # ── audit ────────────────────────────────────────────────────────────
+
+    def test_records_audit_action_on_success(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._seed(client)
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        self._fake_remove_image(monkeypatch, "removed")
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 200
+
+        activity = client.get(
+            "/api/activity", params={"category": "runner_image", "action": "runner_image.rm"}
+        ).json()
+        rec = next(
+            r for r in activity["records"] if r["target"] == "ghcr.io/hal0ai/hal0-combined:0824"
+        )
+        assert rec["outcome"] == "ok"
+        assert rec["after"] == {"outcome": "removed"}
+
+    def test_records_audit_action_as_error_on_conflict(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._seed(client)
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        self._fake_remove_image(monkeypatch, "in-use")
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 409
+
+        activity = client.get(
+            "/api/activity", params={"category": "runner_image", "action": "runner_image.rm"}
+        ).json()
+        rec = next(
+            r for r in activity["records"] if r["target"] == "ghcr.io/hal0ai/hal0-combined:0824"
+        )
+        assert rec["outcome"] == "error"
+
+    # ── route ordering ───────────────────────────────────────────────────
+
+    def test_delete_tag_route_ordering(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GET single-image still resolves to the catch-all, and DELETE
+        .../tags/{tag} resolves to the new route — neither swallows the
+        other regardless of registration order (#2106)."""
+        self._seed(client)
+
+        get_resp = client.get(f"/api/runner-images/{self.IMAGE_ID}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["id"] == self.IMAGE_ID
+
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        self._fake_remove_image(monkeypatch, "removed")
+        delete_resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert delete_resp.status_code == 200
+        assert delete_resp.json() == {"removed": True, "outcome": "removed"}
+
+        # GET still resolves correctly for the id afterward too.
+        get_resp2 = client.get(f"/api/runner-images/{self.IMAGE_ID}")
+        assert get_resp2.status_code == 200
+        assert all(t["tag"] != "0824" for t in get_resp2.json()["tags"])

--- a/tests/api/test_runner_images_routes.py
+++ b/tests/api/test_runner_images_routes.py
@@ -1195,6 +1195,89 @@ class TestDeleteRunnerImageTag:
         assert err["code"] == "runner_image.tag_not_found"
         assert err["details"] == {"image_id": self.IMAGE_ID, "tag": "9999"}
 
+    # ── pull-race guard (fix round 1, #2106) ────────────────────────────
+
+    def test_in_flight_pull_of_same_tag_409s_catalogue_untouched(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A running pull for THIS tag must block the delete — otherwise the
+        pull can complete after ``store.remove_tag`` and re-stamp
+        ``local_path``/``downloaded_at`` via ``set_local_state``, leaving the
+        row ``downloaded=True`` with zero tag rows (reviewer-reproduced
+        race, fix round 1)."""
+        from hal0.registry.runner_pull import make_job
+
+        self._seed(client)
+        job = make_job(self.IMAGE_ID, "ghcr.io/hal0ai/hal0-combined:0824", tag="0824")
+        job.state = "running"
+        client.app.state.runner_image_pull_jobs[self.IMAGE_ID] = job
+
+        def _boom(ref: str):
+            raise AssertionError("seam must not be reached while a pull is in flight")
+
+        monkeypatch.setattr("hal0.providers.podman_mutate.remove_image", _boom)
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "runner_image.pull_in_progress"
+
+        detail = client.get(f"/api/runner-images/{self.IMAGE_ID}").json()
+        assert any(t["tag"] == "0824" for t in detail["tags"])
+
+    def test_queued_untagged_job_also_blocks(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An older untagged job record (``job.tag is None``) always pulls
+        the headline — it must block a delete of the headline tag too."""
+        from hal0.registry.runner_pull import make_job
+
+        self._seed(client)
+        job = make_job(self.IMAGE_ID, "ghcr.io/hal0ai/hal0-combined:0826")
+        job.state = "queued"
+        client.app.state.runner_image_pull_jobs[self.IMAGE_ID] = job
+        monkeypatch.setattr(
+            "hal0.providers.podman_mutate.remove_image",
+            lambda ref: (_ for _ in ()).throw(AssertionError("seam must not be reached")),
+        )
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0826")
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "runner_image.pull_in_progress"
+
+    def test_in_flight_pull_of_a_different_tag_does_not_block(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A running pull for a DIFFERENT tag of the same id must not block
+        deleting an unrelated, already-downloaded tag."""
+        from hal0.registry.runner_pull import make_job
+
+        self._seed(client)
+        job = make_job(self.IMAGE_ID, "ghcr.io/hal0ai/hal0-combined:0826", tag="0826")
+        job.state = "running"
+        client.app.state.runner_image_pull_jobs[self.IMAGE_ID] = job
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        self._fake_remove_image(monkeypatch, "removed")
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 200
+
+    def test_terminal_job_does_not_block(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A completed/failed/cancelled job record for this id is stale, not
+        in-flight — it must not block the delete."""
+        from hal0.registry.runner_pull import make_job
+
+        self._seed(client)
+        job = make_job(self.IMAGE_ID, "ghcr.io/hal0ai/hal0-combined:0824", tag="0824")
+        job.state = "completed"
+        client.app.state.runner_image_pull_jobs[self.IMAGE_ID] = job
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        self._fake_remove_image(monkeypatch, "removed")
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 200
+
     # ── in-use guards ────────────────────────────────────────────────────
 
     def test_app_level_guard_409_names_slot_on_exact_ref_match(
@@ -1398,7 +1481,38 @@ class TestDeleteRunnerImageTag:
             r for r in activity["records"] if r["target"] == "ghcr.io/hal0ai/hal0-combined:0824"
         )
         assert rec["outcome"] == "ok"
-        assert rec["after"] == {"outcome": "removed"}
+        assert rec["after"] == {"outcome": "removed", "catalogue_removed": True}
+
+    def test_desync_logged_and_recorded_when_seam_removes_but_no_catalogue_row(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Fix round 1 (#2106, low finding): the seam agreeing the bytes are
+        gone doesn't guarantee ``store.remove_tag`` found a matching row —
+        e.g. the headline tag validated via ``image.tag`` with no
+        ``runner_image_tag`` row ever synced for it. That desync must be
+        both audited (``rec.after.catalogue_removed`` is ``False``) and
+        logged, without turning an honest 200 into an error."""
+        import logging
+
+        from hal0.registry.runner_image import RunnerImage
+
+        store = client.app.state.runner_image_registry
+        store.upsert(RunnerImage(id="ghost", image="ghcr.io/x/ghost", tag="only"))
+        # Deliberately no set_tags call — no runner_image_tag row for "only".
+        monkeypatch.setattr("hal0.api.routes.runner_images._slot_image_usage", lambda: {})
+        self._fake_remove_image(monkeypatch, "removed")
+
+        with caplog.at_level(logging.WARNING, logger="hal0.api.routes.runner_images"):
+            resp = client.delete("/api/runner-images/ghost/tags/only")
+        assert resp.status_code == 200
+        assert resp.json() == {"removed": True, "outcome": "removed"}
+        assert "runner_image.rm_catalogue_desync" in caplog.text
+
+        activity = client.get(
+            "/api/activity", params={"category": "runner_image", "action": "runner_image.rm"}
+        ).json()
+        rec = next(r for r in activity["records"] if r["target"] == "ghcr.io/x/ghost:only")
+        assert rec["after"] == {"outcome": "removed", "catalogue_removed": False}
 
     def test_records_audit_action_as_error_on_conflict(
         self, client: TestClient, monkeypatch: pytest.MonkeyPatch

--- a/tests/cli/test_runner_image_commands.py
+++ b/tests/cli/test_runner_image_commands.py
@@ -17,6 +17,7 @@ import pytest
 from typer.testing import CliRunner
 
 from hal0.cli.runner_image_commands import app as runner_images_app
+from hal0.providers import podman_mutate
 from hal0.registry.runner_image import RunnerImage
 from hal0.registry.runner_image_store import RunnerImageStore
 
@@ -91,3 +92,103 @@ class TestPull:
 
         assert result.exit_code != 0
         assert result.output.strip()
+
+
+class TestRm:
+    """``hal0 runner-images rm <id> --tag TAG`` (#2106 D2, CLI surface).
+
+    Mirrors ``DELETE /api/runner-images/{id}/tags/{tag}``'s guard order —
+    ``podman_mutate.remove_image`` is monkeypatched at the module attribute
+    the CLI calls through (``hal0.providers.podman_mutate.remove_image``),
+    same idiom the route's own tests use, so no real seam/subprocess is
+    exercised.
+    """
+
+    def test_unknown_id_errors(self, store: RunnerImageStore) -> None:
+        result = runner.invoke(runner_images_app, ["rm", "nope", "--tag", "0826"])
+
+        assert result.exit_code != 0
+        assert "not in catalogue" in result.output
+
+    def test_missing_tag_option_errors(self, store: RunnerImageStore) -> None:
+        store.upsert(_image())
+
+        result = runner.invoke(runner_images_app, ["rm", "x/a"])
+
+        assert result.exit_code != 0
+
+    def test_unknown_tag_errors(self, store: RunnerImageStore) -> None:
+        store.upsert(_image())
+
+        result = runner.invoke(runner_images_app, ["rm", "x/a", "--tag", "does-not-exist"])
+
+        assert result.exit_code != 0
+        assert "not catalogued" in result.output
+
+    def test_removed_happy_path(
+        self, store: RunnerImageStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store.upsert(_image())
+        monkeypatch.setattr(podman_mutate, "remove_image", lambda ref, **kw: ("removed", None))
+
+        result = runner.invoke(runner_images_app, ["rm", "x/a", "--tag", "0826"])
+
+        assert result.exit_code == 0, result.output
+        assert "removed ghcr.io/x/a:0826" in result.output
+        assert store.get("x/a") is None or "0826" not in [t.tag for t in store.get("x/a").tags]
+
+    def test_missing_outcome_still_exits_zero_and_clears_catalogue(
+        self, store: RunnerImageStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store.upsert(_image())
+        monkeypatch.setattr(podman_mutate, "remove_image", lambda ref, **kw: ("missing", None))
+
+        result = runner.invoke(runner_images_app, ["rm", "x/a", "--tag", "0826"])
+
+        assert result.exit_code == 0, result.output
+        assert "not on disk" in result.output.lower()
+        assert "catalogue entry cleared" in result.output.lower()
+
+    def test_seam_in_use_refuses(
+        self, store: RunnerImageStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store.upsert(_image())
+        monkeypatch.setattr(podman_mutate, "remove_image", lambda ref, **kw: ("in-use", None))
+
+        result = runner.invoke(runner_images_app, ["rm", "x/a", "--tag", "0826"])
+
+        assert result.exit_code != 0
+        assert "in use" in result.output.lower()
+
+    def test_slot_in_use_refuses_and_names_slot(
+        self, store: RunnerImageStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store.upsert(_image())
+        monkeypatch.setattr(
+            "hal0.api.routes.runner_images._slot_image_usage",
+            lambda: {"brain": "ghcr.io/x/a:0826"},
+        )
+
+        def _boom(ref: str, **kw: object) -> tuple[str, None]:
+            raise AssertionError("seam-level remove_image should not be reached")
+
+        monkeypatch.setattr(podman_mutate, "remove_image", _boom)
+
+        result = runner.invoke(runner_images_app, ["rm", "x/a", "--tag", "0826"])
+
+        assert result.exit_code != 0
+        assert "brain" in result.output
+        assert "in use" in result.output.lower()
+
+    def test_unknown_seam_outcome_errors_with_reason(
+        self, store: RunnerImageStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store.upsert(_image())
+        monkeypatch.setattr(
+            podman_mutate, "remove_image", lambda ref, **kw: ("unknown", "grant-denied")
+        )
+
+        result = runner.invoke(runner_images_app, ["rm", "x/a", "--tag", "0826"])
+
+        assert result.exit_code != 0
+        assert "grant-denied" in result.output

--- a/tests/cli/test_runner_image_commands.py
+++ b/tests/cli/test_runner_image_commands.py
@@ -192,3 +192,22 @@ class TestRm:
 
         assert result.exit_code != 0
         assert "grant-denied" in result.output
+
+    def test_not_service_user_outcome_errors_actionably(
+        self, store: RunnerImageStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The not-service-user case is the one an operator hits interactively
+        (running the CLI from a dev/admin shell, not as the hal0 service
+        account) — its error text should tell them what to actually do next,
+        not just name the reason code."""
+        store.upsert(_image())
+        monkeypatch.setattr(
+            podman_mutate, "remove_image", lambda ref, **kw: ("unknown", "not-service-user")
+        )
+
+        result = runner.invoke(runner_images_app, ["rm", "x/a", "--tag", "0826"])
+
+        assert result.exit_code != 0
+        assert "not-service-user" in result.output
+        assert "sudo -u hal0 hal0 runner-images rm" in result.output
+        assert "root" in result.output.lower()

--- a/tests/installer/test_podman_rw_validation.py
+++ b/tests/installer/test_podman_rw_validation.py
@@ -267,5 +267,7 @@ def test_ro_wrapper_help_has_no_write_verbs() -> None:
 
 
 def test_ro_wrapper_still_parses() -> None:
-    proc = subprocess.run(["bash", "-n", str(RO_WRAPPER)], capture_output=True, text=True, check=False)
+    proc = subprocess.run(
+        ["bash", "-n", str(RO_WRAPPER)], capture_output=True, text=True, check=False
+    )
     assert proc.returncode == 0, proc.stderr

--- a/tests/installer/test_podman_rw_validation.py
+++ b/tests/installer/test_podman_rw_validation.py
@@ -1,0 +1,271 @@
+"""runner-images v3 PHASE 4, Task 1 — the FIRST privileged WRITE surface for
+podman: ``installer/wrappers/hal0-podman-rw``.
+
+``hal0-podman-ro`` (packaging/sudoers/hal0-podman-ro) is read-only by design:
+slots run ROOTFUL podman (Quadlet units under /etc/containers/systemd/,
+root's image store), so hal0-api — running as the unprivileged ``hal0``
+service user — needs a root-side seam to even SEE that store, and #1889
+deliberately keeps rm/run/build/exec/pull off that seam.
+
+D1(a)/D2 of the runner-images v3 spec need hal0-api to be able to PULL and
+REMOVE images in that same rootful store (the one slots actually launch
+from) — a bare rootless ``podman pull``/``podman rmi`` from hal0-api would
+write to the wrong store entirely, the mirror-image of the #1889 bug this
+sibling wrapper exists to avoid re-creating. Hence a new, narrower grant:
+``hal0-podman-rw`` exposes exactly two verbs (``image-pull``, ``image-rm``),
+each taking the same validated image ref as ``-ro``'s argument-taking verbs,
+and reuses that wrapper's exact validation boundary (root-side regex before
+podman ever sees the argv, LC_ALL=C pin, single positional operand only).
+
+These tests exercise the REAL bash wrapper, no root/sudo/podman required for
+the validation-boundary assertions (the ``-ro`` suite's posture) — only
+``check-image-ref`` and the various rc-64/65 short-circuits are reachable
+without podman installed. They also assert that ``-ro`` was not widened: its
+help output must still list no write verb.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hal0.providers.podman_introspect import is_valid_image_ref
+
+REPO = Path(__file__).resolve().parents[2]
+WRAPPER = REPO / "installer" / "wrappers" / "hal0-podman-rw"
+RO_WRAPPER = REPO / "installer" / "wrappers" / "hal0-podman-ro"
+
+# A minimal PATH: the wrapper must not depend on the caller's environment.
+_ENV = {"PATH": "/usr/bin:/bin"}
+
+_DIGEST = "a" * 64
+
+#: Refs that MUST be accepted — same corpus as the -ro suite, since both
+#: wrappers share IMAGE_REF_RE verbatim.
+LEGITIMATE_REFS = [
+    "alpine",
+    "alpine:latest",
+    "alpine:3.19",
+    "docker.io/library/alpine:3.19",
+    "ghcr.io/thinmintdev/hal0-rocmfpx:latest",
+    "quay.io/hal0/runner:v1.0.0-rc.6",
+    "localhost/hal0-toolbox:dev",
+    "localhost:5000/team/img:v1.2.3",
+    "registry.example.com:443/a/b/c/deep:tag",
+    f"ghcr.io/x/y@sha256:{_DIGEST}",
+    f"ghcr.io/x/y:tag@sha256:{_DIGEST}",
+    "rocm/vllm-dev:nightly_main_20260101",
+    "registry.example/team/model__gpu:v1",
+    "team/model--gpu:v1",
+    "my--registry.example.com/a__b/c.d-e_f:tag",
+    "[2001:db8::1]:5000/team/model:v1",
+    "[::1]/local/img",
+]
+
+#: Argv that must never reach podman. Same shapes as the -ro suite.
+MALICIOUS_REFS = [
+    "alpine; rm -rf /",
+    "alpine && id",
+    "alpine || id",
+    "alpine | id",
+    "alpine $(id)",
+    "alpine `id`",
+    "alpine\nid",
+    "alpine\tid",
+    "alpine id",
+    "$(id)",
+    ";id",
+    "&id",
+    ">/etc/passwd",
+    "<(id)",
+    "alpine:tag;whoami",
+    # flag smuggling — a leading '-' must never be readable as an option
+    "-v/:/host",
+    "--format={{.Config}}",
+    "--rm",
+    "-f",
+    "-",
+    # path traversal shapes
+    "../../../etc/shadow",
+    "foo/../../etc/passwd",
+    "foo..bar",
+    "..",
+    "./alpine",
+    "/etc/passwd",
+    # malformed digests
+    "alpine@sha256:zzzz",
+    # IPv6 brackets must not become a hole: only hex+colons inside
+    "[2001:db8::1;id]:5000/foo",
+    "[../etc]/foo",
+    "[]/foo",
+    "[2001:db8::1]extra/foo",
+    "alpine@sha512:" + _DIGEST,
+    "alpine@sha256:" + "a" * 63,
+    "alpine@sha256:" + "A" * 64,
+    # separators the OCI grammar does not allow
+    "-alpine",
+    "alpine-",
+    "foo//bar",
+    "foo/",
+    "/foo",
+    ":latest",
+    "alpine:",
+    "",
+    # unicode / control bytes
+    "alpine\rid",
+    "alpine\x1b[31m",
+    "alpine\x7f",
+    "alpiné",
+    "alpine‮id",
+]
+
+
+def _run(*argv: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(WRAPPER), *argv],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env or _ENV,
+    )
+
+
+def _run_ro(*argv: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(RO_WRAPPER), *argv],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_ENV,
+    )
+
+
+# ── the wrapper is syntactically sound and self-describing ─────────────────
+
+
+def test_wrapper_parses() -> None:
+    proc = subprocess.run(["bash", "-n", str(WRAPPER)], capture_output=True, text=True, check=False)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_help_lists_both_write_verbs() -> None:
+    proc = _run("help")
+    assert proc.returncode == 0, proc.stderr
+    assert "image-pull" in proc.stdout
+    assert "image-rm" in proc.stdout
+
+
+def test_help_documents_the_67_exit_code() -> None:
+    proc = _run("help")
+    assert proc.returncode == 0, proc.stderr
+    assert "67" in proc.stdout
+
+
+def test_unknown_verb_is_rejected() -> None:
+    proc = _run("rm")
+    assert proc.returncode == 64
+    assert "bad cmd" in proc.stderr
+
+
+# ── arg-count / validation rejects (rc 64), reachable without podman ────────
+
+
+@pytest.mark.parametrize("verb", ["image-pull", "image-rm"])
+def test_argument_verbs_require_exactly_one_argument(verb: str) -> None:
+    assert _run(verb).returncode == 64
+    assert _run(verb, "alpine", "extra").returncode == 64
+
+
+@pytest.mark.parametrize("verb", ["image-pull", "image-rm", "check-image-ref"])
+@pytest.mark.parametrize("ref", MALICIOUS_REFS)
+def test_wrapper_rejects_malicious_image_ref(verb: str, ref: str) -> None:
+    proc = _run(verb, ref)
+    assert proc.returncode == 64, f"{verb} ACCEPTED {ref!r} (rc={proc.returncode})"
+    assert "hal0-podman-rw:" in proc.stderr
+
+
+def test_wrapper_rejects_overlong_image_ref() -> None:
+    proc = _run("check-image-ref", "a" * 513)
+    assert proc.returncode == 64
+    assert "too long" in proc.stderr
+    assert _run("check-image-ref", "a" * 512).returncode == 0
+
+
+# ── check-image-ref parity spot-check against -ro ───────────────────────────
+
+
+@pytest.mark.parametrize("ref", LEGITIMATE_REFS)
+def test_check_image_ref_accepts_same_good_refs_as_ro(ref: str) -> None:
+    rw_proc = _run("check-image-ref", ref)
+    ro_proc = _run_ro("check-image-ref", ref)
+    assert rw_proc.returncode == 0, f"rejected {ref!r}: {rw_proc.stderr}"
+    assert rw_proc.returncode == ro_proc.returncode
+    assert rw_proc.stdout == ro_proc.stdout == f"{ref}\n"
+
+
+@pytest.mark.parametrize("ref", [*LEGITIMATE_REFS, *MALICIOUS_REFS, "a" * 513])
+def test_python_image_ref_mirror_agrees_with_the_wrapper(ref: str) -> None:
+    assert is_valid_image_ref(ref) == (_run("check-image-ref", ref).returncode == 0), (
+        f"mirror disagrees with the wrapper on {ref!r}"
+    )
+
+
+# ── locale independence, same pin as -ro ────────────────────────────────────
+
+
+def test_wrapper_pins_the_locale_itself() -> None:
+    src = WRAPPER.read_text()
+    assert "export LC_ALL=C" in src
+    lines = [ln.strip() for ln in src.splitlines()]
+    assert lines.index("export LC_ALL=C") < lines.index(
+        "validate_image_ref() {   # arg: image reference"
+    )
+
+
+# ── exit-code contract: image-rm's rc 0/1/2/other mapping ──────────────────
+
+
+def test_image_rm_source_maps_rmi_exit_codes() -> None:
+    """Structural pin (no podman/root available here): rc 0 -> "removed"/0,
+    rc 1 (no such image) -> "missing"/0 (a real negative answer), rc 2 (image
+    in use by a container) -> the NEW 67, anything else -> podman_failed 66.
+    Never `rmi -f`."""
+    src = WRAPPER.read_text()
+    rmi_line = next(ln.strip() for ln in src.splitlines() if "rmi" in ln and "run_podman" in ln)
+    assert rmi_line == 'run_podman rmi -- "$1"'
+    assert "-f" not in rmi_line
+    assert "removed" in src
+    assert "missing" in src
+    assert "exit 67" in src
+
+
+def test_image_pull_execs_podman_directly() -> None:
+    """`exec` is deliberate: progress lines stream raw to the caller and
+    podman's own exit code passes straight through — no intermediate
+    run_podman capture for this verb."""
+    src = WRAPPER.read_text()
+    assert 'exec "$PODMAN" pull "$1"' in src
+
+
+def test_no_caller_supplied_format_string() -> None:
+    src = WRAPPER.read_text()
+    for line in src.splitlines():
+        if "--format" in line and not line.lstrip().startswith("#"):
+            assert '"$1"' not in line and '"$2"' not in line, line
+
+
+# ── the ro wrapper stays read-only: no widening ─────────────────────────────
+
+
+def test_ro_wrapper_help_has_no_write_verbs() -> None:
+    proc = _run_ro("help")
+    assert proc.returncode == 0, proc.stderr
+    assert "image-pull" not in proc.stdout
+    assert "image-rm" not in proc.stdout
+
+
+def test_ro_wrapper_still_parses() -> None:
+    proc = subprocess.run(["bash", "-n", str(RO_WRAPPER)], capture_output=True, text=True, check=False)
+    assert proc.returncode == 0, proc.stderr

--- a/tests/installer/test_podman_rw_validation.py
+++ b/tests/installer/test_podman_rw_validation.py
@@ -246,7 +246,7 @@ def test_image_pull_execs_podman_directly() -> None:
     podman's own exit code passes straight through — no intermediate
     run_podman capture for this verb."""
     src = WRAPPER.read_text()
-    assert 'exec "$PODMAN" pull "$1"' in src
+    assert 'exec "$PODMAN" pull -- "$1"' in src
 
 
 def test_no_caller_supplied_format_string() -> None:

--- a/tests/providers/test_container_pull_routing.py
+++ b/tests/providers/test_container_pull_routing.py
@@ -1,0 +1,95 @@
+"""#2119 — ``ContainerProvider.pull_image_stream`` routes through the rootful
+write seam when it is available.
+
+The bug this pins: a dashboard-triggered "pull image" landed in hal0-api's
+own ROOTLESS podman store (a bare ``podman pull`` run as the unprivileged
+``hal0`` service user), while slots launch from ROOT's store via Quadlet.
+The pulled image was therefore invisible to every slot that tried to use it
+— the write-side twin of #1889 (reads already fixed to go through
+``hal0-podman-ro``; this is ``hal0-podman-rw`` for the pull itself).
+
+``podman_mutate`` is patched wholesale (``rw_seam_available`` +
+``pull_image_stream_rootful``) rather than ``subprocess``/``asyncio``, so
+these tests never touch sudo, a real ``hal0`` account, or podman.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from hal0.providers import container as container_mod
+from hal0.providers import podman_mutate
+from hal0.providers.container import ContainerProvider
+
+IMAGE = "ghcr.io/thinmintdev/hal0-runner:v1.0.0-rc.6"
+
+
+async def _fake_rootful_pull(image: str) -> AsyncIterator[dict[str, Any]]:
+    yield {"state": "pulling", "layer": 1, "total_layers": 3, "line": f"pulling {image}"}
+    yield {"state": "completed", "layer": 3, "total_layers": 3}
+
+
+@pytest.mark.asyncio
+async def test_pull_routes_through_rootful_seam_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole point of #2119: when the seam is usable, its events stream
+    straight through and the rootless runtime is never consulted."""
+    monkeypatch.setattr(podman_mutate, "rw_seam_available", lambda: True)
+
+    seen: list[str] = []
+
+    async def _rootful(image: str) -> AsyncIterator[dict[str, Any]]:
+        seen.append(image)
+        async for event in _fake_rootful_pull(image):
+            yield event
+
+    monkeypatch.setattr(podman_mutate, "pull_image_stream_rootful", _rootful)
+
+    def _boom() -> str:
+        raise AssertionError("rootless runtime was consulted despite the seam being available")
+
+    monkeypatch.setattr(container_mod, "_container_runtime", _boom)
+
+    events = [e async for e in ContainerProvider().pull_image_stream(IMAGE)]
+
+    assert seen == [IMAGE]
+    assert events == [
+        {"state": "pulling", "layer": 1, "total_layers": 3, "line": f"pulling {IMAGE}"},
+        {"state": "completed", "layer": 3, "total_layers": 3},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pull_falls_back_to_rootless_when_seam_unavailable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Dev checkout / CI / no grant: today's bare ``<runtime> pull`` behavior,
+    exercised exactly as before the seam existed."""
+    monkeypatch.setattr(podman_mutate, "rw_seam_available", lambda: False)
+
+    def _rootful_should_not_run(image: str) -> AsyncIterator[dict[str, Any]]:
+        raise AssertionError("rootful pull was invoked despite the seam being unavailable")
+
+    monkeypatch.setattr(podman_mutate, "pull_image_stream_rootful", _rootful_should_not_run)
+
+    fake_runtime = tmp_path / "fake-pull"
+    fake_runtime.write_text(
+        "#!/bin/sh\n"
+        'echo "Pulling from library/alpine"\n'
+        'echo "abc123: Pulling fs layer"\n'
+        'echo "abc123: Download complete"\n'
+        'echo "abc123: Pull complete"\n'
+        "exit 0\n"
+    )
+    fake_runtime.chmod(0o755)
+    monkeypatch.setattr(container_mod, "_container_runtime", lambda: str(fake_runtime))
+
+    events = [e async for e in ContainerProvider().pull_image_stream("alpine:latest")]
+
+    states = [e["state"] for e in events]
+    assert "pulling" in states
+    assert states[-1] == "completed"

--- a/tests/providers/test_container_pull_routing.py
+++ b/tests/providers/test_container_pull_routing.py
@@ -64,6 +64,49 @@ async def test_pull_routes_through_rootful_seam_when_available(
 
 
 @pytest.mark.asyncio
+async def test_pull_aclose_propagates_to_rootful_inner_generator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fix-round-1 regression: a dashboard cancel calls ``.aclose()`` on the
+    OUTER generator (``runner_pull.run_runner_pull``'s teardown path). A bare
+    ``async for ... yield`` delegation does NOT forward that ``.aclose()`` to
+    the inner rootful generator, so the ROOT-owned
+    ``sudo hal0-podman-rw image-pull`` subprocess it kills in its own
+    ``finally`` would keep pulling until GC eventually (maybe) finalizes it.
+    This pins that the inner generator's cleanup runs BEFORE the outer
+    ``.aclose()`` call returns."""
+    monkeypatch.setattr(podman_mutate, "rw_seam_available", lambda: True)
+
+    cleanup_ran = False
+
+    async def _rootful(image: str) -> AsyncIterator[dict[str, Any]]:
+        nonlocal cleanup_ran
+        try:
+            yield {"state": "pulling", "layer": 1, "total_layers": 3, "line": "layer 1"}
+            yield {"state": "pulling", "layer": 2, "total_layers": 3, "line": "layer 2"}
+            yield {"state": "completed", "layer": 3, "total_layers": 3}
+        finally:
+            cleanup_ran = True
+
+    monkeypatch.setattr(podman_mutate, "pull_image_stream_rootful", _rootful)
+
+    def _boom() -> str:
+        raise AssertionError("rootless runtime was consulted despite the seam being available")
+
+    monkeypatch.setattr(container_mod, "_container_runtime", _boom)
+
+    agen = ContainerProvider().pull_image_stream(IMAGE)
+    first = await agen.__anext__()
+
+    assert first["state"] == "pulling"
+    assert cleanup_ran is False, "inner generator must still be open after only one event"
+
+    await agen.aclose()
+
+    assert cleanup_ran is True, "outer .aclose() must propagate into the inner rootful generator"
+
+
+@pytest.mark.asyncio
 async def test_pull_falls_back_to_rootless_when_seam_unavailable(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Any
 ) -> None:

--- a/tests/providers/test_podman_mutate.py
+++ b/tests/providers/test_podman_mutate.py
@@ -1,0 +1,267 @@
+"""Unit tests for :mod:`hal0.providers.podman_mutate` — the write-side twin
+of :mod:`hal0.providers.podman_introspect` (runner-images v3, D1(a)/D2).
+
+Covers:
+  * :func:`rw_seam_available` — service-user gate AND binary-exists check,
+    no sudo probe.
+  * :func:`remove_image` — outcome mapping for every documented exit code
+    (0/removed, 0/missing, 67/in-use, 1/64/65/66 -> unknown+reason), the bad
+    -ref and not-service-user short-circuits (NO subprocess spawned), and the
+    undefined-stdout-on-rc0 / exec-failure fallbacks.
+  * :func:`pull_image_stream_rootful` — bad ref short-circuits with no
+    subprocess spawned; pulling -> completed happy path; nonzero exit ->
+    failed.
+  * :class:`PullLineParser` — parity test pinning the exact event sequence
+    the pre-extraction ``ContainerProvider.pull_image_stream`` heuristic
+    produced, so the container.py refactor in this same change cannot drift.
+
+``run`` / ``is_hal0_user`` / ``asyncio.create_subprocess_exec`` are injected
+or monkeypatched so this never touches sudo, a real ``hal0`` user, or an
+actual podman binary.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hal0.providers import podman_mutate
+from hal0.providers.podman_mutate import (
+    RW_SEAM_BIN,
+    PullLineParser,
+    pull_image_stream_rootful,
+    remove_image,
+    rw_seam_available,
+)
+
+_REF = "ghcr.io/hal0ai/hal0-toolbox-cpu:latest"
+_BAD_REF = "not a ref!"
+
+
+def _completed(returncode: int = 0, stdout: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = ""
+    return m
+
+
+def _recorder(*, returncode: int = 0, stdout: str = "removed\n"):
+    calls: list[list[str]] = []
+
+    def _run(argv: object, **kwargs: object) -> MagicMock:
+        calls.append(list(argv))  # type: ignore[arg-type]
+        return _completed(returncode, stdout)
+
+    return calls, _run
+
+
+# ── rw_seam_available ────────────────────────────────────────────────────────
+
+
+def test_rw_seam_available_false_when_not_hal0_user(tmp_path, monkeypatch) -> None:
+    fake_bin = tmp_path / "hal0-podman-rw"
+    fake_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(podman_mutate, "RW_SEAM_BIN", str(fake_bin))
+    assert rw_seam_available(is_hal0_user=lambda: False) is False
+
+
+def test_rw_seam_available_false_when_binary_missing(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(podman_mutate, "RW_SEAM_BIN", str(tmp_path / "nope"))
+    assert rw_seam_available(is_hal0_user=lambda: True) is False
+
+
+def test_rw_seam_available_true_when_user_and_binary_present(tmp_path, monkeypatch) -> None:
+    fake_bin = tmp_path / "hal0-podman-rw"
+    fake_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(podman_mutate, "RW_SEAM_BIN", str(fake_bin))
+    assert rw_seam_available(is_hal0_user=lambda: True) is True
+
+
+# ── remove_image: short-circuits (no subprocess call) ───────────────────────
+
+
+def test_remove_image_bad_ref_short_circuits_without_subprocess() -> None:
+    calls, run = _recorder()
+    outcome, reason = remove_image(_BAD_REF, run=run, is_hal0_user=lambda: True)
+
+    assert calls == []
+    assert (outcome, reason) == ("unknown", "invalid-argument")
+
+
+def test_remove_image_not_service_user_short_circuits_without_subprocess() -> None:
+    calls, run = _recorder()
+    outcome, reason = remove_image(_REF, run=run, is_hal0_user=lambda: False)
+
+    assert calls == []
+    assert (outcome, reason) == ("unknown", "not-service-user")
+
+
+# ── remove_image: seam argv ──────────────────────────────────────────────────
+
+
+def test_remove_image_seam_argv() -> None:
+    calls, run = _recorder()
+    remove_image(_REF, run=run, is_hal0_user=lambda: True)
+
+    assert calls == [["sudo", "-n", RW_SEAM_BIN, "image-rm", _REF]]
+
+
+# ── remove_image: outcome mapping ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout", "expected"),
+    [
+        (0, "removed\n", ("removed", None)),
+        (0, "missing\n", ("missing", None)),
+        (67, "", ("in-use", None)),
+        (1, "", ("unknown", "grant-denied")),
+        (64, "", ("unknown", "invalid-argument")),
+        (65, "", ("unknown", "podman-absent")),
+        (66, "", ("unknown", "podman-failed")),
+        (99, "", ("unknown", "seam-error")),  # rc the contract does not define
+        (0, "bogus\n", ("unknown", "seam-error")),  # rc0 with undefined stdout
+    ],
+)
+def test_remove_image_outcome_mapping(returncode, stdout, expected) -> None:
+    _, run = _recorder(returncode=returncode, stdout=stdout)
+    assert remove_image(_REF, run=run, is_hal0_user=lambda: True) == expected
+
+
+def test_remove_image_exec_failure_is_seam_error() -> None:
+    def _raise(*_args: object, **_kwargs: object) -> MagicMock:
+        raise OSError("no such file")
+
+    assert remove_image(_REF, run=_raise, is_hal0_user=lambda: True) == ("unknown", "seam-error")
+
+
+# ── pull_image_stream_rootful ────────────────────────────────────────────────
+
+
+class _FakeStdout:
+    def __init__(self, lines: list[bytes]) -> None:
+        self._iter = iter(lines)
+
+    def __aiter__(self) -> _FakeStdout:
+        return self
+
+    async def __anext__(self) -> bytes:
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+class _FakeProc:
+    def __init__(self, lines: list[bytes], returncode: int) -> None:
+        self.stdout = _FakeStdout(lines)
+        self._returncode = returncode
+        self.killed = False
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        return self._returncode
+
+
+async def test_pull_image_stream_rootful_bad_ref_short_circuits(monkeypatch) -> None:
+    calls: list[tuple] = []
+
+    async def _fake_create(*args: object, **kwargs: object) -> _FakeProc:
+        calls.append(args)
+        return _FakeProc([], 0)
+
+    monkeypatch.setattr(podman_mutate.asyncio, "create_subprocess_exec", _fake_create)
+
+    events = [e async for e in pull_image_stream_rootful(_BAD_REF)]
+
+    assert calls == []
+    assert events == [{"state": "failed", "error": f"invalid image reference: {_BAD_REF}"}]
+
+
+async def test_pull_image_stream_rootful_argv(monkeypatch) -> None:
+    calls: list[tuple] = []
+
+    async def _fake_create(*args: object, **kwargs: object) -> _FakeProc:
+        calls.append(args)
+        return _FakeProc([], 0)
+
+    monkeypatch.setattr(podman_mutate.asyncio, "create_subprocess_exec", _fake_create)
+
+    async for _ in pull_image_stream_rootful(_REF):
+        pass
+
+    assert calls == [("sudo", "-n", RW_SEAM_BIN, "image-pull", _REF)]
+
+
+async def test_pull_image_stream_rootful_pulling_then_completed(monkeypatch) -> None:
+    lines = [
+        b"Pulling fs layer\n",
+        b"Download complete\n",
+    ]
+
+    async def _fake_create(*_args: object, **_kwargs: object) -> _FakeProc:
+        return _FakeProc(lines, 0)
+
+    monkeypatch.setattr(podman_mutate.asyncio, "create_subprocess_exec", _fake_create)
+
+    events = [e async for e in pull_image_stream_rootful(_REF)]
+
+    assert events == [
+        {"state": "pulling", "layer": 0, "total_layers": 1, "line": "Pulling fs layer"},
+        {"state": "pulling", "layer": 1, "total_layers": 1, "line": "Download complete"},
+        {"state": "completed", "layer": 1, "total_layers": 1},
+    ]
+
+
+async def test_pull_image_stream_rootful_nonzero_exit_is_failed(monkeypatch) -> None:
+    async def _fake_create(*_args: object, **_kwargs: object) -> _FakeProc:
+        return _FakeProc([b"some error\n"], 1)
+
+    monkeypatch.setattr(podman_mutate.asyncio, "create_subprocess_exec", _fake_create)
+
+    events = [e async for e in pull_image_stream_rootful(_REF)]
+
+    assert events[-1] == {"state": "failed", "error": "pull exited with code 1"}
+
+
+# ── PullLineParser: parity with the pre-extraction container.py heuristic ──
+
+
+def test_pull_line_parser_matches_pre_extraction_sequence() -> None:
+    """Canned podman/docker-style non-TTY pull output, fed line-by-line.
+
+    This is the exact event sequence ``ContainerProvider.pull_image_stream``
+    produced before its layer-counting logic was extracted into
+    :class:`PullLineParser` — pins the heuristic so container.py's refactor
+    in this change cannot silently drift from it.
+    """
+    lines = [
+        "Trying to pull docker.io/library/alpine:latest...",
+        "Getting image source signatures",
+        "Pulling fs layer",
+        "Waiting",
+        "Verifying Checksum",
+        "Download complete",
+        "Pull complete",
+        "Already exists",
+        "Writing manifest to image destination",
+    ]
+
+    parser = PullLineParser()
+    events = [parser.feed(line) for line in lines]
+
+    assert events == [
+        {"state": "pulling", "layer": 0, "total_layers": 0, "line": lines[0]},
+        {"state": "pulling", "layer": 0, "total_layers": 0, "line": lines[1]},
+        {"state": "pulling", "layer": 0, "total_layers": 1, "line": lines[2]},
+        {"state": "pulling", "layer": 0, "total_layers": 2, "line": lines[3]},
+        {"state": "pulling", "layer": 0, "total_layers": 3, "line": lines[4]},
+        {"state": "pulling", "layer": 1, "total_layers": 3, "line": lines[5]},
+        {"state": "pulling", "layer": 2, "total_layers": 3, "line": lines[6]},
+        {"state": "pulling", "layer": 3, "total_layers": 4, "line": lines[7]},
+        {"state": "pulling", "layer": 3, "total_layers": 4, "line": lines[8]},
+    ]

--- a/tests/providers/test_podman_mutate.py
+++ b/tests/providers/test_podman_mutate.py
@@ -22,6 +22,7 @@ actual podman binary.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -137,6 +138,77 @@ def test_remove_image_exec_failure_is_seam_error() -> None:
     assert remove_image(_REF, run=_raise, is_hal0_user=lambda: True) == ("unknown", "seam-error")
 
 
+# ── remove_image: root fallback (not the hal0 service user, but euid 0) ─────
+
+
+def test_remove_image_root_fallback_removed_no_sudo_in_argv(monkeypatch) -> None:
+    monkeypatch.setattr(podman_mutate.os, "geteuid", lambda: 0)
+    calls, run = _recorder(returncode=0, stdout="")
+
+    outcome, reason = remove_image(
+        _REF, run=run, is_hal0_user=lambda: False, which=lambda _name: "/usr/bin/podman"
+    )
+
+    assert (outcome, reason) == ("removed", None)
+    assert calls == [["/usr/bin/podman", "rmi", "--", _REF]]
+    assert "sudo" not in calls[0]
+
+
+@pytest.mark.parametrize(
+    ("returncode", "expected"),
+    [
+        (0, ("removed", None)),
+        (1, ("missing", None)),
+        (2, ("in-use", None)),
+        (3, ("unknown", "podman-failed")),
+    ],
+)
+def test_remove_image_root_fallback_outcome_mapping(monkeypatch, returncode, expected) -> None:
+    monkeypatch.setattr(podman_mutate.os, "geteuid", lambda: 0)
+    _, run = _recorder(returncode=returncode, stdout="")
+
+    outcome = remove_image(
+        _REF, run=run, is_hal0_user=lambda: False, which=lambda _name: "/usr/bin/podman"
+    )
+
+    assert outcome == expected
+
+
+def test_remove_image_root_fallback_podman_absent(monkeypatch) -> None:
+    monkeypatch.setattr(podman_mutate.os, "geteuid", lambda: 0)
+    calls, run = _recorder()
+
+    outcome = remove_image(_REF, run=run, is_hal0_user=lambda: False, which=lambda _name: None)
+
+    assert outcome == ("unknown", "podman-absent")
+    assert calls == []
+
+
+def test_remove_image_root_fallback_exec_failure_is_podman_failed(monkeypatch) -> None:
+    monkeypatch.setattr(podman_mutate.os, "geteuid", lambda: 0)
+
+    def _raise(*_args: object, **_kwargs: object) -> MagicMock:
+        raise OSError("no such file")
+
+    outcome = remove_image(
+        _REF, run=_raise, is_hal0_user=lambda: False, which=lambda _name: "/usr/bin/podman"
+    )
+
+    assert outcome == ("unknown", "podman-failed")
+
+
+def test_remove_image_non_root_non_service_user_unchanged(monkeypatch) -> None:
+    """Not root and not the hal0 service account: still ``not-service-user``,
+    no fallback, no subprocess call."""
+    monkeypatch.setattr(podman_mutate.os, "geteuid", lambda: 1000)
+    calls, run = _recorder()
+
+    outcome = remove_image(_REF, run=run, is_hal0_user=lambda: False)
+
+    assert outcome == ("unknown", "not-service-user")
+    assert calls == []
+
+
 # ── pull_image_stream_rootful ────────────────────────────────────────────────
 
 
@@ -159,12 +231,51 @@ class _FakeProc:
         self.stdout = _FakeStdout(lines)
         self._returncode = returncode
         self.killed = False
+        self.terminated = False
 
     def kill(self) -> None:
         self.killed = True
 
+    def terminate(self) -> None:
+        self.terminated = True
+
     async def wait(self) -> int:
         return self._returncode
+
+
+class _HangingStdout:
+    """A ``proc.stdout`` whose iterator never advances past its first line.
+
+    Used to hold :func:`podman_mutate.pull_image_stream_rootful` paused
+    mid-stream so the test can ``aclose()`` the generator from the outside —
+    the same way a cancelled consumer (e.g. an HTTP client disconnecting
+    mid-download) tears the generator down — and observe which signal method
+    the ``finally`` block invokes on the still-running seam process.
+    """
+
+    def __init__(self, lines: list[bytes]) -> None:
+        self._iter = iter(lines)
+        self._yielded_first = False
+
+    def __aiter__(self) -> _HangingStdout:
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self._yielded_first:
+            # Never resolves on its own — the test tears the generator down
+            # with aclose() instead of letting this line complete.
+            await asyncio.Future()
+        self._yielded_first = True
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+class _HangingFakeProc(_FakeProc):
+    def __init__(self, lines: list[bytes], returncode: int) -> None:
+        super().__init__(lines, returncode)
+        self.stdout = _HangingStdout(lines)
 
 
 async def test_pull_image_stream_rootful_bad_ref_short_circuits(monkeypatch) -> None:
@@ -226,6 +337,54 @@ async def test_pull_image_stream_rootful_nonzero_exit_is_failed(monkeypatch) -> 
     events = [e async for e in pull_image_stream_rootful(_REF)]
 
     assert events[-1] == {"state": "failed", "error": "pull exited with code 1"}
+
+
+async def test_pull_image_stream_rootful_clean_eof_never_signals_process(monkeypatch) -> None:
+    """Regression: a fully successful pull must not be torn down by the
+    ``finally`` block. Before the fix, ``finally: proc.kill()`` fired
+    unconditionally — including on a clean EOF, in the window before
+    ``await proc.wait()`` — and could turn a completed pull into a reported
+    ``{"state": "failed", "error": "pull exited with code -9"}``."""
+    proc = _FakeProc([b"Pulling fs layer\n", b"Download complete\n"], 0)
+
+    async def _fake_create(*_args: object, **_kwargs: object) -> _FakeProc:
+        return proc
+
+    monkeypatch.setattr(podman_mutate.asyncio, "create_subprocess_exec", _fake_create)
+
+    events = [e async for e in pull_image_stream_rootful(_REF)]
+
+    assert proc.killed is False
+    assert proc.terminated is False
+    assert events[-1] == {"state": "completed", "layer": 1, "total_layers": 1}
+
+
+async def test_pull_image_stream_rootful_cancel_calls_terminate_not_kill(monkeypatch) -> None:
+    """A consumer that tears the generator down mid-stream (cancellation,
+    early ``break``/``aclose()``) must ``terminate()`` (SIGTERM) the seam
+    process, never ``kill()`` (SIGKILL).
+
+    ``proc`` here is ``sudo``, not ``podman`` directly — sudo can relay a
+    catchable signal like SIGTERM to the podman child it launched, but
+    SIGKILL cannot be caught or relayed by sudo at all, so a ``.kill()``
+    here would leave the root-owned ``podman pull`` running, orphaned,
+    to completion or failure with nobody watching.
+    """
+    proc = _HangingFakeProc([b"Pulling fs layer\n"], 0)
+
+    async def _fake_create(*_args: object, **_kwargs: object) -> _HangingFakeProc:
+        return proc
+
+    monkeypatch.setattr(podman_mutate.asyncio, "create_subprocess_exec", _fake_create)
+
+    agen = pull_image_stream_rootful(_REF)
+    first_event = await agen.__anext__()
+    assert first_event["state"] == "pulling"
+
+    await agen.aclose()
+
+    assert proc.terminated is True
+    assert proc.killed is False
 
 
 # ── PullLineParser: parity with the pre-extraction container.py heuristic ──

--- a/tests/providers/test_podman_mutate.py
+++ b/tests/providers/test_podman_mutate.py
@@ -91,7 +91,13 @@ def test_remove_image_bad_ref_short_circuits_without_subprocess() -> None:
     assert (outcome, reason) == ("unknown", "invalid-argument")
 
 
-def test_remove_image_not_service_user_short_circuits_without_subprocess() -> None:
+def test_remove_image_not_service_user_short_circuits_without_subprocess(monkeypatch) -> None:
+    """Pins the persona explicitly: non-service-user AND non-root. Without
+    this pin, a CI runner that executes tests as root (euid 0) falls through
+    into the root fallback added for FIX 3 and calls podman directly instead
+    of short-circuiting — this test is specifically about the short-circuit,
+    so it must not depend on the ambient euid of whatever box runs it."""
+    monkeypatch.setattr(podman_mutate.os, "geteuid", lambda: 1000)
     calls, run = _recorder()
     outcome, reason = remove_image(_REF, run=run, is_hal0_user=lambda: False)
 

--- a/tests/registry/test_runner_image_store.py
+++ b/tests/registry/test_runner_image_store.py
@@ -166,3 +166,119 @@ class TestRunnerImageTag:
         assert dl_img_b.id == "b"
         assert [t.tag for t in dl_img_b.tags] == ["v2"]
         assert dl_img_b.tags[0].digest == "sha256:" + "b" * 64
+
+
+class TestRemoveTag:
+    """``RunnerImageStore.remove_tag`` — per-tag DELETE, disk-reclaim task (D2, #2106)."""
+
+    def _seed(self, store: RunnerImageStore, *, tags: list[str], **overrides) -> None:
+        store.upsert(RunnerImage(id="x", image="ghcr.io/x/a", tag=tags[0], **overrides))
+        store.set_tags("x", [RunnerImageTag(tag=t) for t in tags])
+
+    def test_deletes_the_tag_row(self, store: RunnerImageStore) -> None:
+        self._seed(store, tags=["0826", "0824"])
+        assert store.remove_tag("x", "0824") is True
+        row = store.get("x")
+        assert [t.tag for t in row.tags] == ["0826"]
+
+    def test_unknown_image_id_returns_false(self, store: RunnerImageStore) -> None:
+        assert store.remove_tag("nope", "0824") is False
+
+    def test_unknown_tag_on_known_image_returns_false(self, store: RunnerImageStore) -> None:
+        self._seed(store, tags=["0826"])
+        assert store.remove_tag("x", "9999") is False
+        # the real row is untouched
+        assert [t.tag for t in store.get("x").tags] == ["0826"]
+
+    def test_prunes_available_tags_list(self, store: RunnerImageStore) -> None:
+        self._seed(store, tags=["0826", "0824"], available_tags=["0826", "0824"])
+        store.remove_tag("x", "0824")
+        assert store.get("x").available_tags == ["0826"]
+
+    def test_prunes_available_tags_to_empty_list(self, store: RunnerImageStore) -> None:
+        self._seed(store, tags=["0826"], available_tags=["0826"])
+        store.remove_tag("x", "0826")
+        assert store.get("x").available_tags == []
+
+    def test_tag_absent_from_available_tags_is_a_noop_there(self, store: RunnerImageStore) -> None:
+        """The removed tag might not be images.json's ``available_tags`` at
+        all (e.g. a probe-discovered tag) — pruning must not KeyError."""
+        self._seed(store, tags=["0826", "0824"], available_tags=["0826"])
+        store.remove_tag("x", "0824")
+        assert store.get("x").available_tags == ["0826"]
+
+    def test_notifies_on_change_only_when_a_row_is_deleted(self, store: RunnerImageStore) -> None:
+        self._seed(store, tags=["0826"])
+        calls: list[int] = []
+        store.on_change = lambda: calls.append(1)
+        assert store.remove_tag("x", "nope") is False
+        assert calls == []
+        assert store.remove_tag("x", "0826") is True
+        assert calls == [1]
+
+    # ── marker ruling: clear local_path/downloaded_at iff (a) the marker's
+    # recorded ref matches the removed <image>:<tag>, or (b) no tags remain.
+
+    def test_marker_cleared_when_no_tags_remain(
+        self, store: RunnerImageStore, tmp_path: Path
+    ) -> None:
+        self._seed(store, tags=["0826"])
+        store.set_local_state("x", local_path="/nonexistent/marker.json", downloaded_at="t")
+        assert store.remove_tag("x", "0826") is True
+        row = store.get("x")
+        assert row.local_path is None
+        assert row.downloaded_at is None
+
+    def test_marker_cleared_when_it_matches_the_removed_tag(
+        self, store: RunnerImageStore, tmp_path: Path
+    ) -> None:
+        import json
+
+        self._seed(store, tags=["0826", "0824"])
+        marker = tmp_path / "marker.json"
+        marker.write_text(json.dumps({"image_id": "x", "image": "ghcr.io/x/a:0824"}))
+        store.set_local_state("x", local_path=str(marker), downloaded_at="t")
+
+        assert store.remove_tag("x", "0824") is True
+        row = store.get("x")
+        assert row.local_path is None
+        assert row.downloaded_at is None
+        # the sibling tag row (unrelated to the marker) is untouched
+        assert [t.tag for t in row.tags] == ["0826"]
+
+    def test_marker_untouched_when_it_names_a_surviving_tag(
+        self, store: RunnerImageStore, tmp_path: Path
+    ) -> None:
+        import json
+
+        self._seed(store, tags=["0826", "0824"])
+        marker = tmp_path / "marker.json"
+        marker.write_text(json.dumps({"image_id": "x", "image": "ghcr.io/x/a:0826"}))
+        store.set_local_state("x", local_path=str(marker), downloaded_at="t")
+
+        # Deleting 0824 must not disturb the marker recording 0826's pull.
+        assert store.remove_tag("x", "0824") is True
+        row = store.get("x")
+        assert row.local_path == str(marker)
+        assert row.downloaded_at == "t"
+
+    def test_marker_read_failure_is_fail_soft_and_leaves_marker_alone(
+        self, store: RunnerImageStore
+    ) -> None:
+        """A local_path that isn't readable JSON (missing file, garbage
+        content) must not raise, and — since it can't be confirmed to match
+        the removed tag, and a sibling tag still exists — the marker is
+        left as-is rather than guessed-cleared."""
+        self._seed(store, tags=["0826", "0824"])
+        store.set_local_state("x", local_path="/definitely/does/not/exist.json", downloaded_at="t")
+        assert store.remove_tag("x", "0824") is True
+        row = store.get("x")
+        assert row.local_path == "/definitely/does/not/exist.json"
+        assert row.downloaded_at == "t"
+
+    def test_no_marker_set_stays_none(self, store: RunnerImageStore) -> None:
+        self._seed(store, tags=["0826", "0824"])
+        assert store.remove_tag("x", "0824") is True
+        row = store.get("x")
+        assert row.local_path is None
+        assert row.downloaded_at is None

--- a/tests/updater/test_wrapper_refresh.py
+++ b/tests/updater/test_wrapper_refresh.py
@@ -95,7 +95,14 @@ def test_root_refreshes_every_wrapper_present_in_the_release_tree(
     monkeypatch.setattr("hal0.updater.updater.subprocess.run", fake_run)
     target = _release_tree(
         tmp_path,
-        seams=("hal0-systemctl", "hal0-update", "hal0-agentenv", "hal0-benchctl", "hal0-podman-ro"),
+        seams=(
+            "hal0-systemctl",
+            "hal0-update",
+            "hal0-agentenv",
+            "hal0-benchctl",
+            "hal0-podman-ro",
+            "hal0-podman-rw",
+        ),
     )
 
     result = refresh_privileged_wrappers(target, job_id="job-1")
@@ -106,10 +113,11 @@ def test_root_refreshes_every_wrapper_present_in_the_release_tree(
         "hal0-agentenv",
         "hal0-benchctl",
         "hal0-podman-ro",
+        "hal0-podman-rw",
     }
     assert result["errors"] == {}
     install_calls = [c for c in fake_run.calls if c[0] == "install"]
-    assert len(install_calls) == 5
+    assert len(install_calls) == 6
     for call in install_calls:
         assert call[:3] == ["install", "-m", "0755"]
         assert "-o" in call and "root" in call

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -110,6 +110,13 @@ export const ENDPOINTS = {
   runnerImagePullStatus: (id: string) => `/api/runner-images/${id}/pull/status`,
   runnerImagePullStream: (id: string) => `/api/runner-images/${id}/pull/stream`,
   runnerImagePullCancel: (id: string) => `/api/runner-images/${id}/pull/cancel`,
+  // DELETE — reclaim one catalogued tag's disk bytes (D2). `id` is NOT
+  // re-encoded (see the block comment above); `tag` IS encodeURIComponent'd
+  // — unlike catalogue ids, a tag never legitimately contains `/`, and this
+  // guards a mistyped/free-text tag from smuggling an extra path segment
+  // into the URL.
+  runnerImageDeleteTag: (id: string, tag: string) =>
+    `/api/runner-images/${id}/tags/${encodeURIComponent(tag)}`,
 
   // ── Backends ─────────────────────────────────────────────────────
   // There is NO generic install route — the only install-like operations

--- a/ui/src/api/hooks/useRunnerImages.ts
+++ b/ui/src/api/hooks/useRunnerImages.ts
@@ -12,7 +12,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { apiGet, apiPost, apiPut, Hal0Error } from '../client'
+import { apiDelete, apiGet, apiPost, apiPut, Hal0Error } from '../client'
 import { ENDPOINTS } from '../endpoints'
 
 // Which family default (if any) resolves to this row's image, and where that
@@ -176,6 +176,31 @@ export function useRestartAffected() {
       apiPost<RestartAffectedResult>(ENDPOINTS.runnerImagesRestartAffected, { ref }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['slots'] })
+      qc.invalidateQueries({ queryKey: ['runner-images'] })
+    },
+  })
+}
+
+// ─── useDeleteTag ────────────────────────────────────────────────────
+// DELETE /api/runner-images/{id}/tags/{tag} (D2, #2106): reclaim one
+// catalogued tag's disk bytes. Mirrors useRestartAffected's shape — thrown
+// Hal0Error carries the route's structured codes (`runner_image.tag_in_use`
+// with `details.slots`, `runner_image.pull_in_progress`,
+// `runner_image.rm_unavailable`) for the caller to branch a toast message
+// on. Invalidates `['runner-images']` same as every other mutating hook
+// here — the row's `store_state`/`tags`/`in_use_by` all shift on a
+// successful delete.
+export interface DeleteTagResult {
+  removed: boolean
+  outcome: 'removed' | 'missing'
+}
+
+export function useDeleteTag() {
+  const qc = useQueryClient()
+  return useMutation<DeleteTagResult, Hal0Error, { id: string; tag: string }>({
+    mutationFn: ({ id, tag }) =>
+      apiDelete<DeleteTagResult>(ENDPOINTS.runnerImageDeleteTag(id, tag)),
+    onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['runner-images'] })
     },
   })

--- a/ui/src/dash/__tests__/runner-images-confirm-flow.test.tsx
+++ b/ui/src/dash/__tests__/runner-images-confirm-flow.test.tsx
@@ -93,6 +93,10 @@ vi.mock('@/api/hooks/useRunnerImages', () => ({
     isPending: false,
     mutate: () => {},
   }),
+  useDeleteTag: () => ({
+    isPending: false,
+    mutate: () => {},
+  }),
 }))
 
 const { RunnerImagesView } = await import('../runner-images.jsx')

--- a/ui/src/dash/__tests__/runner-images-view.test.tsx
+++ b/ui/src/dash/__tests__/runner-images-view.test.tsx
@@ -31,9 +31,22 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 // side-effect-free. vi.mock factories are hoisted above imports, so the spy +
 // fixture rows they close over must be hoisted too (mirrors
 // runner-images-confirm-flow.test.tsx's `vi.hoisted` idiom).
-const { apiPostCalls, apiPostBodies, PULL_ROW, imagesOverride, familiesOverride } = vi.hoisted(() => ({
+const {
+  apiPostCalls,
+  apiPostBodies,
+  apiDeleteCalls,
+  deleteOutcome,
+  PULL_ROW,
+  imagesOverride,
+  familiesOverride,
+} = vi.hoisted(() => ({
   apiPostCalls: [] as string[],
   apiPostBodies: [] as unknown[],
+  apiDeleteCalls: [] as string[],
+  // Task 5 (per-tag delete): controls what the mocked apiDelete resolves/
+  // rejects with, per test — a mutable box (same idiom as imagesOverride)
+  // so vi.hoisted mock factories can close over it.
+  deleteOutcome: { current: 'removed' as 'removed' | 'missing' | 'tag_in_use' | 'rm_unavailable' },
   PULL_ROW: {
     id: 'rocmfpx-combined',
     image: 'ghcr.io/hal0ai/hal0-combined',
@@ -102,6 +115,34 @@ vi.mock('@/api/client', async () => {
       apiPostCalls.push(url)
       apiPostBodies.push(body)
       return Promise.resolve({ id: 'job-1', restarted: [] })
+    },
+    // Task 5 (per-tag delete): the real useDeleteTag mutation posts through
+    // apiDelete — mocked at the same client boundary as apiPost above so the
+    // URL it actually builds (encodeURIComponent'd tag, unencoded id) is
+    // what's asserted. `deleteOutcome` picks the response/rejection shape
+    // per test.
+    apiDelete: (url: string) => {
+      apiDeleteCalls.push(url)
+      const outcome = deleteOutcome.current
+      if (outcome === 'removed') return Promise.resolve({ removed: true, outcome: 'removed' })
+      if (outcome === 'missing') return Promise.resolve({ removed: false, outcome: 'missing' })
+      if (outcome === 'tag_in_use') {
+        return Promise.reject(
+          new actual.Hal0Error('runner image tag is in use', {
+            code: 'runner_image.tag_in_use',
+            status: 409,
+            details: { slots: ['brain'] },
+          }),
+        )
+      }
+      // rm_unavailable
+      return Promise.reject(
+        new actual.Hal0Error('image removal seam unavailable', {
+          code: 'runner_image.rm_unavailable',
+          status: 502,
+          details: { reason: 'grant-denied' },
+        }),
+      )
     },
   }
 })
@@ -664,6 +705,108 @@ describe('RunnerImagesView restart-affected-slots (Task 12)', () => {
     })
 
     expect(host.querySelector('[data-testid="ri-restart-affected"]')).toBeNull()
+
+    act(() => { root.unmount() })
+  })
+})
+
+// Task 5 (runner-images-v3 phase 4) — per-tag Delete button. A REAL render
+// (same idiom as Task 6/12 above): a ghost "Delete :<tag>" button sits next
+// to the pull controls, behind the shared ConfirmDialog; confirming DELETEs
+// the picked tag via the real useDeleteTag mutation. Disabled (server still
+// guards) whenever the picked tag IS the headline and the row's `in_use_by`
+// is non-empty — that's the only tag this list payload can name usage for.
+describe('RunnerImagesView per-tag delete (Task 5)', () => {
+  afterEach(() => {
+    apiDeleteCalls.length = 0
+    deleteOutcome.current = 'removed'
+    imagesOverride.current = null
+    document.body.innerHTML = ''
+  })
+
+  function mount() {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const root = createRoot(host)
+    act(() => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: qc },
+          React.createElement(RunnerImagesView),
+        ),
+      )
+    })
+    return { host, root }
+  }
+
+  it('renders the delete button and DELETEs the right URL on confirm', async () => {
+    imagesOverride.current = [{ ...PULL_ROW, in_use_by: [] }]
+    const { host, root } = mount()
+
+    const btn = host.querySelector('[data-testid="ri-delete-tag"]') as HTMLButtonElement
+    expect(btn).toBeTruthy()
+    expect(btn.textContent).toContain('Delete')
+    expect(btn.textContent).toContain(PULL_ROW.tag)
+    expect(btn.disabled).toBe(false)
+    expect(host.querySelector('.modal-backdrop')).toBeNull()
+
+    act(() => { btn.click() })
+    expect(host.querySelector('.modal-backdrop')).toBeTruthy()
+    expect(host.textContent).toContain(PULL_ROW.tag)
+
+    const confirmBtn = Array.from(host.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Delete',
+    ) as HTMLButtonElement
+    expect(confirmBtn).toBeTruthy()
+    await act(async () => {
+      confirmBtn.click()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(apiDeleteCalls[apiDeleteCalls.length - 1]).toBe(
+      `/api/runner-images/${PULL_ROW.id}/tags/${PULL_ROW.tag}`,
+    )
+    expect(host.querySelector('.modal-backdrop')).toBeNull()
+
+    act(() => { root.unmount() })
+  })
+
+  it('is disabled with an explanatory title when the headline pick is in_use_by', () => {
+    imagesOverride.current = [{ ...PULL_ROW, in_use_by: ['brain', 'ops'] }]
+    const { host, root } = mount()
+
+    const btn = host.querySelector('[data-testid="ri-delete-tag"]') as HTMLButtonElement
+    expect(btn).toBeTruthy()
+    expect(btn.disabled).toBe(true)
+    expect(btn.title).toMatch(/brain/)
+    expect(btn.title).toMatch(/ops/)
+
+    act(() => { root.unmount() })
+  })
+
+  it('reports the "missing" outcome distinctly from "removed"', async () => {
+    imagesOverride.current = [{ ...PULL_ROW, in_use_by: [] }]
+    deleteOutcome.current = 'missing'
+    const { host, root } = mount()
+
+    const btn = host.querySelector('[data-testid="ri-delete-tag"]') as HTMLButtonElement
+    act(() => { btn.click() })
+    const confirmBtn = Array.from(host.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Delete',
+    ) as HTMLButtonElement
+    await act(async () => {
+      confirmBtn.click()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(apiDeleteCalls.length).toBe(1)
+    expect(host.querySelector('.modal-backdrop')).toBeNull()
 
     act(() => { root.unmount() })
   })

--- a/ui/src/dash/runner-images.jsx
+++ b/ui/src/dash/runner-images.jsx
@@ -24,6 +24,7 @@ import {
   useRunnerImagePullsList,
   useSetDefaultImage,
   useRestartAffected,
+  useDeleteTag,
 } from '@/api/hooks/useRunnerImages'
 // Explicit import rather than the legacy window-global (primitives.jsx also
 // publishes ConfirmDialog on window) — the settings pages' idiom. Keeps this
@@ -483,7 +484,9 @@ function RunnerCard({ image }) {
   const pull = useRunnerImagePullJob();
   const setDefault = useSetDefaultImage();
   const restartAffected = useRestartAffected();
+  const deleteTag = useDeleteTag();
   const [confirmRestart, setConfirmRestart] = useStateRI(false);
+  const [confirmDelete, setConfirmDelete] = useStateRI(false);
   // Tag picker over the contract's available_tags (headline preselected).
   // null = "follow the headline"; reset whenever the selected row changes.
   const [pickedTag, setPickedTag] = useStateRI(null);
@@ -545,6 +548,45 @@ function RunnerCard({ image }) {
         window.__hal0Toast && window.__hal0Toast(`Restarted ${n} slot${n === 1 ? "" : "s"}`, "info");
       },
       onError: (e) => window.__hal0Toast && window.__hal0Toast(`Restart failed — ${e?.message || "see logs"}`, "err"),
+    });
+  };
+
+  // Per-tag delete (D2, #2106, Task 5). `in_use_by` is only ever computed
+  // server-side for the row's HEADLINE ref (enrich_row's `row_ref`) — the
+  // same limitation `headlineRef`/`onRestartAffected` above already lean
+  // on — so the UX-level disable can only speak for the headline pick. A
+  // non-headline pick is NOT known to be safe either way; it's left
+  // enabled and the server's own guards (app-level slot check, then the
+  // seam's rc-67 backstop) are the real authority regardless of what this
+  // button allows.
+  const deleteDisabledReason =
+    selTag === image.tag && inUseBy.length > 0
+      ? `In use by ${inUseBy.join(", ")} — restart or repoint those slots first.`
+      : null;
+  const deleteRef = `${image.image}:${selTag}`;
+  const onDeleteTag = () => {
+    setConfirmDelete(false);
+    deleteTag.mutate({ id: image.id, tag: selTag }, {
+      onSuccess: (res) => {
+        const msg = res?.outcome === "missing"
+          ? `${deleteRef} was not on disk — catalogue entry cleared`
+          : `Removed ${deleteRef}`;
+        window.__hal0Toast && window.__hal0Toast(msg, "info");
+      },
+      onError: (e) => {
+        if (e?.code === "runner_image.tag_in_use") {
+          const slots = e?.details?.slots;
+          const suffix = Array.isArray(slots) && slots.length ? ` (${slots.join(", ")})` : "";
+          window.__hal0Toast && window.__hal0Toast(`Tag is in use${suffix} — not removed.`, "err");
+        } else if (e?.code === "runner_image.rm_unavailable") {
+          window.__hal0Toast && window.__hal0Toast(
+            `Image removal is unavailable on this box (${e?.details?.reason || "seam unreachable"}).`,
+            "err",
+          );
+        } else {
+          window.__hal0Toast && window.__hal0Toast(`Delete failed — ${e?.message || "see logs"}`, "err");
+        }
+      },
     });
   };
 
@@ -683,6 +725,13 @@ function RunnerCard({ image }) {
                 onClick={() => setConfirmRestart(true)}
               >Restart {inUseBy.length} affected slot{inUseBy.length === 1 ? "" : "s"}</button>
             )}
+            <button
+              className="btn ghost"
+              data-testid="ri-delete-tag"
+              disabled={deleteTag.isPending || !!deleteDisabledReason}
+              title={deleteDisabledReason || `Delete ${deleteRef} and reclaim its disk bytes`}
+              onClick={() => setConfirmDelete(true)}
+            >{Icons.trash} Delete <span className="mono" style={{fontSize: 10, opacity: .7}}>:{selTag}</span></button>
           </div>
         )}
         {pull.imageId === image.id && pull.error && (
@@ -715,6 +764,17 @@ function RunnerCard({ image }) {
         }
         confirmLabel="Restart"
         footerNote="A slot that fails to restart is skipped and logged — the rest still restart."
+      />
+
+      <ConfirmDialog
+        open={confirmDelete}
+        onCancel={() => setConfirmDelete(false)}
+        onConfirm={onDeleteTag}
+        title={`Delete ${deleteRef}`}
+        message={`Delete tag "${selTag}" of ${image.image} and reclaim its bytes on this box's local store. This cannot be undone.`}
+        confirmLabel="Delete"
+        destructive
+        footerNote="The server still refuses if a slot or container is using this image."
       />
     </div>
   );


### PR DESCRIPTION
Runner-images v3 **phase 4**: the first privileged WRITE seam. Dashboard/CLI pulls now land in root's image store (the one slots launch from — closes the #2119 class for managed pulls), and operators can delete an image tag with real disk reclaim, guarded against deleting anything running. Implements spec decisions D1(a) and D2 (approved 2026-08-30).

## What changed

**`hal0-podman-rw`** (new wrapper + separate sudoers grant): exactly two verbs. `image-pull <ref>` — validate, then `exec podman pull -- <ref>`, progress streamed raw, podman's exit code passes through. `image-rm <ref>` — plain `podman rmi` (never `-f`): rc 0 → `removed`, absent → `missing` (real negative, exit 0), **exit 67** when podman refuses (in use by a container, or has child images — not distinguishable, callers must not read 67 as retry-later), 66 operational. Same doctrine as `-ro`: `LC_ALL=C` pin, byte-identical ref grammar, fixed argv, `--` separators, binary-pinned grant, independently revocable. `-ro` itself is untouched and stays read-only.

**Pull routing**: `ContainerProvider.pull_image_stream` delegates to the rootful seam when available (service user + binary present), rootless fallback for dev/CI. Cancel is deterministic end-to-end: `contextlib.aclosing` propagates `.aclose()` into the seam generator, and the cleanup sends **SIGTERM** (sudo relays catchable signals; SIGKILL would orphan the root-owned podman). Clean-EOF never signals — no false `failed -9` on successful pulls.

**Delete**: `DELETE /api/runner-images/{id}/tags/{tag}` — guard order: 404 → 409 `pull_in_progress` (an in-flight pull of that tag blocks delete) → 409 `tag_in_use` naming slots (server-side usage check) → seam rm (podman's own in-use/child refusal → 409; seam unreachable → 502, catalogue untouched — never a fake delete) → catalogue tag row + marker cleanup, audited (`rec.after` carries outcome + catalogue_removed, desync warning logged). Dashboard: confirm-gated per-tag Delete with honest outcome toasts. CLI: `hal0 runner-images rm <id> --tag` with the same guard order; works as the `hal0` service user via the seam or as root via direct `podman rmi` fallback.

**Installer/updater**: `-rw` wrapper + grant installed beside `-ro` (visudo-gated), removed by uninstall, refreshed by `hal0 update` — the refresh installs unconditionally, so **a v1.0.0 box gets the wrapper and grant automatically on update** (verified against the refresh code path + its empty-destination test fixture). Sixth seam wired into preflight/doctor/seam-check inventories (shell/python parity test).

## Security posture (final review judgment)

`image-pull` adds essentially no new privilege — a compromised `hal0` account could already stage an arbitrary-image rootful Quadlet via the existing `write-quadlet` grant; disk exhaustion is the net-new nuisance. `image-rm` is genuinely new destructive capacity but recoverable, never forced, doubly guarded (route policy + podman's own refusal); the wrapper enforces grammar, callers enforce catalogue policy — consistent with the seam doctrine.

## Merge gate: live-box checklist (run on ct150 before merging)

1. Cancel kills podman: start a big pull, cancel, `ps -ef | grep 'podman pull'` empty within seconds.
2. 5–10 repeated successful pulls: no spurious `failed -9/-15`.
3. Pull lands rootful: `sudo podman images` shows the ref; slot start needs no Quadlet re-pull.
4. Grant-denied posture: move the sudoers file aside → pull fails loudly, doctor shows the seam red; restore.
5. Upgrade path on a real 1.0.0 box: `hal0 update` refreshes wrapper + sudoers, pull works with no reinstall.
6. Delete: non-in-use tag (bytes gone, catalogue + marker cleaned); in-use tag (409 naming slots); parented image (seam 67 → 409).
7. `visudo -cf` on the real grant file; CLI `rm` as root and as `sudo -u hal0`.
8. Uninstall sweep removes `/etc/sudoers.d/hal0-podman-rw`.
9. Locale spot-check: `LANG=tr_TR.UTF-8` in the unit env — validator still rejects `alpiné`-class refs.

Deferred follow-ups are in the session ledger (grant-denied pull UX hint, audit of refused pre-check attempts, optional repo-prefix allowlist on `image-rm`).

Part of #2106 (the delete half). Closes the managed-pull leg of #2119; coexists with #2121 (subuid fixes the rootless FALLBACK; this makes rootful the primary path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014khK1DWzgMXAzF83tMroiC
