### PR TITLE
chore(runner-images): v3 polish — specialties, grant UX, delete auditing, truth parity

### DIFF
--- a/src/hal0/api/routes/runner_images.py
+++ b/src/hal0/api/routes/runner_images.py
@@ -119,6 +119,7 @@ def enrich_row(
     defaults: Mapping[str, tuple[str, str]],
     slot_usage: Mapping[str, str],
     local: LocalImagesDigests | None,
+    specialties: Mapping[str, list[str]] = {},
 ) -> dict[str, Any]:
     """One catalogue row + the derived catalogue-v2/v3 contract fields. Pure.
 
@@ -140,8 +141,17 @@ def enrich_row(
     (``None`` when neither store answered) — store-truth (v3): ``store_state``
     ("present"/"missing"/"unknown"), per-tag ``downloaded`` (``None`` when
     the store is unknown), ``store_context``, and ``badges``.
+
+    ``specialties`` maps repo (``_repo_of`` shape) -> the sorted union of
+    every :data:`hal0.runners.RUNNER_IMAGES` entry's
+    ``supports.specialties`` whose image resolves to that repo (see
+    :func:`_repo_specialties`, hoisted once per request beside ``defaults``)
+    — the catalogue-v3 field the UI's ``groupRows`` (``runner-images.jsx``)
+    reads to route a row into the "Specialized" group. ``[]`` for a repo no
+    specialty runner claims — every plain toolbox image included.
     """
     row = _image_to_dict(image)
+    row["specialties"] = list(specialties.get(image.image, []))
     is_default: dict[str, str] | None = None
     for family, (ref, source) in defaults.items():
         if _repo_of(ref) == image.image:
@@ -179,6 +189,30 @@ def enrich_row(
     row["store_context"] = local.context if local else None
     row["badges"] = _tag_badges(image)
     return row
+
+
+def _repo_specialties() -> dict[str, list[str]]:
+    """Repo (``_repo_of`` shape) -> sorted union of every
+    :data:`hal0.runners.RUNNER_IMAGES` entry's ``supports.specialties``
+    whose ``runner.image`` resolves to that repo.
+
+    Computed ONCE per request (hoisted beside ``defaults``/``slot_usage`` in
+    :func:`_request_context`) — this is a pure fold over the in-process
+    ``RUNNER_IMAGES`` registry, no I/O, but the union-per-repo shape is worth
+    computing once rather than per row. A repo shared by more than one
+    runner key (e.g. ``rocmfpx``/``vulkanfpx`` both resolving to
+    ``DEFAULT_ROCMFPX_IMAGE``, neither of which carries a specialty today)
+    unions cleanly to the same result either way.
+    """
+    from hal0.runners import RUNNER_IMAGES
+
+    out: dict[str, set[str]] = {}
+    for runner in RUNNER_IMAGES.values():
+        specialties = runner.supports.specialties
+        if not specialties:
+            continue
+        out.setdefault(_repo_of(runner.image), set()).update(specialties)
+    return {repo: sorted(vals) for repo, vals in out.items()}
 
 
 def _effective_defaults() -> dict[str, tuple[str, str]]:
@@ -468,15 +502,18 @@ async def _restart_slot(name: str, request: Request) -> None:
 
 
 def _request_context() -> tuple[
-    dict[str, tuple[str, str]], dict[str, str], LocalImagesDigests | None
+    dict[str, tuple[str, str]], dict[str, str], LocalImagesDigests | None, dict[str, list[str]]
 ]:
-    """One ``defaults``/``slot_usage``/``local`` triple, shared by every row
-    AND the families payload for a single request — computed once each
-    (``_local_store`` is explicitly "one store read per request")."""
+    """One ``defaults``/``slot_usage``/``local``/``specialties`` quadruple,
+    shared by every row AND the families payload for a single request —
+    computed once each (``_local_store`` is explicitly "one store read per
+    request"; ``_repo_specialties`` is a pure in-process fold, hoisted here
+    for the same one-per-request discipline)."""
     defaults = _effective_defaults()
     slot_usage = _slot_image_usage()
     local = _local_store()
-    return defaults, slot_usage, local
+    specialties = _repo_specialties()
+    return defaults, slot_usage, local, specialties
 
 
 def _enrich_with(
@@ -484,21 +521,27 @@ def _enrich_with(
     defaults: Mapping[str, tuple[str, str]],
     slot_usage: Mapping[str, str],
     local: LocalImagesDigests | None,
+    specialties: Mapping[str, list[str]] = {},
 ) -> list[dict[str, Any]]:
     """Enrich every row against one already-computed request context.
 
     The shared tail of ``_enriched``, ``list_runner_images``, and
     ``sync_runner_images_route`` — each of the latter two already has its
-    own ``defaults``/``slot_usage``/``local`` on hand (to also feed
-    ``_safe_families_payload``), so this factors out the row-enrichment
-    list comprehension instead of repeating it three ways.
+    own ``defaults``/``slot_usage``/``local``/``specialties`` on hand (to
+    also feed ``_safe_families_payload``), so this factors out the
+    row-enrichment list comprehension instead of repeating it three ways.
     """
-    return [enrich_row(i, defaults=defaults, slot_usage=slot_usage, local=local) for i in images]
+    return [
+        enrich_row(
+            i, defaults=defaults, slot_usage=slot_usage, local=local, specialties=specialties
+        )
+        for i in images
+    ]
 
 
 def _enriched(images: list[RunnerImage]) -> list[dict[str, Any]]:
-    defaults, slot_usage, local = _request_context()
-    return _enrich_with(images, defaults, slot_usage, local)
+    defaults, slot_usage, local, specialties = _request_context()
+    return _enrich_with(images, defaults, slot_usage, local, specialties)
 
 
 def _safe_families_payload(
@@ -523,8 +566,8 @@ async def list_runner_images(request: Request) -> dict[str, Any]:
     plus the launch-truth ``families`` summary (catalogue v3, task 9)."""
     store = request.app.state.runner_image_registry
     images = store.list()
-    defaults, slot_usage, local = _request_context()
-    rows = _enrich_with(images, defaults, slot_usage, local)
+    defaults, slot_usage, local, specialties = _request_context()
+    rows = _enrich_with(images, defaults, slot_usage, local, specialties)
     return {
         "images": rows,
         "families": _safe_families_payload(images, defaults, slot_usage, local),
@@ -573,8 +616,8 @@ async def sync_runner_images_route(request: Request) -> dict[str, Any]:
     """
     store = request.app.state.runner_image_registry
     result = await sync_runner_images(store)
-    defaults, slot_usage, local = _request_context()
-    rows = _enrich_with(result.images, defaults, slot_usage, local)
+    defaults, slot_usage, local, specialties = _request_context()
+    rows = _enrich_with(result.images, defaults, slot_usage, local, specialties)
     return {
         "images": rows,
         "families": _safe_families_payload(result.images, defaults, slot_usage, local),

--- a/src/hal0/api/routes/runner_images.py
+++ b/src/hal0/api/routes/runner_images.py
@@ -740,53 +740,67 @@ async def delete_runner_image_tag(image_id: str, tag: str, request: Request) -> 
          update the catalogue via ``store.remove_tag`` and respond 200.
 
     Audited the same way ``restart-affected`` is: ``record_action`` with
-    category ``"runner_image"``, action ``"runner_image.rm"``, target the
-    ``image:tag`` ref — a raised 409/502 inside the block is recorded
-    ``outcome="error"`` and re-raised (``hal0.activity.audit_action``'s
-    confirmation guarantee), so the audit trail is honest either way.
+    category ``"runner_image"``, action ``"runner_image.rm"`` — but here
+    ``record_action`` wraps the WHOLE handler, pre-checks included, not
+    just the seam call. A refused delete (any of the five guards above) is
+    a real user-visible outcome and belongs in the trail exactly as much as
+    a successful one: ``hal0.activity.audit_action`` records
+    ``outcome="error"`` on any raised exception INSIDE the block (then
+    re-raises, so the normal error envelope is untouched) — that includes
+    an ``Hal0Error`` like ``NotFound``/``Conflict`` just as much as a bug,
+    which is exactly the behaviour this route now leans on for guards 1-4.
+    ``target`` starts as ``<image_id>:<tag>`` (the only ref this handler
+    can name before the catalogue lookup resolves ``image.image``) and is
+    upgraded to the real ``image:tag`` ref the moment ``image`` is known,
+    same target shape either way once past guard 1.
     """
-    store = request.app.state.runner_image_registry
-    image = store.get(image_id)
-    if image is None:
-        raise NotFound(
-            f"runner image {image_id!r} not in catalogue",
-            details={"image_id": image_id},
-            code="runner_image.not_found",
-        )
-    tag_known = (
-        tag == image.tag or any(t.tag == tag for t in image.tags) or tag in image.available_tags
-    )
-    if not tag_known:
-        raise NotFound(
-            f"tag {tag!r} not catalogued for {image_id!r}",
-            details={"image_id": image_id, "tag": tag},
-            code="runner_image.tag_not_found",
-        )
-
-    jobs: dict[str, RunnerPullJob] = request.app.state.runner_image_pull_jobs
-    job = jobs.get(image_id)
-    if job is not None and job.state in ("queued", "running") and job.tag in (tag, None):
-        raise Conflict(
-            f"a pull for {image_id!r} tag {tag!r} is in progress; cancel it first",
-            details={"image_id": image_id, "tag": tag},
-            code="runner_image.pull_in_progress",
-        )
-
-    ref = f"{image.image}:{tag}"
-    in_use_slots = _tag_in_use_by(image, tag, _slot_image_usage())
-    if in_use_slots:
-        raise Conflict(
-            f"runner image tag {ref!r} is in use",
-            details={"image_id": image_id, "tag": tag, "slots": in_use_slots},
-            code="runner_image.tag_in_use",
-        )
-
     from hal0.api._audit import record_action
     from hal0.providers import podman_mutate
 
+    store = request.app.state.runner_image_registry
+
     async with record_action(
-        request, category="runner_image", action="runner_image.rm", target=ref
+        request,
+        category="runner_image",
+        action="runner_image.rm",
+        target=f"{image_id}:{tag}",
     ) as rec:
+        image = store.get(image_id)
+        if image is None:
+            raise NotFound(
+                f"runner image {image_id!r} not in catalogue",
+                details={"image_id": image_id},
+                code="runner_image.not_found",
+            )
+        tag_known = (
+            tag == image.tag or any(t.tag == tag for t in image.tags) or tag in image.available_tags
+        )
+        if not tag_known:
+            raise NotFound(
+                f"tag {tag!r} not catalogued for {image_id!r}",
+                details={"image_id": image_id, "tag": tag},
+                code="runner_image.tag_not_found",
+            )
+
+        jobs: dict[str, RunnerPullJob] = request.app.state.runner_image_pull_jobs
+        job = jobs.get(image_id)
+        if job is not None and job.state in ("queued", "running") and job.tag in (tag, None):
+            raise Conflict(
+                f"a pull for {image_id!r} tag {tag!r} is in progress; cancel it first",
+                details={"image_id": image_id, "tag": tag},
+                code="runner_image.pull_in_progress",
+            )
+
+        ref = f"{image.image}:{tag}"
+        rec.target = ref
+        in_use_slots = _tag_in_use_by(image, tag, _slot_image_usage())
+        if in_use_slots:
+            raise Conflict(
+                f"runner image tag {ref!r} is in use",
+                details={"image_id": image_id, "tag": tag, "slots": in_use_slots},
+                code="runner_image.tag_in_use",
+            )
+
         outcome, reason = await asyncio.to_thread(podman_mutate.remove_image, ref)
         rec.after = {"outcome": outcome}
         if outcome == "in-use":

--- a/src/hal0/cli/runner_image_commands.py
+++ b/src/hal0/cli/runner_image_commands.py
@@ -63,13 +63,21 @@ def _store_state(image: RunnerImage, local: LocalImagesDigests | None) -> str:
     """``present``/``missing``/``unknown`` for one row.
 
     Same rule as ``hal0.api.routes.runner_images.enrich_row``'s headline
-    fallback: digest match first, then an exact ``image:tag`` match in the
-    local refs. ``unknown`` when neither podman store answered at all.
+    fallback (v3 store-truth): digest-set membership FIRST, using the
+    headline tag's own per-tag digest fact from ``image.tags`` (the
+    ``runner_image_tag`` rows) rather than the row's scalar ``image.digest``
+    column — a headline whose ``runner_image_tag`` row carries a fresher
+    digest than the scalar column (or whose scalar column was never
+    backfilled) still matches correctly. Exact ``image:tag`` ref match is
+    the fallback when no digest is known either way. ``unknown`` when
+    neither podman store answered at all.
     """
     if local is None:
         return "unknown"
     local_digests = set(filter(None, local.refs.values()))
-    if image.digest and image.digest in local_digests:
+    headline = next((t for t in image.tags if t.tag == image.tag), None)
+    digest = headline.digest if headline is not None else image.digest
+    if digest and digest in local_digests:
         return "present"
     ref = f"{image.image}:{image.tag}"
     return "present" if ref in local.refs else "missing"
@@ -82,6 +90,22 @@ _STATE_BADGE = {
 }
 
 
+def _headline_badge(image: RunnerImage) -> str:
+    """The headline tag's badge value (``"validated"``/``"candidate"``/
+    ``"deprecated"``), or ``""`` — reuses
+    ``hal0.api.routes.runner_images._tag_badges`` (same frozen
+    ``hal0.config.schema`` image-ref sets the API's catalogue rows read) so
+    the CLI never re-derives its own copy of the badge rule. Import stays
+    fail-soft: a future rename/removal of that helper degrades the CLI's
+    ``Badges`` column to always-empty rather than crashing ``ls``.
+    """
+    try:
+        from hal0.api.routes.runner_images import _tag_badges
+    except ImportError:
+        return ""
+    return _tag_badges(image).get(image.tag, "")
+
+
 @app.command("ls")
 def ls() -> None:
     """List every catalogued runner image."""
@@ -89,20 +113,28 @@ def ls() -> None:
     images = store.list()
     local = _local_store()
 
+    badges = {image.id: _headline_badge(image) for image in images}
+    show_badges = any(badges.values())
+
     table = Table(title="Runner images")
     table.add_column("ID", style="bold")
     table.add_column("Image:Tag")
     table.add_column("Store")
     table.add_column("Tags", justify="right")
+    if show_badges:
+        table.add_column("Badges")
     for image in images:
         state = _store_state(image, local)
         tag_count = len(image.available_tags) if image.available_tags else 1
-        table.add_row(
+        row = [
             image.id,
             f"{image.image}:{image.tag}",
             _STATE_BADGE[state],
             str(tag_count),
-        )
+        ]
+        if show_badges:
+            row.append(badges[image.id] or "[dim]—[/dim]")
+        table.add_row(*row)
     console.print(table)
     if not images:
         console.print("[dim]no runner images catalogued yet — run `hal0 runner-images sync`.[/dim]")

--- a/src/hal0/cli/runner_image_commands.py
+++ b/src/hal0/cli/runner_image_commands.py
@@ -91,8 +91,8 @@ _STATE_BADGE = {
 
 
 def _headline_badge(image: RunnerImage) -> str:
-    """The headline tag's badge value (``"validated"``/``"candidate"``/
-    ``"deprecated"``), or ``""`` — reuses
+    """The headline tag's badge value (validated / candidate / the
+    retired-pin marker), or ``""`` — reuses
     ``hal0.api.routes.runner_images._tag_badges`` (same frozen
     ``hal0.config.schema`` image-ref sets the API's catalogue rows read) so
     the CLI never re-derives its own copy of the badge rule. Import stays

--- a/src/hal0/providers/podman_mutate.py
+++ b/src/hal0/providers/podman_mutate.py
@@ -177,6 +177,20 @@ async def pull_image_stream_rootful(image: str) -> AsyncIterator[dict[str, Any]]
     A bad image reference is rejected HERE, before any subprocess is
     spawned — no ``sudo`` round-trip is spent on a ref the wrapper would
     reject anyway.
+
+    A bare nonzero exit code is a poor error message on its own — rc 1 is
+    what ``sudo -n`` itself returns for a denied/misconfigured grant
+    (missing NOPASSWD entry, sudoers not yet installed, mid-upgrade race),
+    the single most actionable failure this seam can hit. When the process
+    exits 1 AND nothing that looked like real podman progress ever came
+    through (either no output line at all, or every line matched sudo's own
+    diagnostic shapes — ``sudo:``-prefixed, or containing "a password is
+    required") the ``"failed"`` event's ``error`` names the seam and the
+    grant file (``/etc/sudoers.d/hal0-podman-rw``) instead of just the exit
+    code. Any other nonzero exit — or an rc 1 that followed real pull
+    output — keeps the bare ``pull exited with code N`` message: that
+    failure happened well past the sudo gate, and blaming the grant would
+    be dishonest.
     """
     if not is_valid_image_ref(image):
         yield {"state": "failed", "error": f"invalid image reference: {image}"}
@@ -194,6 +208,8 @@ async def pull_image_stream_rootful(image: str) -> AsyncIterator[dict[str, Any]]
 
     parser = PullLineParser()
     clean_eof = False
+    saw_any_line = False
+    sudo_shaped_lines = True
 
     try:
         assert proc.stdout is not None
@@ -201,6 +217,9 @@ async def pull_image_stream_rootful(image: str) -> AsyncIterator[dict[str, Any]]
             line = raw.decode("utf-8", errors="replace").rstrip()
             if not line:
                 continue
+            saw_any_line = True
+            if not (line.startswith("sudo:") or "a password is required" in line):
+                sudo_shaped_lines = False
             yield parser.feed(line)
         clean_eof = True
     except Exception as exc:
@@ -233,6 +252,19 @@ async def pull_image_stream_rootful(image: str) -> AsyncIterator[dict[str, Any]]
             "state": "completed",
             "layer": parser.done_layers,
             "total_layers": parser.total_layers,
+        }
+    elif exit_code == 1 and (not saw_any_line or sudo_shaped_lines):
+        # rc 1 with either no output at all, or output that only ever looked
+        # like sudo's own diagnostics (never a real podman progress line) —
+        # the write seam's grant is the far likelier culprit than podman
+        # itself, so name it instead of leaving an operator to guess at a
+        # bare exit code (see packaging/sudoers/hal0-podman-rw).
+        yield {
+            "state": "failed",
+            "error": (
+                "write seam grant denied or misconfigured — check "
+                f"/etc/sudoers.d/hal0-podman-rw (pull exited with code {exit_code})"
+            ),
         }
     else:
         yield {"state": "failed", "error": f"pull exited with code {exit_code}"}

--- a/tests/api/test_runner_images_routes.py
+++ b/tests/api/test_runner_images_routes.py
@@ -358,6 +358,59 @@ class TestEnrichRow:
         assert row["in_use_by"] == ["agent", "utility"]
         assert row["is_default"] is None
 
+    def test_specialties_defaults_to_empty_list_when_omitted(self) -> None:
+        """``specialties`` is an opt-in kwarg (default ``{}``) — every
+        existing ``enrich_row`` call site in this file predates it and must
+        keep working unchanged."""
+        from hal0.api.routes.runner_images import enrich_row
+
+        row = enrich_row(
+            _row("ghcr.io/hal0ai/hal0-combined", "0824"),
+            defaults={},
+            slot_usage={},
+            local=None,
+        )
+        assert row["specialties"] == []
+
+    def test_specialties_matched_by_repo(self) -> None:
+        from hal0.api.routes.runner_images import enrich_row
+
+        row = enrich_row(
+            _row("ghcr.io/hal0ai/hal0-promptforge", "v2.3-qwen38"),
+            defaults={},
+            slot_usage={},
+            local=None,
+            specialties={"ghcr.io/hal0ai/hal0-promptforge": ["promptforge"]},
+        )
+        assert row["specialties"] == ["promptforge"]
+
+
+class TestSpecialtiesRoute:
+    """``specialties`` is the catalogue-v3 field the UI's ``groupRows``
+    (``ui/src/dash/runner-images.jsx``) reads to route a row into the
+    "Specialized" group — sourced from :data:`hal0.runners.RUNNER_IMAGES`'s
+    ``supports.specialties``, matched by repo (any tag), and hoisted once
+    per request (:func:`hal0.api.routes.runner_images._repo_specialties`)."""
+
+    def test_promptforge_row_carries_specialties_rocmfpx_row_does_not(
+        self, client: TestClient
+    ) -> None:
+        from hal0.api.routes.runner_images import _repo_of
+        from hal0.config.schema import DEFAULT_PROMPTFORGE_IMAGE, DEFAULT_ROCMFPX_IMAGE
+        from hal0.registry.runner_image import RunnerImage
+
+        store = client.app.state.runner_image_registry
+        pf_repo = _repo_of(DEFAULT_PROMPTFORGE_IMAGE)
+        rocm_repo = _repo_of(DEFAULT_ROCMFPX_IMAGE)
+        store.upsert(RunnerImage(id="pf", image=pf_repo, tag="v2.3-qwen38"))
+        store.upsert(RunnerImage(id="rocm", image=rocm_repo, tag="0826"))
+
+        rows = client.get("/api/runner-images").json()["images"]
+        pf_row = next(r for r in rows if r["id"] == "pf")
+        rocm_row = next(r for r in rows if r["id"] == "rocm")
+        assert pf_row["specialties"] == ["promptforge"]
+        assert rocm_row["specialties"] == []
+
 
 # ── per-tag pull (catalogue v2 follow-up to #2043/#2044) ────────────────────
 

--- a/tests/api/test_runner_images_routes.py
+++ b/tests/api/test_runner_images_routes.py
@@ -1585,6 +1585,72 @@ class TestDeleteRunnerImageTag:
         )
         assert rec["outcome"] == "error"
 
+    def _records(self, client: TestClient) -> list[dict[str, Any]]:
+        return client.get(
+            "/api/activity", params={"category": "runner_image", "action": "runner_image.rm"}
+        ).json()["records"]
+
+    def test_unknown_image_404_is_audited(self, client: TestClient) -> None:
+        """A refused delete on a completely unknown id is a real user-visible
+        outcome too — it must leave an audit row, not just the 404 response.
+        No ``image.image`` is known yet at this point, so the target falls
+        back to ``<image_id>:<tag>``."""
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 404
+
+        rec = next(r for r in self._records(client) if r["target"] == f"{self.IMAGE_ID}:0824")
+        assert rec["outcome"] == "error"
+
+    def test_unknown_tag_404_is_audited(self, client: TestClient) -> None:
+        self._seed(client)
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/9999")
+        assert resp.status_code == 404
+
+        rec = next(r for r in self._records(client) if r["target"] == f"{self.IMAGE_ID}:9999")
+        assert rec["outcome"] == "error"
+
+    def test_app_level_in_use_guard_409_is_audited(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The pre-check application-level in-use guard (fires BEFORE the
+        seam is ever called) must also leave an audit row — this used to run
+        entirely outside the ``record_action`` block."""
+        self._seed(client)
+        monkeypatch.setattr(
+            "hal0.api.routes.runner_images._slot_image_usage",
+            lambda: {"brain": "ghcr.io/hal0ai/hal0-combined:0824"},
+        )
+
+        def _boom(ref: str):
+            raise AssertionError("seam must not be reached when app-level guard fires")
+
+        monkeypatch.setattr("hal0.providers.podman_mutate.remove_image", _boom)
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 409
+
+        rec = next(
+            r for r in self._records(client) if r["target"] == "ghcr.io/hal0ai/hal0-combined:0824"
+        )
+        assert rec["outcome"] == "error"
+
+    def test_pull_in_progress_409_is_audited(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hal0.registry.runner_pull import make_job
+
+        self._seed(client)
+        job = make_job(self.IMAGE_ID, "ghcr.io/hal0ai/hal0-combined:0824", tag="0824")
+        job.state = "running"
+        client.app.state.runner_image_pull_jobs[self.IMAGE_ID] = job
+
+        resp = client.delete(f"/api/runner-images/{self.IMAGE_ID}/tags/0824")
+        assert resp.status_code == 409
+
+        rec = next(r for r in self._records(client) if r["target"] == f"{self.IMAGE_ID}:0824")
+        assert rec["outcome"] == "error"
+
     # ── route ordering ───────────────────────────────────────────────────
 
     def test_delete_tag_route_ordering(

--- a/tests/cli/test_runner_image_commands.py
+++ b/tests/cli/test_runner_image_commands.py
@@ -18,7 +18,8 @@ from typer.testing import CliRunner
 
 from hal0.cli.runner_image_commands import app as runner_images_app
 from hal0.providers import podman_mutate
-from hal0.registry.runner_image import RunnerImage
+from hal0.providers.podman_introspect import LocalImagesDigests
+from hal0.registry.runner_image import RunnerImage, RunnerImageTag
 from hal0.registry.runner_image_store import RunnerImageStore
 
 runner = CliRunner()
@@ -63,6 +64,47 @@ class TestLs:
 
         assert result.exit_code == 0, result.output
         assert "no runner images" in result.output.lower()
+
+    def test_digest_match_shows_present_even_when_ref_differs(
+        self, store: RunnerImageStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Store state must be derived from the row's per-tag digest facts
+        (``image.tags``, the ``runner_image_tag`` rows), not just an exact
+        ``image:tag`` ref match — the same digest-first rule
+        ``hal0.api.routes.runner_images.enrich_row`` uses (v3 store-truth).
+        Here the headline tag's own digest matches a LOCAL ref filed under a
+        completely different name, which an exact-ref-only check (the old
+        CLI behaviour, keyed off ``image.digest`` alone) would miss and
+        wrongly report "missing"."""
+        store.upsert(_image())
+        store.set_tags("x/a", [RunnerImageTag(tag="0826", digest="sha256:" + "a" * 64)])
+        monkeypatch.setattr(
+            "hal0.providers.podman_introspect.images_digests",
+            lambda: LocalImagesDigests(
+                refs={"ghcr.io/x/a:renamed": "sha256:" + "a" * 64}, context="rootful"
+            ),
+        )
+
+        result = runner.invoke(runner_images_app, ["ls"])
+
+        assert result.exit_code == 0, result.output
+        assert "present" in result.output.lower()
+        assert "missing" not in result.output.lower()
+
+    def test_badges_column_shown_when_any_row_has_a_badge(self, store: RunnerImageStore) -> None:
+        """A ``Badges`` column appears (reusing the same schema constants
+        the API's ``_tag_badges`` reads) when at least one catalogued row's
+        headline tag matches one — here the promptforge candidate ref."""
+        from hal0.config.schema import DEFAULT_PROMPTFORGE_IMAGE
+
+        image_repo, _, tag = DEFAULT_PROMPTFORGE_IMAGE.rpartition(":")
+        store.upsert(_image(id="pf", image=image_repo, tag=tag, available_tags=[tag]))
+
+        result = runner.invoke(runner_images_app, ["ls"])
+
+        assert result.exit_code == 0, result.output
+        assert "badges" in result.output.lower()
+        assert "candidate" in result.output.lower()
 
 
 class TestPull:

--- a/tests/providers/test_podman_mutate.py
+++ b/tests/providers/test_podman_mutate.py
@@ -345,6 +345,79 @@ async def test_pull_image_stream_rootful_nonzero_exit_is_failed(monkeypatch) -> 
     assert events[-1] == {"state": "failed", "error": "pull exited with code 1"}
 
 
+# ── pull_image_stream_rootful: grant-denied rc-1 message enrichment ────────
+
+
+_GRANT_DENIED_MESSAGE = (
+    "write seam grant denied or misconfigured — check /etc/sudoers.d/hal0-podman-rw "
+    "(pull exited with code 1)"
+)
+
+
+async def test_pull_image_stream_rootful_rc1_no_events_yields_grant_denied(monkeypatch) -> None:
+    """``sudo -n`` denies before the child even runs: no stdout at all, rc 1.
+    That is the "no events yielded" shape of a grant-denied failure —
+    enrich the message so an operator isn't left staring at a bare
+    ``pull exited with code 1``."""
+
+    async def _fake_create(*_args: object, **_kwargs: object) -> _FakeProc:
+        return _FakeProc([], 1)
+
+    monkeypatch.setattr(podman_mutate.asyncio, "create_subprocess_exec", _fake_create)
+
+    events = [e async for e in pull_image_stream_rootful(_REF)]
+
+    assert events == [{"state": "failed", "error": _GRANT_DENIED_MESSAGE}]
+
+
+async def test_pull_image_stream_rootful_rc1_sudo_error_line_yields_grant_denied(
+    monkeypatch,
+) -> None:
+    """``sudo -n`` prints its own diagnostic to stderr (merged into stdout
+    here) before exiting 1 — every yielded line is sudo-shaped, so this is
+    still honestly "no real pull activity happened", just enriched."""
+
+    async def _fake_create(*_args: object, **_kwargs: object) -> _FakeProc:
+        return _FakeProc([b"sudo: a password is required\n"], 1)
+
+    monkeypatch.setattr(podman_mutate.asyncio, "create_subprocess_exec", _fake_create)
+
+    events = [e async for e in pull_image_stream_rootful(_REF)]
+
+    assert events[-1] == {"state": "failed", "error": _GRANT_DENIED_MESSAGE}
+
+
+async def test_pull_image_stream_rootful_rc1_after_real_progress_stays_bare(monkeypatch) -> None:
+    """The pull actually started (a real podman progress line came through)
+    before something killed it at rc 1 — that is NOT a grant-denial shape,
+    so the bare exit-code message stays honest rather than blaming sudo for
+    a failure that happened well past the sudo gate."""
+
+    async def _fake_create(*_args: object, **_kwargs: object) -> _FakeProc:
+        return _FakeProc([b"Pulling fs layer\n"], 1)
+
+    monkeypatch.setattr(podman_mutate.asyncio, "create_subprocess_exec", _fake_create)
+
+    events = [e async for e in pull_image_stream_rootful(_REF)]
+
+    assert events[-1] == {"state": "failed", "error": "pull exited with code 1"}
+
+
+async def test_pull_image_stream_rootful_rc2_stays_bare_even_with_no_events(monkeypatch) -> None:
+    """The enrichment is scoped to rc 1 (the sudo/grant exit code) only —
+    any other nonzero exit keeps the plain message, even with zero
+    events yielded."""
+
+    async def _fake_create(*_args: object, **_kwargs: object) -> _FakeProc:
+        return _FakeProc([], 2)
+
+    monkeypatch.setattr(podman_mutate.asyncio, "create_subprocess_exec", _fake_create)
+
+    events = [e async for e in pull_image_stream_rootful(_REF)]
+
+    assert events == [{"state": "failed", "error": "pull exited with code 2"}]
+
+
 async def test_pull_image_stream_rootful_clean_eof_never_signals_process(monkeypatch) -> None:
     """Regression: a fully successful pull must not be torn down by the
     ``finally`` block. Before the fix, ``finally: proc.kill()`` fired

--- a/tests/registry/test_runner_image_sync.py
+++ b/tests/registry/test_runner_image_sync.py
@@ -559,6 +559,82 @@ async def test_sync_persists_tags(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_probe_fetches_headline_manifest_exactly_once(tmp_path: Path) -> None:
+    """Regression: :func:`probe_ghcr_package` must not double-fetch the
+    headline tag's manifest — once for the top-level digest/size
+    resolution, once more inside the per-tag ``available_tags`` loop. The
+    loop's ``t == resolved_tag`` branch reuses the already-fetched result
+    instead of re-probing (see the "Reuse the headline manifest result"
+    comment in the module) — this pins that at the request-count level,
+    not just the output shape ``test_probe_resolves_digest_per_tag`` already
+    covers, so a regression that re-fetches the same ref (same output,
+    doubled GHCR traffic) would still be caught here."""
+    from hal0.registry.runner_image_sync import probe_ghcr_package
+
+    manifest_refs: list[str] = []
+    base_handler = _route_handler(images_json=_IMAGES_JSON, tags=["0826", "0824"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "/manifests/" in url:
+            _, _, ref = url.partition("/manifests/")
+            manifest_refs.append(ref)
+        return base_handler(request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        await probe_ghcr_package("hal0ai/hal0-toolbox-cpu", client=client, tag="0826")
+    finally:
+        await client.aclose()
+
+    # "0826" is both the pinned headline AND a member of available_tags —
+    # exactly the case the reuse branch exists for.
+    assert manifest_refs.count("0826") == 1
+    assert manifest_refs.count("0824") == 1
+
+
+@pytest.mark.asyncio
+async def test_second_sync_probe_failure_retains_existing_tag_rows(tmp_path: Path) -> None:
+    """Regression: a package that synced successfully once, then FAILS its
+    probe on a second sync run (e.g. a transient GHCR 500 on the token
+    endpoint), must not lose its previously-persisted ``runner_image_tag``
+    rows. ``sync_runner_images``'s per-package loop ``continue``s straight
+    past ``store.upsert``/``store.set_tags`` on a probe exception — this
+    pins that the existing tag rows survive that skip untouched, store-side,
+    not just that the id stays in ``probe_errors``."""
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    good_handler = _route_handler(images_json=_IMAGES_JSON, tags=["0826", "0824"])
+    client = httpx.AsyncClient(transport=httpx.MockTransport(good_handler))
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.probe_errors == {}
+    cpu_before = store.get("cpu")
+    assert cpu_before is not None
+    assert [t.tag for t in cpu_before.tags] == ["latest", "0826", "0824"]
+
+    failing_handler = _route_handler(
+        images_json=_IMAGES_JSON,
+        ghcr_fail={"hal0ai/hal0-toolbox-cpu"},
+        tags=["0826", "0824"],
+    )
+    client2 = httpx.AsyncClient(transport=httpx.MockTransport(failing_handler))
+    try:
+        result2 = await sync_runner_images(store, client=client2)
+    finally:
+        await client2.aclose()
+
+    assert "cpu" in result2.probe_errors
+    cpu_after = store.get("cpu")
+    assert cpu_after is not None
+    assert [(t.tag, t.digest) for t in cpu_after.tags] == [
+        (t.tag, t.digest) for t in cpu_before.tags
+    ]
+
+
+@pytest.mark.asyncio
 async def test_sync_result_rows_carry_fresh_tags_on_first_sync(tmp_path: Path) -> None:
     """The SyncResult rows returned by sync_runner_images must already carry
     the freshly-probed tags — not the tag table's state from BEFORE this

--- a/ui/src/dash/__tests__/runner-images-view.test.tsx
+++ b/ui/src/dash/__tests__/runner-images-view.test.tsx
@@ -811,3 +811,56 @@ describe('RunnerImagesView per-tag delete (Task 5)', () => {
     act(() => { root.unmount() })
   })
 })
+
+// Pull button label — store truth, not the retired `local_path` marker.
+// `local_path` is a pre-v3 field the catalogue can leave stale (or unset
+// even after a real pull, on a store-read miss); `image.downloaded` is the
+// v3 enriched field (`store_state === "present"`, or the `local_path`
+// fallback ONLY when the store itself couldn't be read) — the button must
+// key off that, not the raw marker.
+describe('RunnerImagesView pull button label (store truth, #polish item D)', () => {
+  afterEach(() => {
+    imagesOverride.current = null
+    document.body.innerHTML = ''
+  })
+
+  function mount() {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const root = createRoot(host)
+    act(() => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: qc },
+          React.createElement(RunnerImagesView),
+        ),
+      )
+    })
+    return { host, root }
+  }
+
+  it('reads "Re-pull" from image.downloaded even when local_path is unset', () => {
+    imagesOverride.current = [{ ...PULL_ROW, local_path: null, downloaded: true }]
+    const { host, root } = mount()
+
+    const btn = host.querySelector('[data-testid="ri-pull"]') as HTMLButtonElement
+    expect(btn.textContent).toContain('Re-pull')
+
+    act(() => { root.unmount() })
+  })
+
+  it('reads "Pull" from image.downloaded even when local_path is a stale marker', () => {
+    imagesOverride.current = [
+      { ...PULL_ROW, local_path: '/var/lib/hal0/runner-images/stale.json', downloaded: false },
+    ]
+    const { host, root } = mount()
+
+    const btn = host.querySelector('[data-testid="ri-pull"]') as HTMLButtonElement
+    expect(btn.textContent).toContain('Pull')
+    expect(btn.textContent).not.toContain('Re-pull')
+
+    act(() => { root.unmount() })
+  })
+})

--- a/ui/src/dash/runner-images.jsx
+++ b/ui/src/dash/runner-images.jsx
@@ -703,7 +703,7 @@ function RunnerCard({ image }) {
               data-testid="ri-pull"
               onClick={onPull}
             >
-              {Icons.download} {image.local_path ? "Re-pull" : "Pull"} <span className="mono" style={{fontSize: 10, opacity: .7}}>:{selTag}</span>
+              {Icons.download} {image.downloaded ? "Re-pull" : "Pull"} <span className="mono" style={{fontSize: 10, opacity: .7}}>:{selTag}</span>
             </button>
             {family && (
               <button


### PR DESCRIPTION
Five reviewed follow-ups from the v3 / phase-4 final-review ledgers, one commit each:

1. **Specialties surfaced on catalogue rows** — `enrich_row` emits `specialties` from `RUNNER_IMAGES` supports (repo-matched, once per request), making the dashboard's "Specialized" group live end-to-end. Honest caveat: today's only specialty runner (promptforge) is also a default family, and defaults win the grouping — so the group becomes *reachable* now but only populates once a non-default specialty image ships.
2. **Grant-denied pull UX** — a rootful pull dying at sudo (rc 1, sudo-shaped/no output) now says `write seam grant denied or misconfigured — check /etc/sudoers.d/hal0-podman-rw` instead of a bare exit code. Heuristic keys on sudo's canonical `-n` denial message; other sudo phrasings fall back to the bare message (exit code always still shown).
3. **Refused delete attempts are audited** — `record_action` now wraps the whole DELETE handler, so blocked attempts (404s, in-use/pull-in-progress 409s) land in the audit trail; response codes/bodies unchanged, single audit row per request verified.
4. **Truth parity** — CLI `ls` derives store state from per-tag digest facts (same digest-first rule as the API) and shows badges; the dashboard Pull button label reads store-truth `downloaded` instead of the retired marker field.
5. **Sync test hardening** — fault-injection-verified regression guards: headline manifest fetched exactly once per probe; a failed re-sync leaves existing tag rows intact.

Review: independent pass, verdict READY with zero fixes — both new sync tests confirmed load-bearing by injecting the regressions they guard against. 159 targeted backend tests + 263 vitest green; ruff/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014khK1DWzgMXAzF83tMroiC
