### PR TITLE
feat(ci): inline scar-ok waiver for the scar-marker ratchet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,9 @@ enforces the ones marked **(gated)**.
    fails if the live count exceeds it. A de-scar PR *lowers* the baseline
    (`python scripts/check_sunset.py --update-baseline`, then commit the
    drop); new work must not raise it — a genuinely new shim carries a
-   `HAL0-SUNSET` marker instead (rule 4).
+   `HAL0-SUNSET` marker instead (rule 4). A false-positive line may be
+   waived inline with `# scar-ok: <reason>` (the reason is required; a
+   bare `# scar-ok` still counts) — waived lines are reported in CI output.
 
 6. **Deep modules, small interfaces.** Splitting a big file is only the
    first step. Each resulting module must expose a narrow, intent-oriented

--- a/scripts/check_sunset.py
+++ b/scripts/check_sunset.py
@@ -12,6 +12,9 @@ Two checks, both baselined to pass green the day they're introduced:
    may only go DOWN. It's frozen in ``scripts/scar_baseline.txt``; CI fails if the
    live count exceeds the baseline. Each de-scar PR lowers the baseline; a newly
    introduced shim must instead carry a HAL0-SUNSET marker (which check #1 tracks).
+   A false-positive line may be waived inline with ``# scar-ok: <reason>`` (reason
+   required — bare ``# scar-ok`` does not waive); waived lines are reported so
+   drift stays visible in CI logs.
 
 Usage:
   python scripts/check_sunset.py                    # check (CI + `make check-sunset`)
@@ -33,6 +36,8 @@ BASELINE = Path(__file__).resolve().parent / "scar_baseline.txt"
 
 # Keep in lockstep with docs: this is the canonical scar-marker definition.
 SCAR_RE = re.compile(r"removed in #|DEPRECATED|deprecated|\blegacy\b|backward.compat|compat shim")
+# Inline ratchet waiver: requires a non-empty reason after the colon.
+SCAR_OK_RE = re.compile(r"#\s*scar-ok:\s*\S")
 SUNSET_RE = re.compile(r"HAL0-SUNSET:\s*v?(\d+)\.(\d+)(?:\.(\d+))?")
 PROJECT_VERSION_RE = re.compile(r"^(\d+)\.(\d+)(?:\.(\d+))?(.*)$")
 PEP440_PRERELEASE_RE = re.compile(r"^\.?(?:a|alpha|b|beta|rc|pre|preview|dev)", re.IGNORECASE)
@@ -72,14 +77,19 @@ def _py_files() -> list[Path]:
     return sorted(SRC.rglob("*.py"))
 
 
-def scar_count() -> int:
-    n = 0
+def scar_count() -> tuple[int, int]:
+    """Return ``(counted, waived)`` scar-marker line totals across ``src/``."""
+    counted = waived = 0
     for f in _py_files():
         with suppress(OSError):
-            n += sum(
-                1 for line in f.read_text(errors="ignore").splitlines() if SCAR_RE.search(line)
-            )
-    return n
+            for line in f.read_text(errors="ignore").splitlines():
+                if not SCAR_RE.search(line):
+                    continue
+                if SCAR_OK_RE.search(line):
+                    waived += 1
+                else:
+                    counted += 1
+    return counted, waived
 
 
 def overdue_markers(cur: ProjectVersion) -> list[tuple[Path, int, tuple[int, int, int]]]:
@@ -105,7 +115,7 @@ def _fmt(v: tuple[int, int, int]) -> str:
 def main(argv: list[str]) -> int:
     cur = current_version()
     if "--update-baseline" in argv:
-        c = scar_count()
+        c, _ = scar_count()
         BASELINE.write_text(f"{c}\n")
         print(f"scar_baseline.txt <- {c}")
         return 0
@@ -126,7 +136,9 @@ def main(argv: list[str]) -> int:
             raise ValueError(f"invalid scar baseline: {BASELINE}") from exc
     else:
         base = 10**9
-    cnt = scar_count()
+    cnt, waived = scar_count()
+    if waived:
+        print(f"scar waivers in effect: {waived}")
     if cnt > base:
         fail = True
         print(

--- a/tests/scripts/test_check_sunset.py
+++ b/tests/scripts/test_check_sunset.py
@@ -94,3 +94,74 @@ def test_main_overdue_branch_reports_full_prerelease_version(
 
     assert check_sunset.main([]) == 1
     assert "OVERDUE HAL0-SUNSET shims (current v1.0.0-alpha.0)" in capsys.readouterr().out
+
+
+def test_scar_ok_waiver_excludes_line(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_project(
+        tmp_path,
+        monkeypatch,
+        version="1.0.0",
+        source="x = 1  # DEPRECATED  # scar-ok: false positive, name of an upstream field\n",
+    )
+
+    assert check_sunset.scar_count() == (0, 1)
+
+
+def test_bare_scar_ok_does_not_waive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_project(
+        tmp_path,
+        monkeypatch,
+        version="1.0.0",
+        source="x = 1  # DEPRECATED  # scar-ok\ny = 2  # DEPRECATED  # scar-ok:\n",
+    )
+
+    assert check_sunset.scar_count() == (2, 0)
+
+
+def test_main_reports_waiver_total(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_project(
+        tmp_path,
+        monkeypatch,
+        version="1.0.0",
+        source=(
+            "x = 1  # DEPRECATED  # scar-ok: false positive\n"
+            "y = 2  # compat shim  # scar-ok: waived with reason\n"
+        ),
+    )
+
+    assert check_sunset.main([]) == 0
+    out = capsys.readouterr().out
+    assert "scar waivers in effect: 2" in out
+    assert "scar markers: 0 <= baseline 0" in out
+
+
+def test_main_silent_when_no_waivers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_project(tmp_path, monkeypatch, version="1.0.0")
+
+    assert check_sunset.main([]) == 0
+    assert "scar waivers" not in capsys.readouterr().out
+
+
+def test_update_baseline_uses_waiver_aware_count(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_project(
+        tmp_path,
+        monkeypatch,
+        version="1.0.0",
+        source="x = 1  # legacy field\ny = 2  # DEPRECATED  # scar-ok: false positive\n",
+    )
+
+    assert check_sunset.main(["--update-baseline"]) == 0
+    assert "scar_baseline.txt <- 1" in capsys.readouterr().out
+    assert (tmp_path / "scar_baseline.txt").read_text() == "1\n"


### PR DESCRIPTION
Runner-images v3 deferred pool item 6 (mechanism operator-approved): inline waiver for the scar-marker ratchet.

## What

- `scripts/check_sunset.py:38` adds `SCAR_OK_RE = re.compile(r"#\s*scar-ok:\s*\S")` — a line matching `SCAR_RE` is excluded from the ratchet when it also carries `# scar-ok: <non-empty reason>`. A bare `# scar-ok` (or `# scar-ok:` with no reason) does NOT waive, forcing a justification.
- `scar_count()` (`scripts/check_sunset.py:78`) now returns `(counted, waived)`; the check prints `scar waivers in effect: N` (one line, only when N > 0) so drift stays visible in CI logs (`scripts/check_sunset.py:135`). `--update-baseline` writes the same waiver-aware count (`scripts/check_sunset.py:112`).
- `SCAR_RE`, `SUNSET_RE`, the sunset check, and `scripts/scar_baseline.txt` are untouched.
- Docstring documents the waiver form (`scripts/check_sunset.py:14-17`); CONTRIBUTING.md anti-scar rule 5 updated in the same spirit.

## Evidence

- `pytest tests/scripts/test_check_sunset.py -q` → **10 passed** (5 pre-existing + 5 new: waived line excluded, bare/empty `scar-ok` still counted, waiver total printed, silent at zero waivers, waiver-aware `--update-baseline`).
- `python scripts/check_sunset.py` → `✅ scar markers: 193 <= baseline 193` — count unchanged (no waivers exist in `src/` yet; `_py_files()` at `scripts/check_sunset.py:74` globs `src/` only, so test fixtures are not scanned).
- `ruff check` / `ruff format --check` clean on both touched Python files.

Sample output line when waivers exist: `scar waivers in effect: 2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWn23rRvwECyNfLya4JQip
