### PR TITLE
fix(slot-view): fold superseded runner-key spellings in the binary lift

### DIFF
--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -341,10 +341,35 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
         #   threads: 0 = unset (runtime default)
         #   binary:  "" = derive the HW-gated default from device
         #   image_pin: null = release default (RUNNER_IMAGES[binary])
+        # One carve-out from "verbatim" (#2141): a superseded runner-key
+        # spelling (``vulkanfpx``, collapse spec §2/§3) folds to its
+        # canonical key here, mirroring the SlotConfig read-side heal the
+        # serve path's raw-dict flow bypasses — the drawer must never see
+        # the retired spelling, and its next Save persists the canonical
+        # key. Genuinely unknown keys still surface verbatim (the drawer's
+        # out-of-vocab option owns that surface). Warn-once per key so a
+        # pre-collapse box nudges the operator without flooding the journal
+        # on every 5s poll (reuses the runners module's dedup, same as the
+        # env-override warning).
         threads_val = cfg.get("threads")
         entry["threads"] = threads_val if isinstance(threads_val, int) else None
         binary_val = cfg.get("binary")
-        entry["binary"] = binary_val if isinstance(binary_val, str) else None
+        if isinstance(binary_val, str) and binary_val:
+            from hal0.runners import _warn_once, canonical_runner_key
+
+            canon = canonical_runner_key(binary_val)
+            if canon != binary_val:
+                _warn_once(
+                    "slot_view.binary_alias",
+                    binary_val,
+                    "slot_view.binary_alias slot=%s key=%s canonical=%s",
+                    name,
+                    binary_val,
+                    canon,
+                )
+            entry["binary"] = canon
+        else:
+            entry["binary"] = binary_val if isinstance(binary_val, str) else None
         entry["image_pin"] = cfg.get("image_pin")
         # METRICS (#1810) — completes the HW-grid lift: SlotConfig.metrics
         # controls whether --metrics reaches llama-server's argv. Surface it

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -486,6 +486,23 @@ class TestConfigEnrichment:
         assert e["binary"] is None
         assert e["image_pin"] is None
 
+    def test_binary_alias_spelling_folds_to_canonical(self) -> None:
+        # #2141: a persisted ``binary = "vulkanfpx"`` (pre-collapse TOML) must
+        # surface as the canonical ``rocmfpx`` so the edit drawer never sees
+        # the retired spelling — the launch path already heals it via
+        # ``get_runner``; the view lift is the surface that leaked. The next
+        # drawer Save then persists the canonical key naturally.
+        cfg = _llm_cfg(binary="vulkanfpx")
+        e = config_enrichment([cfg])["chat"]
+        assert e["binary"] == "rocmfpx"
+
+    def test_binary_unknown_key_still_surfaces_verbatim(self) -> None:
+        # Genuinely unknown keys are NOT rewritten — the drawer's
+        # out-of-vocab option owns that surface (collapse spec §2).
+        cfg = _llm_cfg(binary="ghost")
+        e = config_enrichment([cfg])["chat"]
+        assert e["binary"] == "ghost"
+
     def test_ngl_prefers_top_level_over_nested(self) -> None:
         # Migration compat: a slot with BOTH the legacy nested
         # [model].n_gpu_layers and the new top-level field surfaces the


### PR DESCRIPTION
Fixes #2141 (found by the vulkanfpx-collapse spec §6 manual trace on ct150).

The launch path heals `binary = "vulkanfpx"` through `get_runner`'s permanent alias, but the slot-view lift surfaced the raw TOML spelling: the drawer showed the out-of-vocab fallback ("vulkanfpx · vulkan · not in image" + warning) instead of the spec-promised healed `rocmfpx · vulkan` selection, and the serve path's raw-dict flow never fired the alias warning.

- `slot_view` `binary` lift folds via `canonical_runner_key` — one carve-out from the "surfaced verbatim" dirty-tracking doctrine, documented in place; the drawer's next Save persists the canonical key naturally.
- Genuinely unknown keys still surface verbatim (the out-of-vocab option owns that surface) — pinned by a test.
- Warn-once per key (`slot_view.binary_alias`) via the runners module's dedup, so a pre-collapse box nudges the operator without flooding the journal on every 5s poll.

TDD: alias-fold test watched RED (surfaced `vulkanfpx`) then GREEN; unknown-key verbatim test pinned. `tests/slot_view/` 81 passed, `tests/runners/` 53 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCt4SFUmy5rGFpvPjPDttW