### PR TITLE
fix(preflight): add DPkg::Lock::Timeout to every apt-get call in preflight.sh

### DIFF
--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -180,8 +180,8 @@ _main_py_autoinstall() {
     info "no Python >=3.${MAIN_PY_MIN_MINOR} found — attempting to install ${cand} (${fam})"
     case "${fam}" in
         debian)
-            DEBIAN_FRONTEND=noninteractive apt-get update -qq >/dev/null 2>&1 || true
-            DEBIAN_FRONTEND=noninteractive apt-get install -y -q "${cand}" "${cand}-venv" >/dev/null 2>&1 || return 1 ;;
+            DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 update -qq >/dev/null 2>&1 || true
+            DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y -q "${cand}" "${cand}-venv" >/dev/null 2>&1 || return 1 ;;
         fedora) "$(pkg_mgr)" install -y "${cand}" >/dev/null 2>&1 || return 1 ;;
         # Arch/openSUSE/Alpine ship a single rolling python; a pinned older
         # minor isn't reliably in the base repos (mirrors
@@ -266,8 +266,8 @@ _hindsight_py_autoinstall() {
         cand="python3.${v}"
         case "${fam}" in
             debian)
-                DEBIAN_FRONTEND=noninteractive apt-get update -qq >/dev/null 2>&1 || true
-                DEBIAN_FRONTEND=noninteractive apt-get install -y -q "${cand}" "${cand}-venv" >/dev/null 2>&1 || continue ;;
+                DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 update -qq >/dev/null 2>&1 || true
+                DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y -q "${cand}" "${cand}-venv" >/dev/null 2>&1 || continue ;;
             fedora) "$(pkg_mgr)" install -y "${cand}" >/dev/null 2>&1 || continue ;;
             # Arch/openSUSE/Alpine ship a single rolling python; a pinned older
             # minor isn't reliably in the base repos. Skip — the metadata-gate
@@ -397,8 +397,8 @@ preflight_venv() {
         local ok=1
         case "$(distro_family)" in
             debian)
-                DEBIAN_FRONTEND=noninteractive apt-get update -qq || true
-                DEBIAN_FRONTEND=noninteractive apt-get install -y -q python3-venv python3-pip || ok=0
+                DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 update -qq || true
+                DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y -q python3-venv python3-pip || ok=0
                 ;;
             fedora) "${pm}" install -y python3 python3-pip || ok=0 ;;
             suse) zypper install -y python3 python3-pip || ok=0 ;;
@@ -678,7 +678,7 @@ preflight_container_runtime() {
         info "installing podman (required for hal0 inference slots)"
         local ok=1
         case "${pm}" in
-            apt-get) DEBIAN_FRONTEND=noninteractive apt-get install -y -q podman || ok=0 ;;
+            apt-get) DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y -q podman || ok=0 ;;
             dnf) dnf install -y podman || ok=0 ;;
             yum) yum install -y podman || ok=0 ;;
             zypper) zypper install -y podman || ok=0 ;;
@@ -755,7 +755,7 @@ preflight_git() {
         info "installing git (required for Hermes agent provisioning)"
         local ok=1
         case "${pm}" in
-            apt-get) DEBIAN_FRONTEND=noninteractive apt-get install -y -q git || ok=0 ;;
+            apt-get) DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y -q git || ok=0 ;;
             dnf) dnf install -y git || ok=0 ;;
             yum) yum install -y git || ok=0 ;;
             zypper) zypper install -y git || ok=0 ;;
@@ -1426,7 +1426,7 @@ _node_autoinstall() {
         debian)
             if curl -fsSL "https://deb.nodesource.com/setup_${NODE_MIN_MAJOR}.x" -o /tmp/hal0-nodesource-setup.sh 2>/dev/null \
                 && DEBIAN_FRONTEND=noninteractive bash /tmp/hal0-nodesource-setup.sh >/dev/null 2>&1; then
-                DEBIAN_FRONTEND=noninteractive apt-get install -y -q nodejs >/dev/null 2>&1
+                DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y -q nodejs >/dev/null 2>&1
             fi
             rm -f /tmp/hal0-nodesource-setup.sh
             ;;

--- a/tests/installer/test_preflight_git.py
+++ b/tests/installer/test_preflight_git.py
@@ -165,6 +165,36 @@ exit 0
         assert "-y" in marker.read_text()
         assert "git" in marker.read_text()
 
+    def test_apt_get_invocation_carries_lock_timeout(self, tmp_path: Path) -> None:
+        # #2125: preflight_git's apt-get branch omitted the
+        # `-o DPkg::Lock::Timeout` flag its own failure hint recommends
+        # (installer/install.sh uses it on every apt-get call; this file did
+        # not). A concurrent dpkg lock holder (unattended-upgrades,
+        # apt-daily — both routine on a freshly booted box) then makes the
+        # bare `apt-get install` fail immediately instead of waiting, and
+        # Hermes provisioning is skipped for what is really just a race.
+        d = tmp_path / "bin"
+        d.mkdir()
+        marker = tmp_path / "apt-get.called"
+        apt_get_body = f"""#!/usr/bin/env bash
+echo "$@" > {marker}
+cat > {d / "git"} <<'GITEOF'
+#!/usr/bin/env bash
+echo 'git version 2.43.0'
+exit 0
+GITEOF
+chmod +x {d / "git"}
+exit 0
+"""
+        _write_exe(d / "apt-get", apt_get_body)
+        proc = _run("preflight_git; exit $?\n", d, extra_env={"HAL0_GIT_REQUIRED": "1"})
+        assert proc.returncode == 0, proc.stderr
+        assert marker.exists(), "apt-get was never invoked — auto-install path not taken"
+        invocation = marker.read_text()
+        assert "-o DPkg::Lock::Timeout=" in invocation, (
+            f"apt-get invocation missing DPkg::Lock::Timeout: {invocation!r}"
+        )
+
     def test_apt_get_present_but_install_fails_is_a_hard_failure(self, tmp_path: Path) -> None:
         d = tmp_path / "bin"
         d.mkdir()


### PR DESCRIPTION
## What changed

`preflight_git`'s apt-get branch (installer/lib/preflight.sh:758) omitted the
`-o DPkg::Lock::Timeout` flag that its own failure hint recommends
(`sudo apt-get -o DPkg::Lock::Timeout=120 install -y git`). On a freshly
booted Ubuntu box, `unattended-upgrades` / `apt-daily` routinely hold the
dpkg lock; without the timeout, `apt-get` fails immediately instead of
waiting it out, and Hermes provisioning is skipped for what is really just a
race — reported on a v1.0.0 fresh install of ct163.

## Root cause, and why the fix is broader than the reported line

The reported symptom (git install fails, hermes skipped) traces to a single
missing flag on one apt-get call, but `installer/install.sh` uses
`-o DPkg::Lock::Timeout=120` on *every* apt-get invocation it makes, while
`installer/lib/preflight.sh` used it on *none* of its six apt-get call
sites. That's a convention gap in the whole file, not a one-off typo, so
every other preflight apt-get install in this file races the same lock:

- `_main_py_autoinstall` (python3.\<floor\> autoinstall) — update + install
- `_hindsight_py_autoinstall` (Hindsight-compatible python autoinstall) — update + install
- `preflight_venv` (python3-venv/python3-pip autoinstall)
- `preflight_container_runtime` (podman autoinstall)
- `preflight_git` (git autoinstall — the reported call site)
- `_node_autoinstall` (nodejs install after the NodeSource setup script)

All six now carry `-o DPkg::Lock::Timeout=120`, matching install.sh's
established convention exactly.

## How it was verified

- Added a regression test to `tests/installer/test_preflight_git.py`
  (`test_apt_get_invocation_carries_lock_timeout`) asserting the apt-get
  invocation `preflight_git` shells out to (mocked, `HAL0_GIT_REQUIRED=1`
  path) contains `-o DPkg::Lock::Timeout=`.
- Confirmed **red**: sourced the pre-fix `preflight.sh` (git HEAD) directly
  and drove `preflight_git` through the same mocked-apt-get harness — the
  recorded invocation was `install -y -q git`, missing the flag, reproducing
  the exact defect from #2125.
- Confirmed **green**: `tests/installer/test_preflight_git.py` — 12/12
  passed after the fix.
- `bash -n` syntax check on `installer/lib/preflight.sh` and
  `installer/install.sh`.
- `ruff check` and `ruff format --check` on `src tests` (repo-wide) — both
  clean.

Also ran the full `tests/installer/` suite. 215 pre-existing failures were
observed there, all unrelated to this change: macOS `._*` AppleDouble
resource-fork files already present (untracked, gitignored) in this worktree
confuse shell-file-scanning tests (`test_ui_helper_contract.py`,
`test_systemctl_dropin_validation.py`, `test_systemctl_quadlet_validation.py`),
and `test_bootstrap_prereq_parity.py::TestAllPresentOnLinux` fails on this
macOS dev host's "hal0 only supports Linux" gate. Neither touches
`preflight_git`/apt-get and neither is affected by this diff.

## Scope

`installer/lib/preflight.sh` and its regression test only, per the fix
wave's isolation rule (this file is also touched by #2084 and #2126 — not
run in the same batch). CHANGELOG.md deliberately left untouched (#1545).

Closes #2125