### PR TITLE
feat(memory): converge the bundled hindsight engine to 0.9.2 on every upgrade path

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2798,7 +2798,12 @@ fi
 if [[ "${DEV_MODE}" -eq 1 ]]; then
     info "dev mode — skipping post-activation migrations (no system writes)"
 else
-    info "running post-activation migrations (schema + seed-profile/mtp/vulkan-slot/image-pin/extra-args)"
+    info "running post-activation migrations (schema + seed-profile/mtp/vulkan-slot/image-pin/extra-args + memory-engine)"
+    # Export so the heredoc's python child sees them (same posture as
+    # HAL0_RESET_PROFILES above): the memory-engine pass honors the skip
+    # hatch and the interpreter override.
+    export HAL0_SKIP_HINDSIGHT="${HAL0_SKIP_HINDSIGHT:-}"
+    export HAL0_HINDSIGHT_PYTHON="${HAL0_HINDSIGHT_PYTHON:-}"
     hal0_migration_step "post-activation migrations" <<'PYEOF'
 from hal0.config.migrations.v2 import PROFILE_CATALOG_SCHEMA_VERSION
 from hal0.updater.updater import run_post_activation_migrations
@@ -3246,6 +3251,26 @@ smoke_update_check() {
     "${HAL0_BIN}" update --check >/dev/null 2>&1
 }
 
+smoke_memory_engine_version() {
+    # The engine's /version must report exactly the pinned api_version — the
+    # install/upgrade paths were BOTH blind to a stale engine venv before the
+    # engine-upgrade pass existed, and this probe is what keeps them honest
+    # (a staleness signal only; behavior gates on /version `features`, never
+    # the version string). Fail-soft like the rest, skipped when the engine
+    # was skipped or never installed.
+    [[ "${HAL0_SKIP_HINDSIGHT:-0}" -eq 1 ]] && return 0
+    # Overridable unit path so the probe is drivable through fakes in
+    # tests/installer/test_install_smoke_probes.py.
+    [[ -f "${HINDSIGHT_UNIT_DST:-/etc/systemd/system/hindsight-api.service}" ]] || return 0
+    local resp
+    resp="$(curl -fsS -m 10 "http://127.0.0.1:9177/version" 2>/dev/null)" || return 1
+    printf '%s' "${resp}" | "${PY}" -c 'import json, sys
+try:
+    sys.exit(0 if json.load(sys.stdin).get("api_version") == sys.argv[1] else 1)
+except Exception:
+    sys.exit(1)' "${HINDSIGHT_PIN}" 2>/dev/null
+}
+
 run_post_install_smoke() {
     if smoke_structured_output; then
         info "structured-output probe ok (gateway /v1, json_object)"
@@ -3260,6 +3285,13 @@ run_post_install_smoke() {
         SMOKE_FAILED+=("update-check")
         warn "'${HAL0_BIN} update --check' FAILED — the update path is broken and the next release will not install"
         warn "  re-run '${HAL0_BIN} update --check' to see why (daemon reachability / manifest fetch / cosign verify)"
+    fi
+    if smoke_memory_engine_version; then
+        info "memory-engine version probe ok (hindsight-api ${HINDSIGHT_PIN} on :9177)"
+    else
+        SMOKE_FAILED+=("memory-engine-version")
+        warn "memory-engine version probe FAILED — :9177/version does not report the pinned ${HINDSIGHT_PIN}"
+        warn "  the engine is unreachable or stale; check 'journalctl -u hindsight-api -n 40' and the post-activation migrations output above"
     fi
 }
 
@@ -3296,6 +3328,19 @@ else
     # its extraction/reflection LLM is hal0/utility on :8080 (used lazily — the
     # unit sets HINDSIGHT_API_SKIP_LLM_VERIFICATION so it binds without a loaded
     # model). Escape hatch: HAL0_SKIP_HINDSIGHT=1.
+    #
+    # This block only CREATES the venv (fresh install). UPGRADING an existing
+    # venv to the pin is the engine-upgrade migration pass
+    # (hal0.memory.engine_upgrade, run by run_post_activation_migrations from
+    # the migration step earlier in this script and by `hal0 update`), so on a
+    # re-run the engine may already have been stopped/started once above —
+    # every step below is idempotent against that.
+    #
+    # HINDSIGHT_PIN must match hal0.memory.engine_upgrade.HINDSIGHT_API_PIN —
+    # tests/installer/test_hindsight_pin_lockstep.py enforces it. Kept as a
+    # shell literal (not read from the venv) so the fresh-install branch works
+    # even when the python side is broken.
+    HINDSIGHT_PIN="0.9.2"
     HS_DIR="${VAR_DIR}/memory/hindsight"
     HINDSIGHT_UNIT_SRC="${REPO_ROOT}/installer/systemd/hindsight-api.service"
     if [[ "${HAL0_SKIP_HINDSIGHT:-0}" -ne 1 && -f "${HINDSIGHT_UNIT_SRC}" ]]; then
@@ -3321,7 +3366,7 @@ else
             # /health poll below is the real gate on whether the engine came up.
             hs_installed=0
             if [[ "${hs_fallback}" -ne 1 ]]; then
-                if "${hs_pip}" install "hindsight-api==0.8.4" -q; then
+                if "${hs_pip}" install "hindsight-api==${HINDSIGHT_PIN}" -q; then
                     hs_installed=1
                 else
                     hs_pyver="$("${HS_DIR}/.venv/bin/python" -c 'import sys;print("%d.%d"%sys.version_info[:2])' 2>/dev/null || echo '?')"
@@ -3331,7 +3376,7 @@ else
             if [[ "${hs_installed}" -ne 1 ]]; then
                 [[ "${hs_fallback}" -eq 1 ]] && \
                     info "installing hindsight-api with --ignore-requires-python (no Python 3.11-3.13 available; litellm's 3.14 gate is metadata-only)"
-                if "${hs_pip}" install --ignore-requires-python "hindsight-api==0.8.4" -q; then
+                if "${hs_pip}" install --ignore-requires-python "hindsight-api==${HINDSIGHT_PIN}" -q; then
                     hs_installed=1
                 else
                     warn "hindsight-api install failed — memory engine will be unavailable"
@@ -3339,7 +3384,16 @@ else
                 fi
             fi
         else
-            info "hindsight-api venv already present — skipping pip install"
+            # Existing venv: upgrading it was the engine-upgrade migration
+            # pass's job (see the block comment above) — just report where it
+            # landed so a failed pass is visible right here, not only in the
+            # migration-step output further up.
+            hs_have="$("${HS_DIR}/.venv/bin/python" -c 'import importlib.metadata as m; print(m.version("hindsight-api"))' 2>/dev/null || echo '?')"
+            if [[ "${hs_have}" == "${HINDSIGHT_PIN}" ]]; then
+                info "hindsight-api ${hs_have} already at pin — venv up to date"
+            else
+                warn "hindsight-api venv present at ${hs_have} (pinned ${HINDSIGHT_PIN}) — the engine-upgrade pass did not converge; see the post-activation migrations output above and re-run after fixing"
+            fi
         fi
         # The unit runs as hal0 with HOME=${HS_DIR}; hand it the whole tree.
         chown -R hal0:hal0 "${VAR_DIR}/memory" 2>/dev/null || true

--- a/src/hal0/api/routes/_memory_subgraph.py
+++ b/src/hal0/api/routes/_memory_subgraph.py
@@ -19,6 +19,10 @@ from typing import Any
 #: caused_by: 43}) — without this alias real causal edges silently floor to
 #: the semantic weight below, understating causal salience everywhere this
 #: feeds into (degree_by_node, rank_by_degree, ego_bfs, the units endpoint).
+#: The 0.9.2 wheels change no graph routes or schemas (and add no native
+#: subgraph/ego endpoint — this composition layer stays), but link-type
+#: emission is engine-internal: re-verify the counts live after the 0.9.x
+#: engine upgrade lands.
 _TYPE_WEIGHT = {
     "causal": 4.0,
     "caused_by": 4.0,

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -278,6 +278,36 @@ async def graph_status(request: Request) -> dict[str, Any]:
     return status
 
 
+async def _all_banks(client: Any) -> list[Any] | None:
+    """Every bank entry, walking hindsight's paginated list when it is one.
+
+    hindsight-api >= 0.9 pages ``/v1/default/banks`` (default ``limit=100``,
+    real count in ``total``); 0.8.x ignores the paging params and returns the
+    whole list with no ``total``. One shape handles both: keep fetching pages
+    while ``total`` says there is more, stop immediately when the response
+    carries no ``total`` (unpaginated engine — the first response was
+    everything). Raises nothing; returns ``None`` when the first page fails.
+    """
+    page = 100
+    banks: list[Any] = []
+    offset = 0
+    while True:
+        try:
+            resp = await client.request_json(
+                "GET", f"/v1/default/banks?limit={page}&offset={offset}"
+            )
+        except Exception:
+            return banks or None
+        chunk = resp.get("banks") if isinstance(resp, dict) else resp
+        if not isinstance(chunk, list):
+            return banks or None
+        banks += chunk
+        total = resp.get("total") if isinstance(resp, dict) else None
+        if total is None or len(banks) >= int(total) or not chunk:
+            return banks
+        offset += page
+
+
 async def _augment_build_counters(request: Request, status: dict[str, Any]) -> None:
     """Replace the provider's placeholder ``0``/``None`` build counters with
     real extraction/consolidation activity aggregated from Hindsight's
@@ -299,8 +329,7 @@ async def _augment_build_counters(request: Request, status: dict[str, Any]) -> N
         except Exception:
             return None
 
-    banks_resp = await _get("/v1/default/banks")
-    banks = banks_resp.get("banks") if isinstance(banks_resp, dict) else banks_resp
+    banks = await _all_banks(client)
     if not isinstance(banks, list):
         return
 
@@ -384,12 +413,7 @@ async def retry_failed_extractions(request: Request) -> dict[str, Any]:
     _PAGE = 100
     _CAP = 2000  # backstop; far above any real failed-op count
 
-    banks_resp = None
-    try:
-        banks_resp = await client.request_json("GET", "/v1/default/banks")
-    except Exception as exc:
-        raise MemoryUnavailable("could not enumerate memory banks") from exc
-    banks = banks_resp.get("banks") if isinstance(banks_resp, dict) else banks_resp
+    banks = await _all_banks(client)
     if not isinstance(banks, list):
         raise MemoryUnavailable("could not enumerate memory banks")
 

--- a/src/hal0/api/routes/memory_admin.py
+++ b/src/hal0/api/routes/memory_admin.py
@@ -211,13 +211,22 @@ async def engine_status(request: Request) -> dict[str, Any]:
     version, banks = await asyncio.gather(
         _probe(client, "/version"), _probe(client, "/v1/default/banks")
     )
+    if isinstance(banks, dict):
+        # hindsight-api >= 0.9 paginates the banks list (default limit=100)
+        # and reports the real count in `total`; 0.8.x has neither, so fall
+        # back to counting the page.
+        banks_total = banks.get("total")
+        if banks_total is None:
+            banks_total = len(banks.get("banks", []))
+    else:
+        banks_total = None
     return {
         "enabled": True,
         "engine": "hindsight",
         "reachable": version is not None or banks is not None,
         "version": (version or {}).get("api_version"),
         "features": (version or {}).get("features"),
-        "banks_total": len(banks.get("banks", [])) if isinstance(banks, dict) else None,
+        "banks_total": banks_total,
     }
 
 
@@ -527,8 +536,9 @@ async def bank_units(request: Request, bank_id: str) -> dict[str, Any]:
 
 #: #1024 dry-run preview: bank-stats keys carrying stored-item counts. Best
 #: effort — Hindsight versions differ, so absent keys are simply omitted.
-#: These are the real hindsight-api 0.8.4 ``/v1/default/banks/{bank}/stats``
-#: keys (verified live) — NOT the ``memory_count``/``document_count``/
+#: These are the real hindsight-api ``/v1/default/banks/{bank}/stats`` keys
+#: (verified live on 0.8.4; unchanged in the 0.9.2 wheels, which only add
+#: ``last_memory_write_at``) — NOT the ``memory_count``/``document_count``/
 #: ``entity_count`` keys that endpoint has never returned (#1653).
 _PREVIEW_COUNT_KEYS = ("total_nodes", "total_documents", "total_observations")
 
@@ -634,8 +644,10 @@ async def delete_bank_memories(request: Request, bank_id: str) -> Any:
 # ── /banks/{bank_id}/document-transfer — cross-bank migration (NOT a table
 #    passthrough) ─────────────────────────────────────────────────────────────
 #
-# hindsight-api>=0.8.0 (source-verified against the v0.8.4 tag; absent from
-# the 0.7.2 instance this router was built against — gate on
+# hindsight-api>=0.8.0 (source-verified against the v0.8.4 tag and re-checked
+# against the 0.9.2 wheels — both endpoints unchanged; 0.9.2 additionally
+# ships an async ``document-transfer/export`` variant this router does not
+# use. Absent from the 0.7.2 instance this router was built against — gate on
 # ``features.document_export_api``/``document_import_api`` from ``/version``,
 # not the version string). GET returns a ZIP file (source bank's documents +
 # optionally their observations); POST accepts that ZIP as a multipart

--- a/src/hal0/cli/doctor_all.py
+++ b/src/hal0/cli/doctor_all.py
@@ -1006,6 +1006,43 @@ def check_hindsight_llm_auth(
     return Check(name, title, _PASS, "memory engine carries a current client-tier LLM key")
 
 
+def check_memory_engine_version(*, memory: dict[str, Any] | None) -> Check:
+    """The engine should be at the pinned version — staleness signal only.
+
+    Both upgrade paths converge the engine venv via the post-activation
+    migration pass (``hal0.memory.engine_upgrade``); a box that reports an
+    older ``api_version`` missed or failed that pass. Advisory by
+    convention: behavior gates on ``/version`` ``features``, never the
+    version string (see memory_admin's document-transfer gate), so a stale
+    engine WARNs with the remedy and never fails the roll-up.
+
+    ``memory`` is the ``GET /api/memory/engine`` payload the roll-up already
+    fetched — one probe, two rows.
+    """
+    from hal0.memory.engine_upgrade import HINDSIGHT_API_PIN
+
+    name, title = "memory_engine_version", "Memory engine version"
+    if memory is None:
+        return Check(name, title, _WARN, "engine status unreachable — is hal0-api up?")
+    if memory.get("engine") in (None, "") or not memory.get("enabled", True):
+        return Check(name, title, _PASS, "memory disabled — nothing to check")
+    if not memory.get("reachable"):
+        # check_memory (the shared classifier) already reports reachability;
+        # a second row saying the same thing would be noise.
+        return Check(name, title, _PASS, "engine unreachable — see the memory row")
+    version = memory.get("version")
+    if version == HINDSIGHT_API_PIN:
+        return Check(name, title, _PASS, f"hindsight-api {version} matches the pin")
+    return Check(
+        name,
+        title,
+        _WARN,
+        f"engine reports {version or 'unknown'} but this release pins {HINDSIGHT_API_PIN} — "
+        "the engine-upgrade pass missed or failed; run `hal0 update` (or re-run install.sh) "
+        "and check the journal for updater.memory_engine_upgrade_failed",
+    )
+
+
 def check_hermes_anchor_window(
     *,
     base: str | None = None,
@@ -1147,6 +1184,7 @@ def build_all_checks(base: str | None = None) -> list[Check]:
         check_hermes_mcp_config_auth(auth=auth_payload),
         check_hermes_anchor_window(base=base),
         check_hindsight_llm_auth(auth=auth_payload),
+        check_memory_engine_version(memory=payloads["memory"]),
     ]
     return verify_rows + extra_rows
 
@@ -1234,6 +1272,7 @@ __all__ = [
     "check_hermes_mcp_config_auth",
     "check_hindsight_llm_auth",
     "check_mcp_mounts",
+    "check_memory_engine_version",
     "check_migrations",
     "check_model_store",
     "check_ports",

--- a/src/hal0/cli/memory_migrate_commands.py
+++ b/src/hal0/cli/memory_migrate_commands.py
@@ -4,10 +4,12 @@
 bank by tag, so multiple per-agent private banks can be consolidated under
 a shared/unified bank without losing which agent a fact came from.
 
-Upstream mechanics (source-verified against the hindsight-api v0.8.4 tag —
-the live instance this CLI was built against is still 0.7.2, which lacks
-all of this; ``--apply`` gates on ``/version``'s ``features.document_export_api``/
-``document_import_api`` flags so it fails loud rather than guessing):
+Upstream mechanics (source-verified against the hindsight-api v0.8.4 tag and
+re-checked against the 0.9.2 wheels — every endpoint/flag below is unchanged
+there, and 0.9.2's import replays the archive deterministically without LLM
+calls, so a unify stays cheap; ``--apply`` gates on ``/version``'s
+``features.document_export_api``/``document_import_api`` flags so it fails
+loud rather than guessing):
 
 * ``GET .../document-transfer?include_observations=`` exports a source
   bank's documents (optionally their observations) as a ZIP.

--- a/src/hal0/cli/memory_ops_commands.py
+++ b/src/hal0/cli/memory_ops_commands.py
@@ -31,9 +31,20 @@ def _require_api() -> str:
 
 
 def _all_bank_ids() -> list[str]:
-    result = api_get("/api/memory/banks")
-    banks = (result or {}).get("banks", []) if isinstance(result, dict) else []
-    return [str(b["bank_id"]) for b in banks if "bank_id" in b]
+    # hindsight-api >= 0.9 pages the banks list (default limit=100, real count
+    # in `total`); 0.8.x ignores the params and returns everything with no
+    # `total`, so a missing `total` means the first page was the whole list.
+    page = 100
+    ids: list[str] = []
+    offset = 0
+    while True:
+        result = api_get("/api/memory/banks", params={"limit": str(page), "offset": str(offset)})
+        banks = (result or {}).get("banks", []) if isinstance(result, dict) else []
+        ids += [str(b["bank_id"]) for b in banks if "bank_id" in b]
+        total = result.get("total") if isinstance(result, dict) else None
+        if total is None or len(ids) >= int(total) or not banks:
+            return ids
+        offset += page
 
 
 def _list_bank_ops(bank: str, *, failed_only: bool) -> list[dict[str, Any]]:

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -360,6 +360,7 @@ _MIGRATION_PASS_LABELS: dict[str, str] = {
     "updater.vulkan_migration_failed": "gpu-vulkan slot relabel",
     "updater.image_retag_failed": "runner image retag",
     "updater.extra_args_sanitize_failed": "managed extra_args sanitisation",
+    "updater.memory_engine_upgrade_failed": "memory engine upgrade",
 }
 
 

--- a/src/hal0/memory/engine_upgrade.py
+++ b/src/hal0/memory/engine_upgrade.py
@@ -1,0 +1,504 @@
+"""Converge the bundled hindsight-api engine venv onto the pinned version.
+
+The memory engine lives in its own venv at ``${var_lib}/memory/hindsight/.venv``
+with an embedded postgres data dir at ``.pg0`` beside it. install.sh creates the
+venv on a fresh box but deliberately never touches an existing one, and ``hal0
+update`` swaps only the hal0 install tree — so before this pass existed, a box
+installed at one engine version stayed there forever (the #1689/#1844 "update
+never refreshes X" class; see GH issue for the 0.8.4 → 0.9.2 bump).
+
+This module is the single owner of the engine version pin
+(:data:`HINDSIGHT_API_PIN`) and of the upgrade itself
+(:func:`upgrade_memory_engine`), which ``run_post_activation_migrations`` runs
+as its last pass on both upgrade paths (``hal0 update`` commit and install.sh's
+re-run heredoc — GH #1475 single-sequence seam). Fresh installs stay
+install.sh's job: the pass no-ops when no venv exists.
+
+Upgrade shape — build-aside, swap, verify, roll back:
+
+* the replacement venv is built at ``.venv.new`` while the old engine keeps
+  serving, so a pip/network failure costs nothing;
+* the engine is stopped and ``.pg0`` is snapshotted to ``.pg0.pre-<old>``
+  BEFORE the new engine ever starts, because hindsight-api runs its alembic
+  migrations on startup and they are effectively one-way (an old engine cannot
+  run against a migrated schema) — the snapshot is the only rollback;
+* after the swap the pass polls ``/health`` and requires ``/version`` to
+  report exactly the pin; any postcheck failure restores both the old venv and
+  the snapshot.
+
+``hal0 update --rollback`` re-activates the previous hal0 tree but leaves the
+engine (and its migrated ``.pg0``) on the new version — acceptable because the
+engine's HTTP surface is additive across the supported window, and reverting a
+one-way DB migration behind the operator's back would be worse.
+
+Privileges: on the ``hal0 update`` path this runs as the unprivileged ``hal0``
+user (the venv and ``.pg0`` are hal0-owned; service stop/start routes through
+:class:`hal0.system.seam.SystemCtlSeam`'s companion-unit arms). On the
+install.sh path it runs as root — everything the pass creates is chowned back
+to ``hal0:hal0`` because postgres refuses a data dir not owned by the running
+user.
+
+Never raises for operational failures — returns a status dict (the
+``apply_extraction_slot`` posture) so the migration sequence's best-effort
+wrapper only ever catches genuine bugs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from hal0.config.paths import var_lib
+from hal0.system.seam import SystemCtlSeam
+
+log = structlog.get_logger(__name__)
+
+#: The engine version every box converges on. Single source of truth —
+#: install.sh's ``HINDSIGHT_PIN`` shell variable must match
+#: (tests/installer/test_hindsight_pin_lockstep.py enforces it).
+HINDSIGHT_API_PIN = "0.9.2"
+
+#: Full unit name — must key into ``COMPANION_SERVICE_UNITS`` so the seam
+#: routes to the wrapper's ``svc-stop/svc-start hindsight`` arms (a bare
+#: ``hindsight-api`` would fall through to a polkit-blocked systemctl).
+SERVICE = "hindsight-api.service"
+
+#: Loopback base the unit binds; the same literal install.sh polls.
+ENGINE_BASE_URL = "http://127.0.0.1:9177"
+
+#: Interpreter band the engine supports, mirroring installer/lib/preflight.sh's
+#: ``HINDSIGHT_PY_MIN_MINOR``/``HINDSIGHT_PY_MAX_MINOR`` (kept as constants
+#: there too, "so bumping the supported band is a one-line change").
+PY_MIN_MINOR = 11
+PY_MAX_MINOR = 13
+
+#: Each pip invocation gets its own cap well under the post-swap migration
+#: subprocess envelope (2700s in updater.py) so the outer process always has
+#: headroom to emit its JSON result even when a wheel build wedges.
+_PIP_TIMEOUT_S = 2400
+_VENV_TIMEOUT_S = 120
+_PROBE_TIMEOUT_S = 30
+_SYSTEMCTL_TIMEOUT_S = 120.0
+#: /health poll after the swapped engine starts. Longer than install.sh's 120s
+#: fresh-install poll: the first boot on an upgraded ``.pg0`` also runs the
+#: engine's alembic chain before the socket comes up.
+_HEALTH_POLL_TOTAL_S = 180
+_HEALTH_POLL_STEP_S = 3
+#: Shorter poll for "did the OLD engine come back" after a rollback.
+_ROLLBACK_HEALTH_POLL_TOTAL_S = 60
+
+#: Snapshot must fit with headroom; refuse to gamble the only rollback on a
+#: nearly-full disk.
+_SNAPSHOT_FREE_FACTOR = 1.5
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+def hindsight_dir() -> Path:
+    """The engine's home: venv, ``.pg0`` and caches live under it."""
+    return var_lib() / "memory" / "hindsight"
+
+
+def _run(
+    runner: Runner, args: list[str], *, timeout: float, **kwargs: Any
+) -> subprocess.CompletedProcess:
+    return runner(args, capture_output=True, text=True, timeout=timeout, **kwargs)
+
+
+def _http_get_json(url: str, timeout: float = 5.0) -> dict[str, Any] | None:
+    """Best-effort GET returning parsed JSON, ``None`` on any failure."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+def _chown_tree(path: Path) -> None:
+    """``chown -R hal0:hal0`` when running as root (install.sh path).
+
+    Postgres refuses a data dir not owned by the running user, and the unit
+    runs as ``hal0`` — a root-built ``.venv.new`` or root-copied snapshot must
+    not stay root-owned. Best-effort: on a box with no ``hal0`` user (dev/CI)
+    ownership is irrelevant because the caller isn't root either.
+    """
+    if os.geteuid() != 0:
+        return
+    try:
+        for p in [path, *path.rglob("*")]:
+            shutil.chown(p, user="hal0", group="hal0")
+    except (LookupError, OSError) as exc:
+        log.warning("updater.memory_engine_chown_failed", path=str(path), error=str(exc))
+
+
+def _installed_version(runner: Runner, venv: Path) -> str | None:
+    """The ``hindsight-api`` dist version inside ``venv``, or ``None``.
+
+    Asked of the venv's own interpreter — the running process's dist set is
+    the wrong one. ``None`` covers both "no such dist" and "interpreter
+    broken": either way the venv needs a rebuild, and only the rebuilt venv's
+    own probe (never pip's exit code) proves success.
+    """
+    py = venv / "bin" / "python"
+    try:
+        proc = _run(
+            runner,
+            [
+                str(py),
+                "-c",
+                "import importlib.metadata as m; print(m.version('hindsight-api'))",
+            ],
+            timeout=_PROBE_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    version = (proc.stdout or "").strip()
+    return version or None
+
+
+def _interpreter_in_band(runner: Runner, py: str) -> bool:
+    try:
+        proc = _run(
+            runner,
+            [py, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+            timeout=_PROBE_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if proc.returncode != 0:
+        return False
+    try:
+        major, minor = ((proc.stdout or "").strip()).split(".")
+        return int(major) == 3 and PY_MIN_MINOR <= int(minor) <= PY_MAX_MINOR
+    except ValueError:
+        return False
+
+
+def _resolve_interpreter(runner: Runner, venv: Path) -> tuple[str, bool]:
+    """Pick the interpreter for the replacement venv.
+
+    Returns ``(python, fallback)`` where ``fallback=True`` means no in-band
+    3.11-3.13 interpreter was found and pip must bypass the requires-python
+    gate (litellm's metadata-only 3.14 cap — the same dance install.sh's
+    fresh-install branch does). Mirrors preflight.sh's
+    ``resolve_hindsight_python`` order, minus interpreter auto-install (a
+    root apt operation that stays preflight-only):
+
+    1. ``HAL0_HINDSIGHT_PYTHON`` — operator override, honored verbatim.
+    2. The existing venv's own base interpreter (realpath through the
+       ``bin/python`` symlink) — on the ``hal0 update`` path preflight never
+       ran, and the interpreter that built the current venv already proved
+       itself. Falls back to ``pyvenv.cfg``'s ``home`` when the symlink
+       dangles.
+    3. ``python3.13`` / ``python3.12`` / ``python3.11`` on PATH.
+    4. This process's own base interpreter, flagged as out-of-band.
+    """
+    override = os.environ.get("HAL0_HINDSIGHT_PYTHON")
+    if override:
+        return override, not _interpreter_in_band(runner, override)
+
+    base = Path(os.path.realpath(venv / "bin" / "python"))
+    if not base.exists():
+        cfg = venv / "pyvenv.cfg"
+        try:
+            for line in cfg.read_text(encoding="utf-8").splitlines():
+                key, _, value = line.partition("=")
+                if key.strip() == "home" and value.strip():
+                    candidate = Path(value.strip()) / "python3"
+                    if candidate.exists():
+                        base = candidate
+                    break
+        except OSError:
+            pass
+    if base.exists() and _interpreter_in_band(runner, str(base)):
+        return str(base), False
+
+    for name in ("python3.13", "python3.12", "python3.11"):
+        found = shutil.which(name)
+        if found and _interpreter_in_band(runner, found):
+            return found, False
+
+    return os.path.realpath(sys.executable), True
+
+
+def _du_bytes(path: Path) -> int:
+    total = 0
+    for p in path.rglob("*"):
+        try:
+            if p.is_file() and not p.is_symlink():
+                total += p.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _prune_keep_newest(parent: Path, pattern: str) -> None:
+    """Delete all-but-the-newest ``pattern`` entries under ``parent``.
+
+    Called only from the converged branch: debris from PRIOR upgrades is
+    removed only once a LATER run has proven the box healthy on the pin, so a
+    failed upgrade always keeps its forensics and its rollback snapshot.
+    """
+    entries = sorted(parent.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+    for stale in entries[1:]:
+        shutil.rmtree(stale, ignore_errors=True)
+
+
+def _svc(seam: SystemCtlSeam, verb: str, *, check: bool = True) -> None:
+    seam.systemctl("systemctl", verb, SERVICE, check=check, timeout=_SYSTEMCTL_TIMEOUT_S)
+
+
+def _poll_health(http_get: Callable[[str], dict | None], total_s: float) -> bool:
+    deadline = time.monotonic() + total_s
+    while time.monotonic() < deadline:
+        if http_get(f"{ENGINE_BASE_URL}/health") is not None:
+            return True
+        time.sleep(_HEALTH_POLL_STEP_S)
+    return False
+
+
+def upgrade_memory_engine(
+    *,
+    job_id: str | None = None,
+    upgrade: bool = True,
+    seam: SystemCtlSeam | None = None,
+    runner: Runner | None = None,
+    http_get: Callable[[str], dict | None] | None = None,
+    hs_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Bring the engine venv to :data:`HINDSIGHT_API_PIN`, or report why not.
+
+    ``upgrade=False`` is the boot-time diagnose-only mode
+    (``check_outstanding_migrations``): staleness is logged with the remedy
+    but no pip runs, no service stops, and no one-way DB migration is
+    triggered outside an operator-visible update — the
+    ``skip_image_retag``/``repair_hermes_venv=False`` posture.
+
+    ``seam``/``runner``/``http_get``/``hs_dir`` are test injection points
+    (default-constructed = production behaviour), mirroring
+    :func:`hal0.memory.extraction_env.apply_extraction_slot`.
+
+    Returns a status dict whose ``status`` is one of ``skipped``,
+    ``converged``, ``stale``, ``build_failed``, ``snapshot_failed``,
+    ``upgraded``, ``rolled_back``. Only genuine bugs raise.
+    """
+    seam = seam if seam is not None else SystemCtlSeam()
+    runner = runner if runner is not None else subprocess.run
+    http_get = http_get if http_get is not None else _http_get_json
+    hs = hs_dir if hs_dir is not None else hindsight_dir()
+
+    venv = hs / ".venv"
+    venv_new = hs / ".venv.new"
+    pg = hs / ".pg0"
+
+    if os.environ.get("HAL0_SKIP_HINDSIGHT") == "1":
+        return {"status": "skipped", "reason": "HAL0_SKIP_HINDSIGHT=1"}
+
+    # Mid-swap crash recovery: a previous run renamed .venv away and died
+    # before renaming .venv.new in. Restore the newest .venv.old-* so the
+    # normal flow (detect → rebuild) can proceed deterministically.
+    if not venv.exists():
+        old_venvs = sorted(hs.glob(".venv.old-*"), key=lambda p: p.stat().st_mtime, reverse=True)
+        if old_venvs:
+            os.rename(old_venvs[0], venv)
+            log.warning(
+                "updater.memory_engine_midswap_recovered",
+                job_id=job_id,
+                restored=old_venvs[0].name,
+            )
+
+    if not os.access(venv / "bin" / "hindsight-api", os.X_OK):
+        # Fresh install (or a box that never had the engine) — install.sh's
+        # job, not this pass's: it owns interpreter preflight, unit install
+        # and bank seeding.
+        return {"status": "skipped", "reason": "no engine venv (fresh install is install.sh's job)"}
+
+    installed = _installed_version(runner, venv) or "unknown"
+    if installed == HINDSIGHT_API_PIN:
+        _prune_keep_newest(hs, ".venv.old-*")
+        _prune_keep_newest(hs, ".pg0.pre-*")
+        return {"status": "converged", "version": installed}
+
+    if not upgrade:
+        log.warning(
+            "updater.memory_engine_stale",
+            job_id=job_id,
+            installed=installed,
+            pinned=HINDSIGHT_API_PIN,
+            remedy="run 'hal0 update' or re-run install.sh",
+        )
+        return {"status": "stale", "installed": installed, "pinned": HINDSIGHT_API_PIN}
+
+    pg_snap = hs / f".pg0.pre-{installed}"
+    venv_old = hs / f".venv.old-{installed}"
+    result: dict[str, Any] = {
+        "from": installed,
+        "to": HINDSIGHT_API_PIN,
+        "snapshot": str(pg_snap),
+    }
+
+    # ── Build aside (engine still serving; a failure here costs nothing) ──
+    py, fallback = _resolve_interpreter(runner, venv)
+    shutil.rmtree(venv_new, ignore_errors=True)
+    try:
+        proc = _run(runner, [py, "-m", "venv", str(venv_new)], timeout=_VENV_TIMEOUT_S)
+        if proc.returncode != 0:
+            raise subprocess.SubprocessError(proc.stderr or "venv creation failed")
+        pip = str(venv_new / "bin" / "pip")
+        _run(runner, [pip, "install", "--upgrade", "pip", "wheel", "-q"], timeout=_PIP_TIMEOUT_S)
+        spec = f"hindsight-api=={HINDSIGHT_API_PIN}"
+        proc = _run(runner, [pip, "install", spec, "-q"], timeout=_PIP_TIMEOUT_S)
+        if proc.returncode != 0 and not fallback:
+            # Same two-attempt dance as install.sh's fresh-install branch:
+            # litellm's requires-python gate is metadata-only.
+            fallback = True
+        if proc.returncode != 0:
+            proc = _run(
+                runner,
+                [pip, "install", "--ignore-requires-python", spec, "-q"],
+                timeout=_PIP_TIMEOUT_S,
+            )
+            if proc.returncode != 0:
+                raise subprocess.SubprocessError(proc.stderr or "pip install failed")
+        built = _installed_version(runner, venv_new)
+        if built != HINDSIGHT_API_PIN or not os.access(venv_new / "bin" / "hindsight-api", os.X_OK):
+            # pip exit codes lie (#2021); only the venv's own probe is truth.
+            raise subprocess.SubprocessError(
+                f"built venv reports {built!r}, expected {HINDSIGHT_API_PIN!r}"
+            )
+    except (OSError, subprocess.SubprocessError) as exc:
+        shutil.rmtree(venv_new, ignore_errors=True)
+        log.warning(
+            "updater.memory_engine_build_failed",
+            job_id=job_id,
+            error=str(exc),
+            remedy=(
+                f"engine still on {installed}; re-run 'hal0 update' or install.sh "
+                "when the cause (network, disk, interpreter) is fixed"
+            ),
+        )
+        return {**result, "status": "build_failed", "error": str(exc)}
+    _chown_tree(venv_new)
+
+    # ── Stop the engine; quiesce .pg0 for a consistent snapshot ──
+    try:
+        _svc(seam, "stop")
+    except (OSError, subprocess.SubprocessError) as exc:
+        shutil.rmtree(venv_new, ignore_errors=True)
+        log.warning("updater.memory_engine_stop_failed", job_id=job_id, error=str(exc))
+        return {**result, "status": "build_failed", "error": f"stop failed: {exc}"}
+
+    # ── Snapshot: the only rollback for a one-way alembic migration ──
+    if pg.exists() and not pg_snap.exists():
+        free = shutil.disk_usage(hs).free
+        needed = int(_du_bytes(pg) * _SNAPSHOT_FREE_FACTOR)
+        if free < needed:
+            shutil.rmtree(venv_new, ignore_errors=True)
+            _svc(seam, "start", check=False)
+            log.warning(
+                "updater.memory_engine_snapshot_no_space",
+                job_id=job_id,
+                free=free,
+                needed=needed,
+                remedy=f"free {needed} bytes under {hs} and re-run — never upgrading "
+                "without a .pg0 snapshot (the DB migration is one-way)",
+            )
+            return {**result, "status": "snapshot_failed", "error": "insufficient disk space"}
+        proc = _run(runner, ["cp", "-a", str(pg), str(pg_snap)], timeout=_PIP_TIMEOUT_S)
+        if proc.returncode != 0:
+            shutil.rmtree(pg_snap, ignore_errors=True)
+            shutil.rmtree(venv_new, ignore_errors=True)
+            _svc(seam, "start", check=False)
+            log.warning(
+                "updater.memory_engine_snapshot_failed",
+                job_id=job_id,
+                error=proc.stderr,
+            )
+            return {**result, "status": "snapshot_failed", "error": proc.stderr}
+        _chown_tree(pg_snap)
+
+    # ── Swap (two same-fs renames) ──
+    shutil.rmtree(venv_old, ignore_errors=True)
+    os.rename(venv, venv_old)
+    os.rename(venv_new, venv)
+
+    # ── Start + postcheck ──
+    healthy = False
+    try:
+        _svc(seam, "start")
+        healthy = _poll_health(http_get, _HEALTH_POLL_TOTAL_S)
+    except (OSError, subprocess.SubprocessError) as exc:
+        log.warning("updater.memory_engine_start_failed", job_id=job_id, error=str(exc))
+
+    reported: str | None = None
+    if healthy:
+        version_payload = http_get(f"{ENGINE_BASE_URL}/version") or {}
+        reported = version_payload.get("api_version")
+        if reported == HINDSIGHT_API_PIN:
+            log.info(
+                "updater.memory_engine_upgraded",
+                job_id=job_id,
+                installed=installed,
+                pinned=HINDSIGHT_API_PIN,
+            )
+            return {**result, "status": "upgraded"}
+
+    # ── Rollback: a new engine process launched, so alembic may have begun —
+    # restore BOTH the venv and .pg0 (copy, so the snapshot survives a retry).
+    error = (
+        f"/version reported {reported!r}, expected {HINDSIGHT_API_PIN!r} — check "
+        "/etc/systemd/system/hindsight-api.service.d/ for an ExecStart override"
+        if healthy
+        else f"engine failed /health within {_HEALTH_POLL_TOTAL_S}s after swap"
+    )
+    _svc(seam, "stop", check=False)
+    failed_venv = hs / f".venv.failed-{HINDSIGHT_API_PIN}"
+    shutil.rmtree(failed_venv, ignore_errors=True)
+    os.rename(venv, failed_venv)
+    os.rename(venv_old, venv)
+    if pg_snap.exists():
+        shutil.rmtree(pg, ignore_errors=True)
+        proc = _run(runner, ["cp", "-a", str(pg_snap), str(pg)], timeout=_PIP_TIMEOUT_S)
+        if proc.returncode == 0:
+            _chown_tree(pg)
+        else:
+            log.warning(
+                "updater.memory_engine_pg_restore_failed",
+                job_id=job_id,
+                error=proc.stderr,
+                remedy=f"restore {pg_snap} to {pg} by hand, then restart {SERVICE}",
+            )
+    _svc(seam, "start", check=False)
+    old_healthy = _poll_health(http_get, _ROLLBACK_HEALTH_POLL_TOTAL_S)
+    log.warning(
+        "updater.memory_engine_upgrade_failed",
+        job_id=job_id,
+        error=error,
+        old_engine_healthy=old_healthy,
+        remedy=(
+            f"rolled back to {installed} (db restored from {pg_snap}); inspect "
+            f"'journalctl -u {SERVICE}' and {failed_venv}, then re-run 'hal0 update'"
+            if old_healthy
+            else f"engine down after rollback — run 'systemctl restart {SERVICE}' and "
+            f"check the journal; snapshot {pg_snap} is preserved for retry"
+        ),
+    )
+    return {
+        **result,
+        "status": "rolled_back",
+        "error": error,
+        "old_engine_healthy": old_healthy,
+    }

--- a/src/hal0/memory/engine_upgrade.py
+++ b/src/hal0/memory/engine_upgrade.py
@@ -142,6 +142,38 @@ def _chown_tree(path: Path) -> None:
         log.warning("updater.memory_engine_chown_failed", path=str(path), error=str(exc))
 
 
+def _retarget_scripts(venv_new: Path, venv_final: Path) -> None:
+    """Rewrite the build-aside path to the final path in bin/ launchers.
+
+    pip writes console scripts with an ABSOLUTE shebang, so everything built
+    at ``.venv.new`` execs ``<...>/.venv.new/bin/python3.x`` — after the
+    rename swap that interpreter no longer exists and every entry point
+    (systemd's ``ExecStart=…/.venv/bin/hindsight-api`` included) fails
+    ENOENT, while the pre-swap checks all pass (the file exists, is
+    executable, and the version probe names its interpreter explicitly).
+    Found by the component-updates engine gate running the real upgrade:
+    without this, every upgrade fails postcheck and rolls back, and no box
+    can ever converge onto a new pin.
+
+    Plain path substitution over the small text launchers, which also covers
+    pip's ``#!/bin/sh`` trampoline form (long/space-y prefixes) where the
+    path sits in an exec line rather than the shebang. Symlinks
+    (``bin/python*`` → the base interpreter) and binary files are untouched;
+    ``pyvenv.cfg``'s ``home`` points at the base interpreter and needs no
+    rewrite. In-place write preserves each script's mode.
+    """
+    old, new = str(venv_new), str(venv_final)
+    for script in (venv_new / "bin").iterdir():
+        if script.is_symlink() or not script.is_file():
+            continue
+        try:
+            text = script.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue  # compiled/binary launcher — no embedded build path
+        if old in text:
+            script.write_text(text.replace(old, new), encoding="utf-8")
+
+
 def _installed_version(runner: Runner, venv: Path) -> str | None:
     """The ``hindsight-api`` dist version inside ``venv``, or ``None``.
 
@@ -379,6 +411,7 @@ def upgrade_memory_engine(
             raise subprocess.SubprocessError(
                 f"built venv reports {built!r}, expected {HINDSIGHT_API_PIN!r}"
             )
+        _retarget_scripts(venv_new, venv)
     except (OSError, subprocess.SubprocessError) as exc:
         shutil.rmtree(venv_new, ignore_errors=True)
         log.warning(

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1867,6 +1867,7 @@ def run_post_activation_migrations(
     ceiling: int | None = None,
     skip_image_retag: bool = False,
     repair_hermes_venv: bool = True,
+    upgrade_memory_engine_venv: bool = True,
 ) -> tuple[int, int]:
     """Run every post-activation migration pass hal0 ships, in order.
 
@@ -1907,6 +1908,22 @@ def run_post_activation_migrations(
     :func:`_maybe_run_config_migrations` for why (the one-shot v1.0
     profile-catalog reset gate). ``None`` (the default, and what
     install.sh's caller always passes) applies no cap.
+
+    ``upgrade_memory_engine_venv`` gates the hindsight engine-venv
+    convergence pass (:func:`hal0.memory.engine_upgrade.upgrade_memory_engine`).
+    It runs LAST: it is the slowest pass by an order of magnitude (a pip
+    build of the engine's ML wheel set) and it stops/starts the
+    ``hindsight-api`` companion service — every cheap config-convergence
+    pass should land even when it wedges, and it has no ordering dependency
+    on any of them (the engine venv is disjoint state).
+    :func:`check_outstanding_migrations` passes ``False`` — the engine pass
+    is the ``retag_stale_slot_images``/``repair_hermes_venv`` argument taken
+    further still: a boot-time pip is an unbounded network operation, the
+    stop/start is a surprise memory outage on every crash-restart race, and
+    the first start of a newer engine triggers its ONE-WAY database
+    migration — none of which belongs outside an operator-visible update.
+    At boot the pass only logs ``updater.memory_engine_stale`` with the
+    remedy.
 
     ``skip_image_retag`` (#1960 N2) omits ``retag_stale_slot_images``.
     Every OTHER pass here is either purely additive (seed profiles, mtp
@@ -1980,6 +1997,17 @@ def run_post_activation_migrations(
         # Non-fatal: an affected model keeps failing to launch until the
         # operator removes the managed flag in the model drawer.
 
+    try:
+        from hal0.memory.engine_upgrade import upgrade_memory_engine
+
+        upgrade_memory_engine(job_id=job_id, upgrade=upgrade_memory_engine_venv)
+    except Exception as exc:
+        log.warning("updater.memory_engine_upgrade_failed", job_id=job_id, error=str(exc))
+        # Non-fatal: the pass itself reports operational failures as status
+        # dicts (and logs this same event with a remedy); reaching here means
+        # a genuine bug, and the box keeps its current working engine either
+        # way — never a reason to fail an update.
+
     return migration_info
 
 
@@ -2036,6 +2064,7 @@ def check_outstanding_migrations(*, job_id: str | None = None) -> tuple[int, int
             ceiling=ceiling,
             skip_image_retag=True,
             repair_hermes_venv=False,
+            upgrade_memory_engine_venv=False,
         )
     except Exception as exc:
         log.warning("updater.boot_migration_check_failed", job_id=job_id, error=str(exc))
@@ -4140,7 +4169,7 @@ async def _rerender_units_after_swap(job_id: str | None) -> None:
 #: stdout carries nothing but this envelope, scanned from the end.
 _MIGRATION_RESULT_KEY = "hal0_migration_result"
 
-#: The five non-fatal per-pass failure events ``run_post_activation_migrations``
+#: The non-fatal per-pass failure events ``run_post_activation_migrations``
 #: can log without raising (#1960 B2). A pass that swallows its own
 #: exception still exits the subprocess with rc=0 — by design, see that
 #: function's docstring — so it would otherwise be invisible outside
@@ -4153,6 +4182,7 @@ _NON_FATAL_MIGRATION_FAILURE_EVENTS: tuple[str, ...] = (
     "updater.vulkan_migration_failed",
     "updater.image_retag_failed",
     "updater.extra_args_sanitize_failed",
+    "updater.memory_engine_upgrade_failed",
 )
 
 
@@ -4244,7 +4274,13 @@ async def _run_post_activation_migrations_after_swap(
             [sys.executable, "-c", script, payload],
             capture_output=True,
             text=True,
-            timeout=300,
+            # 2700s, not the old 300s: the memory-engine convergence pass may
+            # pip-build the hindsight venv (transformers/sentence-transformers
+            # wheel churn — gigabytes). Its own pip runs are capped at 2400s
+            # (hal0.memory.engine_upgrade._PIP_TIMEOUT_S) so this envelope
+            # always has headroom to emit the JSON result; fast passes still
+            # finish fast — this is a runaway cap, not a wait.
+            timeout=2700,
         )
     except subprocess.TimeoutExpired as exc:
         # Same containment class as _rerender_units_after_swap and the
@@ -4252,8 +4288,8 @@ async def _run_post_activation_migrations_after_swap(
         # rather than return a CompletedProcess, and the old code only
         # handled the "returns a non-zero CompletedProcess" shape (#1960 B1).
         raise UpdateError(
-            "post-activation migrations timed out after 300s in the newly activated tree",
-            details={"job_id": job_id, "timeout": 300},
+            "post-activation migrations timed out after 2700s in the newly activated tree",
+            details={"job_id": job_id, "timeout": 2700},
         ) from exc
     except OSError as exc:
         raise UpdateError(

--- a/tests/api/test_memory_graph_route.py
+++ b/tests/api/test_memory_graph_route.py
@@ -398,7 +398,9 @@ class _HindsightyWrapper(StubWrapper):
 
         class _Client:
             async def request_json(self, method: str, path: str) -> Any:
-                if path == "/v1/default/banks":
+                if path.startswith("/v1/default/banks?") or path == "/v1/default/banks":
+                    # 0.9.x paginates (limit/offset); this 0.8.x-shaped reply
+                    # has no `total`, so the route stops after one page.
                     return {"banks": [{"bank_id": b} for b in parent._stats]}
                 for bank, stats in parent._stats.items():
                     if path == f"/v1/default/banks/{bank}/stats":
@@ -463,7 +465,9 @@ class _RetryWrapper(StubWrapper):
 
         class _Client:
             async def request_json(self, method: str, path: str) -> Any:
-                if method == "GET" and path == "/v1/default/banks":
+                if method == "GET" and (
+                    path.startswith("/v1/default/banks?") or path == "/v1/default/banks"
+                ):
                     return {"banks": [{"bank_id": b} for b in parent._ops]}
                 for bank, ops in parent._ops.items():
                     if method == "GET" and path.startswith(f"/v1/default/banks/{bank}/operations?"):

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -1016,7 +1016,12 @@ def test_memory_engine_version_passes_on_pin_match() -> None:
     from hal0.memory.engine_upgrade import HINDSIGHT_API_PIN
 
     check = da.check_memory_engine_version(
-        memory={"enabled": True, "engine": "hindsight", "reachable": True, "version": HINDSIGHT_API_PIN}
+        memory={
+            "enabled": True,
+            "engine": "hindsight",
+            "reachable": True,
+            "version": HINDSIGHT_API_PIN,
+        }
     )
     assert check.status == "pass"
 

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -929,8 +929,8 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
 
     checks = da.build_all_checks()
     keys = [c.key for c in checks]
-    # 7 verify rows + 16 extras.
-    assert keys[-16:] == [
+    # 7 verify rows + 17 extras.
+    assert keys[-17:] == [
         "auth",
         "models",
         "migrations",
@@ -947,6 +947,7 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
         "hermes_mcp_auth",
         "hermes_anchor_window",
         "hindsight_llm_auth",
+        "memory_engine_version",
     ]
     assert "api" in keys and "runners" in keys
     assert da.overall_verdict(checks) == "ok"
@@ -1006,6 +1007,37 @@ def test_hindsight_llm_auth_passes_on_current_key_fails_on_stale(
     check = da.check_hindsight_llm_auth(auth={"auth_required": True}, unit_path=unit, env_path=env)
     assert check.status == "fail"
     assert "stale" in check.detail
+
+
+# ── memory engine version (staleness signal, never a FAIL) ───────────────────
+
+
+def test_memory_engine_version_passes_on_pin_match() -> None:
+    from hal0.memory.engine_upgrade import HINDSIGHT_API_PIN
+
+    check = da.check_memory_engine_version(
+        memory={"enabled": True, "engine": "hindsight", "reachable": True, "version": HINDSIGHT_API_PIN}
+    )
+    assert check.status == "pass"
+
+
+def test_memory_engine_version_warns_on_stale_engine_with_remedy() -> None:
+    check = da.check_memory_engine_version(
+        memory={"enabled": True, "engine": "hindsight", "reachable": True, "version": "0.8.4"}
+    )
+    assert check.status == "warn"  # advisory: behavior gates on features, not versions
+    assert "hal0 update" in check.detail
+    assert "0.8.4" in check.detail
+
+
+def test_memory_engine_version_passes_when_memory_disabled_or_unreachable() -> None:
+    assert da.check_memory_engine_version(memory={"enabled": True, "engine": None}).status == "pass"
+    # Reachability is the memory row's job — no duplicate noise here.
+    check = da.check_memory_engine_version(
+        memory={"enabled": True, "engine": "hindsight", "reachable": False, "version": None}
+    )
+    assert check.status == "pass"
+    assert da.check_memory_engine_version(memory=None).status == "warn"
 
 
 # ── command ───────────────────────────────────────────────────────────────────

--- a/tests/cli/test_memory_ops_commands.py
+++ b/tests/cli/test_memory_ops_commands.py
@@ -92,7 +92,8 @@ def test_ops_list_fans_out_across_banks(stub_api) -> None:
     payload = json.loads(result.output)
     banks = {op["bank_id"] for op in payload["operations"]}
     assert banks == {"shared", "private__hermes"}
-    assert ("/api/memory/banks", None) in stub_api["get"]
+    # The fan-out enumerates banks through the (0.9.x-paginated) list.
+    assert ("/api/memory/banks", {"limit": "100", "offset": "0"}) in stub_api["get"]
 
 
 def test_ops_list_failed_only_sets_status_param(stub_api) -> None:

--- a/tests/installer/test_hindsight_pin_lockstep.py
+++ b/tests/installer/test_hindsight_pin_lockstep.py
@@ -1,0 +1,49 @@
+"""install.sh's ``HINDSIGHT_PIN`` stays in lockstep with the python constant.
+
+The engine version pin has exactly two declaration sites by design:
+
+* :data:`hal0.memory.engine_upgrade.HINDSIGHT_API_PIN` — read by the
+  engine-upgrade migration pass, the doctor version check, and anything else
+  python-side;
+* ``HINDSIGHT_PIN="..."`` in ``installer/install.sh`` — a shell literal so the
+  fresh-install branch works even when the python side is broken.
+
+This test is the sync mechanism (the ``runner-image-pins`` pattern): bump one
+side and it fails naming the exact value the other side must carry. It also
+sweeps install.sh for stray hard-coded ``hindsight-api==X`` literals so a
+future edit can't quietly reintroduce a third declaration site.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from hal0.memory.engine_upgrade import HINDSIGHT_API_PIN
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
+
+
+def test_install_sh_pin_matches_python_constant() -> None:
+    text = _INSTALL_SH.read_text(encoding="utf-8")
+    match = re.search(r'^\s*HINDSIGHT_PIN="([^"]+)"', text, flags=re.MULTILINE)
+    assert match, "installer/install.sh no longer declares HINDSIGHT_PIN"
+    assert match.group(1) == HINDSIGHT_API_PIN, (
+        f"installer/install.sh pins HINDSIGHT_PIN={match.group(1)!r} but "
+        f"hal0.memory.engine_upgrade.HINDSIGHT_API_PIN is {HINDSIGHT_API_PIN!r} — "
+        "update whichever side is stale so both carry the same version"
+    )
+
+
+def test_install_sh_has_no_stray_hardcoded_pins() -> None:
+    text = _INSTALL_SH.read_text(encoding="utf-8")
+    stray = [
+        line.strip()
+        for line in text.splitlines()
+        if re.search(r"hindsight-api==(?!\$\{HINDSIGHT_PIN\})", line)
+    ]
+    assert not stray, (
+        "install.sh hard-codes a hindsight-api version instead of using "
+        f"${{HINDSIGHT_PIN}}: {stray}"
+    )

--- a/tests/installer/test_install_smoke_probes.py
+++ b/tests/installer/test_install_smoke_probes.py
@@ -175,9 +175,7 @@ def test_memory_engine_probe_skips_when_engine_not_installed(tmp_path: Path) -> 
     installed) — the probe must skip, not fail: curl faked dead proves it
     never even probes."""
     _write_exec(tmp_path / "curl", "exit 7")
-    res = _drive(
-        tmp_path, f'HINDSIGHT_UNIT_DST="{tmp_path}/missing"\nsmoke_memory_engine_version'
-    )
+    res = _drive(tmp_path, f'HINDSIGHT_UNIT_DST="{tmp_path}/missing"\nsmoke_memory_engine_version')
     assert res.returncode == 0, res.stderr
 
 

--- a/tests/installer/test_install_smoke_probes.py
+++ b/tests/installer/test_install_smoke_probes.py
@@ -92,10 +92,11 @@ def _drive(tmp_path: Path, script_body: str) -> subprocess.CompletedProcess[str]
         "#!/usr/bin/env bash\nset -uo pipefail\n"
         "info() { :; }\n"
         'warn() { echo "WARN: $*" >&2; }\n'
-        "HAL0_PORT=8080\nPY=python3\n"
+        "HAL0_PORT=8080\nPY=python3\nHINDSIGHT_PIN=9.9.9\n"
         f"HAL0_BIN={tmp_path}/hal0\n"
         f"{_extract('smoke_structured_output')}\n"
         f"{_extract('smoke_update_check')}\n"
+        f"{_extract('smoke_memory_engine_version')}\n"
         f"{_extract('run_post_install_smoke')}\n"
         "SMOKE_FAILED=()\n"
         f"{script_body}\n",
@@ -151,6 +152,33 @@ def test_smoke_is_fail_soft_and_records_failures(tmp_path: Path) -> None:
     assert "structured-output" in res.stdout
     assert "update-check" in res.stdout
     assert "WARN:" in res.stderr, "fail-soft still has to be LOUD"
+
+
+def test_memory_engine_probe_passes_on_pin_match(tmp_path: Path) -> None:
+    unit = tmp_path / "hindsight-api.service"
+    unit.write_text("[Service]\n", encoding="utf-8")
+    _write_exec(tmp_path / "curl", 'echo \'{"api_version": "9.9.9"}\'')
+    res = _drive(tmp_path, f'HINDSIGHT_UNIT_DST="{unit}"\nsmoke_memory_engine_version')
+    assert res.returncode == 0, res.stderr
+
+
+def test_memory_engine_probe_fails_on_stale_engine(tmp_path: Path) -> None:
+    unit = tmp_path / "hindsight-api.service"
+    unit.write_text("[Service]\n", encoding="utf-8")
+    _write_exec(tmp_path / "curl", 'echo \'{"api_version": "0.8.4"}\'')
+    res = _drive(tmp_path, f'HINDSIGHT_UNIT_DST="{unit}"\nsmoke_memory_engine_version')
+    assert res.returncode != 0
+
+
+def test_memory_engine_probe_skips_when_engine_not_installed(tmp_path: Path) -> None:
+    """No unit file (fresh box with HAL0_SKIP_HINDSIGHT, or engine never
+    installed) — the probe must skip, not fail: curl faked dead proves it
+    never even probes."""
+    _write_exec(tmp_path / "curl", "exit 7")
+    res = _drive(
+        tmp_path, f'HINDSIGHT_UNIT_DST="{tmp_path}/missing"\nsmoke_memory_engine_version'
+    )
+    assert res.returncode == 0, res.stderr
 
 
 def test_smoke_failures_surface_in_the_summary_box() -> None:

--- a/tests/installer/test_migration_convergence.py
+++ b/tests/installer/test_migration_convergence.py
@@ -47,9 +47,9 @@ def test_migration_sequence_runs_engine_pass_by_default_but_not_at_boot() -> Non
     seq_src = inspect.getsource(updater.run_post_activation_migrations)
     assert "upgrade_memory_engine(" in seq_src
     assert "updater.memory_engine_upgrade_failed" in seq_src
-    assert (
-        "updater.memory_engine_upgrade_failed" in updater._NON_FATAL_MIGRATION_FAILURE_EVENTS
-    ), "a swallowed engine-pass failure must surface in commit()'s convergence report"
+    assert "updater.memory_engine_upgrade_failed" in updater._NON_FATAL_MIGRATION_FAILURE_EVENTS, (
+        "a swallowed engine-pass failure must surface in commit()'s convergence report"
+    )
 
 
 def test_install_sh_no_longer_hand_picks_a_migration_subset() -> None:

--- a/tests/installer/test_migration_convergence.py
+++ b/tests/installer/test_migration_convergence.py
@@ -26,6 +26,32 @@ def test_install_sh_calls_the_shared_migration_sequence() -> None:
     )
 
 
+def test_migration_sequence_runs_engine_pass_by_default_but_not_at_boot() -> None:
+    """The memory-engine venv convergence pass must ride the shared sequence
+    on both real upgrade paths (default kwarg — install.sh passes none) while
+    the boot-time safety net opts out: a boot-time pip is an unbounded
+    network op and the first start of a newer engine triggers its one-way DB
+    migration, neither of which belongs outside an operator-visible update
+    (the ``skip_image_retag``/``repair_hermes_venv`` posture, one step
+    further)."""
+    import inspect
+
+    from hal0.updater import updater
+
+    seq = inspect.signature(updater.run_post_activation_migrations)
+    assert seq.parameters["upgrade_memory_engine_venv"].default is True
+
+    boot_src = inspect.getsource(updater.check_outstanding_migrations)
+    assert "upgrade_memory_engine_venv=False" in boot_src
+
+    seq_src = inspect.getsource(updater.run_post_activation_migrations)
+    assert "upgrade_memory_engine(" in seq_src
+    assert "updater.memory_engine_upgrade_failed" in seq_src
+    assert (
+        "updater.memory_engine_upgrade_failed" in updater._NON_FATAL_MIGRATION_FAILURE_EVENTS
+    ), "a swallowed engine-pass failure must surface in commit()'s convergence report"
+
+
 def test_install_sh_no_longer_hand_picks_a_migration_subset() -> None:
     """The old two-heredoc block imported ensure_seed_profiles and
     clear_stale_mtp_overrides directly, skipping _maybe_run_config_migrations,

--- a/tests/memory/test_engine_upgrade.py
+++ b/tests/memory/test_engine_upgrade.py
@@ -46,7 +46,9 @@ def _make_venv_tree(venv: Path) -> None:
     (venv / "bin").mkdir(parents=True)
     for name in ("python", "pip", "hindsight-api"):
         f = venv / "bin" / name
-        f.write_text("#!/bin/sh\n")
+        # Console scripts carry pip's ABSOLUTE shebang naming the venv they
+        # were built in — the shape the shebang-retarget regression rides on.
+        f.write_text(f"#!{venv}/bin/python3.13\n" if name != "python" else "#!/bin/sh\n")
         f.chmod(0o755)
 
 
@@ -183,6 +185,19 @@ def test_happy_path_swaps_snapshots_and_postchecks(hs):
 
 class _NoFreeDisk:
     free = 0
+
+
+def test_swapped_scripts_shebang_points_at_the_final_venv(hs):
+    """pip's absolute shebangs name .venv.new; after the rename swap they
+    must name .venv or every entry point (systemd ExecStart included) execs
+    a deleted interpreter — found by the component-updates engine gate."""
+    result = upgrade_memory_engine(
+        seam=FakeSeam(), runner=FakeRunner(), http_get=_healthy, hs_dir=hs
+    )
+    assert result["status"] == "upgraded"
+    launcher = (hs / ".venv" / "bin" / "hindsight-api").read_text()
+    assert ".venv.new" not in launcher
+    assert f"#!{hs}/.venv/bin/python3.13" in launcher
 
 
 def test_snapshot_disk_full_aborts_and_restarts_old_engine(hs, monkeypatch):

--- a/tests/memory/test_engine_upgrade.py
+++ b/tests/memory/test_engine_upgrade.py
@@ -1,0 +1,253 @@
+"""Unit tests for the memory-engine venv convergence pass.
+
+``upgrade_memory_engine`` rebuilds the hindsight venv aside, snapshots the
+embedded postgres dir, swaps, postchecks ``/health`` + ``/version`` and rolls
+both back on failure. Everything privileged or slow is injected (seam, runner,
+http_get, hs_dir) so the whole state machine runs against a tmp_path.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hal0.memory.engine_upgrade import (
+    HINDSIGHT_API_PIN,
+    upgrade_memory_engine,
+)
+
+OLD_VERSION = "0.8.4"
+
+
+class FakeSeam:
+    """Record every systemctl verb; optionally fail a specific one."""
+
+    def __init__(self, fail_verbs: set[str] | None = None):
+        self.calls: list[tuple[str, ...]] = []
+        self.fail_verbs = fail_verbs or set()
+
+    def systemctl(self, *args: str, check: bool = True, timeout: float | None = None):
+        self.calls.append(args)
+        verb = args[1]
+        if verb in self.fail_verbs and check:
+            raise subprocess.CalledProcessError(1, list(args))
+        return subprocess.CompletedProcess(list(args), 0, "", "")
+
+    @property
+    def verbs(self) -> list[str]:
+        return [c[1] for c in self.calls]
+
+
+def _make_venv_tree(venv: Path) -> None:
+    (venv / "bin").mkdir(parents=True)
+    for name in ("python", "pip", "hindsight-api"):
+        f = venv / "bin" / name
+        f.write_text("#!/bin/sh\n")
+        f.chmod(0o755)
+
+
+class FakeRunner:
+    """Dispatch the pass's subprocess calls against the tmp tree.
+
+    * ``python -m venv X`` materialises a venv skeleton at X;
+    * version probes answer by which venv's interpreter is asked;
+    * pip installs return ``pip_rc``;
+    * ``cp -a`` really copies (the rollback assertions depend on it).
+    """
+
+    def __init__(self, *, pip_rc: int = 0, new_version: str = HINDSIGHT_API_PIN):
+        self.pip_rc = pip_rc
+        self.new_version = new_version
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args, **kwargs):
+        args = [str(a) for a in args]
+        self.calls.append(args)
+        if len(args) >= 4 and args[1:3] == ["-m", "venv"]:
+            _make_venv_tree(Path(args[3]))
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[0] == "cp" and args[1] == "-a":
+            shutil.copytree(args[2], args[3])
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if len(args) >= 3 and args[1] == "-c" and "importlib.metadata" in args[2]:
+            version = self.new_version if ".venv.new" in args[0] else OLD_VERSION
+            return subprocess.CompletedProcess(args, 0, f"{version}\n", "")
+        if len(args) >= 3 and args[1] == "-c" and "version_info" in args[2]:
+            return subprocess.CompletedProcess(args, 0, "3.12\n", "")
+        if "pip" in Path(args[0]).name and "install" in args:
+            if "wheel" in args:  # the pip/wheel bootstrap is always best-effort
+                return subprocess.CompletedProcess(args, 0, "", "")
+            return subprocess.CompletedProcess(args, self.pip_rc, "", "resolver says no")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+
+@pytest.fixture()
+def hs(tmp_path: Path) -> Path:
+    hs = tmp_path / "hindsight"
+    _make_venv_tree(hs / ".venv")
+    (hs / ".pg0").mkdir()
+    (hs / ".pg0" / "PG_VERSION").write_text("18\n")
+    return hs
+
+
+def _healthy(url: str):
+    if url.endswith("/version"):
+        return {"api_version": HINDSIGHT_API_PIN}
+    return {"status": "healthy"}
+
+
+def test_skip_env_hatch(hs, monkeypatch):
+    monkeypatch.setenv("HAL0_SKIP_HINDSIGHT", "1")
+    result = upgrade_memory_engine(seam=FakeSeam(), runner=FakeRunner(), hs_dir=hs)
+    assert result["status"] == "skipped"
+
+
+def test_fresh_install_is_not_our_job(tmp_path):
+    seam = FakeSeam()
+    result = upgrade_memory_engine(seam=seam, runner=FakeRunner(), hs_dir=tmp_path / "empty")
+    assert result["status"] == "skipped"
+    assert seam.calls == []
+
+
+def test_converged_prunes_all_but_newest_debris(hs):
+    runner = FakeRunner()
+    runner.new_version = HINDSIGHT_API_PIN
+
+    def versioned(args, **kwargs):  # the existing venv already reports the pin
+        args = [str(a) for a in args]
+        if len(args) >= 3 and "importlib.metadata" in args[2]:
+            return subprocess.CompletedProcess(args, 0, f"{HINDSIGHT_API_PIN}\n", "")
+        return runner(args, **kwargs)
+
+    for name, age in (
+        (".venv.old-0.7.2", 100),
+        (".venv.old-0.8.4", 50),
+        (".pg0.pre-0.7.2", 100),
+        (".pg0.pre-0.8.4", 50),
+    ):
+        d = hs / name
+        d.mkdir()
+        stamp = d.stat().st_mtime - age
+        os.utime(d, (stamp, stamp))
+
+    seam = FakeSeam()
+    result = upgrade_memory_engine(seam=seam, runner=versioned, hs_dir=hs)
+    assert result == {"status": "converged", "version": HINDSIGHT_API_PIN}
+    assert seam.calls == []
+    assert sorted(p.name for p in hs.glob(".venv.old-*")) == [".venv.old-0.8.4"]
+    assert sorted(p.name for p in hs.glob(".pg0.pre-*")) == [".pg0.pre-0.8.4"]
+
+
+def test_boot_mode_reports_stale_and_touches_nothing(hs):
+    seam = FakeSeam()
+    result = upgrade_memory_engine(upgrade=False, seam=seam, runner=FakeRunner(), hs_dir=hs)
+    assert result["status"] == "stale"
+    assert result["installed"] == OLD_VERSION
+    assert result["pinned"] == HINDSIGHT_API_PIN
+    assert seam.calls == []
+    assert not (hs / ".venv.new").exists()
+
+
+def test_build_failure_never_stops_the_engine(hs):
+    seam = FakeSeam()
+    result = upgrade_memory_engine(seam=seam, runner=FakeRunner(pip_rc=1), hs_dir=hs)
+    assert result["status"] == "build_failed"
+    assert seam.calls == []  # engine never stopped
+    assert not (hs / ".venv.new").exists()  # partial build removed
+    assert (hs / ".venv" / "bin" / "hindsight-api").exists()  # old venv intact
+
+
+def test_wrong_built_version_is_a_build_failure(hs):
+    seam = FakeSeam()
+    runner = FakeRunner(new_version="0.9.1")  # pip "succeeded" but built the wrong thing
+    result = upgrade_memory_engine(seam=seam, runner=runner, hs_dir=hs)
+    assert result["status"] == "build_failed"
+    assert seam.calls == []
+
+
+def test_happy_path_swaps_snapshots_and_postchecks(hs):
+    seam = FakeSeam()
+    result = upgrade_memory_engine(seam=seam, runner=FakeRunner(), http_get=_healthy, hs_dir=hs)
+    assert result["status"] == "upgraded"
+    assert result["from"] == OLD_VERSION and result["to"] == HINDSIGHT_API_PIN
+    assert seam.verbs == ["stop", "start"]
+    assert (hs / f".pg0.pre-{OLD_VERSION}" / "PG_VERSION").exists()  # snapshot taken
+    assert (hs / f".venv.old-{OLD_VERSION}" / "bin" / "hindsight-api").exists()
+    assert (hs / ".venv" / "bin" / "hindsight-api").exists()
+    assert not (hs / ".venv.new").exists()
+
+
+class _NoFreeDisk:
+    free = 0
+
+
+def test_snapshot_disk_full_aborts_and_restarts_old_engine(hs, monkeypatch):
+    monkeypatch.setattr("hal0.memory.engine_upgrade.shutil.disk_usage", lambda _: _NoFreeDisk())
+    seam = FakeSeam()
+    result = upgrade_memory_engine(seam=seam, runner=FakeRunner(), http_get=_healthy, hs_dir=hs)
+    assert result["status"] == "snapshot_failed"
+    assert seam.verbs == ["stop", "start"]  # old engine brought back
+    assert not (hs / ".venv.new").exists()
+    assert not (hs / f".pg0.pre-{OLD_VERSION}").exists()
+    assert (hs / ".venv" / "bin" / "hindsight-api").exists()
+
+
+def test_version_mismatch_after_start_rolls_back_venv_and_pg(hs):
+    def wrong_version(url: str):
+        if url.endswith("/version"):
+            return {"api_version": "0.0.0"}
+        return {"status": "healthy"}
+
+    seam = FakeSeam()
+    result = upgrade_memory_engine(
+        seam=seam, runner=FakeRunner(), http_get=wrong_version, hs_dir=hs
+    )
+    assert result["status"] == "rolled_back"
+    assert result["old_engine_healthy"] is True
+    # stop, start (new engine), stop (rollback), start (old engine)
+    assert seam.verbs == ["stop", "start", "stop", "start"]
+    assert (hs / f".venv.failed-{HINDSIGHT_API_PIN}").exists()  # forensics kept
+    assert (hs / ".venv" / "bin" / "hindsight-api").exists()  # old venv restored
+    assert (hs / f".pg0.pre-{OLD_VERSION}").exists()  # snapshot preserved for retry
+    assert (hs / ".pg0" / "PG_VERSION").exists()  # data dir restored by copy
+
+
+def test_health_timeout_rolls_back(hs, monkeypatch):
+    monkeypatch.setattr("hal0.memory.engine_upgrade._HEALTH_POLL_TOTAL_S", 0)
+
+    def old_engine_only(url: str):
+        return {"status": "healthy"}  # answers once the OLD engine is back
+
+    seam = FakeSeam()
+    result = upgrade_memory_engine(
+        seam=seam, runner=FakeRunner(), http_get=old_engine_only, hs_dir=hs
+    )
+    assert result["status"] == "rolled_back"
+    assert "failed /health" in result["error"]
+    assert (hs / ".venv" / "bin" / "hindsight-api").exists()
+
+
+def test_midswap_crash_recovers_from_venv_old(hs):
+    os.rename(hs / ".venv", hs / f".venv.old-{OLD_VERSION}")  # crash left no .venv
+    seam = FakeSeam()
+    result = upgrade_memory_engine(seam=seam, runner=FakeRunner(), http_get=_healthy, hs_dir=hs)
+    assert result["status"] == "upgraded"  # restored, then upgraded normally
+
+
+def test_root_mode_chowns_artifacts(hs, monkeypatch):
+    chowned: list[str] = []
+    monkeypatch.setattr("hal0.memory.engine_upgrade.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "hal0.memory.engine_upgrade.shutil.chown",
+        lambda p, user=None, group=None: chowned.append(str(p)),
+    )
+    result = upgrade_memory_engine(
+        seam=FakeSeam(), runner=FakeRunner(), http_get=_healthy, hs_dir=hs
+    )
+    assert result["status"] == "upgraded"
+    assert any(".venv.new" in p for p in chowned)  # built venv handed to hal0
+    assert any(f".pg0.pre-{OLD_VERSION}" in p for p in chowned)  # snapshot too

--- a/tests/updater/test_post_swap_migrations.py
+++ b/tests/updater/test_post_swap_migrations.py
@@ -295,7 +295,7 @@ def test_zero_exit_with_no_envelope_raises_update_error(monkeypatch: pytest.Monk
 def test_never_raises_on_internal_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
 
-    def _boom(*, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True):
+    def _boom(*, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True):
         raise RuntimeError("disk full")
 
     monkeypatch.setattr(updater_module, "run_post_activation_migrations", _boom)
@@ -308,7 +308,7 @@ def test_forwards_the_real_migration_result_on_success(monkeypatch: pytest.Monke
     monkeypatch.setattr(
         updater_module,
         "run_post_activation_migrations",
-        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True: (
+        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True: (
             1,
             2,
         ),
@@ -329,7 +329,7 @@ def test_caps_the_ceiling_while_the_profile_catalog_reset_is_outstanding(
     seen: dict[str, Any] = {}
 
     def _fake_migrations(
-        *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True
+        *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True
     ):
         seen["ceiling"] = ceiling
         return (1, 1)
@@ -345,7 +345,7 @@ def test_no_ceiling_when_the_reset_is_not_due(monkeypatch: pytest.MonkeyPatch) -
     seen: dict[str, Any] = {}
 
     def _fake_migrations(
-        *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True
+        *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True
     ):
         seen["ceiling"] = ceiling
         return (1, 1)
@@ -363,7 +363,7 @@ def test_never_calls_reset_profile_catalog(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(
         updater_module,
         "run_post_activation_migrations",
-        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True: (
+        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True: (
             1,
             1,
         ),
@@ -386,7 +386,7 @@ def test_skips_the_image_retag_pass(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, Any] = {}
 
     def _fake_migrations(
-        *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True
+        *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True
     ):
         seen["skip_image_retag"] = skip_image_retag
         return (1, 1)

--- a/tests/updater/test_post_swap_migrations.py
+++ b/tests/updater/test_post_swap_migrations.py
@@ -295,7 +295,14 @@ def test_zero_exit_with_no_envelope_raises_update_error(monkeypatch: pytest.Monk
 def test_never_raises_on_internal_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(updater_module, "profile_reset_status", lambda: {"due": False})
 
-    def _boom(*, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True):
+    def _boom(
+        *,
+        job_id=None,
+        ceiling=None,
+        skip_image_retag=False,
+        repair_hermes_venv=True,
+        upgrade_memory_engine_venv=True,
+    ):
         raise RuntimeError("disk full")
 
     monkeypatch.setattr(updater_module, "run_post_activation_migrations", _boom)
@@ -329,7 +336,12 @@ def test_caps_the_ceiling_while_the_profile_catalog_reset_is_outstanding(
     seen: dict[str, Any] = {}
 
     def _fake_migrations(
-        *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True
+        *,
+        job_id=None,
+        ceiling=None,
+        skip_image_retag=False,
+        repair_hermes_venv=True,
+        upgrade_memory_engine_venv=True,
     ):
         seen["ceiling"] = ceiling
         return (1, 1)
@@ -345,7 +357,12 @@ def test_no_ceiling_when_the_reset_is_not_due(monkeypatch: pytest.MonkeyPatch) -
     seen: dict[str, Any] = {}
 
     def _fake_migrations(
-        *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True
+        *,
+        job_id=None,
+        ceiling=None,
+        skip_image_retag=False,
+        repair_hermes_venv=True,
+        upgrade_memory_engine_venv=True,
     ):
         seen["ceiling"] = ceiling
         return (1, 1)
@@ -386,7 +403,12 @@ def test_skips_the_image_retag_pass(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, Any] = {}
 
     def _fake_migrations(
-        *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True
+        *,
+        job_id=None,
+        ceiling=None,
+        skip_image_retag=False,
+        repair_hermes_venv=True,
+        upgrade_memory_engine_venv=True,
     ):
         seen["skip_image_retag"] = skip_image_retag
         return (1, 1)

--- a/ui/src/api/hooks/useHindsight.ts
+++ b/ui/src/api/hooks/useHindsight.ts
@@ -97,10 +97,17 @@ export function useMemoryEngine() {
 
 // ── banks ────────────────────────────────────────────────────────────────────
 
+// hindsight-api >= 0.9 paginates this passthrough (default limit=100, real
+// count in `total`); 0.8.x returns the whole list with neither. A box with
+// more than 100 banks renders the first page — acceptable for the bank grid,
+// and `total` lets the UI say so if it ever needs to.
 export function useMemoryBanks() {
-  return useQuery<{ banks: MemoryBank[] }>({
+  return useQuery<{ banks: MemoryBank[]; total?: number; limit?: number; offset?: number }>({
     queryKey: ['memory', 'banks'],
-    queryFn: () => apiGet<{ banks: MemoryBank[] }>(ENDPOINTS.memoryBanks),
+    queryFn: () =>
+      apiGet<{ banks: MemoryBank[]; total?: number; limit?: number; offset?: number }>(
+        ENDPOINTS.memoryBanks,
+      ),
     staleTime: 10_000,
     refetchInterval: 30_000,
   })

--- a/ui/src/api/mockFixtures.ts
+++ b/ui/src/api/mockFixtures.ts
@@ -958,14 +958,15 @@ function buildMemoryEngine() {
     enabled: true,
     engine: 'hindsight',
     reachable: true,
-    version: '0.7.2',
+    version: '0.9.2',
     features: { observations: true, mcp: true, mental_models: true },
     banks_total: MEM_BANKS.length,
   }
 }
 
 function buildMemoryBanks() {
-  return { banks: MEM_BANKS }
+  // 0.9.x paginated envelope (total/limit/offset alongside the page).
+  return { banks: MEM_BANKS, total: MEM_BANKS.length, limit: 100, offset: 0 }
 }
 
 // bank-id is the 4th path segment: /api/memory/banks/<bank>/…

--- a/ui/tests/e2e/specs/memory-v2-view.spec.ts
+++ b/ui/tests/e2e/specs/memory-v2-view.spec.ts
@@ -53,7 +53,7 @@ test.describe('Memory view — Hindsight surface (v2 DOM)', () => {
     // buildMemoryEngine() mock: reachable: true, engine: 'hindsight',
     // version: '0.7.2', banks_total: MEM_BANKS.length (6).
     await expect(panel).toContainText('reachable')
-    await expect(panel).toContainText('hindsight 0.7.2')
+    await expect(panel).toContainText('hindsight 0.9.2')
     await expect(panel).toContainText('6')
   })
 


### PR DESCRIPTION
## Problem

The memory engine venv (`${VAR_DIR}/memory/hindsight/.venv`) is pinned `hindsight-api==0.8.4` and upgrade-blind: install.sh only pips a **missing** venv (the venv-exists guard), and `hal0 update` never touches the engine tree at all — the #1689/#1844 "update never refreshes X" class. Every installed box stays on 0.8.4 forever, while 0.9.x carries the `/knowledge-base/*` API the Hindsight coding-agents integrations need (404 today).

## What this does

**New convergence pass** — `src/hal0/memory/engine_upgrade.py`:
- `HINDSIGHT_API_PIN = "0.9.2"` (single source of truth) + `upgrade_memory_engine()`.
- Build-aside/swap/verify/rollback: `.venv.new` is built while the old engine keeps serving (a pip/network failure costs nothing); the engine is stopped via the seam's companion arms and `.pg0` snapshotted **before** the new engine ever starts — 0.9.x runs its alembic chain on startup and it is effectively one-way, so the snapshot is the only rollback; after the swap the pass polls `/health` and requires `/version` == pin; any postcheck failure restores both the venv and the data dir (`.venv.failed-<pin>` kept for forensics).
- Runs as hal0 on the `hal0 update` path (seam for stop/start), as root from install.sh (artifacts chowned back to `hal0:hal0` — postgres refuses a wrong-owned data dir). Mid-swap crash recovery and keep-one debris pruning included.

**Wiring** — `run_post_activation_migrations` runs the pass LAST on both upgrade paths (the #1475 single sequence: `hal0 update` commit's post-swap subprocess and install.sh's migration heredoc). Boot's `check_outstanding_migrations` passes `upgrade_memory_engine_venv=False` (the `skip_image_retag`/`repair_hermes_venv` posture, further still: no boot-time pip, no surprise memory outage, no one-way DB migration outside an operator-visible update — staleness is logged with the remedy instead). Post-swap subprocess timeout 300s→2700s for the 0.9.2 wheel churn (transformers>=5.5 in `[all]`); the pass's own pip runs cap at 2400s so the envelope always reports.

**Surfaces** — `updater.memory_engine_upgrade_failed` added to the non-fatal pass-warning events + CLI label map (yellow convergence line, does not flip `converged`); new doctor row `check_memory_engine_version` (WARN only — behavior keeps gating on `/version` `features` per the document-transfer precedent); new install.sh smoke probe comparing `:9177/version` to the pin; install.sh's existing-venv branch now reports installed-vs-pin instead of silently skipping.

**0.9.2 client compat** (wheels diffed 0.8.4 vs 0.9.2 — routes strictly additive, one real break): the banks list is now paginated (default `limit=100`, real count in `total`). `/engine`'s `banks_total`, both bank-enumeration loops in `routes/memory.py` (new `_all_banks` walker), and the CLI ops fan-out handle both shapes (missing `total` = 0.8.x whole-list); UI types/fixtures updated. Stats keys, operations envelope, document-transfer endpoints, and the extraction drop-in env vars are unchanged upstream — comments re-cited where they claimed 0.8.4-only verification.

**Pin lockstep** — `tests/installer/test_hindsight_pin_lockstep.py` holds install.sh's `HINDSIGHT_PIN` and the python constant in sync and rejects stray `hindsight-api==X` literals (the runner-image-pins pattern).

## Tests

- `tests/memory/test_engine_upgrade.py` — 12 cases over the state machine: converged-prunes, boot-stale-no-writes, build-failure-zero-seam-calls, wrong-built-version, happy-path call order, disk-full abort+restart, version-mismatch full rollback (venv+pg restored by copy, snapshot kept), health-timeout rollback, mid-swap recovery, root-mode chown.
- Migration-sequence assertions (pass on by default, boot opts out, failure event registered), 3 smoke-probe harness cases, 3 doctor cases, fakes/fixtures updated for the paginated banks shape.
- Targeted suites green locally (memory/updater/mcp/config/cli/api-memory + UI mock test). Not exercised here: a live venv build + .pg0 migration — that's the RC validation lane (fresh install at pin, upgrade-in-place from an 0.8.4 box, counts intact).

## Notes for review

- `hal0 update --rollback` intentionally leaves the engine (and its migrated `.pg0`) on the newer version — old client code is wire-compatible (additive surface), and reverting a one-way DB migration behind the operator's back would be worse. Documented in the module docstring.
- Split out as #2145: the pre-existing rollback gap (route never restarts hal0-api; CLI discards `rolled_back_to`/`schema_warning`; CHANGELOG:2514 describes code not in the tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYzLd7shC1x6fC5mar8ZPh