### PR TITLE
fix(providers): podman_mutate follow-ups — pull-teardown SIGKILL escalation, rmi rc fidelity

### DIFF
--- a/src/hal0/providers/podman_mutate.py
+++ b/src/hal0/providers/podman_mutate.py
@@ -91,6 +91,12 @@ _RC_REASON: dict[int, SeamUnanswered] = {
     66: "podman-failed",
 }
 
+#: Seconds :func:`pull_image_stream_rootful`'s abnormal-teardown path waits
+#: after SIGTERM before escalating to SIGKILL. Module-level (rather than a
+#: literal at the call site) so a test can shrink it instead of sitting out
+#: the real grace period.
+TERMINATE_GRACE_SECONDS = 10.0
+
 #: Outcome of a guarded ``image-rm``. ``"unknown"`` pairs with a
 #: :data:`SeamUnanswered` reason (see :func:`remove_image`); the other three
 #: are definitive answers from the seam and carry no reason.
@@ -231,20 +237,32 @@ async def pull_image_stream_rootful(image: str) -> AsyncIterator[dict[str, Any]]
         # cancelled) — never on a clean EOF, where the pull already
         # finished and `proc.wait()` below just reaps the exit code.
         #
-        # SIGTERM, not SIGKILL: `proc` here is `sudo`, not `podman` itself
-        # (see the `create_subprocess_exec` call above). sudo relays
+        # SIGTERM first, not SIGKILL: `proc` here is `sudo`, not `podman`
+        # itself (see the `create_subprocess_exec` call above). sudo relays
         # catchable signals like SIGTERM to the child it launched, so
         # podman gets a chance to unwind (or at least exit) cleanly.
-        # SIGKILL cannot be caught or relayed by sudo, so a `.kill()` here
-        # would leave the root-owned `podman pull` orphaned, running to
-        # completion (or failure) with nobody watching — and, on the
-        # clean-EOF path specifically, killing sudo in the gap between the
-        # stdout pipe closing and `proc.wait()` running turns a fully
+        # SIGKILL cannot be caught or relayed by sudo, so leading with
+        # `.kill()` would leave the root-owned `podman pull` orphaned,
+        # running to completion (or failure) with nobody watching — and, on
+        # the clean-EOF path specifically, killing sudo in the gap between
+        # the stdout pipe closing and `proc.wait()` running turns a fully
         # successful pull into a reported `{"state": "failed", "error":
         # "pull exited with code -9"}`.
+        #
+        # But SIGTERM is a request, not a guarantee: a wedged sudo/podman
+        # that never reacts would otherwise linger indefinitely with nobody
+        # watching it. So after TERMINATE_GRACE_SECONDS without an exit,
+        # escalate to SIGKILL — at that point the orphaned-rootful-child
+        # risk above is the lesser evil versus never reclaiming the
+        # process at all.
         if not clean_eof:
             with contextlib.suppress(ProcessLookupError, OSError):
                 proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), TERMINATE_GRACE_SECONDS)
+            except TimeoutError:
+                with contextlib.suppress(ProcessLookupError, OSError):
+                    proc.kill()
 
     exit_code = await proc.wait()
     if exit_code == 0:
@@ -368,6 +386,7 @@ def remove_image(
 
 __all__ = [
     "RW_SEAM_BIN",
+    "TERMINATE_GRACE_SECONDS",
     "PullLineParser",
     "RemoveOutcome",
     "pull_image_stream_rootful",

--- a/src/hal0/providers/podman_mutate.py
+++ b/src/hal0/providers/podman_mutate.py
@@ -314,7 +314,8 @@ def remove_image(
         ``sudo -n`` denied (``"grant-denied"``), the wrapper's rc 64/65/66
         (``"invalid-argument"``/``"podman-absent"``/``"podman-failed"``), or
         the call raising / an rc or stdout the contract does not define
-        (``"seam-error"``).
+        (``"seam-error"``; an undefined rc keeps that rc in the reason,
+        e.g. ``"seam-error (image-rm exited rc=99)"``).
 
     Root fallback: when ``is_hal0_user()`` is False but this process is
     already root (``os.geteuid() == 0`` — an admin at a root prompt, or
@@ -329,7 +330,9 @@ def remove_image(
       * rc 0 -> ``("removed", None)``
       * rc 1 -> ``("missing", None)``
       * rc 2 -> ``("in-use", None)``
-      * any other rc, or a raise -> ``("unknown", "podman-failed")``
+      * any other rc -> ``("unknown", "podman-failed (podman rmi exited
+        rc=N)")`` — the collapsed bucket keeps the actual rc in the reason
+      * a raise -> ``("unknown", "podman-failed")``
       * ``podman`` absent from ``PATH`` -> ``("unknown", "podman-absent")``
 
     A non-root, non-service-user caller still gets exactly
@@ -360,7 +363,9 @@ def remove_image(
             return ("missing", None)
         if proc.returncode == 2:
             return ("in-use", None)
-        return ("unknown", "podman-failed")
+        # Collapsed bucket for every rc outside the documented {0, 1, 2} —
+        # keep the actual rc in the reason so it is not lost to the caller.
+        return ("unknown", f"podman-failed (podman rmi exited rc={proc.returncode})")
     try:
         proc = run(
             ["sudo", "-n", RW_SEAM_BIN, "image-rm", image],
@@ -381,7 +386,13 @@ def remove_image(
         return ("unknown", "seam-error")
     if proc.returncode == 67:
         return ("in-use", None)
-    return ("unknown", _RC_REASON.get(proc.returncode, "seam-error"))
+    reason = _RC_REASON.get(proc.returncode)
+    if reason is None:
+        # An rc the wrapper's EXIT-CODE CONTRACT does not define — collapsed
+        # to "seam-error", but keep the actual rc in the reason so it is not
+        # lost to the caller.
+        return ("unknown", f"seam-error (image-rm exited rc={proc.returncode})")
+    return ("unknown", reason)
 
 
 __all__ = [

--- a/tests/providers/test_podman_mutate.py
+++ b/tests/providers/test_podman_mutate.py
@@ -284,6 +284,25 @@ class _HangingFakeProc(_FakeProc):
         self.stdout = _HangingStdout(lines)
 
 
+class _TermIgnoringFakeProc(_HangingFakeProc):
+    """A hung process that ignores SIGTERM: ``wait()`` only ever resolves
+    after ``kill()`` — models a wedged ``sudo``/``podman pull`` that never
+    reacts to the relayed SIGTERM, so the teardown path's escalation to
+    SIGKILL is the only thing that can end it."""
+
+    def __init__(self, lines: list[bytes], returncode: int) -> None:
+        super().__init__(lines, returncode)
+        self._exited = asyncio.Event()
+
+    def kill(self) -> None:
+        super().kill()
+        self._exited.set()
+
+    async def wait(self) -> int:
+        await self._exited.wait()
+        return self._returncode
+
+
 async def test_pull_image_stream_rootful_bad_ref_short_circuits(monkeypatch) -> None:
     calls: list[tuple] = []
 
@@ -441,13 +460,15 @@ async def test_pull_image_stream_rootful_clean_eof_never_signals_process(monkeyp
 async def test_pull_image_stream_rootful_cancel_calls_terminate_not_kill(monkeypatch) -> None:
     """A consumer that tears the generator down mid-stream (cancellation,
     early ``break``/``aclose()``) must ``terminate()`` (SIGTERM) the seam
-    process, never ``kill()`` (SIGKILL).
+    process — and, when the process exits within the grace period (as this
+    fake does, immediately), must never escalate to ``kill()`` (SIGKILL).
 
     ``proc`` here is ``sudo``, not ``podman`` directly — sudo can relay a
     catchable signal like SIGTERM to the podman child it launched, but
     SIGKILL cannot be caught or relayed by sudo at all, so a ``.kill()``
     here would leave the root-owned ``podman pull`` running, orphaned,
-    to completion or failure with nobody watching.
+    to completion or failure with nobody watching. Escalation exists only
+    for the wedged case — see the ``escalates_to_kill_after_grace`` test.
     """
     proc = _HangingFakeProc([b"Pulling fs layer\n"], 0)
 
@@ -464,6 +485,35 @@ async def test_pull_image_stream_rootful_cancel_calls_terminate_not_kill(monkeyp
 
     assert proc.terminated is True
     assert proc.killed is False
+
+
+async def test_pull_image_stream_rootful_cancel_escalates_to_kill_after_grace(
+    monkeypatch,
+) -> None:
+    """SIGTERM is polite, not a guarantee: a wedged ``sudo``/``podman pull``
+    that never exits after ``terminate()`` must be ``kill()``ed once the
+    grace period lapses, or teardown blocks forever on a process that will
+    never leave on its own.
+
+    ``TERMINATE_GRACE_SECONDS`` is patched near zero so this test does not
+    actually sit out the production grace period.
+    """
+    proc = _TermIgnoringFakeProc([b"Pulling fs layer\n"], 0)
+
+    async def _fake_create(*_args: object, **_kwargs: object) -> _TermIgnoringFakeProc:
+        return proc
+
+    monkeypatch.setattr(podman_mutate.asyncio, "create_subprocess_exec", _fake_create)
+    monkeypatch.setattr(podman_mutate, "TERMINATE_GRACE_SECONDS", 0.01)
+
+    agen = pull_image_stream_rootful(_REF)
+    first_event = await agen.__anext__()
+    assert first_event["state"] == "pulling"
+
+    await asyncio.wait_for(agen.aclose(), timeout=5.0)
+
+    assert proc.terminated is True
+    assert proc.killed is True
 
 
 # ── PullLineParser: parity with the pre-extraction container.py heuristic ──

--- a/tests/providers/test_podman_mutate.py
+++ b/tests/providers/test_podman_mutate.py
@@ -128,7 +128,10 @@ def test_remove_image_seam_argv() -> None:
         (64, "", ("unknown", "invalid-argument")),
         (65, "", ("unknown", "podman-absent")),
         (66, "", ("unknown", "podman-failed")),
-        (99, "", ("unknown", "seam-error")),  # rc the contract does not define
+        # rc the contract does not define: collapsed to "seam-error", but the
+        # actual rc must survive into the reason string — it is the only
+        # forensic detail the caller ever sees.
+        (99, "", ("unknown", "seam-error (image-rm exited rc=99)")),
         (0, "bogus\n", ("unknown", "seam-error")),  # rc0 with undefined stdout
     ],
 )
@@ -166,7 +169,10 @@ def test_remove_image_root_fallback_removed_no_sudo_in_argv(monkeypatch) -> None
         (0, ("removed", None)),
         (1, ("missing", None)),
         (2, ("in-use", None)),
-        (3, ("unknown", "podman-failed")),
+        # rc outside the documented {0,1,2}: collapsed to "podman-failed",
+        # but the actual rc must survive into the reason string.
+        (3, ("unknown", "podman-failed (podman rmi exited rc=3)")),
+        (125, ("unknown", "podman-failed (podman rmi exited rc=125)")),
     ],
 )
 def test_remove_image_root_fallback_outcome_mapping(monkeypatch, returncode, expected) -> None:


### PR DESCRIPTION
Two small bounded follow-ups from the runner-images v3 deferred pool, both in `src/hal0/providers/podman_mutate.py`, both test-driven.

## 1. SIGTERM→SIGKILL escalation in `pull_image_stream_rootful` (cf414237)

**What:** The abnormal-teardown path (consumer cancelled / closed the generator mid-stream) previously sent only `proc.terminate()` and walked away (`src/hal0/providers/podman_mutate.py:245-247` on `main`). A wedged `sudo`/`podman pull` that ignores SIGTERM lingered indefinitely. Now the teardown waits `TERMINATE_GRACE_SECONDS` (10s) for the process to exit, then escalates to `proc.kill()`:

- `src/hal0/providers/podman_mutate.py:98` — `TERMINATE_GRACE_SECONDS = 10.0`, module-level so tests patch it instead of sleeping.
- `src/hal0/providers/podman_mutate.py:260-265` — terminate, `asyncio.wait_for(proc.wait(), TERMINATE_GRACE_SECONDS)`, kill on `TimeoutError` (Python ≥3.12 per `pyproject.toml:16`, so bare `TimeoutError` covers `asyncio.wait_for`).

**Why SIGTERM-first stays:** `proc` is `sudo`, which relays SIGTERM to the podman child but cannot relay SIGKILL — the escalation is a last resort for a wedged process, and the clean-EOF path still never signals at all (pinned by the existing `test_pull_image_stream_rootful_clean_eof_never_signals_process`).

**Test (written first, red before the fix):** `test_pull_image_stream_rootful_cancel_escalates_to_kill_after_grace` (`tests/providers/test_podman_mutate.py:496`) uses `_TermIgnoringFakeProc` (`tests/providers/test_podman_mutate.py:293`), a fake whose `wait()` only resolves after `kill()`, with the grace patched to 0.01s. The pre-existing `test_pull_image_stream_rootful_cancel_calls_terminate_not_kill` still pins that a process exiting within the grace is never killed.

## 2. `podman rmi` exit-code fidelity in `remove_image` (914339e4)

**What:** Both write paths collapse undocumented return codes into one bucket and dropped the actual rc:

- root fallback: any rc outside {0,1,2} → `("unknown", "podman-failed")` (`main` `src/hal0/providers/podman_mutate.py:345`)
- seam path: any rc outside the wrapper's EXIT-CODE CONTRACT → `("unknown", "seam-error")` via `_RC_REASON.get(..., "seam-error")` (`main` `src/hal0/providers/podman_mutate.py:366`)

Classification is **unchanged** — same outcomes, same buckets. Only the collapsed buckets' reason strings now carry the rc (`src/hal0/providers/podman_mutate.py:368` and `src/hal0/providers/podman_mutate.py:394` on this branch):

- `"podman-failed (podman rmi exited rc=125)"`
- `"seam-error (image-rm exited rc=99)"`

Defined rcs (1/64/65/66/67) and the no-rc failure shapes (exec raise, rc-0 undefined stdout) keep their bare tokens. The only exact-match consumer of a reason string is the CLI's `reason == "not-service-user"` (`src/hal0/cli/runner_image_commands.py:322`), which is untouched; the API route and CLI otherwise embed the reason verbatim in their messages (`src/hal0/api/routes/runner_images.py:815`).

**Tests:** the parametrized mapping tests now pin the rc surviving into the reason — `tests/providers/test_podman_mutate.py:134` (seam rc=99) and `tests/providers/test_podman_mutate.py:174-175` (root fallback rc=3 and rc=125). `rmi` handling was confirmed to live only in `podman_mutate.py` — `container.py` has no rmi code path (grep hits there are unrelated comments).

## Test evidence

```
$ python -m pytest tests/providers/test_podman_mutate.py -x -q
37 passed in 0.48s
```

Downstream consumers of `remove_image` also run green: `tests/api/test_runner_images_routes.py` + `tests/cli/test_runner_image_commands.py` → `102 passed in 22.72s`. `ruff check` / `ruff format --check` clean on both touched files; `scripts/check_sunset.py` clean (scar markers 193 <= baseline 193).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWn23rRvwECyNfLya4JQip
