### PR TITLE
feat(config): machine-readable runner-image pin export for retention

### DIFF
--- a/exports/runner-image-pins.json
+++ b/exports/runner-image-pins.json
@@ -1,0 +1,7 @@
+{
+  "pins": [
+    "ghcr.io/hal0ai/hal0-combined:0826",
+    "ghcr.io/hal0ai/hal0-promptforge:v2.3-qwen38"
+  ],
+  "source": "src/hal0/config/schema.py"
+}

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1067,6 +1067,11 @@ MTP_FLAG_BUNDLE = build_mtp_flag_bundle("rocm")
 #: lazy with no trigger rules — an empty root — so generation ran
 #: unconstrained and every JSON-mode request 500'd at the parse; reproduced
 #: on prod's live LFM slot).
+#: Exported (with :data:`DEFAULT_PROMPTFORGE_IMAGE` and
+#: :data:`VULKAN_CAPABLE_IMAGE_REFS`) via ``exports/runner-image-pins.json``,
+#: which the hal0-runner-images retention automation fetches as its
+#: never-delete allowlist — ``tests/config/test_runner_image_pins_export.py``
+#: keeps the export in lockstep with these constants.
 #: 0824 lineage (2026-08-24): byte-for-byte the 0822 recipe rebuilt for the
 #: #2037 fail-fast entrypoint (supervises llama-server, translates a
 #: non-signal death before /health ever answered 200 into exit 64 so the

--- a/tests/config/test_runner_image_pins_export.py
+++ b/tests/config/test_runner_image_pins_export.py
@@ -1,0 +1,76 @@
+"""``exports/runner-image-pins.json`` stays in lockstep with schema.py.
+
+The retention sweep in ``Hal0ai/hal0-runner-images`` (``scripts/retention.py``)
+must never delete a GHCR image ref that shipped hal0 code still pulls. Its
+``retention-allowlist.json`` ``hal0_code_pins`` list used to be synced by hand
+against the constants in :mod:`hal0.config.schema`; now the retention side
+fetches ``exports/runner-image-pins.json`` from raw.githubusercontent instead,
+and THIS test is the sync mechanism on the hal0 side: bump a pinned image
+constant and this test fails until the export file is regenerated (the failure
+message prints the exact expected file content — paste it over the file).
+
+Membership rule (why these constants and not the others):
+
+* ``DEFAULT_ROCMFPX_IMAGE`` — the default runner every fresh install pulls.
+* ``VULKAN_CAPABLE_IMAGE_REFS`` — the only refs the ``gpu-vulkan`` lane
+  preflight admits; delete one and every slot on that lane bricks.
+* ``DEFAULT_PROMPTFORGE_IMAGE`` — the bundled fallback for the optional
+  promptforge runner (#2132). Its package (``hal0-promptforge``) is inside the
+  retention sweep's blast radius, and its tag shape is not release-shaped, so
+  the allowlist is its only durable protection once the runner-images
+  ``images.json`` entry moves on.
+
+Deliberately excluded: ``STALE_ROCMFPX_IMAGE_REFS`` and
+``NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS`` (string-comparison retag/deny lists —
+hal0 never pulls them, so retention deleting them is harmless), and the two
+``FALLBACK_*`` images (their packages are outside the sweep: retention only
+touches ``hal0-``-prefixed packages in the hal0ai org).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hal0.config.schema import (
+    DEFAULT_PROMPTFORGE_IMAGE,
+    DEFAULT_ROCMFPX_IMAGE,
+    VULKAN_CAPABLE_IMAGE_REFS,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXPORT_PATH = _REPO_ROOT / "exports" / "runner-image-pins.json"
+
+
+def _expected_export_text() -> str:
+    pins = sorted(
+        {DEFAULT_ROCMFPX_IMAGE, DEFAULT_PROMPTFORGE_IMAGE} | set(VULKAN_CAPABLE_IMAGE_REFS)
+    )
+    doc = {"source": "src/hal0/config/schema.py", "pins": pins}
+    return json.dumps(doc, indent=2, sort_keys=True) + "\n"
+
+
+def test_export_file_matches_schema_constants() -> None:
+    expected = _expected_export_text()
+    actual = _EXPORT_PATH.read_text(encoding="utf-8")
+    assert actual == expected, (
+        "exports/runner-image-pins.json is out of date with the image pin "
+        "constants in src/hal0/config/schema.py. The retention automation in "
+        "Hal0ai/hal0-runner-images fetches this file to build its "
+        "never-delete allowlist, so it must be regenerated whenever a pin "
+        "changes. Replace the file's content with exactly this:\n\n"
+        f"{expected}"
+    )
+
+
+def test_export_is_valid_deterministic_json() -> None:
+    # The consumer json.loads() this over raw.githubusercontent — assert the
+    # contract shape independently of the constants' current values.
+    doc = json.loads(_EXPORT_PATH.read_text(encoding="utf-8"))
+    assert set(doc) == {"source", "pins"}
+    assert doc["source"] == "src/hal0/config/schema.py"
+    assert isinstance(doc["pins"], list)
+    assert doc["pins"] == sorted(doc["pins"])
+    assert len(doc["pins"]) == len(set(doc["pins"]))
+    for ref in doc["pins"]:
+        assert ref.startswith("ghcr.io/hal0ai/"), ref


### PR DESCRIPTION
Runner-images v3 deferred pool item 1, hal0 side. The retention sweep in Hal0ai/hal0-runner-images (`scripts/retention.py`) keeps a `hal0_code_pins` allowlist that is hand-synced against the image pin constants in `src/hal0/config/schema.py` — its own `_comment` calls automating that export a known follow-up. This PR ships the export: a tracked, machine-readable file the retention script fetches from raw.githubusercontent, plus an equality test that makes the file impossible to forget.

## Design

**Export + equality test = the cheapest honest sync.** `exports/runner-image-pins.json` is a plain tracked JSON file (deterministic: 2-space indent, sorted keys, sorted unique pins, trailing newline) that the retention side fetches at `raw.githubusercontent.com/Hal0ai/hal0/main/exports/runner-image-pins.json` and `json.loads()`s — same fetch pattern the hal0 side already uses in reverse for the runner-images catalogue (`IMAGES_JSON_URL`, `src/hal0/registry/runner_image_sync.py:47`). No generator script: `tests/config/test_runner_image_pins_export.py` recomputes the export from the live schema constants and asserts byte equality, so any pin bump fails CI until the file is regenerated — and the failure message prints the exact expected file content, which IS the regen mechanism (checked `scripts/`: the closest precedent, `update-toolbox-digests.sh`, patches a registry-queried digest file; there is no repo precedent for a derive-from-Python-constants regen script, and the printed-expected pattern needs no extra moving part).

## What's in the pins list (and what isn't)

Membership rule: a ghcr ref is exported iff shipped hal0 code still pulls it AND it is inside the retention sweep's blast radius (the sweep only touches `hal0-`-prefixed container packages in the hal0ai org — `retention.py:list_org_container_packages`, "Names starting 'hal0-' only").

Included:
- `DEFAULT_ROCMFPX_IMAGE` = `ghcr.io/hal0ai/hal0-combined:0826` (`src/hal0/config/schema.py:1079`) — the default runner every fresh install and unpinned slot pulls.
- `VULKAN_CAPABLE_IMAGE_REFS` (`src/hal0/config/schema.py:1202`) — the only refs the `gpu-vulkan` lane preflight admits (`hal0.providers._gpu.image_serves_vulkan_lane`); currently `{VULKAN_FIXED_IMAGE}` = the same `:0826` ref (`schema.py:1176`), but the export computes the union so a future divergence is carried automatically.
- `DEFAULT_PROMPTFORGE_IMAGE` = `ghcr.io/hal0ai/hal0-promptforge:v2.3-qwen38` (`src/hal0/config/schema.py:1098`) — the specialty pin from #2132/#2133. Reasoning: (1) shipped code depends on it — it is the bundled fallback for the promptforge runner (`src/hal0/runners/__init__.py:161`, lockstep with `manifest.json`'s `toolbox_images.promptforge` digest per `tests/runners/test_registry.py`); (2) its package `hal0-promptforge` is inside the sweep (listed in runner-images `images.json`, id `promptforge`, and matches the `hal0-` prefix filter); (3) its tag fails the release-tag shape `^(\d+|v\d+(\.\d+)*)$` (`retention.py` `RE_RELEASE_TAG` — `v2.3-qwen38` has a suffix), so it earns no keep-newest-N protection; once the runner-images `images.json` entry moves to a newer build, this allowlist becomes the tag's only durable protection while shipped hal0 releases still reference it.

Excluded, deliberately:
- `STALE_ROCMFPX_IMAGE_REFS` (`schema.py:1126`) and `NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS` (`schema.py:1237`) — retag/deny lists consumed by string comparison only; hal0 never pulls these refs, so retention deleting them harms nothing (the #1948 bisect-evidence subset is already carried by the runner-images allowlist's own `evidence` section, which is that repo's concern, not a hal0 code pin).
- `FALLBACK_VULKAN_IMAGE` (`schema.py:1210`, package `amd-strix-halo-toolboxes`) and `FALLBACK_CUDA_IMAGE` (`schema.py:1211`, `ghcr.io/ggml-org/...`) — both outside the sweep's `hal0-` prefix filter (the latter outside the org entirely).
- `manifest.json` toolbox digests — out of scope for a file whose `source` is `src/hal0/config/schema.py`; the promptforge digest is already pinned in runner-images' own `images.json` (per `manifest.json`'s `_notes`), and `images.json` pins are a keep rule of their own in `classify_package`.

One note on the spec'd shape: the file carries exactly the agreed keys `{"source": "src/hal0/config/schema.py", "pins": [...]}`; serialized with `sort_keys=True` per the determinism requirement, `pins` precedes `source` textually — irrelevant to the consumer, which parses JSON.

## Consumer-side follow-up (hal0-runner-images)

Not in this PR: the retention script's fetch of this URL and the removal of the hand-synced `hal0_code_pins` entries. Note the export adds `hal0-promptforge:v2.3-qwen38`, which the current hand-synced list does not carry.

## Test evidence

```
tests/config/test_runner_image_pins_export.py::test_export_file_matches_schema_constants PASSED
tests/config/test_runner_image_pins_export.py::test_export_is_valid_deterministic_json PASSED
2 passed in 2.93s
```

Negative path verified: tampering the export makes the equality test fail with the full expected JSON printed in the assertion message. `scripts/check_sunset.py` green (193 <= 193 baseline; no overdue sunsets); ruff check/format clean on both touched Python files. (Pre-existing local failures in `tests/config/test_schema.py::TestSeededSlotTomls` are macOS AppleDouble `._*.toml` debris in `installer/etc-hal0/slots/`, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWn23rRvwECyNfLya4JQip
