### PR TITLE
fix(installer): stop the post-install seam probe from calling a transient a broken grant (#2084)

### DIFF
--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1575,7 +1575,13 @@ _hal0_seam_grant() {
     # included. The old text printed the bare wrapper name, so an operator who
     # pasted it hit "command not found" (the wrapper is not on sudo's
     # secure_path) and mis-diagnosed a second time.
-    "${report}" "seam ${name}: 'sudo -n -u hal0 sudo -n ${bin} $*' exited ${probe_rc} after ${attempt} attempt(s) — the ${grant} grant does not apply, or the wrapper is stale${last:+ (${last})}"
+    #
+    # Facts first, then a HEDGED reading — the whole point of #2084 is not to
+    # name a cause we did not observe. Three different bugs land here (grant
+    # broken, wrapper stale, transient that outlasted the retry window) and
+    # this line cannot tell them apart. Keep the wording in lock-step with
+    # src/hal0/system/seam_check.py.
+    "${report}" "seam ${name}: 'sudo -n -u hal0 sudo -n ${bin} $*' exited ${probe_rc} after ${attempt} attempt(s)${last:+ (${last})} — usually the ${grant} grant not applying or a stale wrapper, though a transient outlasting the retry window reports identically"
     return 1
 }
 

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1497,6 +1497,88 @@ _hal0_seam_probe() {
     esac
 }
 
+# ── grant probe (#2084) ─────────────────────────────────────────────────────
+#
+# install.sh calls preflight_seams IMMEDIATELY after writing the wrappers and
+# the sudoers drop-ins, on a box whose `hal0` user was itself created minutes
+# earlier. A single failed probe in that window is therefore not evidence that
+# the grant is broken — rc.10/ct151 warned on hal0-podman-ro in the same log
+# second as "wrote /etc/sudoers.d/hal0-podman-ro", and the identical
+# invocation succeeded on the untouched box minutes later. An operator who
+# believes that warning re-runs install.sh for nothing; a validation agent
+# files a regression that does not exist.
+#
+# So: retry, and — the part that actually matters — REPORT WHAT HAPPENED
+# instead of asserting a cause we never observed. The old message threw the
+# probe's stderr away and then named a diagnosis ("the grant does not apply,
+# or the wrapper is stale") it had no evidence for. src/hal0/system/seam_check.py
+# has kept the rc + stderr tail since #1465; this is the shell copy catching
+# up, and the two are meant to stay in lock-step.
+#
+# Every probe verb in _hal0_seam_probe is side-effect-free by construction
+# (`help` prints usage; `check`/`check-slot-token`/`check-image-ref` validate
+# and print), which is exactly what makes re-running one safe.
+HAL0_SEAM_PROBE_ATTEMPTS="${HAL0_SEAM_PROBE_ATTEMPTS:-3}"
+HAL0_SEAM_PROBE_DELAY="${HAL0_SEAM_PROBE_DELAY:-1}"
+# Bounds ONE attempt. Load-bearing now that there are up to three of them: an
+# unbounded sudo that hangs would wedge the installer for good. Mirrors the
+# timeout=20 seam_check.py already passes to subprocess.run.
+HAL0_SEAM_PROBE_TIMEOUT="${HAL0_SEAM_PROBE_TIMEOUT:-20}"
+
+# Run the grant probe ONCE, as the hal0 user. Prints whatever the probe wrote
+# to STDERR on our stdout (its stdout is discarded) and returns the probe's
+# rc. Split out so the retry/report logic below is exercisable in tests
+# without root, without sudo and without a provisioned box.
+_hal0_seam_probe_run() {
+    local bin="$1"; shift
+    # The grant is written for the hal0 user, so the only honest test runs AS
+    # that user. -n keeps both hops non-interactive: a missing grant fails
+    # immediately instead of prompting.
+    local -a cmd=(sudo -n -u hal0 sudo -n "${bin}" "$@")
+    if command -v timeout >/dev/null 2>&1; then
+        cmd=(timeout "${HAL0_SEAM_PROBE_TIMEOUT}" "${cmd[@]}")
+    fi
+    # Order matters: 2>&1 first duplicates the capture pipe onto fd 2, THEN
+    # fd 1 is discarded — so we keep stderr and drop stdout.
+    "${cmd[@]}" 2>&1 >/dev/null
+}
+
+# Prove ONE seam's grant end-to-end, retrying a transient failure.
+# Args: <name> <bin> <grant> <report-fn> <probe word>...
+# Returns 0 when the grant works, 1 once the last attempt has failed.
+_hal0_seam_grant() {
+    local name="$1" bin="$2" grant="$3" report="$4"; shift 4
+    local attempt=0 probe_rc=0 probe_err='' last=''
+
+    while :; do
+        attempt=$(( attempt + 1 ))
+        probe_rc=0
+        probe_err="$(_hal0_seam_probe_run "${bin}" "$@")" || probe_rc=$?
+        (( probe_rc == 0 )) && break
+        (( attempt >= HAL0_SEAM_PROBE_ATTEMPTS )) && break
+        sleep "${HAL0_SEAM_PROBE_DELAY}"
+    done
+
+    if (( probe_rc == 0 )); then
+        if (( attempt > 1 )); then
+            info "seam ${name}: grant verified on attempt ${attempt}/${HAL0_SEAM_PROBE_ATTEMPTS} — the first probe ran before the grant was live, not a fault"
+        fi
+        return 0
+    fi
+
+    # Last non-empty stderr line, capped — the evidence the old message
+    # discarded. `sudo: a password is required` and `hal0-podman-ro: bad slot
+    # token` are entirely different bugs and used to print identically.
+    last="$(printf '%s\n' "${probe_err}" | grep -v '^[[:space:]]*$' | tail -n 1 || true)"
+    last="${last:0:160}"
+    # Quote the command we ACTUALLY ran, full path and both sudo hops
+    # included. The old text printed the bare wrapper name, so an operator who
+    # pasted it hit "command not found" (the wrapper is not on sudo's
+    # secure_path) and mis-diagnosed a second time.
+    "${report}" "seam ${name}: 'sudo -n -u hal0 sudo -n ${bin} $*' exited ${probe_rc} after ${attempt} attempt(s) — the ${grant} grant does not apply, or the wrapper is stale${last:+ (${last})}"
+    return 1
+}
+
 # Verify ONE seam: wrapper present + root-owned + 0755, sudoers drop-in
 # present + root-owned + 0440, and — the fact that actually matters — the
 # grant works when exercised AS the hal0 user. Returns non-zero on any
@@ -1538,13 +1620,7 @@ _preflight_seam() {
         # current one).
         local -a probe_argv=()
         read -r -a probe_argv <<< "${probe}"
-        # The grant is written for the hal0 user, so the only honest test runs
-        # AS that user. -n keeps it non-interactive: a missing grant fails
-        # immediately instead of prompting.
-        if ! sudo -n -u hal0 sudo -n "${bin}" "${probe_argv[@]}" >/dev/null 2>&1; then
-            "${report}" "seam ${name}: 'sudo -n ${name} ${probe}' failed as the hal0 user — the ${grant} grant does not apply, or the wrapper is stale"
-            rc=1
-        fi
+        _hal0_seam_grant "${name}" "${bin}" "${grant}" "${report}" "${probe_argv[@]}" || rc=1
     fi
     return "${rc}"
 }

--- a/src/hal0/system/seam_check.py
+++ b/src/hal0/system/seam_check.py
@@ -42,6 +42,7 @@ than silently implied.
 from __future__ import annotations
 
 import os
+import shlex
 import stat as stat_mod
 import subprocess
 from collections.abc import Callable
@@ -250,10 +251,18 @@ def probe_seam(
                 if not grant_ok:
                     stderr = (proc.stderr or "").strip().splitlines()
                     tail = stderr[-1][:160] if stderr else ""
+                    # Quote the command we ACTUALLY ran — full wrapper path,
+                    # both sudo hops (#2084). The old text printed the bare
+                    # `sudo -n <name> <probe>`, which an operator cannot paste:
+                    # the wrapper is not on sudo's secure_path, so it fails for
+                    # an unrelated reason and mis-diagnoses a second time.
+                    # Hedged, and worded to match installer/lib/preflight.sh:
+                    # a broken grant and a stale wrapper are different bugs and
+                    # this probe cannot tell them apart.
                     grant_detail = (
-                        f"{spec.name}: `sudo -n {spec.name} {' '.join(spec.probe)}` exited "
-                        f"{proc.returncode} as {SERVICE_USER} — the {grant} grant does not "
-                        f"apply{f' ({tail})' if tail else ''}"
+                        f"{spec.name}: `{shlex.join(argv)}` exited "
+                        f"{proc.returncode}{f' ({tail})' if tail else ''} — usually the "
+                        f"{grant} grant not applying or a stale wrapper"
                     )
 
     return SeamStatus(

--- a/tests/installer/test_seam_verification.py
+++ b/tests/installer/test_seam_verification.py
@@ -111,6 +111,167 @@ def test_preflight_seams_is_not_in_preflight_all() -> None:
     assert "preflight_seams()" in text
 
 
+# ── the grant probe: transients, and honest reporting (#2084) ─────────────────
+#
+# install.sh runs preflight_seams in the same log second as "wrote
+# /etc/sudoers.d/hal0-podman-ro", on a box whose hal0 user was created minutes
+# earlier. rc.10/ct151 warned there; the identical invocation succeeded on the
+# untouched box minutes later. These pin the retry AND the message, because
+# the message is what an operator (or a validation agent) acts on.
+
+
+def _call_probe(
+    tmp_path: Path,
+    *,
+    fail_attempts: int,
+    stderr_line: str = "",
+    attempts: int = 3,
+    name: str = "hal0-podman-ro",
+    required: str = "optional",
+    set_e: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Drive `_preflight_seam` past its stat checks with a stubbed grant probe.
+
+    Two shell-level stubs, both installed *after* sourcing so they shadow the
+    real definitions: ``stat`` (tmp files belong to the test user, and the
+    ownership check would otherwise short-circuit before the probe) and
+    ``_hal0_seam_probe_run`` (no root, no sudo, no provisioned box in CI).
+
+    ``set -e`` is on by default because install.sh runs ``set -euo pipefail``:
+    a retry loop that aborts the installer on its first failed attempt would
+    be a worse bug than the one being fixed.
+    """
+    bin_dir, sudoers_dir = _seam_dirs(tmp_path, names=(name,))
+    counter = tmp_path / "attempts"
+    argv_log = tmp_path / "argv"
+    flags = "set -euo pipefail" if set_e else "set -uo pipefail"
+    script = f"""
+{flags}
+source "{REPO}/installer/lib/ui.sh"
+source "{PREFLIGHT}"
+
+stat() {{
+    case "$2" in
+        '%a')    case "$3" in *sudoers.d*) echo 440 ;; *) echo 755 ;; esac ;;
+        '%U:%G') echo root:root ;;
+        '%U')    echo root ;;
+    esac
+}}
+
+echo 0 > "{counter}"
+_hal0_seam_probe_run() {{
+    local n
+    n=$(( $(cat "{counter}") + 1 ))
+    echo "$n" > "{counter}"
+    printf '%s\\n' "$*" >> "{argv_log}"
+    if (( n <= {fail_attempts} )); then
+        printf '%s\\n' "{stderr_line}"
+        return 1
+    fi
+    return 0
+}}
+
+HAL0_SEAM_PROBE_ATTEMPTS={attempts}
+HAL0_SEAM_PROBE_DELAY=0
+rc=0
+_preflight_seam "{name}" "{required}" "{bin_dir}" "{sudoers_dir}" || rc=$?
+echo "rc=$rc"
+echo "attempts=$(cat "{counter}")"
+echo "argv=$(cat "{argv_log}" 2>/dev/null | head -1)"
+"""
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False, cwd=str(REPO)
+    )
+
+
+def test_a_transient_grant_probe_failure_is_retried(tmp_path: Path) -> None:
+    """The rc.10/ct151 false negative: one failed probe, healthy seam."""
+    proc = _call_probe(tmp_path, fail_attempts=1)
+
+    assert "rc=0" in proc.stdout, proc.stderr
+    assert "attempts=2" in proc.stdout
+    assert "does not apply" not in proc.stderr
+
+
+def test_a_retried_probe_says_so_rather_than_passing_silently(tmp_path: Path) -> None:
+    """A seam that needed a second look is worth one line in the log."""
+    proc = _call_probe(tmp_path, fail_attempts=1)
+
+    assert "grant verified on attempt 2/3" in proc.stdout
+
+
+def test_the_probe_is_not_retried_when_it_passes_first_time(tmp_path: Path) -> None:
+    proc = _call_probe(tmp_path, fail_attempts=0)
+
+    assert "rc=0" in proc.stdout
+    assert "attempts=1" in proc.stdout
+    assert "grant verified on attempt" not in proc.stdout  # nothing to report
+
+
+def test_a_genuinely_broken_grant_still_fails_after_every_attempt(tmp_path: Path) -> None:
+    """Retrying must not turn a real breakage into a pass."""
+    proc = _call_probe(tmp_path, fail_attempts=99)
+
+    assert "rc=1" in proc.stdout
+    assert "attempts=3" in proc.stdout
+    assert "3 attempt" in proc.stderr
+
+
+def test_the_failure_quotes_the_command_it_actually_ran(tmp_path: Path) -> None:
+    """Nit 1 on #2084: the old text printed the bare wrapper name.
+
+    `sudo -n hal0-podman-ro …` is not what the check runs and fails for an
+    unrelated reason when pasted — the wrapper is not on sudo's secure_path —
+    so the printed command sent operators down a second wrong path.
+    """
+    proc = _call_probe(tmp_path, fail_attempts=99)
+
+    bin_path = str(tmp_path / "bin" / "hal0-podman-ro")
+    assert f"sudo -n -u hal0 sudo -n {bin_path} check-slot-token hal0probe" in proc.stderr
+    assert "'sudo -n hal0-podman-ro" not in proc.stderr
+
+
+def test_the_failure_reports_the_probe_rc_and_its_stderr(tmp_path: Path) -> None:
+    """Report the evidence, don't assert a cause we never observed.
+
+    seam_check.py has carried rc + stderr tail since #1465; the shell copy
+    threw both away, so "sudo: a password is required" (grant broken) and
+    "bad slot token" (wrapper stale) printed identically.
+    """
+    proc = _call_probe(tmp_path, fail_attempts=99, stderr_line="sudo: a password is required")
+
+    assert "exited 1" in proc.stderr
+    assert "sudo: a password is required" in proc.stderr
+
+
+def test_the_retry_loop_does_not_abort_an_installer_running_set_e(tmp_path: Path) -> None:
+    """install.sh is `set -euo pipefail`; a failing attempt must not kill it."""
+    proc = _call_probe(tmp_path, fail_attempts=2, set_e=True)
+
+    assert "rc=0" in proc.stdout, proc.stderr
+    assert "attempts=3" in proc.stdout
+
+
+def test_required_seams_get_the_same_retry(tmp_path: Path) -> None:
+    """The transient is not podman-ro's; a load-bearing seam must not die on it."""
+    proc = _call_probe(tmp_path, fail_attempts=1, name="hal0-systemctl", required="required")
+
+    assert "rc=0" in proc.stdout, proc.stderr
+    assert "attempts=2" in proc.stdout
+
+
+def test_one_probe_attempt_is_bounded_by_a_timeout() -> None:
+    """Retrying an unbounded sudo would wedge the installer for 3x as long.
+
+    seam_check.py already passes timeout=20 to subprocess.run; keep the shell
+    copy in lock-step.
+    """
+    text = PREFLIGHT.read_text()
+    body = text.split("_hal0_seam_probe_run() {", 1)[1].split("\n}", 1)[0]
+    assert "timeout" in body
+    assert 'HAL0_SEAM_PROBE_TIMEOUT="${HAL0_SEAM_PROBE_TIMEOUT:-20}"' in text
+
+
 # ── inventory parity ───────────────────────────────────────────────────────────
 
 

--- a/tests/installer/test_seam_verification.py
+++ b/tests/installer/test_seam_verification.py
@@ -126,16 +126,23 @@ def _call_probe(
     fail_attempts: int,
     stderr_line: str = "",
     attempts: int = 3,
+    delay: str = "0",
     name: str = "hal0-podman-ro",
     required: str = "optional",
     set_e: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     """Drive `_preflight_seam` past its stat checks with a stubbed grant probe.
 
-    Two shell-level stubs, both installed *after* sourcing so they shadow the
-    real definitions: ``stat`` (tmp files belong to the test user, and the
-    ownership check would otherwise short-circuit before the probe) and
-    ``_hal0_seam_probe_run`` (no root, no sudo, no provisioned box in CI).
+    Shell-level stubs, all installed *after* sourcing so they shadow the real
+    definitions: ``stat`` (tmp files belong to the test user, and the ownership
+    check would otherwise short-circuit before the probe), ``sleep`` (logs the
+    delay it was handed) and ``_hal0_seam_probe_run`` (no root, no sudo, no
+    provisioned box in CI).
+
+    Stubbing ``_hal0_seam_probe_run`` buys hermetic retry/report coverage at
+    the cost of the one thing that lives *inside* it — which stream the probe
+    keeps. ``test_the_probe_keeps_stderr_drops_stdout_and_returns_the_rc``
+    stubs the layer below instead and covers exactly that.
 
     ``set -e`` is on by default because install.sh runs ``set -euo pipefail``:
     a retry loop that aborts the installer on its first failed attempt would
@@ -144,11 +151,20 @@ def _call_probe(
     bin_dir, sudoers_dir = _seam_dirs(tmp_path, names=(name,))
     counter = tmp_path / "attempts"
     argv_log = tmp_path / "argv"
+    sleep_log = tmp_path / "slept"
     flags = "set -euo pipefail" if set_e else "set -uo pipefail"
     script = f"""
 {flags}
 source "{REPO}/installer/lib/ui.sh"
 source "{PREFLIGHT}"
+
+# Logs what the loop asked to sleep for, then really sleeps it — the delay is
+# a knob install.sh ships at 1s, so it has to be a value that reaches `sleep`,
+# not just a variable that exists.
+sleep() {{
+    printf '%s\\n' "$1" >> "{sleep_log}"
+    command sleep "$1"
+}}
 
 stat() {{
     case "$2" in
@@ -172,12 +188,13 @@ _hal0_seam_probe_run() {{
 }}
 
 HAL0_SEAM_PROBE_ATTEMPTS={attempts}
-HAL0_SEAM_PROBE_DELAY=0
+HAL0_SEAM_PROBE_DELAY={delay}
 rc=0
 _preflight_seam "{name}" "{required}" "{bin_dir}" "{sudoers_dir}" || rc=$?
 echo "rc=$rc"
 echo "attempts=$(cat "{counter}")"
 echo "argv=$(cat "{argv_log}" 2>/dev/null | head -1)"
+echo "slept=$(cat "{sleep_log}" 2>/dev/null | tr '\\n' ',')"
 """
     return subprocess.run(
         ["bash", "-c", script], capture_output=True, text=True, check=False, cwd=str(REPO)
@@ -258,6 +275,77 @@ def test_required_seams_get_the_same_retry(tmp_path: Path) -> None:
 
     assert "rc=0" in proc.stdout, proc.stderr
     assert "attempts=2" in proc.stdout
+
+
+def test_the_configured_delay_is_what_the_loop_actually_sleeps(tmp_path: Path) -> None:
+    """The knob has to reach `sleep`; install.sh ships it at 1s, not 0."""
+    proc = _call_probe(tmp_path, fail_attempts=1, delay="0.25")
+
+    assert "rc=0" in proc.stdout, proc.stderr
+    assert "attempts=2" in proc.stdout
+    assert "slept=0.25," in proc.stdout  # once, between the two attempts
+
+
+def _stub_sudo_probe(
+    tmp_path: Path, *, rc: int, stdout_line: str, stderr_line: str
+) -> subprocess.CompletedProcess[str]:
+    """Run the REAL `_hal0_seam_probe_run` against a `sudo` stub on PATH.
+
+    A real executable, not a shell function: the probe may wrap the command in
+    `timeout`, which execs its child itself and would never see a function.
+    """
+    stub_dir = tmp_path / "stub-bin"
+    stub_dir.mkdir()
+    argv_log = tmp_path / "sudo-argv"
+    sudo = stub_dir / "sudo"
+    sudo.write_text(
+        "#!/bin/bash\n"
+        f'printf "%s\\n" "$*" > "{argv_log}"\n'
+        f'printf "%s\\n" "{stdout_line}"\n'
+        f'printf "%s\\n" "{stderr_line}" >&2\n'
+        f"exit {rc}\n"
+    )
+    sudo.chmod(0o755)
+    script = f"""
+set -uo pipefail
+source "{REPO}/installer/lib/ui.sh"
+source "{PREFLIGHT}"
+export PATH="{stub_dir}:$PATH"
+rc=0
+captured="$(_hal0_seam_probe_run /usr/lib/hal0/bin/hal0-podman-ro check-slot-token hal0probe)" || rc=$?
+echo "rc=${{rc}}"
+echo "captured=${{captured}}"
+echo "argv=$(cat "{argv_log}")"
+"""
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False, cwd=str(REPO)
+    )
+
+
+def test_the_probe_keeps_stderr_drops_stdout_and_returns_the_rc(tmp_path: Path) -> None:
+    """The headline of #2084, at the only layer that can show it.
+
+    `sudo … >/dev/null 2>&1` threw the evidence away; the fix is `2>&1 >/dev/null`,
+    which keeps the probe's stderr (`sudo: a password is required` vs `bad slot
+    token` — different bugs) and drops its chatty stdout. Every other test here
+    stubs `_hal0_seam_probe_run` itself, so this redirection is invisible to
+    them: flipping it back leaves them green.
+    """
+    proc = _stub_sudo_probe(
+        tmp_path,
+        rc=7,
+        stdout_line="hal0probe-slot-token-that-must-not-be-captured",
+        stderr_line="sudo: a password is required",
+    )
+
+    assert "rc=7" in proc.stdout, proc.stderr  # the probe's own rc, not sudo's or 1
+    assert "captured=sudo: a password is required" in proc.stdout
+    assert "hal0probe-slot-token-that-must-not-be-captured" not in proc.stdout
+    # …and it is the two-hop command that ran, not the bare wrapper name.
+    assert (
+        "argv=-n -u hal0 sudo -n /usr/lib/hal0/bin/hal0-podman-ro check-slot-token hal0probe"
+        in proc.stdout
+    )
 
 
 def test_one_probe_attempt_is_bounded_by_a_timeout() -> None:

--- a/tests/system/test_seam_check.py
+++ b/tests/system/test_seam_check.py
@@ -180,6 +180,55 @@ def test_grant_failure_is_surfaced_with_the_sudo_error(tmp_path: Path) -> None:
     assert status.ok is False
 
 
+def test_grant_failure_quotes_the_command_it_actually_ran(tmp_path: Path) -> None:
+    """#2084: the detail printed `sudo -n <name> <probe>` — a command nothing ran.
+
+    :func:`grant_probe_argv` builds two sudo hops through the wrapper's full
+    path. The bare-name form fails for an *unrelated* reason when an operator
+    pastes it (the wrapper is not on sudo's ``secure_path``), so the row sent
+    them down a second wrong path — and this detail is what ``hal0 doctor``
+    prints.
+    """
+    bin_dir, sudoers = _install(tmp_path, "hal0-update")
+    run = FakeRun(returncode=1, stderr="sudo: a password is required")
+
+    status = probe_seam(
+        _UPDATE, bin_dir=bin_dir, sudoers_dir=sudoers, euid=0, run=run, stat=_stat_as_root
+    )
+
+    assert " ".join(run.calls[0]) in status.grant_detail
+    assert f"sudo -n -u hal0 sudo -n {bin_dir / 'hal0-update'} check" in status.grant_detail
+    assert "sudo -n hal0-update check" not in status.grant_detail
+
+
+def test_grant_failure_wording_stays_in_lock_step_with_the_shell_copy(tmp_path: Path) -> None:
+    """Same finding, same words. The two copies are meant to agree (#1465, #2084).
+
+    Both hedge, too: a probe can fail because the grant is broken, because the
+    wrapper is stale, or — installer side — because the write→verify transient
+    outlasted the retry window. All three print the same line, so neither copy
+    may claim to have told them apart.
+    """
+    bin_dir, sudoers = _install(tmp_path, "hal0-update")
+
+    status = probe_seam(
+        _UPDATE,
+        bin_dir=bin_dir,
+        sudoers_dir=sudoers,
+        euid=0,
+        run=FakeRun(returncode=1, stderr="sudo: a password is required"),
+        stat=_stat_as_root,
+    )
+
+    shared = "grant not applying or a stale wrapper"
+    preflight = (
+        Path(__file__).resolve().parents[2] / "installer" / "lib" / "preflight.sh"
+    ).read_text()
+    assert shared in status.grant_detail
+    assert shared in preflight
+    assert "does not apply" not in status.grant_detail  # unhedged; we never observed it
+
+
 def test_working_grant_passes_every_fact(tmp_path: Path) -> None:
     bin_dir, sudoers = _install(tmp_path, "hal0-update")
 


### PR DESCRIPTION
## What

`installer/lib/preflight.sh` — the post-install privileged-seam verification's grant probe now **retries, bounds each attempt, and reports what it observed** instead of taking one silent attempt and naming a cause it never saw.

## Why

rc.10 / ct151 (#2084): the installer warned

```
!!  seam hal0-podman-ro: 'sudo -n hal0-podman-ro check-slot-token hal0probe' failed as the hal0 user — the /etc/sudoers.d/hal0-podman-ro grant does not apply, or the wrapper is stale
```

in the **same log second** as its own `OK wrote /etc/sudoers.d/hal0-podman-ro`. Minutes later, on the untouched box, the identical invocation succeeded — wrapper `root:root 0755`, grant `root 0440`, `visudo`-clean.

The transient is real, but it is not the root cause. The root cause is that `_preflight_seam` let a **single, unretried, evidence-discarding** attempt be the verdict:

1. **The check threw away its own evidence and then asserted a diagnosis.** `sudo … >/dev/null 2>&1` discarded both the rc and the probe's stderr, and the message went on to name *"the grant does not apply, or the wrapper is stale"* — a cause nothing in the check had observed. `sudo: a password is required` (grant genuinely broken) and `hal0-podman-ro: bad slot token` (wrapper genuinely stale) printed **identically**. `src/hal0/system/seam_check.py` has carried the rc + stderr tail since #1465 (`seam_check.py:246-256`); the shell copy had quietly drifted out of the lock-step the file's own header asks for.
2. **One attempt**, so any transient in the write→verify window became a permanent verdict. Every probe verb in `_hal0_seam_probe` is side-effect-free by construction (`help` prints usage; `check` / `check-slot-token` / `check-image-ref` validate and print, never touching podman) — which is exactly what makes re-running one safe.
3. **The message misquoted the command it ran** (nit 1 on the issue): it printed the bare wrapper name while the check ran the full `${bin}` path through two sudo hops. An operator pasting `sudo -n hal0-podman-ro …` gets a *different* failure — the wrapper is not on sudo's `secure_path` — and mis-diagnoses a second time.

Cost of the old behaviour: an operator re-runs `install.sh` for nothing, and a validation agent files a regression that does not exist. #1889 made podman-ro the only source of truth for a running slot's `image_status`/`actual_image`, and kit v6 treats a warned-but-actually-healthy seam as its own finding class, so this warning is acted on.

## How

New in `preflight.sh`, all inside the seam block:

- `_hal0_seam_probe_run` — one attempt, as the hal0 user, **keeping stderr** (stdout discarded) and returning the probe's rc. Split out so the retry/report logic is exercisable in tests with no root, no sudo and no provisioned box.
- `_hal0_seam_grant` — up to `HAL0_SEAM_PROBE_ATTEMPTS` (3) attempts, `HAL0_SEAM_PROBE_DELAY` (1s) apart. A grant that only came up on a later attempt logs `grant verified on attempt 2/3 — the first probe ran before the grant was live, not a fault` rather than passing silently. A grant that never comes up reports **the command that actually ran** (`sudo -n -u hal0 sudo -n /usr/lib/hal0/bin/hal0-podman-ro check-slot-token hal0probe`), the exit code, the attempt count, and the probe's own last stderr line.
- `HAL0_SEAM_PROBE_TIMEOUT` (20s) bounds each attempt — load-bearing now that there are up to three of them, and it mirrors the `timeout=20` `seam_check.py` already passes to `subprocess.run`. `install.sh` is `set -euo pipefail`; the loop is written to be safe under it.

Behaviour for a genuinely broken grant is unchanged apart from the message: required seams still `err` + `die` the install, optional seams still `warn` and continue. Worst-case added wall time on a healthy box is zero (first attempt passes); on a genuinely broken one, 2s of `sleep` plus two extra instant `sudo -n` rejections.

## Verification

`tests/installer/test_seam_verification.py` gains 9 tests, all of which **fail on `main` and pass here** (verified by reverting only `preflight.sh` under them: `9 failed, 13 passed` → `22 passed`). They drive the real `_preflight_seam` past its `stat` checks with two shell-level stubs installed after sourcing (`stat`, because tmp files belong to the test user; `_hal0_seam_probe_run`, because CI has no root/sudo/hal0 user):

- the rc.10/ct151 shape — one failed probe on a healthy seam → `rc=0`, two attempts, no warning;
- the retry is announced, and is *not* announced when the first attempt passed;
- a genuinely broken grant still fails, after exactly `HAL0_SEAM_PROBE_ATTEMPTS` attempts;
- the failure quotes the full two-hop command and **not** the old bare-name form;
- the failure carries the probe's rc and its stderr tail;
- the loop does not abort a caller running `set -euo pipefail` (install.sh's mode);
- required seams get the same retry — the transient is not podman-ro's;
- one attempt is bounded by a timeout, in lock-step with `seam_check.py`.

Checks run:

- `pytest tests/installer/test_seam_verification.py tests/installer/test_podman_ro_validation.py` → **388 passed**
- `pytest tests/installer/` → same 215 pre-existing macOS-environment failures as `main` (AppleDouble `._*.sh` files under `installer/comfyui/`, `stat -c` etc.), `962 passed` on main → `971 passed` here, i.e. +9 and nothing newly red
- `ruff check` / `ruff format --check` on the touched file → clean (repo-wide `ruff check` shows only the 17 pre-existing `packaging/toolbox/**` findings)
- `bash -n installer/lib/preflight.sh` → clean
- the #2081 reporter-scope guard (`test_ui_helper_contract.py`) re-run manually with the AppleDouble files skipped → no offenders; the new code only calls `info` and the existing `"${report}"` indirection

## Deliberately out of scope

- **Reordering the optional-seam probes relative to the service-start phase** (the issue's second suggestion). Bigger blast radius in `install.sh`, and it would only move the window rather than close it — the retry already separates "verified too fast" from "genuinely broken", and the new message tells you which one you got.
- **The Python mirror** (`src/hal0/system/seam_check.py`). It runs long after install (`hal0 doctor`), has no write→verify window, and already reports rc + stderr tail. Read-only context here.
- **`CHANGELOG.md`** — per #1545, one consolidated CHANGELOG PR lands at the end of the wave.

Closes #2084
