### PR TITLE
feat(runner-images): surface per-image llama.cpp build provenance

### DIFF
--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -878,7 +878,7 @@ async def system_info_endpoint(request: Request) -> dict[str, Any]:
     means neither context could reach podman at all.
     """
     from hal0.api.routes.health import list_features
-    from hal0.runners import RUNNER_IMAGES, resolve_runner_image
+    from hal0.runners import RUNNER_IMAGES, canonical_family, resolve_runner_image
 
     hardware = await get_hardware(request)
     features = await list_features(request)
@@ -886,12 +886,37 @@ async def system_info_endpoint(request: Request) -> dict[str, Any]:
     local_repos = images_result.repos if images_result is not None else None
     podman_context = images_result.context if images_result is not None else "unavailable"
 
+    # Build provenance for each runner's EFFECTIVE image (h0/runner-provenance):
+    # the effective ref comes from the runner-image routes' defaults map (the
+    # override tier included — what a slot actually launches), and provenance
+    # is looked up in the SYNC-CACHED catalogue only. No live registry call on
+    # this request path: an unsynced tag degrades to provenance=None, and any
+    # failure here degrades the whole lookup the same way (never a 500 —
+    # provenance is display metadata).
+    effective_defaults: dict[str, tuple[str, str]] = {}
+    catalogue: list[Any] = []
+    try:
+        from hal0.api.routes.runner_images import _effective_defaults
+
+        effective_defaults = _effective_defaults()
+        catalogue = request.app.state.runner_image_registry.list()
+    except Exception:
+        log.warning("system_info.provenance_context_failed", exc_info=True)
+
     backends: dict[str, Any] = {}
     for key, runner in RUNNER_IMAGES.items():
         try:
             image = resolve_runner_image(runner)
         except Exception:
             image = runner.image
+        provenance = None
+        try:
+            from hal0.api.routes.runner_images import provenance_for_ref
+
+            eff = effective_defaults.get(canonical_family(key))
+            provenance = provenance_for_ref(eff[0] if eff else image, catalogue)
+        except Exception:
+            log.warning("system_info.provenance_lookup_failed", key=key, exc_info=True)
         backends[key] = {
             "image": image,
             "runtime_family": runner.runtime_family,
@@ -922,6 +947,11 @@ async def system_info_endpoint(request: Request) -> dict[str, Any]:
                 # degrade it to GGUF-only.
                 "specialties": list(runner.supports.specialties),
             },
+            # llama.cpp build provenance of the runner's effective image
+            # ({"source_repo", "revision", "patch_count"} | null) — see the
+            # provenance block above. The slot drawer's Runner select and
+            # RunnerCard render it; null renders nothing.
+            "provenance": provenance,
             "state": _backend_state(image, local_repos),
         }
 

--- a/src/hal0/api/routes/runner_images.py
+++ b/src/hal0/api/routes/runner_images.py
@@ -151,6 +151,13 @@ def enrich_row(
     — the catalogue-v3 field the UI's ``groupRows`` (``runner-images.jsx``)
     reads to route a row into the "Specialized" group. ``[]`` for a repo no
     specialty runner claims — every plain toolbox image included.
+
+    Build provenance (h0/runner-provenance): every ``tags[]`` entry carries
+    ``provenance`` (``{"source_repo", "revision", "patch_count"}`` | null —
+    :class:`hal0.registry.runner_image.RunnerImageTag`, populated by the
+    sync's config-blob label probe), and the HEADLINE tag's provenance is
+    hoisted to ``row["provenance"]`` (null when the headline has no tag row
+    or its probe failed).
     """
     row = _image_to_dict(image)
     row["specialties"] = list(specialties.get(image.image, []))
@@ -176,6 +183,11 @@ def enrich_row(
     tag_list = image.tags or []
     row["tags"] = [{**t.model_dump(), "downloaded": _tag_state(t)} for t in tag_list]
     headline = next((t for t in tag_list if t.tag == image.tag), None)
+    # Build provenance (h0/runner-provenance): every ``tags[]`` entry carries
+    # its own sync-probed ``provenance`` via ``model_dump()`` above; the
+    # HEADLINE tag's is additionally hoisted to the row so list/card readers
+    # don't re-scan the tag list. None when the probe failed/hasn't run.
+    row["provenance"] = headline.provenance if headline is not None else None
     if local is None:
         row["store_state"] = "unknown"
         row["downloaded"] = bool(image.local_path)  # marker only as last resort
@@ -191,6 +203,33 @@ def enrich_row(
     row["store_context"] = local.context if local else None
     row["badges"] = _tag_badges(image)
     return row
+
+
+def provenance_for_ref(ref: str, images: list[RunnerImage]) -> dict[str, Any] | None:
+    """Sync-cached build provenance for one image ref, or None. Pure.
+
+    Resolves ``ref`` against the already-read catalogue rows only — the
+    slot-drawer request path (``GET /api/system-info``) must never make a
+    live registry call, so a tag the sync hasn't probed simply answers
+    ``None``. A ``repo:tag`` ref matches a row of that repo carrying a tag
+    row of that name (bare-repo refs read as ``latest``, podman's own
+    default); a digest-pinned ``repo@sha256:...`` ref matches by the tag
+    row's resolved digest instead — the ref shape ``manifest_image_ref``
+    produces (see :func:`_families_payload`'s digest-pin note).
+    """
+    repo = _repo_of(ref)
+    body, _, digest = ref.partition("@")
+    tag: str | None = None
+    if not digest:
+        _head, sep, tail = body.rpartition(":")
+        tag = tail if sep and "/" not in tail else "latest"
+    for image in images:
+        if image.image != repo:
+            continue
+        for t in image.tags:
+            if (digest and t.digest == digest) or (tag is not None and t.tag == tag):
+                return t.provenance
+    return None
 
 
 def _repo_specialties() -> dict[str, list[str]]:
@@ -864,4 +903,4 @@ async def get_runner_image(image_id: str, request: Request) -> dict[str, Any]:
     return _enriched([image])[0]
 
 
-__all__ = ["enrich_row", "router"]
+__all__ = ["enrich_row", "provenance_for_ref", "router"]

--- a/src/hal0/db/migrations/009_runner_image_tag_provenance.sql
+++ b/src/hal0/db/migrations/009_runner_image_tag_provenance.sql
@@ -1,0 +1,11 @@
+-- 009_runner_image_tag_provenance.sql  (schema version 9)
+--
+-- Per-tag llama.cpp build provenance (h0/runner-provenance): the sync
+-- probe now reads the image CONFIG BLOB's OCI labels
+-- (org.opencontainers.image.source / .revision, dev.hal0.runner.patches)
+-- so an operator can tell an upstream Vulkan/ROCm build apart from the
+-- ROCmFPX one. Stored as a JSON object
+-- {"source_repo": ..., "revision": ..., "patch_count": ...}; NULL means
+-- the blob probe failed, hasn't run, or the image carries no such labels.
+
+ALTER TABLE runner_image_tag ADD COLUMN provenance_json TEXT;

--- a/src/hal0/registry/runner_image.py
+++ b/src/hal0/registry/runner_image.py
@@ -23,6 +23,13 @@ class RunnerImageTag(BaseModel):
     digest: str | None = None
     size_bytes: int | None = None
     last_seen: str | None = None
+    #: llama.cpp build provenance read from the image config blob's OCI
+    #: labels during sync (``hal0.registry.runner_image_sync``):
+    #: ``{"source_repo": str|None, "revision": str|None,
+    #: "patch_count": int|None}``. ``None`` when the blob probe failed,
+    #: hasn't run, or the image carries none of the labels — consumers
+    #: render nothing in that case rather than a placeholder.
+    provenance: dict[str, Any] | None = None
 
 
 class RunnerImage(BaseModel):

--- a/src/hal0/registry/runner_image_store.py
+++ b/src/hal0/registry/runner_image_store.py
@@ -60,6 +60,22 @@ def _row_to_runner_image(row: sqlite3.Row) -> RunnerImage:
     )
 
 
+def _load_provenance(raw: str | None) -> dict[str, Any] | None:
+    """Decode a ``runner_image_tag.provenance_json`` cell, fail-soft.
+
+    A malformed or non-object cell reads back as ``None`` (the same value
+    an unprobed tag carries) rather than raising — provenance is display
+    metadata and must never break a catalogue read.
+    """
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def _marker_matches_ref(local_path: str, ref: str) -> bool:
     """Best-effort: does the marker JSON at ``local_path`` record ``ref``?
 
@@ -127,8 +143,8 @@ class RunnerImageStore:
     def _tags_by_image(self, conn: sqlite3.Connection) -> dict[str, list[RunnerImageTag]]:
         """Fetch all tags grouped by image_id, in insertion order."""
         tag_rows = conn.execute(
-            "SELECT image_id, tag, digest, size_bytes, last_seen FROM runner_image_tag "
-            "ORDER BY image_id, ord"
+            "SELECT image_id, tag, digest, size_bytes, last_seen, provenance_json "
+            "FROM runner_image_tag ORDER BY image_id, ord"
         ).fetchall()
         tags_by_image: dict[str, list[RunnerImageTag]] = {}
         for tag_row in tag_rows:
@@ -141,6 +157,7 @@ class RunnerImageStore:
                     digest=tag_row["digest"],
                     size_bytes=tag_row["size_bytes"],
                     last_seen=tag_row["last_seen"],
+                    provenance=_load_provenance(tag_row["provenance_json"]),
                 )
             )
         return tags_by_image
@@ -195,11 +212,20 @@ class RunnerImageStore:
         with self._connect() as conn:
             self._ensure_migrated(conn)
             rows = conn.execute(
-                "SELECT tag, digest, size_bytes, last_seen FROM runner_image_tag "
-                "WHERE image_id = ? ORDER BY ord",
+                "SELECT tag, digest, size_bytes, last_seen, provenance_json "
+                "FROM runner_image_tag WHERE image_id = ? ORDER BY ord",
                 (image_id,),
             ).fetchall()
-        return [RunnerImageTag(**dict(r)) for r in rows]
+        return [
+            RunnerImageTag(
+                tag=r["tag"],
+                digest=r["digest"],
+                size_bytes=r["size_bytes"],
+                last_seen=r["last_seen"],
+                provenance=_load_provenance(r["provenance_json"]),
+            )
+            for r in rows
+        ]
 
     # ── writes ───────────────────────────────────────────────────────────
 
@@ -296,10 +322,18 @@ class RunnerImageStore:
                 conn.execute("DELETE FROM runner_image_tag WHERE image_id = ?", (image_id,))
                 conn.executemany(
                     "INSERT INTO runner_image_tag "
-                    "(image_id, tag, digest, size_bytes, last_seen, ord) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    "(image_id, tag, digest, size_bytes, last_seen, ord, provenance_json) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
                     [
-                        (image_id, t.tag, t.digest, t.size_bytes, t.last_seen, i)
+                        (
+                            image_id,
+                            t.tag,
+                            t.digest,
+                            t.size_bytes,
+                            t.last_seen,
+                            i,
+                            json.dumps(t.provenance) if t.provenance is not None else None,
+                        )
                         for i, t in enumerate(tags)
                     ],
                 )

--- a/src/hal0/registry/runner_image_sync.py
+++ b/src/hal0/registry/runner_image_sync.py
@@ -27,6 +27,14 @@ Fetch failures degrade gracefully at every layer: a malformed/unreachable
 ``images.json`` still lets already-known GHCR packages sync (tag/digest/size
 only, no metadata); a single package's GHCR probe failing doesn't abort the
 whole sync run.
+
+Per-tag build provenance (h0/runner-provenance): alongside each tag's
+manifest probe, the image CONFIG BLOB (manifest → ``config.digest`` → blob
+GET) is fetched and its OCI labels (``org.opencontainers.image.source`` /
+``.revision``, ``dev.hal0.runner.patches``) are folded into
+``RunnerImageTag.provenance`` — so an operator can tell the upstream
+llama.cpp Vulkan/ROCm build apart from the ROCmFPX fork one. A failed blob
+fetch degrades that tag to ``provenance=None``, never fails the sync.
 """
 
 from __future__ import annotations
@@ -55,6 +63,14 @@ _OCI_MANIFEST_ACCEPT = (
     "application/vnd.docker.distribution.manifest.v2+json"
 )
 _HTTP_TIMEOUT_S = 15.0
+
+#: OCI labels the runner-image builds stamp into the image CONFIG blob —
+#: the llama.cpp build provenance an operator needs to tell the upstream
+#: Vulkan/ROCm build apart from the ROCmFPX one (verified live on the
+#: published ghcr.io/hal0ai packages).
+_LABEL_SOURCE = "org.opencontainers.image.source"
+_LABEL_REVISION = "org.opencontainers.image.revision"
+_LABEL_PATCHES = "dev.hal0.runner.patches"
 
 
 @dataclass
@@ -205,6 +221,45 @@ async def _ghcr_list_tags(repo: str, *, token: str, client: httpx.AsyncClient) -
     return [t for t in raw if not is_noise_tag(t)]
 
 
+def provenance_from_labels(labels: Any) -> dict[str, Any] | None:
+    """Build-provenance dict from an image config blob's ``config.Labels``.
+
+    Pure and exported (tested directly, same discipline as
+    :func:`sort_tags_newest_first`). Returns
+    ``{"source_repo", "revision", "patch_count"}`` with each field ``None``
+    when its label is absent; ``patch_count`` is the count of non-empty
+    entries in the comma-split ``dev.hal0.runner.patches`` value (``0`` for
+    a present-but-empty label — pristine upstream). Returns ``None`` when
+    ``labels`` isn't a dict or carries none of the three labels, so a
+    labelless image reads exactly like an unprobed one.
+    """
+    if not isinstance(labels, dict):
+        return None
+    source = labels.get(_LABEL_SOURCE)
+    revision = labels.get(_LABEL_REVISION)
+    patches = labels.get(_LABEL_PATCHES)
+    if not any(isinstance(v, str) for v in (source, revision, patches)):
+        return None
+    patch_count: int | None = None
+    if isinstance(patches, str):
+        patch_count = len([p for p in patches.split(",") if p.strip()])
+    return {
+        "source_repo": source if isinstance(source, str) and source else None,
+        "revision": revision if isinstance(revision, str) and revision else None,
+        "patch_count": patch_count,
+    }
+
+
+def _manifest_config_digest(payload: Any) -> str | None:
+    """``config.digest`` of one image manifest (never of an index)."""
+    if not isinstance(payload, dict):
+        return None
+    config = payload.get("config")
+    if isinstance(config, dict) and isinstance(config.get("digest"), str):
+        return config["digest"]
+    return None
+
+
 def _manifest_content_size(payload: Any) -> int | None:
     """Sum ``config.size`` + every ``layers[].size`` of one image manifest."""
     if not isinstance(payload, dict):
@@ -252,15 +307,18 @@ def _pick_index_manifest(payload: dict[str, Any]) -> str | None:
 
 async def _ghcr_manifest_info(
     repo: str, ref: str, *, token: str, client: httpx.AsyncClient
-) -> tuple[str | None, int | None]:
-    """Return ``(digest, size_bytes)`` for one tag; either may be None.
+) -> tuple[str | None, int | None, str | None]:
+    """Return ``(digest, size_bytes, config_digest)`` for one tag; any may
+    be None.
 
     Unlike a bare HEAD (whose ``content-length`` is the size of the manifest
     *document*, a couple of KB), this GETs the manifest body and sums the
     config + layer blob sizes — the actual compressed image size, matching
     what GHCR's package UI reports. Multi-arch indexes are followed one
     level down to the linux/amd64 image manifest. The digest reported is
-    the top-level one (what ``podman pull repo@digest`` would resolve).
+    the top-level one (what ``podman pull repo@digest`` would resolve);
+    ``config_digest`` is the IMAGE manifest's ``config.digest`` (the child's
+    for an index) — what the provenance blob probe fetches.
     """
     resp = await client.get(
         f"https://ghcr.io/v2/{repo}/manifests/{ref}",
@@ -276,6 +334,7 @@ async def _ghcr_manifest_info(
         payload = None
 
     size = _manifest_content_size(payload)
+    config_digest = _manifest_config_digest(payload)
     if size is None and isinstance(payload, dict):
         child_digest = _pick_index_manifest(payload)
         if child_digest:
@@ -286,13 +345,50 @@ async def _ghcr_manifest_info(
             )
             if child.status_code < 400:
                 try:
-                    size = _manifest_content_size(child.json())
+                    child_payload = child.json()
                 except ValueError:
-                    size = None
+                    child_payload = None
+                size = _manifest_content_size(child_payload)
+                config_digest = _manifest_config_digest(child_payload)
     if size is None:
         length = resp.headers.get("content-length")
         size = int(length) if length and length.isdigit() else None
-    return digest, size
+    return digest, size, config_digest
+
+
+async def _ghcr_tag_provenance(
+    repo: str, config_digest: str | None, *, token: str, client: httpx.AsyncClient
+) -> dict[str, Any] | None:
+    """Fetch one tag's config blob and extract its provenance labels.
+
+    Fail-soft by contract: any failure (no config digest resolved, HTTP
+    error, non-JSON blob) degrades to ``None`` — provenance never fails a
+    tag row, let alone the sync run.
+    """
+    if not config_digest:
+        return None
+    try:
+        resp = await client.get(
+            f"https://ghcr.io/v2/{repo}/blobs/{config_digest}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=_HTTP_TIMEOUT_S,
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(f"HTTP {resp.status_code}")
+        payload = resp.json()
+    except (httpx.HTTPError, RuntimeError, ValueError) as exc:
+        log.warning(
+            "runner_images.config_blob_probe_failed repo=%s digest=%s error=%s",
+            repo,
+            config_digest,
+            exc,
+        )
+        return None
+    if not isinstance(payload, dict):
+        return None
+    config = payload.get("config")
+    labels = config.get("Labels") if isinstance(config, dict) else None
+    return provenance_from_labels(labels)
 
 
 async def probe_ghcr_package(
@@ -321,7 +417,18 @@ async def probe_ghcr_package(
         tags = []
     available = sort_tags_newest_first(tags)
     resolved_tag = tag if tag is not None else (available[0] if available else "latest")
-    digest, size = await _ghcr_manifest_info(repo, resolved_tag, token=token, client=client)
+    digest, size, config_digest = await _ghcr_manifest_info(
+        repo, resolved_tag, token=token, client=client
+    )
+    # Build provenance from the config blob's OCI labels — but never for a
+    # noise-tag headline (an images.json pin should never name one, but the
+    # per-tag blob GET is real registry traffic worth gating anyway;
+    # `available` is already noise-filtered at _ghcr_list_tags).
+    provenance = (
+        None
+        if is_noise_tag(resolved_tag)
+        else await _ghcr_tag_provenance(repo, config_digest, token=token, client=client)
+    )
 
     # Resolve a digest for every catalogued tag (catalogue v3).
     now = datetime.now(UTC).isoformat()
@@ -331,19 +438,37 @@ async def probe_ghcr_package(
     for t in available:
         if t == resolved_tag:
             # Reuse the headline manifest result.
-            tag_rows.append(RunnerImageTag(tag=t, digest=digest, size_bytes=size, last_seen=now))
+            tag_rows.append(
+                RunnerImageTag(
+                    tag=t, digest=digest, size_bytes=size, last_seen=now, provenance=provenance
+                )
+            )
             continue
         try:
-            t_digest, t_size = await _ghcr_manifest_info(repo, t, token=token, client=client)
+            t_digest, t_size, t_config = await _ghcr_manifest_info(
+                repo, t, token=token, client=client
+            )
         except (httpx.HTTPError, RuntimeError, ValueError) as exc:
             log.warning("runner_images.tag_probe_failed repo=%s tag=%s error=%s", repo, t, exc)
-            t_digest, t_size = None, None
-        tag_rows.append(RunnerImageTag(tag=t, digest=t_digest, size_bytes=t_size, last_seen=now))
+            t_digest, t_size, t_config = None, None, None
+        t_prov = await _ghcr_tag_provenance(repo, t_config, token=token, client=client)
+        tag_rows.append(
+            RunnerImageTag(
+                tag=t, digest=t_digest, size_bytes=t_size, last_seen=now, provenance=t_prov
+            )
+        )
 
     # If resolved_tag (pinned or fallback) is not in available, prepend it.
     if resolved_tag not in available:
         tag_rows.insert(
-            0, RunnerImageTag(tag=resolved_tag, digest=digest, size_bytes=size, last_seen=now)
+            0,
+            RunnerImageTag(
+                tag=resolved_tag,
+                digest=digest,
+                size_bytes=size,
+                last_seen=now,
+                provenance=provenance,
+            ),
         )
 
     return RunnerImage(
@@ -456,6 +581,7 @@ __all__ = [
     "fetch_images_json",
     "is_noise_tag",
     "probe_ghcr_package",
+    "provenance_from_labels",
     "sort_tags_newest_first",
     "sync_runner_images",
 ]

--- a/tests/api/test_runner_images_routes.py
+++ b/tests/api/test_runner_images_routes.py
@@ -9,7 +9,7 @@ is stubbed via the ``runner_pull_jobs.provider_factory`` monkeypatch seam.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
 import httpx
 import pytest
@@ -383,6 +383,91 @@ class TestEnrichRow:
             specialties={"ghcr.io/hal0ai/hal0-promptforge": ["promptforge"]},
         )
         assert row["specialties"] == ["promptforge"]
+
+    def test_provenance_passthrough_and_headline_hoist(self) -> None:
+        """h0/runner-provenance: every tags[] entry carries its sync-probed
+        provenance, and the HEADLINE tag's is hoisted to row["provenance"]."""
+        from hal0.api.routes.runner_images import enrich_row
+        from hal0.registry.runner_image import RunnerImage, RunnerImageTag
+
+        prov = {
+            "source_repo": "https://github.com/hal0ai/ROCmFPX.git",
+            "revision": "0a59adde1c5b2f3a4d6e7f8091a2b3c4d5e6f708",
+            "patch_count": 4,
+        }
+        image = RunnerImage(
+            id="rocmfpx",
+            image="ghcr.io/hal0ai/hal0-rocmfpx",
+            tag="0826",
+            tags=[
+                RunnerImageTag(tag="0826", digest="sha256:a", provenance=prov),
+                RunnerImageTag(tag="0824", digest="sha256:b", provenance=None),
+            ],
+        )
+        row = enrich_row(image, defaults={}, slot_usage={}, local=None)
+        assert row["tags"][0]["provenance"] == prov
+        assert row["tags"][1]["provenance"] is None
+        assert row["provenance"] == prov
+
+    def test_provenance_none_when_headline_has_no_tag_row(self) -> None:
+        """Absent provenance stays null — the contract is 'render nothing',
+        never a placeholder dict."""
+        from hal0.api.routes.runner_images import enrich_row
+
+        row = enrich_row(
+            _row("ghcr.io/hal0ai/hal0-combined", "0824"),
+            defaults={},
+            slot_usage={},
+            local=None,
+        )
+        assert row["provenance"] is None
+
+
+class TestProvenanceForRef:
+    """Pure lookup the system-info route uses to stamp each runner's
+    effective image with its sync-cached provenance — no live registry
+    call, so anything unsynced answers None."""
+
+    _PROV: ClassVar[dict[str, Any]] = {
+        "source_repo": "https://github.com/ggml-org/llama.cpp.git",
+        "revision": "c841aee",
+        "patch_count": 0,
+    }
+
+    def _catalogue(self):
+        from hal0.registry.runner_image import RunnerImage, RunnerImageTag
+
+        return [
+            RunnerImage(
+                id="vulkan",
+                image="ghcr.io/hal0ai/hal0-toolbox-vulkan",
+                tag="0826",
+                tags=[
+                    RunnerImageTag(tag="0826", digest="sha256:aaa", provenance=self._PROV),
+                    RunnerImageTag(tag="0824", digest="sha256:bbb", provenance=None),
+                ],
+            )
+        ]
+
+    def test_tag_ref_matches(self) -> None:
+        from hal0.api.routes.runner_images import provenance_for_ref
+
+        got = provenance_for_ref("ghcr.io/hal0ai/hal0-toolbox-vulkan:0826", self._catalogue())
+        assert got == self._PROV
+
+    def test_digest_pinned_ref_matches_by_digest(self) -> None:
+        from hal0.api.routes.runner_images import provenance_for_ref
+
+        got = provenance_for_ref("ghcr.io/hal0ai/hal0-toolbox-vulkan@sha256:aaa", self._catalogue())
+        assert got == self._PROV
+
+    def test_unsynced_tag_or_unknown_repo_is_none(self) -> None:
+        from hal0.api.routes.runner_images import provenance_for_ref
+
+        cat = self._catalogue()
+        assert provenance_for_ref("ghcr.io/hal0ai/hal0-toolbox-vulkan:9999", cat) is None
+        assert provenance_for_ref("ghcr.io/hal0ai/hal0-toolbox-vulkan:0824", cat) is None
+        assert provenance_for_ref("ghcr.io/hal0ai/other:0826", cat) is None
 
 
 class TestSpecialtiesRoute:

--- a/tests/registry/test_runner_image_sync.py
+++ b/tests/registry/test_runner_image_sync.py
@@ -16,6 +16,7 @@ from hal0.registry.runner_image_store import RunnerImageStore
 from hal0.registry.runner_image_sync import (
     IMAGES_JSON_URL,
     fetch_images_json,
+    provenance_from_labels,
     sync_runner_images,
 )
 
@@ -669,3 +670,159 @@ async def test_sync_result_rows_carry_fresh_tags_on_first_sync(tmp_path: Path) -
     assert cpu.tags[0].digest == "sha256:hal0ai-hal0-toolbox-cpu-latest"
     assert cpu.tags[1].digest == "sha256:hal0ai-hal0-toolbox-cpu-0826"
     assert cpu.tags[2].digest == "sha256:hal0ai-hal0-toolbox-cpu-0824"
+
+
+# ── build provenance (h0/runner-provenance: config-blob OCI labels) ─────────
+
+
+_ROCMFPX_LABELS = {
+    "org.opencontainers.image.source": "https://github.com/hal0ai/ROCmFPX.git",
+    "org.opencontainers.image.revision": "0a59adde1c5b2f3a4d6e7f8091a2b3c4d5e6f708",
+    "dev.hal0.runner.patches": "hip-graphs,fp4-mma,tunable-ops,rocm-7-abi",
+}
+
+_UPSTREAM_LABELS = {
+    "org.opencontainers.image.source": "https://github.com/ggml-org/llama.cpp.git",
+    "org.opencontainers.image.revision": "c841aee0d5b9e2f1a3c4d5e6f708192a3b4c5d6e",
+    "dev.hal0.runner.patches": "",
+}
+
+
+def test_provenance_from_labels_extracts_all_three() -> None:
+    prov = provenance_from_labels(_ROCMFPX_LABELS)
+    assert prov == {
+        "source_repo": "https://github.com/hal0ai/ROCmFPX.git",
+        "revision": "0a59adde1c5b2f3a4d6e7f8091a2b3c4d5e6f708",
+        "patch_count": 4,
+    }
+
+
+def test_provenance_from_labels_empty_patches_is_zero() -> None:
+    """Pristine upstream stamps an EMPTY patch list — that's patch_count 0,
+    a positive claim ("no patches"), not an absent one."""
+    prov = provenance_from_labels(_UPSTREAM_LABELS)
+    assert prov is not None
+    assert prov["patch_count"] == 0
+    assert prov["source_repo"] == "https://github.com/ggml-org/llama.cpp.git"
+
+
+def test_provenance_from_labels_partial_labels_keep_none_fields() -> None:
+    prov = provenance_from_labels({"org.opencontainers.image.revision": "abc1234def"})
+    assert prov == {"source_repo": None, "revision": "abc1234def", "patch_count": None}
+
+
+def test_provenance_from_labels_absent_or_unlabelled_is_none() -> None:
+    assert provenance_from_labels(None) is None
+    assert provenance_from_labels("not a dict") is None
+    assert provenance_from_labels({}) is None
+    assert provenance_from_labels({"unrelated.label": "x"}) is None
+
+
+def _provenance_handler(
+    *,
+    labels_by_ref: dict[str, dict[str, str]],
+    blob_fail: bool = False,
+    tags: list[str] | None = None,
+):
+    """MockTransport handler whose image manifests carry a ``config.digest``
+    and whose ``/blobs/<digest>`` route serves the config blob — the shape
+    the provenance probe walks (manifest → config.digest → blob GET).
+    """
+    tag_list = tags if tags is not None else ["latest"]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url == IMAGES_JSON_URL:
+            return httpx.Response(200, json=_IMAGES_JSON)
+        if url.startswith("https://ghcr.io/token"):
+            return httpx.Response(200, json={"token": "tok"})
+        if "/manifests/" in url:
+            repo, _, ref = url.split("https://ghcr.io/v2/")[1].partition("/manifests/")
+            return httpx.Response(
+                200,
+                headers={"docker-content-digest": f"sha256:{repo.replace('/', '-')}-{ref}"},
+                json={
+                    "schemaVersion": 2,
+                    "config": {"size": 345, "digest": f"sha256:cfg-{ref}"},
+                    "layers": [{"size": 6000}, {"size": 6000}],
+                },
+            )
+        if "/blobs/" in url:
+            if blob_fail:
+                return httpx.Response(500, content=b"nope")
+            _, _, blob_digest = url.partition("/blobs/")
+            ref = blob_digest.removeprefix("sha256:cfg-")
+            return httpx.Response(200, json={"config": {"Labels": labels_by_ref.get(ref) or {}}})
+        if "/tags/list" in url:
+            return httpx.Response(200, json={"tags": tag_list})
+        return httpx.Response(404, content=b"unrouted: " + url.encode())
+
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_sync_probe_extracts_and_persists_provenance(tmp_path: Path) -> None:
+    """Each tag's config blob labels land in RunnerImageTag.provenance and
+    survive the store round-trip (runner_image_tag.provenance_json)."""
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    handler = _provenance_handler(
+        labels_by_ref={"latest": _ROCMFPX_LABELS, "0824": _UPSTREAM_LABELS},
+        tags=["0824", "latest"],
+    )
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.probe_errors == {}
+    cpu = store.get("cpu")
+    assert cpu is not None
+    by_tag = {t.tag: t.provenance for t in cpu.tags}
+    assert by_tag["latest"] == {
+        "source_repo": "https://github.com/hal0ai/ROCmFPX.git",
+        "revision": "0a59adde1c5b2f3a4d6e7f8091a2b3c4d5e6f708",
+        "patch_count": 4,
+    }
+    assert by_tag["0824"] == {
+        "source_repo": "https://github.com/ggml-org/llama.cpp.git",
+        "revision": "c841aee0d5b9e2f1a3c4d5e6f708192a3b4c5d6e",
+        "patch_count": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_blob_fetch_failure_degrades_to_none_provenance(tmp_path: Path) -> None:
+    """A failing config-blob GET never fails the sync — the tag row simply
+    carries provenance=None, digest/size untouched."""
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    handler = _provenance_handler(labels_by_ref={}, blob_fail=True, tags=["latest"])
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.probe_errors == {}
+    cpu = store.get("cpu")
+    assert cpu is not None
+    assert cpu.digest == "sha256:hal0ai-hal0-toolbox-cpu-latest"
+    assert all(t.provenance is None for t in cpu.tags)
+
+
+@pytest.mark.asyncio
+async def test_unlabelled_config_blob_reads_as_none_provenance(tmp_path: Path) -> None:
+    """A reachable blob with no provenance labels reads back exactly like an
+    unprobed tag — None, never an all-None placeholder dict."""
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    handler = _provenance_handler(labels_by_ref={}, tags=["latest"])
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.probe_errors == {}
+    cpu = store.get("cpu")
+    assert cpu is not None
+    assert all(t.provenance is None for t in cpu.tags)

--- a/ui/src/dash/__tests__/runner-images-view.test.tsx
+++ b/ui/src/dash/__tests__/runner-images-view.test.tsx
@@ -155,6 +155,9 @@ const {
   tagLanes,
   MUTABLE_TAGS,
   RunnerImagesView,
+  provenanceRepoName,
+  formatProvenanceShort,
+  formatProvenanceFull,
 } = await import('../runner-images.jsx')
 
 // Minimal contract-shaped row; overrides per case.
@@ -200,6 +203,66 @@ describe('groupRows', () => {
   it('tolerates empty/absent input', () => {
     expect(groupRows([])).toEqual({ defaults: [], specialized: [], other: [] })
     expect(groupRows(undefined)).toEqual({ defaults: [], specialized: [], other: [] })
+  })
+})
+
+// h0/runner-provenance — llama.cpp build-provenance formatters. Contract:
+// `provenance: {source_repo, revision, patch_count} | null` (per tag row,
+// hoisted to row.provenance for the headline; same shape on system-info's
+// per-runner entries). Absent/empty provenance must format to null so
+// callers render EXACTLY what they render today — no placeholder text.
+describe('provenance formatters', () => {
+  const ROCMFPX = {
+    source_repo: 'https://github.com/hal0ai/ROCmFPX.git',
+    revision: '0a59adde1c5b2f3a4d6e7f8091a2b3c4d5e6f708',
+    patch_count: 4,
+  }
+  const UPSTREAM = {
+    source_repo: 'https://github.com/ggml-org/llama.cpp.git',
+    revision: 'c841aee0d5b9e2f1a3c4d5e6f708192a3b4c5d6e',
+    patch_count: 0,
+  }
+
+  it('provenanceRepoName strips .git but keeps llama.cpp as-is', () => {
+    expect(provenanceRepoName(ROCMFPX.source_repo)).toBe('ROCmFPX')
+    expect(provenanceRepoName(UPSTREAM.source_repo)).toBe('llama.cpp')
+    expect(provenanceRepoName('https://example.com/x/fork')).toBe('fork')
+    expect(provenanceRepoName(null)).toBeNull()
+    expect(provenanceRepoName('')).toBeNull()
+  })
+
+  it('formatProvenanceShort: fork with patches', () => {
+    expect(formatProvenanceShort(ROCMFPX)).toBe('ROCmFPX @0a59add (+4 patches)')
+  })
+
+  it('formatProvenanceShort: pristine upstream omits the patch suffix', () => {
+    expect(formatProvenanceShort(UPSTREAM)).toBe('llama.cpp @c841aee')
+  })
+
+  it('formatProvenanceShort: singular patch reads "+1 patch"', () => {
+    expect(formatProvenanceShort({ ...ROCMFPX, patch_count: 1 }))
+      .toBe('ROCmFPX @0a59add (+1 patch)')
+  })
+
+  it('formatProvenanceShort: partial labels degrade to what exists', () => {
+    expect(formatProvenanceShort({ source_repo: ROCMFPX.source_repo, revision: null, patch_count: null }))
+      .toBe('ROCmFPX')
+    expect(formatProvenanceShort({ source_repo: null, revision: 'abc1234def', patch_count: null }))
+      .toBe('@abc1234')
+  })
+
+  it('formatProvenanceShort: absent/empty provenance is null (render nothing)', () => {
+    expect(formatProvenanceShort(null)).toBeNull()
+    expect(formatProvenanceShort(undefined)).toBeNull()
+    expect(formatProvenanceShort({ source_repo: null, revision: null, patch_count: null })).toBeNull()
+  })
+
+  it('formatProvenanceFull keeps the full source URL', () => {
+    expect(formatProvenanceFull(ROCMFPX))
+      .toBe('https://github.com/hal0ai/ROCmFPX.git @0a59add (+4 patches)')
+    expect(formatProvenanceFull(UPSTREAM))
+      .toBe('https://github.com/ggml-org/llama.cpp.git @c841aee')
+    expect(formatProvenanceFull(null)).toBeNull()
   })
 })
 

--- a/ui/src/dash/hw-cascade.js
+++ b/ui/src/dash/hw-cascade.js
@@ -68,7 +68,9 @@ export function optionValue(binary, backend) {
  * @param slotType    slot.type — gates runner families via FAMILY_SLOT_TYPES
  *
  * Returns `{ options, fallback, emptyPin }`:
- * - options: [{binary, backend, device, specialties}] — the dropdown rows
+ * - options: [{binary, backend, device, specialties, provenance}] — the
+ *   dropdown rows; `provenance` is the runner row's build-provenance
+ *   object (h0/runner-provenance, from system-info) or undefined
  * - fallback: pinned ref is outside the catalog, so options are the
  *   device-fit union, not an enumeration of the image
  * - emptyPin: a catalog image is pinned, but nothing in it fits this slot
@@ -95,11 +97,16 @@ export function backendOptions({ backends, pinnedImage, device, slotType }) {
 		const specialties = Array.isArray(r.supports?.specialties)
 			? r.supports.specialties
 			: undefined;
+		// Build provenance of the runner's effective image (system-info's
+		// `provenance` field, h0/runner-provenance) — passed through so the
+		// option label can name the llama.cpp build; absent on an older
+		// backend payload, and the label then renders exactly as today.
+		const provenance = r.provenance || undefined;
 		const sups = runnerBackends(r);
 		if (sups.length === 0) {
 			// Backend-agnostic runner: one option, device untouched.
 			if (r.device_class && r.device_class !== devClass) continue;
-			options.push({ binary: key, backend: "", device, specialties });
+			options.push({ binary: key, backend: "", device, specialties, provenance });
 			continue;
 		}
 		for (const be of sups) {
@@ -110,13 +117,19 @@ export function backendOptions({ backends, pinnedImage, device, slotType }) {
 				// a re-create, not an edit.
 				if (deviceClassOf(target) !== devClass) continue;
 				if (r.device_class && r.device_class !== devClass) continue;
-				options.push({ binary: key, backend: be, device: target, specialties });
+				options.push({
+					binary: key,
+					backend: be,
+					device: target,
+					specialties,
+					provenance,
+				});
 			} else {
 				// Unmapped token (e.g. npu): only valid when it IS the slot's
 				// backend already — never a flip.
 				if (be !== devBe) continue;
 				if (r.device_class && r.device_class !== devClass) continue;
-				options.push({ binary: key, backend: be, device, specialties });
+				options.push({ binary: key, backend: be, device, specialties, provenance });
 			}
 		}
 	}

--- a/ui/src/dash/runner-images.jsx
+++ b/ui/src/dash/runner-images.jsx
@@ -181,6 +181,58 @@ export function newerTagAvailable(image) {
   return cand !== image.tag;               // pre-v3 fallback, unchanged
 }
 
+// ── Build provenance (h0/runner-provenance) ─────────────────────────────
+// The sync probe reads each tag's image-config OCI labels into
+// `provenance: {source_repo, revision, patch_count} | null` (per tag row,
+// hoisted to `row.provenance` for the headline; the system-info payload
+// carries the same shape per runner). All helpers return null when the
+// provenance is absent/empty so callers render EXACTLY what they render
+// today — no placeholder text.
+
+// Short repo name: last path segment of `source_repo` minus a `.git`
+// suffix — with `llama.cpp` kept as-is (its `.cpp` is the name, and
+// upstream's repo path ends in `llama.cpp.git` → `llama.cpp`).
+export function provenanceRepoName(sourceRepo) {
+  if (!sourceRepo || typeof sourceRepo !== 'string') return null;
+  const last = sourceRepo.replace(/\/+$/, '').split('/').pop();
+  if (!last) return null;
+  return last.endsWith('.git') ? last.slice(0, -4) || null : last;
+}
+
+// `(+4 patches)` / `(+1 patch)` — null for 0/absent (pristine upstream
+// carries an empty patch list, which shouldn't render as noise).
+function provenancePatchSuffix(patchCount) {
+  if (typeof patchCount !== 'number' || patchCount <= 0) return null;
+  return `(+${patchCount} patch${patchCount === 1 ? '' : 'es'})`;
+}
+
+// Compact provenance string for select options / fit-check lines, e.g.
+// `ROCmFPX @0a59add (+4 patches)` or `llama.cpp @c841aee`. Partial labels
+// degrade to whatever parts exist; null when nothing renders.
+export function formatProvenanceShort(prov) {
+  if (!prov) return null;
+  const parts = [
+    provenanceRepoName(prov.source_repo),
+    prov.revision ? `@${String(prov.revision).slice(0, 7)}` : null,
+    provenancePatchSuffix(prov.patch_count),
+  ].filter(Boolean);
+  return parts.length ? parts.join(' ') : null;
+}
+
+// Full provenance line for the RunnerCard detail: source URL + short
+// revision + patch count, e.g.
+// `https://github.com/ggml-org/llama.cpp.git @c841aee` (upstream, no
+// patches) or `<fork URL> @0a59add (+4 patches)`.
+export function formatProvenanceFull(prov) {
+  if (!prov) return null;
+  const parts = [
+    prov.source_repo || null,
+    prov.revision ? `@${String(prov.revision).slice(0, 7)}` : null,
+    provenancePatchSuffix(prov.patch_count),
+  ].filter(Boolean);
+  return parts.length ? parts.join(' ') : null;
+}
+
 // Tag option label for the card's <select>: the tag name, its digest alias
 // (`= <earlier tag>`) when it points at the same manifest as one already
 // listed, a downloaded checkmark, and a trailing badge suffix.
@@ -615,6 +667,14 @@ function RunnerCard({ image }) {
         <div><div className="k">publish</div><div className="v">{image.publish || "—"}</div></div>
         <div><div className="k">manifest key</div><div className="v">{image.manifest_key || "—"}</div></div>
         <div><div className="k">in use by</div><div className="v mono">{inUseBy.length ? inUseBy.join(", ") : "—"}</div></div>
+        {/* Build provenance (headline tag) — absent provenance renders
+            exactly what rendered before this line existed: nothing. */}
+        {formatProvenanceFull(image.provenance) && (
+          <div data-testid="ri-provenance">
+            <div className="k">build source</div>
+            <div className="v mono" title={image.provenance.revision || undefined}>{formatProvenanceFull(image.provenance)}</div>
+          </div>
+        )}
       </div>
 
       {image.notes && (

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -25,6 +25,9 @@ import {
 	optionValue,
 	selectedBackendValue,
 } from "./hw-cascade.js";
+// llama.cpp build-provenance formatter (h0/runner-provenance) — shared with
+// the Runner Images page so option labels and the RunnerCard can't drift.
+import { formatProvenanceShort } from "./runner-images.jsx";
 import { useSlotLogsStream } from "@/api/hooks/useLogs";
 import { ENDPOINTS } from "@/api/endpoints";
 import { normalizeApiModel, isUpstreamModel } from "@/lib/normalizeApiModel";
@@ -1061,9 +1064,14 @@ function EditSlotDrawer({ open, slot, onClose }) {
 			const backendsCat = systemInfoQuery.data?.backends ?? {};
 			const selRunner = binary ? backendsCat[binary] : null;
 			const sup = selRunner ? runnerBackends(selRunner) : [];
+			// Same provenance string the Runner select's option labels carry
+			// (h0/runner-provenance) — the fit-check line names the exact
+			// llama.cpp build it's warning about; absent provenance renders
+			// the line exactly as before.
+			const selProv = formatProvenanceShort(selRunner?.provenance);
 			if (binary && sup.length > 0 && !sup.includes(selCross.backend))
 				crossCautions.push(
-					`Runner binary "${binary}" does not list backend "${selCross.backend}" — clear it or pick a matching binary.`,
+					`Runner binary "${binary}${selProv ? ` — ${selProv}` : ""}" does not list backend "${selCross.backend}" — clear it or pick a matching binary.`,
 				);
 			if ((imagePin || "").trim())
 				crossCautions.push(
@@ -1690,6 +1698,15 @@ function EditSlotDrawer({ open, slot, onClose }) {
 													{Array.isArray(o.specialties) &&
 													o.specialties.length > 0
 														? ` · ${o.specialties.join(", ")}`
+														: ""}
+													{/* llama.cpp build provenance of the runner's
+													    effective image (h0/runner-provenance) — e.g.
+													    `rocmfpx — ROCmFPX @0a59add (+4 patches)` vs
+													    `upstream — llama.cpp @c841aee`. Absent
+													    provenance renders exactly what rendered
+													    before. */}
+													{formatProvenanceShort(o.provenance)
+														? ` — ${formatProvenanceShort(o.provenance)}`
 														: ""}
 												</option>
 											))}


### PR DESCRIPTION
Surfaces per-image llama.cpp build provenance so an operator can tell the upstream image's Vulkan/ROCm build apart from the ROCmFPX one. Ground truth verified live on a box: runner images carry `org.opencontainers.image.source`, `org.opencontainers.image.revision`, and `dev.hal0.runner.patches` OCI labels in the image config blob.

## Contract change

`GET /api/runner-images` (+ `/sync`, `/downloaded`, single-image GET) rows:

```jsonc
"tags": [{ "tag": "...", "digest": "...",
           "provenance": { "source_repo": "https://github.com/hal0ai/ROCmFPX.git",
                           "revision": "0a59add...", "patch_count": 4 } | null, ... }],
"provenance": { ... } | null   // hoisted from the HEADLINE tag's row
```

`GET /api/system-info` — each `backends[key]` entry gains `"provenance": {...} | null` for the runner's **effective** image (defaults map, override tier included), resolved against the sync-cached catalogue only — **no live registry call** on that request path; an unsynced tag answers `null`.

`patch_count` = count of non-empty comma-split entries of `dev.hal0.runner.patches` (`0` for pristine upstream's empty label, `null` when the label is absent). All-absent labels, a failed blob fetch, or an unprobed tag read as `provenance: null` — the UI renders exactly what it rendered before (no placeholder).

## Implementation (file:line)

**Sync probe** — `src/hal0/registry/runner_image_sync.py`
- `provenance_from_labels` (pure, exported): `runner_image_sync.py:224`
- manifest → `config.digest` (index follows its linux/amd64 child): `runner_image_sync.py:337`, `:352`
- `_ghcr_tag_provenance` (config-blob GET, fail-soft to `None`): `runner_image_sync.py:359`
- wired per tag in `probe_ghcr_package`, headline gated on `is_noise_tag` (available_tags is already noise-filtered at `_ghcr_list_tags`): `runner_image_sync.py:430`, `:454`

**Persistence**
- `RunnerImageTag.provenance`: `src/hal0/registry/runner_image.py:32`
- migration 009 (`runner_image_tag.provenance_json`): `src/hal0/db/migrations/009_runner_image_tag_provenance.sql`
- store read/write (`_load_provenance` fail-soft decode): `src/hal0/registry/runner_image_store.py:64`, `:146`, `:215`, and `set_tags` insert

**API**
- `enrich_row` per-tag passthrough + headline hoist (docstring updated): `src/hal0/api/routes/runner_images.py:190` (contract note at `:159`)
- `provenance_for_ref` (pure, tag- or digest-pinned ref → cached provenance): `runner_images.py:208`
- system-info per-runner stamp (fail-soft, canonical-family fold): `src/hal0/api/routes/hardware.py:917`, `:954`

**UI**
- pure helpers `provenanceRepoName` / `formatProvenanceShort` / `formatProvenanceFull`: `ui/src/dash/runner-images.jsx:195`, `:212`, `:226`
- RunnerCard "build source" detail line: `runner-images.jsx:672`
- hw-cascade option passthrough: `ui/src/dash/hw-cascade.js:104`
- Backend select option suffix: `ui/src/dash/slot-modals.jsx:1708`; fit-check caution: `slot-modals.jsx:1071`

Sample option labels: `rocmfpx — ROCmFPX @0a59add (+4 patches)` · `upstream — llama.cpp @c841aee`

## Test evidence

- `tests/registry/test_runner_image_sync.py` + `test_runner_image_store.py`: **56 passed** (new: label extraction, empty-patches→0, blob-500 degrade, unlabelled-blob→null, store round-trip)
- `tests/api/test_runner_images_routes.py` + `test_system_info_route.py`: **104 passed** (new: enrich_row passthrough/hoist, `provenance_for_ref` tag/digest/miss)
- `tests/registry/test_schema_migration.py`: **11 passed** (migration 009)
- vitest `runner-images-view` + `runner-images-confirm-flow` + `runner-images-pull-terminal` + `hw-cascade`: **57 passed** (new: provenance formatter present/absent/partial cases)
- `ruff check` + `ruff format --check` clean on touched python; `scripts/check_sunset.py`: scar markers 193 <= baseline 193; `vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWn23rRvwECyNfLya4JQip
