### PR TITLE
docs(installer): note why hal0-podman-rw carries no repo-prefix allowlist

### DIFF
--- a/installer/wrappers/hal0-podman-rw
+++ b/installer/wrappers/hal0-podman-rw
@@ -37,6 +37,11 @@
 #   * `image-rm` never passes `-f`: a caller can only remove an image that is
 #     NOT in use, never force-evict one out from under a running slot.
 #
+# A repo-prefix allowlist inside this wrapper was considered and judged not
+# required: the wrapper enforces argument GRAMMAR, and the callers (the hal0
+# catalogue layer) enforce repo POLICY — which registries/repos a ref may
+# name. A second policy point here would drift against the first.
+#
 # EXIT-CODE CONTRACT (extends hal0-podman-ro's with one NEW code):
 #
 #   * rc 0   — the verb completed and produced a DEFINITIVE, on-purpose


### PR DESCRIPTION
Closes runner-images v3 deferred pool item 2 with a doc note, per final-review judgment.

Adds four comment lines to the `installer/wrappers/hal0-podman-rw` header recording that an in-wrapper repo-prefix allowlist was considered and judged not required: the wrapper enforces argument grammar (the closed OCI ref regex, root-side), while the callers — the hal0 catalogue layer — enforce repo policy. Adding a second policy point inside the wrapper would drift against the first.

No behavior change; comment-only. `bash -n` clean. Only the rw wrapper is touched — `hal0-podman-ro` and `packaging/sudoers/hal0-podman-rw` were checked and neither cross-references an allowlist, so nothing there goes stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWn23rRvwECyNfLya4JQip