### PR TITLE
feat: component update system — unified pins, converge, status/retry surface

### DIFF
--- a/.github/workflows/hindsight-pin-gate.yml
+++ b/.github/workflows/hindsight-pin-gate.yml
@@ -14,10 +14,20 @@
 # what makes "required" safe here.
 name: hindsight-pin-gate
 
+# No `paths:` filter here, deliberately: with one, GitHub never reports a
+# status for this workflow on a PR that doesn't touch
+# src/hal0/memory/engine_upgrade.py at all, and a branch-protection required
+# check that never reports goes to "Expected" forever — it blocks merging
+# every other PR, not just ones that skip the gate. Running `detect` on
+# every PR is cheap (one checkout + a grep), so it always runs; `engine-gate`
+# itself still only runs `if: needs.detect.outputs.changed == 'true'`.
+#
+# Required-check note: if `engine-gate` is marked required on the protected
+# branch, a *skipped* job (the `if:` evaluates false) still reports success
+# to branch protection — that is what makes marking it required safe even
+# though most PRs skip it.
 on:
-  pull_request:
-    paths:
-      - "src/hal0/memory/engine_upgrade.py"
+  pull_request: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/hindsight-pin-gate.yml
+++ b/.github/workflows/hindsight-pin-gate.yml
@@ -67,6 +67,36 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
+      # BEFORE setup-python, deliberately: this step deletes preinstalled
+      # toolchains, and anything it removed after setup-python would be gone
+      # from under the interpreter the job then depends on.
+      - name: Make room for the engine venvs
+        # A hindsight-api venv is a full torch install (CUDA wheels included —
+        # the engine forces CPU at runtime but pip still pulls them) plus the
+        # bundled BGE embedder, and the gate holds FOUR of them at once: per
+        # engine dir the pass keeps the superseded venv (.venv.old-* on the
+        # upgrade leg, .venv.failed-* on the rollback leg) beside the live one.
+        # ubuntu-latest's root volume does not fit that. So drop the
+        # preinstalled toolchains nothing here uses, and put pytest's tmp tree
+        # on the runner's large scratch disk. `df` output is the receipt when
+        # a future engine release outgrows even this.
+        #
+        # AGENT_TOOLSDIRECTORY is NOT in the delete list: on hosted Ubuntu it
+        # is /opt/hostedtoolcache, which is exactly where setup-python lays the
+        # interpreter down. Removing it would either destroy the job's own
+        # Python or force a needless re-download.
+        #
+        # /mnt/gate (the PARENT) is what gets chowned, not just the basetemp:
+        # pytest's TempPathFactory rm_rf()s the --basetemp path and re-mkdir()s
+        # it, which needs write on its parent. Chowning only the leaf leaves
+        # root-owned /mnt as the parent and the run dies with PermissionError.
+        run: |
+          set -euo pipefail
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost || true
+          sudo mkdir -p /mnt/gate/tmp
+          sudo chown -R "$(id -u):$(id -g)" /mnt/gate
+          df -h / /mnt
       - uses: actions/setup-python@v6
         with:
           # Inside engine_upgrade.PY_MIN_MINOR..PY_MAX_MINOR (3.11-3.13), and
@@ -79,25 +109,8 @@ jobs:
       - name: Install
         # Same --frozen/--python posture as ci.yml's python job.
         run: uv sync --frozen --extra dev --python "$(which python)"
-      - name: Make room for the engine venvs
-        # A hindsight-api venv is a full torch install (CUDA wheels included —
-        # the engine forces CPU at runtime but pip still pulls them) plus the
-        # bundled BGE embedder, and the gate holds FOUR of them at once: per
-        # engine dir the pass keeps the superseded venv (.venv.old-* on the
-        # upgrade leg, .venv.failed-* on the rollback leg) beside the live one.
-        # ubuntu-latest's root volume does not fit that. So drop the
-        # preinstalled toolchains nothing here uses, and put pytest's tmp tree
-        # on the runner's large scratch disk. `df` output is the receipt when
-        # a future engine release outgrows even this.
-        run: |
-          set -euo pipefail
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-                      /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
-          sudo mkdir -p /mnt/gate-tmp
-          sudo chown "$(id -u):$(id -g)" /mnt/gate-tmp
-          df -h / /mnt
       - name: upgrade / rollback / contract gate
         env:
           HAL0_ENGINE_GATE: "1"
           HAL0_GATE_OLD_PIN: ${{ needs.detect.outputs.old_pin }}
-        run: uv run pytest tests/memory/test_engine_gate.py -v --basetemp=/mnt/gate-tmp
+        run: uv run pytest tests/memory/test_engine_gate.py -v --basetemp=/mnt/gate/tmp

--- a/.github/workflows/hindsight-pin-gate.yml
+++ b/.github/workflows/hindsight-pin-gate.yml
@@ -1,0 +1,103 @@
+# Evidence gate for HINDSIGHT_API_PIN bumps (spec §5).
+#
+# src/hal0/memory/engine_upgrade.py is the single owner of the engine version
+# pin, and the upgrade it performs runs a ONE-WAY alembic migration on every
+# box's embedded postgres. Reviewing the diff cannot tell you whether the new
+# engine actually starts on a migrated .pg0, whether the data survives, whether
+# the rollback path still works, or whether the REST surface hal0 calls is
+# still there — only running it against the real engines can. So a PR that
+# changes the pin must prove it here before it can merge.
+#
+# The job is skipped (not failed) when the file changed but the pin did not,
+# so refactors of the pass stay cheap. Mark `engine-gate` a required check on
+# the protected branch — a job that never runs still reports success, which is
+# what makes "required" safe here.
+name: hindsight-pin-gate
+
+on:
+  pull_request:
+    paths:
+      - "src/hal0/memory/engine_upgrade.py"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
+      old_pin: ${{ steps.diff.outputs.old_pin }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so the base commit's copy of the file is fetchable.
+          fetch-depth: 0
+      - id: diff
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          pin() { grep -oP 'HINDSIGHT_API_PIN = "\K[^"]+' || true; }
+          # `|| true` inside the braces: under pipefail a missing base copy of
+          # the file would otherwise abort the step instead of reporting "no
+          # base pin" (the new-module case handled below).
+          old=$( { git show "origin/${BASE_REF}:src/hal0/memory/engine_upgrade.py" 2>/dev/null || true; } | pin )
+          new=$(pin < src/hal0/memory/engine_upgrade.py)
+          echo "base pin: '${old}' -> head pin: '${new}'"
+          echo "old_pin=${old}" >> "$GITHUB_OUTPUT"
+          # No base pin means the module is new on this PR: there is no prior
+          # engine version to upgrade FROM, so there is nothing to gate.
+          if [ -n "${old}" ] && [ "${old}" != "${new}" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  engine-gate:
+    needs: detect
+    if: needs.detect.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    # Two full hindsight-api installs (each pulls torch + the bundled BGE
+    # embedder) plus two embedded-postgres first boots and a one-way migration.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          # Inside engine_upgrade.PY_MIN_MINOR..PY_MAX_MINOR (3.11-3.13), and
+          # the same primary CI runs. The gate builds its throwaway engine
+          # venvs from this interpreter.
+          python-version: "3.12"
+          cache: pip
+      - name: Install uv
+        run: pip install uv
+      - name: Install
+        # Same --frozen/--python posture as ci.yml's python job.
+        run: uv sync --frozen --extra dev --python "$(which python)"
+      - name: Make room for the engine venvs
+        # A hindsight-api venv is a full torch install (CUDA wheels included —
+        # the engine forces CPU at runtime but pip still pulls them) plus the
+        # bundled BGE embedder, and the gate holds FOUR of them at once: per
+        # engine dir the pass keeps the superseded venv (.venv.old-* on the
+        # upgrade leg, .venv.failed-* on the rollback leg) beside the live one.
+        # ubuntu-latest's root volume does not fit that. So drop the
+        # preinstalled toolchains nothing here uses, and put pytest's tmp tree
+        # on the runner's large scratch disk. `df` output is the receipt when
+        # a future engine release outgrows even this.
+        run: |
+          set -euo pipefail
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
+          sudo mkdir -p /mnt/gate-tmp
+          sudo chown "$(id -u):$(id -g)" /mnt/gate-tmp
+          df -h / /mnt
+      - name: upgrade / rollback / contract gate
+        env:
+          HAL0_ENGINE_GATE: "1"
+          HAL0_GATE_OLD_PIN: ${{ needs.detect.outputs.old_pin }}
+        run: uv run pytest tests/memory/test_engine_gate.py -v --basetemp=/mnt/gate-tmp

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -97,6 +97,8 @@ src/hal0/
 ├── memory/          # Hindsight engine client/provider + MemoryRecord
 ├── mcp/             # hal0-admin + hal0-memory FastMCP servers
 ├── omni_router/     # client-side OpenAI tool-calling loop
+├── components/      # release-pinned component catalog + converge arms
+│                    #   (spec: update system)
 ├── updater/         # self-update (cosign-verified, atomic swap)
 ├── installer/       # first-run wizard backend, hardware probe writer
 ├── voice/           # emptied in #620 (in-process Moonshine/Kokoro
@@ -109,6 +111,18 @@ src/hal0/
 The dedicated auth packages (`auth/`, `api/auth/`,
 `api/middleware/auth.py`) were removed: hal0-api binds `0.0.0.0:8080`
 open, and LAN trust plus an upstream reverse proxy own authentication.
+
+**Component updates.** `components/` catalogs the four hal0-shipped
+components that converge alongside a `hal0 update`: OpenWebUI (the
+podman companion container), runner images (slot toolbox images),
+Hermes, and Hindsight. None of them float independently — each
+component's pin travels *inside* the hal0 release, so converging a
+box to a release converges its components too (the final pass of
+`Updater.commit`'s post-swap migrations, `hal0.components.runner.
+converge_components`). `hal0 update status` reports installed vs.
+pinned version and convergence state per component; `hal0 update
+component <id>` re-runs one component's converge arm without a full
+update.
 
 The capabilities layer remains a **thin overlay** on the flat slot
 layer as a UX surface, not a replacement. Slot configs under
@@ -341,10 +355,14 @@ and the composite `hal0` upstream config — all idempotently.
   lifespan-scoped `ApprovalQueue`. Audit rows flow through journald via
   the `hal0.mcp.audit` logger; `GET /api/agents/{name}/activity` reads
   them back for the dashboard Activity tab.
-* **Skills catalog** — `GET /api/agents/skills` returns the static
-  catalog (`HERMES_TOOL_CATALOG` + `HAL0_MCP_TOOL_CATALOG`) the
-  dashboard sidebar renders. Bumps ride the weekly `hermes-sdk-diff`
-  drift PRs (see [Upstream pin](#upstream-pin)).
+* **Skills catalog** — `GET /api/agents/skills`
+  (`src/hal0/api/routes/agents.py`) returns the dashboard's Agent →
+  Skills tab catalogue, sourced from the static `AGENT_SKILLS` tuple in
+  `hal0.agents.persona` (a v0.3 UI listing; per-skill call counts still
+  stub to zero pending a registry-backed follow-up, #227). This is not
+  the MCP tool list: the admin MCP server's real tool catalog lives in
+  `src/hal0/mcp/admin.py`, documented in
+  [`docs/reference/mcp-tools.mdx`](./docs/reference/mcp-tools.mdx).
 * **Identity** — an agent identity card is published once into the
   `agents` memory namespace during first-run bootstrap and cleaned on
   uninstall. `X-hal0-Agent` is the header the proxy injects on every
@@ -362,9 +380,8 @@ and the composite `hal0` upstream config — all idempotently.
 | `src/hal0/api/agents/personas.py`              | `/api/agents/{id}/personas[/{pid}/activate]` |
 | `src/hal0/api/agents/chat_proxy.py`            | WS proxy + session REST shim                 |
 | `src/hal0/api/agents/restart.py`               | `POST /api/agents/{id}/restart`              |
-| `src/hal0/api/agents/skills.py`                | `GET /api/agents/skills`                     |
 | `src/hal0/api/agents/memory_stats.py`          | `GET /api/agents/{id}/memory/stats`          |
-| `src/hal0/api/routes/agents.py`                | install / uninstall / activity               |
+| `src/hal0/api/routes/agents.py`                | list / persona-enums / `GET /skills` / install / uninstall / activity |
 | `src/hal0/api/routes/approvals.py`             | approval inbox                               |
 | `src/hal0/api/plugins/`                        | plugin host (manifest + static assets)       |
 | `src/hal0/cli/agent_shim.py`                   | `/usr/local/bin/hal0-agent` (unit ExecStart) |

--- a/docs/guides/update-and-rollback.mdx
+++ b/docs/guides/update-and-rollback.mdx
@@ -307,6 +307,44 @@ re-run it — this whole section is a one-time migration concern, not an
 ongoing behavior of `hal0 update`.
 </Aside>
 
+## Component updates
+
+Four components carry their own release-pinned version alongside hal0
+itself: OpenWebUI (the companion container), runner images, Hermes, and
+Hindsight. None of them float independently — each pin travels *inside*
+the hal0 release, so a normal `hal0 update` converges all four as part of
+applying. Reach for `hal0 update status` and `hal0 update component <id>`
+for a narrower view, or to retry just the piece that's stuck.
+
+```sh
+hal0 update status
+```
+
+Prints the same hal0 version/channel check as `hal0 update --check`, plus
+a table of installed / pinned / status for each component. `status` is
+`converged` once the box matches the release pin; anything else
+(`pending`, `stale`, or a failure status) still needs to catch up. Exits
+**2** when a component is outstanding — useful for scripting a gate on
+full convergence, not just "hal0 itself is current."
+
+```sh
+hal0 update component runner-images
+hal0 update component hermes --check
+```
+
+Re-runs one component's converge arm without a full `hal0 update` — a
+retry surface for a component that's stuck (e.g. `build_failed` after a
+transient pull failure). `--check` prints the status row without
+converging.
+
+<Aside type="note">
+An apply that leaves the profile-catalog reset (see above) or a component
+unconverged still reports the update as applied, but exits **2** —
+distinct from a failed update (exit 1). `hal0 update` prints the same
+convergence report and component table inline after an apply, so you
+don't need a separate `hal0 update status` call to see what's left.
+</Aside>
+
 ## Roll back
 
 If an update misbehaves, revert to the previously installed tree:
@@ -333,12 +371,24 @@ decoupled.
 
 ```sh
 hal0 update owui --check
-hal0 update owui --target <digest>
-hal0 update owui --yes --force
+hal0 update owui --yes
+hal0 update owui --target <digest> --yes
+hal0 update owui --clear-override --yes
 ```
 
-Independent of the main `hal0 update` flow — repins the bundled
-OpenWebUI container by SHA-256 digest.
+`hal0 update owui` is a thin alias for `hal0 update component openwebui`
+(see [Component updates](#component-updates) above) — it converges the
+bundled OpenWebUI container to whatever pin hal0 carries for it, the same
+as a plain `hal0 update` would. There is no independent `--tag`
+float-to-upstream flag any more; the pin rides hal0 releases like every
+other component.
+
+`--target <digest>` (`sha256:…` or bare 64-hex) pins an explicit digest
+override instead, for holding OWUI outside the release cadence. The
+override persists across future converges — including a plain `hal0
+update` — until you drop it with `--clear-override`, which converges the
+container back to the release pin. `--check` prints the status row only;
+`--yes`/`-y` skips the confirmation prompt.
 
 ## See also
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -81,6 +81,9 @@ hal0 setup [--auto] [--storage-dir DIR] [--no-pull] [--no-extensions] [--no-slot
 ```sh
 hal0 update [--channel stable|preview|nightly] [--check] [--rollback]
             [--target VERSION] [--yes|-y] [--restart-slots]
+hal0 update status
+hal0 update component <id> [--check]
+hal0 update owui [--check] [--target DIGEST] [--clear-override] [--yes|-y]
 ```
 
 | Flag | Meaning |
@@ -92,10 +95,34 @@ hal0 update [--channel stable|preview|nightly] [--check] [--rollback]
 | `--yes` / `-y` | Skip the confirmation prompt. |
 | `--restart-slots` | Bounce only drifted slots after update. |
 
-`hal0 update owui` manages the bundled OpenWebUI container separately:
-`--check`, `--tag` (upstream tag, default `:main`; ignored if `--target` set), `--target`
-(pin an explicit digest), `--yes`/`-y`, `--force` (repin/pull/restart even if the digest
-already matches).
+An apply that leaves any operator-facing convergence outstanding (the
+one-shot v1.0 profile-catalog reset, or a component below still `pending`)
+exits **2** rather than reporting a clean success — distinct from a failed
+update (`die()` → exit 1).
+
+`hal0 update status` prints the same hal0 version/channel check plus a
+per-component table (installed / pinned / status) for the four
+release-pinned components — OpenWebUI, runner images, Hermes, and
+Hindsight; their pins ride hal0 releases rather than updating
+independently. Exits **2** if any component isn't converged yet
+(`pending`, `stale`, or a failure status), so it doubles as a scriptable
+convergence gate.
+
+`hal0 update component <id>` re-runs one component's converge arm — a
+per-component alternative to a full `hal0 update` for retrying just the
+piece that's stuck. `--check` prints that component's status row without
+converging it. `<id>` is one of `openwebui`, `runner-images`, `hermes`,
+`hindsight` (see `hal0 update status` for the live list).
+
+`hal0 update owui` converges the bundled OpenWebUI companion container to
+its release-carried pin — a thin alias for `hal0 update component
+openwebui`. There is no more independent `--tag` float-to-upstream flag:
+the pin now rides hal0 releases like every other component. `--target
+DIGEST` (`sha256:…` or bare 64-hex) pins an explicit digest override
+instead, which persists across future converges until cleared;
+`--clear-override` drops it and converges back to the release pin.
+`--check` prints the status row only; `--yes`/`-y` skips the confirmation
+prompt.
 
 <Aside type="caution">
 On a v1.0 update, the profile catalog is reset once (gated on a schema-version

--- a/docs/reference/mcp-tools.mdx
+++ b/docs/reference/mcp-tools.mdx
@@ -94,6 +94,8 @@ overrides for the handful that don't map 1:1 onto their route live in
 | `updater_channel_get` | `GET /api/updates/channel` |
 | `updater_slot_drift` | `GET /api/updates/slot-drift` |
 | `updater_job_status` | `GET /api/updates/status/{job_id}` |
+| `component_status` | `GET /api/updates/components` |
+| `update_check` | `GET /api/updates/check` |
 | `doctor_report` | `GET /api/doctor` |
 | `health_system` | `GET /api/health/system` |
 | `feature_list` | `GET /api/features` |
@@ -170,6 +172,7 @@ overrides for the handful that don't map 1:1 onto their route live in
 | `slot_delete` | `DELETE /api/slots/{name}` |
 | `slot_restart` | `POST /api/slots/{name}/restart` |
 | `slot_rename` | `POST /api/slots/{name}/rename` |
+| `component_converge` | `POST /api/updates/components/{component_id}/converge` |
 | `capability_set` | `POST /api/capabilities/{slot}/{child}` |
 | `config_write` | `PUT /api/settings` |
 | `provider_credential_write` | `POST /api/providers/{name}/credentials` |

--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -92,7 +92,11 @@
 set -euo pipefail
 
 UNIT_PREFIX="hal0-slot@"
-UNIT_DIR="/etc/systemd/system"
+# Overridable so `repin-owui` (component-updates task 3) can be exercised
+# against a fake unit tree in tests, same fallback shape as everything else
+# in this file that accepts a caller-supplied value: production never sets
+# UNIT_DIR in the environment, so this is a no-op there.
+UNIT_DIR="${UNIT_DIR:-/etc/systemd/system}"
 SELF_UNIT="hal0-api.service"
 
 # Bundled-agent template unit (hal0-agent@<id>.service). Separate prefix +
@@ -832,6 +836,28 @@ case "$cmd" in
     exec systemctl "${cmd#svc-}" "$unit"
     ;;
 
+  repin-owui)                  # repin-owui <sha256:digest> — OWUI companion image pin
+    # `hal0 update owui` repins the *installed* OpenWebUI companion unit —
+    # the one privileged write that verb needs, same posture as the other
+    # atomic tmp+mv arms above: the digest is validated BEFORE the unit is
+    # touched, and rewriting happens via tmp+mv, never in place. The mode is
+    # fixed at 0644 rather than copied from the original ($unit) — matching
+    # every other write arm in this file (write-quadlet, write-*-dropin) —
+    # instead of a GNU-only `chmod --reference`, which is also what
+    # install.sh's `cp` leaves the shipped unit at.
+    digest="${1:-}"
+    [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || die "repin-owui: bad digest"
+    unit="${UNIT_DIR}/hal0-openwebui.service"
+    [[ -f "$unit" ]] || die "repin-owui: $unit not found"
+    tmp="$(mktemp "${unit}.XXXXXX")"
+    trap 'rm -f "$tmp"' EXIT
+    sed -E "s|open-webui@sha256:[0-9a-f]{64}|open-webui@${digest}|g" "$unit" > "$tmp"
+    chmod 0644 "$tmp"
+    mv -f "$tmp" "$unit"
+    trap - EXIT
+    systemctl daemon-reload
+    ;;
+
   restart-self)                # literal-only: restart hal0-api.service, never a variable name
     # --no-block: this is invoked BY hal0-api, from inside hal0-api.service's
     # own cgroup. A blocking `systemctl restart` waits for the unit to stop —
@@ -865,6 +891,7 @@ usage: hal0-systemctl <command> [slot-id|agent-id]
   enable-agent <agent-id>          systemctl enable ${AGENT_UNIT_PREFIX}<id>.service
   svc-<verb> <openwebui|hindsight|hermes-gateway>
                                    systemctl <verb> on the mapped companion unit
+  repin-owui <sha256:digest>       rewrite the OpenWebUI companion image pin + daemon-reload
   restart-self                     systemctl restart ${SELF_UNIT}
 EOF
     ;;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ markers = [
   "podman: needs a real container runtime (podman/docker) reachable on the host",
   "systemd: needs a live systemd/journald (systemctl, journalctl)",
   "network: needs outbound network access (registry pulls, live HTTP endpoints)",
+  "engine_gate: hindsight pin-bump evidence gate (network + embedded pg; HAL0_ENGINE_GATE=1)",
 ]
 
 [tool.mypy]

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -690,6 +690,15 @@ async def check_updates(request: Request) -> dict[str, Any]:
 
     # A revoked (yanked) latest is never offered as an available update.
     update_available = bool(latest) and not revoked and _is_newer(latest, __version__)
+
+    def _components_pending() -> int:
+        try:
+            from hal0.components.status import component_status_snapshot
+
+            return int(component_status_snapshot()["pending"])
+        except Exception:
+            return 0  # courtesy field — never fail /check over it
+
     # #1585: the one-shot v1.0 profile-catalog reset runs inside commit(), so a
     # box updated 0.9.8→1.0 by the OLD daemon (which had no reset) lands
     # converged-except-for-this and then goes silent — `hal0 update` says
@@ -705,6 +714,7 @@ async def check_updates(request: Request) -> dict[str, Any]:
         "manifest_url": url,
         "manifest": manifest if isinstance(manifest, dict) else {},
         "profile_reset": await asyncio.to_thread(profile_reset_status),
+        "components_pending": await asyncio.to_thread(_components_pending),
     }
 
 

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -1134,8 +1134,12 @@ async def converge_component_route(component_id: str, request: Request) -> dict[
 
     job_id = uuid.uuid4().hex[:12]
     jobs[job_id] = {
-        "id": job_id, "state": "queued", "phase": f"converge:{component_id}",
-        "created_at": time.time(), "updated_at": time.time(), "error": None,
+        "id": job_id,
+        "state": "queued",
+        "phase": f"converge:{component_id}",
+        "created_at": time.time(),
+        "updated_at": time.time(),
+        "error": None,
     }
     _persist_job(jobs[job_id])
     _spawn_update_task(request, _run_component_job(jobs, job_id, component_id, arm_kwargs))

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -1051,7 +1051,7 @@ async def set_channel(request: Request) -> dict[str, str]:
 
 @router.get("/components")
 async def list_components(request: Request) -> dict[str, Any]:
-    """Per-component version/converge status (catalog × state × live probes)."""
+    """Per-component version/converge status (catalog x state x live probes)."""
     from hal0.components.status import component_status_snapshot
 
     return await asyncio.to_thread(component_status_snapshot)

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -89,6 +89,16 @@ class UpdateEditableRefused(Hal0Error):
     status = 409
 
 
+class ComponentNotFound(Hal0Error):
+    code = "system.component_not_found"
+    status = 404
+
+
+class ComponentConvergeBusy(Hal0Error):
+    code = "system.component_converge_busy"
+    status = 409
+
+
 def _refuse_if_editable() -> None:
     """Preflight: hard-refuse an update on an editable/dev install (audit 4.1).
 
@@ -1035,6 +1045,84 @@ async def list_components(request: Request) -> dict[str, Any]:
     from hal0.components.status import component_status_snapshot
 
     return await asyncio.to_thread(component_status_snapshot)
+
+
+async def _run_component_job(
+    jobs: dict[str, dict[str, Any]], job_id: str, component_id: str, arm_kwargs: dict[str, Any]
+) -> None:
+    from hal0.components.registry import component_by_id
+    from hal0.components.runner import converge_component
+
+    job = jobs[job_id]
+    job["state"] = "running"
+    job["updated_at"] = time.time()
+    _persist_job(job)
+    comp = component_by_id(component_id)
+    try:
+        result = await asyncio.to_thread(converge_component, comp, job_id=job_id, **arm_kwargs)
+    except Exception as exc:
+        job["state"] = "failed"
+        job["error"] = str(exc)
+    else:
+        job["component_result"] = result
+        failed = result.get("status") in ("build_failed", "snapshot_failed", "rolled_back")
+        job["state"] = "failed" if failed else "applied"
+        if failed:
+            job["error"] = result.get("error")
+    finally:
+        job["updated_at"] = time.time()
+        _persist_job(job)
+
+
+@router.post("/components/{component_id}/converge", status_code=202)
+async def converge_component_route(component_id: str, request: Request) -> dict[str, Any]:
+    """Re-run one component's converge arm (spec §3 — the retry surface)."""
+    from hal0.components.registry import component_by_id
+    from hal0.components.runner import _arm_kwargs
+
+    comp = component_by_id(component_id)
+    if comp is None:
+        raise ComponentNotFound(
+            f"no component {component_id!r}", details={"component": component_id}
+        )
+    jobs = _update_jobs(request)
+    if any(j.get("state") in ("queued", "running") for j in jobs.values()):
+        raise ComponentConvergeBusy(
+            "an update or converge job is already in flight",
+            details={"component": component_id},
+        )
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    # Reuse runner._arm_kwargs so the per-component flag mapping (e.g. the
+    # hindsight arm's ``upgrade`` kwarg spelling) isn't duplicated here.
+    # job_id is dropped from the base mapping and passed explicitly by
+    # ``_run_component_job`` once the job id is known.
+    arm_kwargs: dict[str, Any] = _arm_kwargs(
+        comp, job_id=None, apply=True, image_retag=True, engine=True, hermes_install=True
+    )
+    arm_kwargs.pop("job_id", None)
+    if component_id == "openwebui" and isinstance(body, dict):
+        target = body.get("target")
+        if isinstance(target, str):
+            from hal0.openwebui.image_pin import normalize_digest
+
+            normalized = normalize_digest(target)
+            if normalized is None:
+                raise BadRequest("target must be a sha256 digest", details={"target": target})
+            arm_kwargs["target_digest"] = normalized
+        if body.get("clear_override") is True:
+            arm_kwargs["clear_override"] = True
+
+    job_id = uuid.uuid4().hex[:12]
+    jobs[job_id] = {
+        "id": job_id, "state": "queued", "phase": f"converge:{component_id}",
+        "created_at": time.time(), "updated_at": time.time(), "error": None,
+    }
+    _persist_job(jobs[job_id])
+    _spawn_update_task(request, _run_component_job(jobs, job_id, component_id, arm_kwargs))
+    return dict(jobs[job_id])
 
 
 # ── /slot-drift + /restart-slots (installer-setup WS-J, #1111) ───────────────

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -1095,16 +1095,23 @@ async def converge_component_route(component_id: str, request: Request) -> dict[
         raise ComponentNotFound(
             f"no component {component_id!r}", details={"component": component_id}
         )
+    # Parse the body BEFORE the busy check, deliberately: `await
+    # request.json()` yields control back to the event loop, so if the busy
+    # check ran first, two concurrent converge POSTs could both observe an
+    # empty/idle `jobs` dict, both pass the check, and both register + spawn
+    # a job — running two converge arms for the same component at once.
+    # With no `await` between the check and the job-dict write below, the
+    # check-then-register span is atomic from the event loop's perspective.
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
     jobs = _update_jobs(request)
     if any(j.get("state") in ("queued", "running") for j in jobs.values()):
         raise ComponentConvergeBusy(
             "an update or converge job is already in flight",
             details={"component": component_id},
         )
-    try:
-        body = await request.json()
-    except Exception:
-        body = {}
     # Reuse runner._arm_kwargs so the per-component flag mapping (e.g. the
     # hindsight arm's ``upgrade`` kwarg spelling) isn't duplicated here.
     # job_id is dropped from the base mapping and passed explicitly by

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -1026,6 +1026,17 @@ async def set_channel(request: Request) -> dict[str, str]:
     return {"channel": channel}
 
 
+# ── /components (spec 2026-08-30 §3) ───────────────────────────────────────
+
+
+@router.get("/components")
+async def list_components(request: Request) -> dict[str, Any]:
+    """Per-component version/converge status (catalog × state × live probes)."""
+    from hal0.components.status import component_status_snapshot
+
+    return await asyncio.to_thread(component_status_snapshot)
+
+
 # ── /slot-drift + /restart-slots (installer-setup WS-J, #1111) ───────────────
 #
 # ``rerender_slot_units`` (updater) rewrites each on-disk slot unit through

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -355,7 +355,6 @@ _MIGRATION_PASS_LABELS: dict[str, str] = {
     "updater.seed_profiles_prune_failed": "seed-profile cleanup",
     "updater.mtp_migration_failed": "mtp override cleanup",
     "updater.vulkan_migration_failed": "gpu-vulkan slot relabel",
-    "updater.image_retag_failed": "runner image retag",
     "updater.extra_args_sanitize_failed": "managed extra_args sanitisation",
     "updater.memory_engine_upgrade_failed": "memory engine upgrade",
     "updater.components_converge_failed": "component convergence",
@@ -743,7 +742,21 @@ def update(
         # running the pre-update command so the operator can opt into a restart.
         _print_drift_banner(_fetch_slot_drift())
         converged = _print_convergence(final.get("convergence"))
-        components_ok = _print_component_table(_component_rows())
+        # hal0-api is mid-self-restart right after commit applies (the unit
+        # files were just re-rendered), so a strict _component_rows() fetch
+        # here can 409/connection-refuse on a clean apply. Use the tolerant
+        # variant and treat "couldn't recheck" as success rather than
+        # fabricating an exit-2 convergence failure — `hal0 update status`
+        # still does the strict check.
+        component_rows = _component_rows_tolerant()
+        if component_rows is None:
+            console.print(
+                "[dim]components not re-checked — hal0-api restarting; "
+                "run `hal0 update status`[/dim]"
+            )
+            components_ok = True
+        else:
+            components_ok = _print_component_table(component_rows)
         if converged and components_ok:
             console.print(Panel("[green]update applied.[/green]", border_style="green"))
             return
@@ -788,6 +801,22 @@ def _component_rows() -> list[dict]:
     except CliApiError as exc:
         die(str(exc))
         return []
+    return body.get("components") or []
+
+
+def _component_rows_tolerant() -> list[dict] | None:
+    """Fetch the /api/updates/components rows, or None on an API error.
+
+    Used right after a self-update commit, where hal0-api may be mid
+    self-restart and briefly unreachable/erroring — that is not a
+    convergence failure, just a fetch that couldn't happen yet. Callers
+    that want strict "die on API error" behavior (e.g. `hal0 update
+    status`) should keep using `_component_rows()` instead.
+    """
+    try:
+        body = api_get("/api/updates/components")
+    except CliApiError:
+        return None
     return body.get("components") or []
 
 

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -16,12 +16,9 @@ Surface:
 
 from __future__ import annotations
 
-import os
-import subprocess
 import sys
 import time
 from enum import StrEnum
-from pathlib import Path
 
 import httpx
 import typer
@@ -746,7 +743,8 @@ def update(
         # running the pre-update command so the operator can opt into a restart.
         _print_drift_banner(_fetch_slot_drift())
         converged = _print_convergence(final.get("convergence"))
-        if converged:
+        components_ok = _print_component_table(_component_rows())
+        if converged and components_ok:
             console.print(Panel("[green]update applied.[/green]", border_style="green"))
             return
         # Refuse to report a clean success while the old on-disk shape survives:
@@ -767,209 +765,170 @@ def update(
         die(f"update {state}: {err}")
 
 
-# ── hal0 update owui — repin the OpenWebUI companion image ─────────────────────
+# ── hal0 update status / component — per-component convergence (spec §3) ──────
 #
-# OpenWebUI is a podman container pinned by sha256 manifest-list digest in the
-# installed unit (packaging/systemd/hal0-openwebui.service, copied to
-# /etc/systemd/system by install.sh). It is NOT in manifest.json, and the hal0
-# self-updater does not touch companion units — so a runtime repin of the
-# installed unit is durable across `hal0 update` (only a fresh install.sh run
-# rewrites it). This command resolves a digest (upstream tag or explicit
-# --target), repins the unit, pulls, and restarts. The pure text seam lives in
-# hal0.openwebui.image_pin; the release-source pin sites (install.sh + the
-# packaging unit) are a separate maintainer concern — see
-# scripts/update-owui-digest.sh + the pin-consistency test.
+# The daemon owns the component catalog (hal0.components.*): GET
+# /api/updates/components reports each component's installed/pinned/status,
+# and POST /api/updates/components/{id}/converge (re)runs its converge arm as
+# a background job, polled the same way as the self-update prepare/commit
+# jobs above. These verbs give an operator a component-scoped alternative to
+# the all-or-nothing bare `hal0 update` for retrying just the piece that's
+# stuck.
+
+#: Component statuses that mean "not converged yet" — everything else
+#: (currently just "converged", plus the openwebui-only "override" and
+#: "not-installed") counts as settled for the purposes of the exit code.
+_COMPONENT_PENDING = ("pending", "stale", "build_failed", "snapshot_failed", "rolled_back")
 
 
-def _dev_mode() -> bool:
-    """True under an ``install.sh --dev`` layout (HAL0_HOME set).
-
-    In dev we rewrite the unit file but skip the privileged podman/systemctl
-    side effects — there is no real service to bounce.
-    """
-    return bool(os.environ.get("HAL0_HOME", "").strip())
-
-
-def _run_cmd(argv: list[str], *, timeout: float) -> tuple[int | None, str, str]:
-    """Run ``argv``; return ``(rc, stdout, stderr)``. rc=None on spawn/timeout."""
+def _component_rows() -> list[dict]:
+    """Fetch the /api/updates/components rows, or die on an API error."""
     try:
-        proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, check=False)
-    except subprocess.TimeoutExpired:
-        return None, "", f"{argv[0]} timed out after {timeout:.0f}s"
-    except (FileNotFoundError, OSError) as exc:
-        return None, "", f"{argv[0]} not runnable: {exc}"
-    return proc.returncode, proc.stdout, proc.stderr
+        body = api_get("/api/updates/components")
+    except CliApiError as exc:
+        die(str(exc))
+        return []
+    return body.get("components") or []
 
 
-def _resolve_owui_upstream_digest(tag: str) -> str:
-    """Resolve the published ghcr.io manifest-list digest for OWUI ``tag``.
+def _print_component_table(rows: list[dict]) -> bool:
+    """Render the component table; True when everything is converged."""
+    table = Table(title="Components", show_header=True, header_style="bold")
+    for col in ("component", "installed", "pinned", "status"):
+        table.add_column(col)
+    all_ok = True
+    for row in rows:
+        status_txt = row.get("status", "?")
+        if status_txt in _COMPONENT_PENDING:
+            all_ok = False
+            status_txt = f"[yellow]{status_txt}[/yellow]"
+        elif status_txt == "converged":
+            status_txt = "[green]converged[/green]"
+        pinned = row.get("pinned") or "—"
+        if row.get("pin_label"):
+            pinned = f"{pinned} ({row['pin_label']})"
+        table.add_row(row.get("name", row.get("id", "?")), str(row.get("installed") or "—"), str(pinned), status_txt)
+    console.print(table)
+    for row in rows:
+        if row.get("status") in _COMPONENT_PENDING and (row.get("error") or row.get("remedy")):
+            remedy = row.get("remedy") or f"retry with: hal0 update component {row['id']}"
+            console.print(
+                f"[yellow]![/yellow] {row['id']}: {row.get('error') or ''} "
+                f"[dim]{remedy}[/dim]"
+            )
+    return all_ok
 
-    Reuses the anonymous OCI probe the toolbox surface already ships. Raises
-    ``httpx.HTTPError`` / ``RuntimeError`` / ``ValueError`` on failure for the
-    caller to turn into a clean ``die``.
-    """
-    import httpx
 
-    from hal0.cli.doctor_commands import _ghcr_anon_token, _ghcr_manifest_digest
-    from hal0.openwebui.image_pin import OPENWEBUI_GHCR_REPO
-
-    with httpx.Client(follow_redirects=True) as client:
-        token = _ghcr_anon_token(OPENWEBUI_GHCR_REPO, client=client)
-        return _ghcr_manifest_digest(OPENWEBUI_GHCR_REPO, tag, token=token, client=client)
-
-
-def _write_unit_atomic(unit: Path, text: str) -> None:
-    """Rewrite ``unit`` in place, preserving mode, via a same-dir temp + replace."""
+@update_app.command("status")
+def update_status_cmd() -> None:
+    """Show hal0 + per-component version/convergence status (exit 2 if outstanding)."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
     try:
-        mode = unit.stat().st_mode & 0o777
-    except OSError:
-        mode = 0o644
-    tmp = unit.with_name(f".{unit.name}.tmp")
-    tmp.write_text(text, encoding="utf-8")
-    os.chmod(tmp, mode)
-    os.replace(tmp, unit)
+        body = api_get("/api/updates/check")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    _print_check(body)
+    if not _print_component_table(_component_rows()):
+        console.print("[dim](exit 2 = components not converged — run `hal0 update` "
+                      "or `hal0 update component <id>`)[/dim]")
+        raise typer.Exit(2)
+
+
+@update_app.command("component")
+def update_component_cmd(
+    component_id: str = typer.Argument(..., help="Component id (see `hal0 update status`)."),
+    check: bool = typer.Option(False, "--check", help="Status row only; don't converge."),
+) -> None:
+    """Converge (or re-try) one component to its release pin."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    rows = [r for r in _component_rows() if r.get("id") == component_id]
+    if not rows:
+        die(f"unknown component {component_id!r} — run `hal0 update status` for the list")
+        return
+    _print_component_table(rows)
+    if check:
+        return
+    _converge_component(component_id)
+
+
+def _converge_component(component_id: str, body: dict | None = None) -> None:
+    try:
+        job = api_post(f"/api/updates/components/{component_id}/converge", json=body or {})
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    job_id = job.get("id")
+    if not job_id:
+        die("server returned no job id")
+        return
+    console.print(f"[cyan]converging {component_id}:[/cyan] {job_id}")
+    final = _poll_job(job_id, terminal=("applied", "failed"))
+    result = final.get("component_result") or {}
+    if final.get("state") == "applied":
+        console.print(Panel(
+            f"[green]{component_id} {result.get('status', 'converged')}[/green]"
+            + (f" [dim]{result.get('from')} → {result.get('to')}[/dim]" if result.get("to") else ""),
+            border_style="green",
+        ))
+        return
+    die(f"{component_id} converge failed: {final.get('error') or 'unknown error'}"
+        + (f" — {result.get('remedy')}" if result.get("remedy") else ""))
+
+
+# ── hal0 update owui — converge the OpenWebUI companion to its release pin ────
+#
+# OpenWebUI is a podman container whose pin now rides hal0 releases (the
+# component catalog owns it — hal0.components.openwebui_arm — same as every
+# other component). This is a thin alias for `hal0 update component openwebui`
+# that also exposes the --target / --clear-override operator escape hatches
+# (spec §2) for pinning an explicit digest outside the release cadence. The
+# old --tag float-to-upstream flag, and the unit-rewrite/podman-pull/systemctl
+# legwork it drove client-side, are gone — the daemon does that work now.
 
 
 @update_app.command("owui")
 def update_owui(
-    check: bool = typer.Option(
-        False,
-        "--check",
-        help="Only report the pinned vs upstream digest; don't repin or restart.",
-    ),
-    tag: str | None = typer.Option(
-        None,
-        "--tag",
-        help="Upstream tag to resolve (default: OpenWebUI's :main). Ignored with --target.",
-    ),
+    check: bool = typer.Option(False, "--check", help="Status only; don't converge."),
     target: str | None = typer.Option(
-        None,
-        "--target",
-        help="Pin an explicit digest (sha256:… or bare 64-hex) instead of resolving a tag.",
+        None, "--target",
+        help="Pin an explicit digest override (sha256:… or bare 64-hex) instead of the release pin.",
     ),
-    yes: bool = typer.Option(
-        False, "--yes", "-y", help="Skip the confirmation prompt before repinning."
+    clear_override: bool = typer.Option(
+        False, "--clear-override", help="Drop a --target override; converge back to the release pin.",
     ),
-    force: bool = typer.Option(
-        False,
-        "--force",
-        help="Repin + pull + restart even when the digest already matches.",
-    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt."),
 ) -> None:
-    """Update the OpenWebUI companion container to a newer pinned image.
+    """Converge the OpenWebUI companion to its release-carried pin.
 
-    OpenWebUI runs as a podman container pinned by sha256 digest in its systemd
-    unit. This resolves a target digest (upstream ``--tag`` or explicit
-    ``--target``), repins the installed unit, pulls the image, and restarts
-    ``hal0-openwebui``. The repin is durable — ``hal0 update`` (the hal0
-    self-update) never rewrites companion units.
+    Alias for `hal0 update component openwebui`, plus the --target /
+    --clear-override operator escape hatches (spec §2). The old --tag
+    float-to-upstream flag is gone: pins ride hal0 releases.
     """
-    from hal0.openwebui import image_pin
-
-    unit = image_pin.installed_unit_path()
-    if not unit.is_file():
-        die(f"OpenWebUI unit not found at {unit} — is the OpenWebUI companion installed?")
-        return
-    text = unit.read_text(encoding="utf-8")
-    current = image_pin.parse_pinned_digest(text)
-    if current is None:
-        die(
-            f"could not read a consistent pinned digest from {unit} "
-            "(no pin, or the two pins disagree — inspect the unit)."
-        )
-        return
-
-    # ── Resolve the target digest ────────────────────────────────────────────
-    resolve_tag = tag or image_pin.OPENWEBUI_DEFAULT_TAG
-    if target is not None:
-        target_digest = image_pin.normalize_digest(target)
-        if target_digest is None:
-            die(f"--target {target!r} is not a sha256 digest (expected sha256:<64-hex> or 64-hex).")
-            return
-        source = "target"
-    else:
-        try:
-            target_digest = _resolve_owui_upstream_digest(resolve_tag)
-        except Exception as exc:
-            die(f"could not resolve ghcr.io {image_pin.OPENWEBUI_IMAGE_REPO}:{resolve_tag}: {exc}")
-            return
-        if not image_pin.is_sha256_digest(target_digest):
-            die(f"ghcr.io returned an unexpected digest for :{resolve_tag}: {target_digest!r}")
-            return
-        source = f"ghcr :{resolve_tag}"
-
-    drifted = target_digest != current
-    table = Table(title="OpenWebUI image pin", show_header=False)
-    table.add_column(style="bold")
-    table.add_column()
-    table.add_row("pinned (now)", current)
-    table.add_row(f"target ({source})", target_digest)
-    table.add_row(
-        "status", "[green]newer available[/green]" if drifted else "[dim]up to date[/dim]"
-    )
-    console.print(table)
-
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
     if check:
+        rows = [r for r in _component_rows() if r.get("id") == "openwebui"]
+        _print_component_table(rows)
         return
+    body: dict[str, object] = {}
+    if target is not None:
+        from hal0.openwebui.image_pin import normalize_digest
 
-    if not drifted and not force:
-        console.print(
-            "[dim]already pinned to that digest — nothing to do (use --force to re-pull).[/dim]"
-        )
-        return
-
-    dev = _dev_mode()
-    if not dev and hasattr(os, "geteuid") and os.geteuid() != 0:
-        die("repinning the unit and restarting hal0-openwebui need root — re-run with sudo.")
-        return
-
-    short = target_digest[:19] + "…"
-    if (
-        not yes
-        and _interactive()
-        and not typer.confirm(f"Repin OpenWebUI → {short}?", default=True)
-    ):
-        console.print("[dim]aborted — unit unchanged.[/dim]")
-        return
-
-    ref = image_pin.pinned_ref(target_digest)
-
-    # Pull FIRST (unless dev): if the new image isn't pullable, abort before
-    # touching the unit so we never leave it pointing at an unusable digest.
-    if not dev:
-        console.print(f"[cyan]pulling[/cyan] {ref}")
-        rc, _out, err = _run_cmd(["podman", "pull", ref], timeout=600.0)
-        if rc != 0:
-            die(f"podman pull failed — unit unchanged: {err.strip() or f'exit {rc}'}")
+        normalized = normalize_digest(target)
+        if normalized is None:
+            die(f"--target {target!r} is not a sha256 digest")
             return
-
-    new_text, count = image_pin.repin_unit_text(text, target_digest)
-    if count == 0:  # pragma: no cover — parse_pinned_digest already proved a match
-        die("internal error: no digest occurrences rewritten in the unit.")
+        body["target"] = normalized
+    if clear_override:
+        body["clear_override"] = True
+    prompt = "Repin OpenWebUI?" if not target else f"Repin OpenWebUI → {body['target'][:19]}…?"
+    if not yes and _interactive() and not typer.confirm(prompt, default=True):
+        console.print("[dim]aborted.[/dim]")
         return
-    try:
-        _write_unit_atomic(unit, new_text)
-    except OSError as exc:
-        die(f"could not write {unit}: {exc}")
-        return
-    console.print(f"[green]repinned[/green] {unit} ({count} occurrence(s))")
-
-    if dev:
-        console.print("[dim]dev mode (HAL0_HOME set): skipping daemon-reload / restart.[/dim]")
-        return
-
-    rc, _out, err = _run_cmd(["systemctl", "daemon-reload"], timeout=30.0)
-    if rc != 0:
-        console.print(
-            f"[yellow]systemctl daemon-reload failed:[/yellow] {err.strip() or f'exit {rc}'}"
-        )
-
-    console.print(f"[cyan]restarting[/cyan] {image_pin.OPENWEBUI_UNIT_NAME}")
-    rc, _out, err = _run_cmd(["systemctl", "restart", image_pin.OPENWEBUI_UNIT_NAME], timeout=120.0)
-    if rc != 0:
-        die(
-            f"restart failed: {err.strip() or f'exit {rc}'}. "
-            f"The unit is repinned; check `journalctl -u {image_pin.OPENWEBUI_UNIT_NAME} -n 40`."
-        )
-        return
-    console.print(Panel("[green]OpenWebUI updated.[/green]", border_style="green"))
+    _converge_component("openwebui", body)

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -361,6 +361,7 @@ _MIGRATION_PASS_LABELS: dict[str, str] = {
     "updater.image_retag_failed": "runner image retag",
     "updater.extra_args_sanitize_failed": "managed extra_args sanitisation",
     "updater.memory_engine_upgrade_failed": "memory engine upgrade",
+    "updater.components_converge_failed": "component convergence",
 }
 
 

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -836,14 +836,18 @@ def _print_component_table(rows: list[dict]) -> bool:
         pinned = row.get("pinned") or "—"
         if row.get("pin_label"):
             pinned = f"{pinned} ({row['pin_label']})"
-        table.add_row(row.get("name", row.get("id", "?")), str(row.get("installed") or "—"), str(pinned), status_txt)
+        table.add_row(
+            row.get("name", row.get("id", "?")),
+            str(row.get("installed") or "—"),
+            str(pinned),
+            status_txt,
+        )
     console.print(table)
     for row in rows:
         if row.get("status") in _COMPONENT_PENDING and (row.get("error") or row.get("remedy")):
             remedy = row.get("remedy") or f"retry with: hal0 update component {row['id']}"
             console.print(
-                f"[yellow]![/yellow] {row['id']}: {row.get('error') or ''} "
-                f"[dim]{remedy}[/dim]"
+                f"[yellow]![/yellow] {row['id']}: {row.get('error') or ''} [dim]{remedy}[/dim]"
             )
     return all_ok
 
@@ -861,8 +865,10 @@ def update_status_cmd() -> None:
         return
     _print_check(body)
     if not _print_component_table(_component_rows()):
-        console.print("[dim](exit 2 = components not converged — run `hal0 update` "
-                      "or `hal0 update component <id>`)[/dim]")
+        console.print(
+            "[dim](exit 2 = components not converged — run `hal0 update` "
+            "or `hal0 update component <id>`)[/dim]"
+        )
         raise typer.Exit(2)
 
 
@@ -899,14 +905,22 @@ def _converge_component(component_id: str, body: dict | None = None) -> None:
     final = _poll_job(job_id, terminal=("applied", "failed"))
     result = final.get("component_result") or {}
     if final.get("state") == "applied":
-        console.print(Panel(
-            f"[green]{component_id} {result.get('status', 'converged')}[/green]"
-            + (f" [dim]{result.get('from')} → {result.get('to')}[/dim]" if result.get("to") else ""),
-            border_style="green",
-        ))
+        console.print(
+            Panel(
+                f"[green]{component_id} {result.get('status', 'converged')}[/green]"
+                + (
+                    f" [dim]{result.get('from')} → {result.get('to')}[/dim]"
+                    if result.get("to")
+                    else ""
+                ),
+                border_style="green",
+            )
+        )
         return
-    die(f"{component_id} converge failed: {final.get('error') or 'unknown error'}"
-        + (f" — {result.get('remedy')}" if result.get("remedy") else ""))
+    die(
+        f"{component_id} converge failed: {final.get('error') or 'unknown error'}"
+        + (f" — {result.get('remedy')}" if result.get("remedy") else "")
+    )
 
 
 # ── hal0 update owui — converge the OpenWebUI companion to its release pin ────
@@ -924,11 +938,14 @@ def _converge_component(component_id: str, body: dict | None = None) -> None:
 def update_owui(
     check: bool = typer.Option(False, "--check", help="Status only; don't converge."),
     target: str | None = typer.Option(
-        None, "--target",
+        None,
+        "--target",
         help="Pin an explicit digest override (sha256:… or bare 64-hex) instead of the release pin.",
     ),
     clear_override: bool = typer.Option(
-        False, "--clear-override", help="Drop a --target override; converge back to the release pin.",
+        False,
+        "--clear-override",
+        help="Drop a --target override; converge back to the release pin.",
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt."),
 ) -> None:

--- a/src/hal0/components/__init__.py
+++ b/src/hal0/components/__init__.py
@@ -1,0 +1,15 @@
+from hal0.components.registry import COMPONENTS, ComponentDef, component_by_id
+from hal0.components.state import (
+    components_state_path,
+    load_component_state,
+    record_component_result,
+)
+
+__all__ = [
+    "COMPONENTS",
+    "ComponentDef",
+    "component_by_id",
+    "components_state_path",
+    "load_component_state",
+    "record_component_result",
+]

--- a/src/hal0/components/hermes_arm.py
+++ b/src/hal0/components/hermes_arm.py
@@ -129,7 +129,10 @@ def converge_hermes(
         return {**result, "status": "converged"}
     if not apply:
         log.warning(
-            "components.hermes_stale", job_id=job_id, installed=installed, pinned=pinned,
+            "components.hermes_stale",
+            job_id=job_id,
+            installed=installed,
+            pinned=pinned,
             remedy="run 'hal0 update'",
         )
         return {**result, "status": "stale"}
@@ -145,7 +148,8 @@ def converge_hermes(
         return {**result, "status": "build_failed", "error": f"post-install probe failed: {exc}"}
     if not probe.get("ok"):
         return {
-            **result, "status": "build_failed",
+            **result,
+            "status": "build_failed",
             "error": f"rebuilt venv fails its own probe: {probe.get('error')}",
             "remedy": "run 'sudo hal0 agent provision hermes --repair'",
         }
@@ -160,15 +164,23 @@ def converge_hermes(
     # up the rebuilt venv — same reason repair_hermes_mcp_client bounces
     # hermes-gateway. Best-effort.
     for argv in (
-        (["sudo", "-n", SEAM_BIN, "try-restart-agent", "hermes"]
-         if is_hal0_user() else ["systemctl", "try-restart", "hal0-agent@hermes.service"]),
-        (["sudo", "-n", SEAM_BIN, "svc-restart", "hermes-gateway"]
-         if is_hal0_user() else ["systemctl", "try-restart", "hermes-gateway.service"]),
+        (
+            ["sudo", "-n", SEAM_BIN, "try-restart-agent", "hermes"]
+            if is_hal0_user()
+            else ["systemctl", "try-restart", "hal0-agent@hermes.service"]
+        ),
+        (
+            ["sudo", "-n", SEAM_BIN, "svc-restart", "hermes-gateway"]
+            if is_hal0_user()
+            else ["systemctl", "try-restart", "hermes-gateway.service"]
+        ),
     ):
         try:
             runner(argv, capture_output=True, text=True, timeout=_CTL_TIMEOUT_S)
         except (OSError, subprocess.SubprocessError) as exc:
-            log.warning("components.hermes_restart_failed", job_id=job_id, argv=argv[0], error=str(exc))
+            log.warning(
+                "components.hermes_restart_failed", job_id=job_id, argv=argv[0], error=str(exc)
+            )
 
     log.info("components.hermes_upgraded", job_id=job_id, installed=installed, pinned=pinned)
     return {**result, "status": "upgraded", "from": installed, "to": pinned}

--- a/src/hal0/components/hermes_arm.py
+++ b/src/hal0/components/hermes_arm.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import json
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import structlog
 

--- a/src/hal0/components/hermes_arm.py
+++ b/src/hal0/components/hermes_arm.py
@@ -10,6 +10,7 @@ No snapshot machinery — hermes has no one-way DB; HERMES_HOME untouched.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from typing import Any, Callable
@@ -30,6 +31,42 @@ def stamp_path() -> Path:
     return var_lib() / "state" / "agents" / "hermes" / "venv.pin"
 
 
+def _provision_checkpoint_path() -> Path:
+    return var_lib() / "state" / "agents" / "hermes" / "provision.json"
+
+
+def _installed_pin_from_provision_checkpoint() -> str | None:
+    """Fall back to the provisioner's last-run report for the installed pin.
+
+    No box provisioned before the venv.pin stamp existed has one — see
+    ``hermes_arm.stamp_path`` — so on those boxes ``installed_hermes_pin``
+    would otherwise report "not installed" on an install that has been
+    running fine, and the first `hal0 update` needlessly rebuilds the live
+    venv. ``hermes_provision._write_run_report`` (hermes_provision.py:6618)
+    writes a flat JSON object with a top-level ``hermes_version`` key on
+    every provision/repair run; that is the same identifier
+    ``_hermes_version_pin()`` produces, which is what the venv.pin stamp
+    also holds. Parsed defensively: any missing file, bad JSON, non-dict
+    top level, or non-string/empty ``hermes_version`` reads as "no
+    fallback available" (``None``) rather than raising.
+    """
+    try:
+        text = _provision_checkpoint_path().read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    value = data.get("hermes_version")
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
 def installed_hermes_pin(venv: Path | None = None) -> str | None:
     """The pin identifier stamped after the last successful converge.
 
@@ -47,6 +84,13 @@ def installed_hermes_pin(venv: Path | None = None) -> str | None:
     tests) this one follows the sandbox and the hardcoded FHS constant does
     not — gating on the constant made this getter permanently blind to a
     freshly-written, correctly-sandboxed stamp in exactly that posture.
+
+    When the venv.pin stamp is absent or empty — every box provisioned
+    before this component-status pass shipped — fall back to the
+    ``hermes_version`` recorded in the provisioner's ``provision.json``
+    checkpoint (see :func:`_installed_pin_from_provision_checkpoint`)
+    rather than misreporting a working install as not-installed. The
+    stamp wins whenever it is present.
     """
     venv = venv or (var_lib() / "venvs" / "hermes")
     if not (venv / "bin" / "python").exists():
@@ -54,8 +98,10 @@ def installed_hermes_pin(venv: Path | None = None) -> str | None:
     try:
         value = stamp_path().read_text(encoding="utf-8").strip()
     except OSError:
-        return None
-    return value or None
+        value = ""
+    if value:
+        return value
+    return _installed_pin_from_provision_checkpoint()
 
 
 def converge_hermes(

--- a/src/hal0/components/hermes_arm.py
+++ b/src/hal0/components/hermes_arm.py
@@ -33,17 +33,24 @@ def stamp_path() -> Path:
 def installed_hermes_pin(venv: Path | None = None) -> str | None:
     """The pin identifier stamped after the last successful converge.
 
-    ``venv`` is accepted for interface symmetry with the other component
-    getters but does not gate the read: the stamp is a single canonical
-    file (one hermes install per box, spec §1), not venv-relative, and
-    "is hermes provisioned at all" is already ``converge_hermes``'s own
-    concern via its own ``bin/python`` check. Gating this getter on
-    ``hermes.HERMES_VENV_DEFAULT`` (a hardcoded FHS path, not HAL0_HOME-aware
-    like :func:`stamp_path`) would make it blind to the stamp under any
-    HAL0_HOME sandbox — the dev/test posture this whole module is written
-    to run under.
+    Gated on the venv actually existing: a deprovisioned box (venv
+    removed, stamp file surviving under ``var_lib()`` — state is preserved
+    across uninstall unless ``--keep-data`` is dropped) must read as
+    ``None``, not as a stale "converged"/"pending" verdict, or the
+    component-status derivation (spec §1 / Task 8) misreports an
+    uninstalled component as still on some version.
+
+    The default is ``var_lib() / "venvs" / "hermes"`` rather than
+    ``hermes.HERMES_VENV_DEFAULT`` directly: in production ``HAL0_HOME`` is
+    unset and the two are the same path
+    (``/var/lib/hal0/venvs/hermes``), but under HAL0_HOME sandboxing (dev,
+    tests) this one follows the sandbox and the hardcoded FHS constant does
+    not — gating on the constant made this getter permanently blind to a
+    freshly-written, correctly-sandboxed stamp in exactly that posture.
     """
-    del venv
+    venv = venv or (var_lib() / "venvs" / "hermes")
+    if not (venv / "bin" / "python").exists():
+        return None
     try:
         value = stamp_path().read_text(encoding="utf-8").strip()
     except OSError:

--- a/src/hal0/components/hermes_arm.py
+++ b/src/hal0/components/hermes_arm.py
@@ -1,0 +1,120 @@
+"""Converge the bundled Hermes venv onto the requirements.txt pin (spec §1).
+
+Reuses the provisioner's own install + probe seams exactly as
+``updater.repair_hermes_mcp_client`` does (that pass heals import-broken
+venvs; this arm heals VERSION drift — both land on the state a fresh
+provision produces). The build identity is a stamp file, not a dist-probe:
+the pin may be a git ref, which no importlib.metadata probe can confirm.
+No snapshot machinery — hermes has no one-way DB; HERMES_HOME untouched.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any, Callable
+
+import structlog
+
+from hal0.config.paths import var_lib
+from hal0.system.seam import SEAM_BIN, is_hal0_service_user
+
+log = structlog.get_logger(__name__)
+
+_CTL_TIMEOUT_S = 120.0
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+def stamp_path() -> Path:
+    return var_lib() / "state" / "agents" / "hermes" / "venv.pin"
+
+
+def installed_hermes_pin(venv: Path | None = None) -> str | None:
+    """The pin identifier stamped after the last successful converge.
+
+    ``venv`` is accepted for interface symmetry with the other component
+    getters but does not gate the read: the stamp is a single canonical
+    file (one hermes install per box, spec §1), not venv-relative, and
+    "is hermes provisioned at all" is already ``converge_hermes``'s own
+    concern via its own ``bin/python`` check. Gating this getter on
+    ``hermes.HERMES_VENV_DEFAULT`` (a hardcoded FHS path, not HAL0_HOME-aware
+    like :func:`stamp_path`) would make it blind to the stamp under any
+    HAL0_HOME sandbox — the dev/test posture this whole module is written
+    to run under.
+    """
+    del venv
+    try:
+        value = stamp_path().read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return value or None
+
+
+def converge_hermes(
+    *,
+    job_id: str | None = None,
+    apply: bool = True,
+    runner: Runner | None = None,
+    venv: Path | None = None,
+    is_hal0_user: Callable[[], bool] | None = None,
+) -> dict[str, Any]:
+    from hal0.agents import hermes_provision as hermes
+
+    runner = runner if runner is not None else subprocess.run
+    is_hal0_user = is_hal0_user if is_hal0_user is not None else is_hal0_service_user
+    venv = venv or hermes.HERMES_VENV_DEFAULT
+
+    if not (venv / "bin" / "python").exists():
+        return {"status": "skipped", "reason": "hermes not provisioned"}
+
+    pinned = hermes._hermes_version_pin()
+    installed = installed_hermes_pin(venv)
+    result: dict[str, Any] = {"installed": installed, "pinned": pinned}
+    if installed == pinned:
+        return {**result, "status": "converged"}
+    if not apply:
+        log.warning(
+            "components.hermes_stale", job_id=job_id, installed=installed, pinned=pinned,
+            remedy="run 'hal0 update'",
+        )
+        return {**result, "status": "stale"}
+
+    try:
+        hermes._install_venv(venv, hermes.HERMES_REQUIREMENTS)
+    except Exception as exc:
+        return {**result, "status": "build_failed", "error": f"venv install failed: {exc}"}
+
+    try:
+        probe = hermes._probe_mcp_client(venv / "bin" / "python", None, agent_id="hermes")
+    except Exception as exc:
+        return {**result, "status": "build_failed", "error": f"post-install probe failed: {exc}"}
+    if not probe.get("ok"):
+        return {
+            **result, "status": "build_failed",
+            "error": f"rebuilt venv fails its own probe: {probe.get('error')}",
+            "remedy": "run 'sudo hal0 agent provision hermes --repair'",
+        }
+
+    try:
+        stamp_path().parent.mkdir(parents=True, exist_ok=True)
+        stamp_path().write_text(pinned + "\n", encoding="utf-8")
+    except OSError as exc:
+        log.warning("components.hermes_stamp_failed", job_id=job_id, error=str(exc))
+
+    # Bounce the agent unit (and its gateway) so the running process picks
+    # up the rebuilt venv — same reason repair_hermes_mcp_client bounces
+    # hermes-gateway. Best-effort.
+    for argv in (
+        (["sudo", "-n", SEAM_BIN, "try-restart-agent", "hermes"]
+         if is_hal0_user() else ["systemctl", "try-restart", "hal0-agent@hermes.service"]),
+        (["sudo", "-n", SEAM_BIN, "svc-restart", "hermes-gateway"]
+         if is_hal0_user() else ["systemctl", "try-restart", "hermes-gateway.service"]),
+    ):
+        try:
+            runner(argv, capture_output=True, text=True, timeout=_CTL_TIMEOUT_S)
+        except (OSError, subprocess.SubprocessError) as exc:
+            log.warning("components.hermes_restart_failed", job_id=job_id, argv=argv[0], error=str(exc))
+
+    log.info("components.hermes_upgraded", job_id=job_id, installed=installed, pinned=pinned)
+    return {**result, "status": "upgraded", "from": installed, "to": pinned}

--- a/src/hal0/components/openwebui_arm.py
+++ b/src/hal0/components/openwebui_arm.py
@@ -12,7 +12,11 @@ dicts, the ``upgrade_memory_engine`` posture.
 Operator override: ``--target`` persists the digest to
 ``/var/lib/hal0/state/openwebui.pin-override``; while present, converge
 holds the box at the override (status ``override``) instead of the
-release pin. ``clear_override`` removes it.
+release pin. ``clear_override`` removes it. The marker is written
+whenever ``target_digest`` is supplied — including when it already
+matches the installed digest, so a subsequent un-targeted converge still
+holds the box at the operator's pin instead of drifting back to the
+release pin the moment nothing needs pulling.
 """
 
 from __future__ import annotations
@@ -102,6 +106,17 @@ def converge_openwebui(
 
     result: dict[str, Any] = {"installed": current, "pinned": desired}
     if current == desired:
+        if target_digest is not None:
+            # The operator's --target already matches what's installed —
+            # still persist the marker so a subsequent un-targeted converge
+            # holds the box here instead of drifting back to the release
+            # pin (spec §2: --target always writes the override marker).
+            try:
+                override_path().parent.mkdir(parents=True, exist_ok=True)
+                override_path().write_text(target_digest + "\n", encoding="utf-8")
+            except OSError as exc:
+                log.warning("components.owui_override_persist_failed", job_id=job_id, error=str(exc))
+            return {**result, "status": "override"}
         return {**result, "status": "override" if overridden else "converged"}
     if not apply:
         log.warning(

--- a/src/hal0/components/openwebui_arm.py
+++ b/src/hal0/components/openwebui_arm.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 
 import os
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import structlog
 

--- a/src/hal0/components/openwebui_arm.py
+++ b/src/hal0/components/openwebui_arm.py
@@ -116,12 +116,17 @@ def converge_openwebui(
                 override_path().parent.mkdir(parents=True, exist_ok=True)
                 override_path().write_text(target_digest + "\n", encoding="utf-8")
             except OSError as exc:
-                log.warning("components.owui_override_persist_failed", job_id=job_id, error=str(exc))
+                log.warning(
+                    "components.owui_override_persist_failed", job_id=job_id, error=str(exc)
+                )
             return {**result, "status": "override"}
         return {**result, "status": "override" if overridden else "converged"}
     if not apply:
         log.warning(
-            "components.owui_stale", job_id=job_id, installed=current, pinned=desired,
+            "components.owui_stale",
+            job_id=job_id,
+            installed=current,
+            pinned=desired,
             remedy="run 'hal0 update' or 'hal0 update owui'",
         )
         return {**result, "status": "override" if overridden else "stale"}
@@ -129,9 +134,7 @@ def converge_openwebui(
     # ── Pull first ──
     ref = image_pin.pinned_ref(desired)
     pull_argv = (
-        ["sudo", "-n", _PODMAN_RW, "image-pull", ref]
-        if is_hal0_user()
-        else ["podman", "pull", ref]
+        ["sudo", "-n", _PODMAN_RW, "image-pull", ref] if is_hal0_user() else ["podman", "pull", ref]
     )
     try:
         proc = runner(pull_argv, capture_output=True, text=True, timeout=_PULL_TIMEOUT_S)
@@ -150,13 +153,16 @@ def converge_openwebui(
         try:
             proc = runner(
                 ["sudo", "-n", SEAM_BIN, "repin-owui", desired],
-                capture_output=True, text=True, timeout=_CTL_TIMEOUT_S,
+                capture_output=True,
+                text=True,
+                timeout=_CTL_TIMEOUT_S,
             )
         except (OSError, subprocess.SubprocessError) as exc:
             return {**result, "status": "build_failed", "error": f"repin failed: {exc}"}
         if proc.returncode != 0:
             return {
-                **result, "status": "build_failed",
+                **result,
+                "status": "build_failed",
                 "error": f"repin failed: {(proc.stderr or '').strip() or f'exit {proc.returncode}'}",
             }
     else:
@@ -189,7 +195,8 @@ def converge_openwebui(
         restarted = False
     if not restarted:
         log.warning(
-            "components.owui_restart_failed", job_id=job_id,
+            "components.owui_restart_failed",
+            job_id=job_id,
             remedy=f"repinned; run 'systemctl restart {image_pin.OPENWEBUI_UNIT_NAME}' and check its journal",
         )
     log.info("components.owui_repinned", job_id=job_id, from_=current, to=desired)

--- a/src/hal0/components/openwebui_arm.py
+++ b/src/hal0/components/openwebui_arm.py
@@ -1,0 +1,180 @@
+"""Converge the OpenWebUI companion image onto the release pin (spec §2).
+
+Pull FIRST, repin second, restart last — a failed pull never strands the
+unit on an unpullable digest (the order `hal0 update owui` proved). On a
+provisioned box (process runs as the hal0 service user) the unit rewrite
++ daemon-reload route through `sudo -n hal0-systemctl repin-owui` and the
+image pull through `sudo -n hal0-podman-rw image-pull` (rootful store —
+the one the unit launches from); dev/test processes rewrite the unit
+directly and pull with bare podman. Never raises operationally — status
+dicts, the ``upgrade_memory_engine`` posture.
+
+Operator override: ``--target`` persists the digest to
+``/var/lib/hal0/state/openwebui.pin-override``; while present, converge
+holds the box at the override (status ``override``) instead of the
+release pin. ``clear_override`` removes it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Callable
+
+import structlog
+
+from hal0.config.paths import var_lib
+from hal0.openwebui import image_pin
+from hal0.system.seam import SEAM_BIN, is_hal0_service_user
+
+log = structlog.get_logger(__name__)
+
+_PODMAN_RW = "/usr/lib/hal0/bin/hal0-podman-rw"
+_PULL_TIMEOUT_S = 600.0
+_CTL_TIMEOUT_S = 120.0
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+def override_path() -> Path:
+    return var_lib() / "state" / "openwebui.pin-override"
+
+
+def read_pin_override() -> str | None:
+    try:
+        value = override_path().read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return value if image_pin.is_sha256_digest(value) else None
+
+
+def _write_unit_atomic(unit: Path, text: str) -> None:
+    mode = unit.stat().st_mode & 0o777
+    tmp = unit.with_name(f".{unit.name}.tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.chmod(tmp, mode)
+    os.replace(tmp, unit)
+
+
+def converge_openwebui(
+    *,
+    job_id: str | None = None,
+    apply: bool = True,
+    target_digest: str | None = None,
+    clear_override: bool = False,
+    runner: Runner | None = None,
+    is_hal0_user: Callable[[], bool] | None = None,
+    unit_path: Path | None = None,
+) -> dict[str, Any]:
+    runner = runner if runner is not None else subprocess.run
+    is_hal0_user = is_hal0_user if is_hal0_user is not None else is_hal0_service_user
+    unit = unit_path if unit_path is not None else image_pin.installed_unit_path()
+
+    if not unit.is_file():
+        return {"status": "skipped", "reason": "openwebui unit not installed"}
+    try:
+        text = unit.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {"status": "build_failed", "error": f"unit unreadable: {exc}"}
+    current = image_pin.parse_pinned_digest(text)
+    if current is None:
+        return {
+            "status": "build_failed",
+            "error": "no consistent pinned digest in unit",
+            "remedy": f"inspect {unit} — pins missing or disagree",
+        }
+
+    if clear_override:
+        try:
+            override_path().unlink(missing_ok=True)
+        except OSError as exc:
+            log.warning("components.owui_override_clear_failed", job_id=job_id, error=str(exc))
+
+    override = None if clear_override else read_pin_override()
+    overridden = False
+    if target_digest is not None:
+        desired = target_digest
+    elif override is not None:
+        desired, overridden = override, True
+    else:
+        desired = image_pin.OPENWEBUI_IMAGE_PIN
+
+    result: dict[str, Any] = {"installed": current, "pinned": desired}
+    if current == desired:
+        return {**result, "status": "override" if overridden else "converged"}
+    if not apply:
+        log.warning(
+            "components.owui_stale", job_id=job_id, installed=current, pinned=desired,
+            remedy="run 'hal0 update' or 'hal0 update owui'",
+        )
+        return {**result, "status": "override" if overridden else "stale"}
+
+    # ── Pull first ──
+    ref = image_pin.pinned_ref(desired)
+    pull_argv = (
+        ["sudo", "-n", _PODMAN_RW, "image-pull", ref]
+        if is_hal0_user()
+        else ["podman", "pull", ref]
+    )
+    try:
+        proc = runner(pull_argv, capture_output=True, text=True, timeout=_PULL_TIMEOUT_S)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {**result, "status": "build_failed", "error": f"pull failed: {exc}"}
+    if proc.returncode != 0:
+        return {
+            **result,
+            "status": "build_failed",
+            "error": f"pull failed: {(proc.stderr or '').strip() or f'exit {proc.returncode}'}",
+            "remedy": "unit unchanged; fix network/registry access and retry",
+        }
+
+    # ── Repin ──
+    if is_hal0_user():
+        try:
+            proc = runner(
+                ["sudo", "-n", SEAM_BIN, "repin-owui", desired],
+                capture_output=True, text=True, timeout=_CTL_TIMEOUT_S,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return {**result, "status": "build_failed", "error": f"repin failed: {exc}"}
+        if proc.returncode != 0:
+            return {
+                **result, "status": "build_failed",
+                "error": f"repin failed: {(proc.stderr or '').strip() or f'exit {proc.returncode}'}",
+            }
+    else:
+        new_text, count = image_pin.repin_unit_text(text, desired)
+        if count == 0:
+            return {**result, "status": "build_failed", "error": "no pin occurrences rewritten"}
+        try:
+            _write_unit_atomic(unit, new_text)
+        except OSError as exc:
+            return {**result, "status": "build_failed", "error": f"unit write failed: {exc}"}
+        runner(["systemctl", "daemon-reload"], capture_output=True, text=True, timeout=30.0)
+
+    # ── Persist / restart ──
+    if target_digest is not None:
+        try:
+            override_path().parent.mkdir(parents=True, exist_ok=True)
+            override_path().write_text(target_digest + "\n", encoding="utf-8")
+        except OSError as exc:
+            log.warning("components.owui_override_persist_failed", job_id=job_id, error=str(exc))
+
+    restart_argv = (
+        ["sudo", "-n", SEAM_BIN, "svc-restart", "openwebui"]
+        if is_hal0_user()
+        else ["systemctl", "restart", image_pin.OPENWEBUI_UNIT_NAME]
+    )
+    try:
+        proc = runner(restart_argv, capture_output=True, text=True, timeout=_CTL_TIMEOUT_S)
+        restarted = proc.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        restarted = False
+    if not restarted:
+        log.warning(
+            "components.owui_restart_failed", job_id=job_id,
+            remedy=f"repinned; run 'systemctl restart {image_pin.OPENWEBUI_UNIT_NAME}' and check its journal",
+        )
+    log.info("components.owui_repinned", job_id=job_id, from_=current, to=desired)
+    return {**result, "status": "upgraded", "from": current, "to": desired, "restarted": restarted}

--- a/src/hal0/components/registry.py
+++ b/src/hal0/components/registry.py
@@ -1,0 +1,161 @@
+"""Declarative catalog of hal0-shipped updatable components (spec §1).
+
+One ``ComponentDef`` per component. Everything the update surface needs to
+reason about a component lives here: the release-carried pin, the on-box
+version probe, and the converge arm. Callables are lazy (module-local
+functions doing local imports) so this stays a cheap import like
+``hal0.services.registry``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class ComponentDef:
+    id: str
+    name: str
+    kind: str  # "container-unit" | "slot-images" | "venv"
+    #: Join key into hal0.services.registry (dashboard rollup); None = no
+    #: service row (runner-images).
+    service_id: str | None
+    pinned: Callable[[], str]
+    installed: Callable[[], str | None]
+    #: Converge arm — status-dict posture, never raises operationally.
+    converge: Callable[..., dict[str, Any]]
+
+
+def _openwebui_pinned() -> str:
+    from hal0.openwebui.image_pin import OPENWEBUI_IMAGE_PIN
+
+    return OPENWEBUI_IMAGE_PIN
+
+
+def _openwebui_installed() -> str | None:
+    from hal0.openwebui.image_pin import installed_unit_path, parse_pinned_digest
+
+    unit = installed_unit_path()
+    try:
+        return parse_pinned_digest(unit.read_text(encoding="utf-8"))
+    except OSError:
+        return None
+
+
+def _openwebui_converge(**kwargs: Any) -> dict[str, Any]:
+    from hal0.components.openwebui_arm import converge_openwebui
+
+    return converge_openwebui(**kwargs)
+
+
+def _runner_images_pinned() -> str:
+    from hal0.runners import RUNNER_IMAGES
+
+    return f"{len(RUNNER_IMAGES)} images"
+
+
+def _runner_images_installed() -> str | None:
+    # Per-image truth lives in the converge result's detail rows; the
+    # component-level cell mirrors pinned so status derives from the last
+    # converge result, not a version diff.
+    return _runner_images_pinned()
+
+
+def _runner_images_converge(**kwargs: Any) -> dict[str, Any]:
+    from hal0.components.runner_images_arm import converge_runner_images
+
+    return converge_runner_images(**kwargs)
+
+
+def _hermes_pinned() -> str:
+    from hal0.agents.hermes_provision import _hermes_version_pin
+
+    return _hermes_version_pin()
+
+
+def _hermes_installed() -> str | None:
+    try:
+        from hal0.components.hermes_arm import installed_hermes_pin
+    except ImportError:
+        return None
+    return installed_hermes_pin()
+
+
+def _hermes_converge(**kwargs: Any) -> dict[str, Any]:
+    from hal0.components.hermes_arm import converge_hermes
+
+    return converge_hermes(**kwargs)
+
+
+def _hindsight_pinned() -> str:
+    from hal0.memory.engine_upgrade import HINDSIGHT_API_PIN
+
+    return HINDSIGHT_API_PIN
+
+
+def _hindsight_installed() -> str | None:
+    import subprocess
+
+    from hal0.memory.engine_upgrade import _installed_version, hindsight_dir
+
+    return _installed_version(subprocess.run, hindsight_dir() / ".venv")
+
+
+def _hindsight_converge(**kwargs: Any) -> dict[str, Any]:
+    from hal0.memory.engine_upgrade import upgrade_memory_engine
+
+    return upgrade_memory_engine(**kwargs)
+
+
+#: Converge order. Hindsight LAST — slowest pass by an order of magnitude
+#: and the only one that stops a companion service mid-pass (see
+#: run_post_activation_migrations' ordering note for the same rule).
+COMPONENTS: tuple[ComponentDef, ...] = (
+    ComponentDef(
+        id="openwebui",
+        name="OpenWebUI",
+        kind="container-unit",
+        service_id="openwebui",
+        pinned=_openwebui_pinned,
+        installed=_openwebui_installed,
+        converge=_openwebui_converge,
+    ),
+    ComponentDef(
+        id="runner-images",
+        name="Runner images",
+        kind="slot-images",
+        service_id=None,
+        pinned=_runner_images_pinned,
+        installed=_runner_images_installed,
+        converge=_runner_images_converge,
+    ),
+    ComponentDef(
+        id="hermes",
+        name="Hermes",
+        kind="venv",
+        service_id="hermes",
+        pinned=_hermes_pinned,
+        installed=_hermes_installed,
+        converge=_hermes_converge,
+    ),
+    ComponentDef(
+        id="hindsight",
+        name="Hindsight",
+        kind="venv",
+        service_id="hindsight",
+        pinned=_hindsight_pinned,
+        installed=_hindsight_installed,
+        converge=_hindsight_converge,
+    ),
+)
+
+
+def component_by_id(component_id: str) -> ComponentDef | None:
+    for comp in COMPONENTS:
+        if comp.id == component_id:
+            return comp
+    return None
+
+
+__all__ = ["COMPONENTS", "ComponentDef", "component_by_id"]

--- a/src/hal0/components/registry.py
+++ b/src/hal0/components/registry.py
@@ -9,8 +9,9 @@ functions doing local imports) so this stays a cheap import like
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 
 @dataclass(frozen=True)

--- a/src/hal0/components/registry.py
+++ b/src/hal0/components/registry.py
@@ -75,10 +75,8 @@ def _hermes_pinned() -> str:
 
 
 def _hermes_installed() -> str | None:
-    try:
-        from hal0.components.hermes_arm import installed_hermes_pin
-    except ImportError:
-        return None
+    from hal0.components.hermes_arm import installed_hermes_pin
+
     return installed_hermes_pin()
 
 

--- a/src/hal0/components/runner.py
+++ b/src/hal0/components/runner.py
@@ -10,7 +10,8 @@ lands in components.json. Only genuine bugs inside an arm are caught here
 from __future__ import annotations
 
 import sys
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import structlog
 

--- a/src/hal0/components/runner.py
+++ b/src/hal0/components/runner.py
@@ -50,8 +50,13 @@ def _resolve_converge(comp: ComponentDef) -> Callable[..., dict[str, Any]]:
 
 
 def _arm_kwargs(
-    comp: ComponentDef, *, job_id: str | None, apply: bool,
-    image_retag: bool, engine: bool, hermes_install: bool,
+    comp: ComponentDef,
+    *,
+    job_id: str | None,
+    apply: bool,
+    image_retag: bool,
+    engine: bool,
+    hermes_install: bool,
 ) -> dict[str, Any]:
     if comp.id == "hindsight":
         # engine_upgrade's own kwarg spelling; boot passes upgrade=False.
@@ -119,8 +124,12 @@ def converge_components(
     results: dict[str, dict[str, Any]] = {}
     for comp in COMPONENTS:
         kwargs = _arm_kwargs(
-            comp, job_id=job_id, apply=apply,
-            image_retag=image_retag, engine=engine, hermes_install=hermes_install,
+            comp,
+            job_id=job_id,
+            apply=apply,
+            image_retag=image_retag,
+            engine=engine,
+            hermes_install=hermes_install,
         )
         diagnose_only = _is_diagnose_only(comp, kwargs)
         results[comp.id] = converge_component(comp, diagnose_only=diagnose_only, **kwargs)

--- a/src/hal0/components/runner.py
+++ b/src/hal0/components/runner.py
@@ -15,9 +15,15 @@ from typing import Any, Callable
 import structlog
 
 from hal0.components.registry import COMPONENTS, ComponentDef
-from hal0.components.state import record_component_result
+from hal0.components.state import load_component_state, record_component_result
 
 log = structlog.get_logger(__name__)
+
+#: Statuses that carry operator-facing failure breadcrumbs (error/remedy —
+#: what the dashboard Retry affordance reads). A boot-time diagnose-only
+#: pass must not clobber one of these with a generic "stale"/"pending"
+#: result that has no error/remedy of its own (M1, final-review).
+_FAILURE_STATUSES = ("build_failed", "snapshot_failed", "rolled_back")
 
 
 def _resolve_converge(comp: ComponentDef) -> Callable[..., dict[str, Any]]:
@@ -56,12 +62,47 @@ def _arm_kwargs(
     return {"job_id": job_id, "apply": apply}
 
 
-def converge_component(comp: ComponentDef, **kwargs: Any) -> dict[str, Any]:
+def _is_diagnose_only(comp: ComponentDef, kwargs: dict[str, Any]) -> bool:
+    """Whether ``kwargs`` (as built by :func:`_arm_kwargs`) runs a probe-only
+    pass for ``comp`` rather than one that may actually converge it.
+
+    hindsight's arm spells its apply flag ``upgrade`` instead of ``apply``
+    (see ``_arm_kwargs``) — every other arm uses ``apply``.
+    """
+    if comp.id == "hindsight":
+        return not kwargs.get("upgrade", True)
+    return not kwargs.get("apply", True)
+
+
+def converge_component(
+    comp: ComponentDef, *, diagnose_only: bool = False, **kwargs: Any
+) -> dict[str, Any]:
     try:
         result = _resolve_converge(comp)(**kwargs)
     except Exception as exc:  # genuine bug in an arm — isolate it
         log.warning("components.converge_arm_crashed", component=comp.id, error=str(exc))
         result = {"status": "build_failed", "error": str(exc)}
+
+    # Boot-time diagnose (apply=False) runs on every daemon restart. If the
+    # last recorded result for this component was a real failure
+    # (build_failed/snapshot_failed/rolled_back — the statuses that carry
+    # the error/remedy the dashboard's Retry affordance reads), a
+    # diagnose-only result must not overwrite it: diagnose reports drift
+    # ("stale"/"pending"), not the richer failure breadcrumb, so recording
+    # it here would silently erase the operator-facing detail on every
+    # restart until someone happens to retry. An apply=True pass (retry,
+    # `hal0 update`) always records — it may be curing or re-confirming the
+    # failure, and either way its result is the freshest truth.
+    if diagnose_only:
+        existing = load_component_state().get(comp.id) or {}
+        if existing.get("status") in _FAILURE_STATUSES:
+            log.info(
+                "components.diagnose_skip_record",
+                component=comp.id,
+                existing_status=existing.get("status"),
+            )
+            return result
+
     record_component_result(comp.id, result)
     return result
 
@@ -80,5 +121,6 @@ def converge_components(
             comp, job_id=job_id, apply=apply,
             image_retag=image_retag, engine=engine, hermes_install=hermes_install,
         )
-        results[comp.id] = converge_component(comp, **kwargs)
+        diagnose_only = _is_diagnose_only(comp, kwargs)
+        results[comp.id] = converge_component(comp, diagnose_only=diagnose_only, **kwargs)
     return results

--- a/src/hal0/components/runner.py
+++ b/src/hal0/components/runner.py
@@ -1,0 +1,84 @@
+"""Sequential best-effort converge over the component catalog (spec §1).
+
+Called as the final pass of ``run_post_activation_migrations`` (both
+upgrade paths) and per-component by the retry route. Catalog order is the
+converge order; one component failing never blocks the next; every result
+lands in components.json. Only genuine bugs inside an arm are caught here
+— arms themselves report operational failures as status dicts.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Callable
+
+import structlog
+
+from hal0.components.registry import COMPONENTS, ComponentDef
+from hal0.components.state import record_component_result
+
+log = structlog.get_logger(__name__)
+
+
+def _resolve_converge(comp: ComponentDef) -> Callable[..., dict[str, Any]]:
+    """Re-resolve the arm callable by name in its defining module at call
+    time rather than trusting the reference ``ComponentDef.converge``
+    captured at catalog-build time.
+
+    ``registry.COMPONENTS`` is a module-level tuple built once at import,
+    so its ``converge`` fields are bound to the function OBJECTS that
+    existed at that moment. ``unittest.mock.patch`` on the module-level
+    name (e.g. ``hal0.components.registry._openwebui_converge``) reassigns
+    that name in the module's namespace but cannot retroactively change an
+    already-captured reference. Looking the name up again here, against
+    the live module namespace, is what lets tests patch each arm's
+    module-level wrapper.
+    """
+    fn = comp.converge
+    module = sys.modules.get(getattr(fn, "__module__", None))
+    name = getattr(fn, "__name__", None)
+    if module is not None and name is not None and hasattr(module, name):
+        return getattr(module, name)
+    return fn
+
+
+def _arm_kwargs(
+    comp: ComponentDef, *, job_id: str | None, apply: bool,
+    image_retag: bool, engine: bool, hermes_install: bool,
+) -> dict[str, Any]:
+    if comp.id == "hindsight":
+        # engine_upgrade's own kwarg spelling; boot passes upgrade=False.
+        return {"job_id": job_id, "upgrade": apply and engine}
+    if comp.id == "runner-images":
+        return {"job_id": job_id, "apply": apply and image_retag}
+    if comp.id == "hermes":
+        return {"job_id": job_id, "apply": apply and hermes_install}
+    return {"job_id": job_id, "apply": apply}
+
+
+def converge_component(comp: ComponentDef, **kwargs: Any) -> dict[str, Any]:
+    try:
+        result = _resolve_converge(comp)(**kwargs)
+    except Exception as exc:  # genuine bug in an arm — isolate it
+        log.warning("components.converge_arm_crashed", component=comp.id, error=str(exc))
+        result = {"status": "build_failed", "error": str(exc)}
+    record_component_result(comp.id, result)
+    return result
+
+
+def converge_components(
+    *,
+    job_id: str | None = None,
+    apply: bool = True,
+    image_retag: bool = True,
+    engine: bool = True,
+    hermes_install: bool = True,
+) -> dict[str, dict[str, Any]]:
+    results: dict[str, dict[str, Any]] = {}
+    for comp in COMPONENTS:
+        kwargs = _arm_kwargs(
+            comp, job_id=job_id, apply=apply,
+            image_retag=image_retag, engine=engine, hermes_install=hermes_install,
+        )
+        results[comp.id] = converge_component(comp, **kwargs)
+    return results

--- a/src/hal0/components/runner_images_arm.py
+++ b/src/hal0/components/runner_images_arm.py
@@ -9,7 +9,8 @@ status-dict shape and contributes per-image ``detail`` rows.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import structlog
 

--- a/src/hal0/components/runner_images_arm.py
+++ b/src/hal0/components/runner_images_arm.py
@@ -1,0 +1,42 @@
+"""Runner-image component arm (spec §1).
+
+The heavy lifting already exists: ``resolve_runner_image`` (env override →
+manifest pin → bundled default) answers "what should each slot run" and
+``retag_stale_slot_images`` moves slot TOMLs + profiles off known former
+defaults during an update. This arm wraps them into the component
+status-dict shape and contributes per-image ``detail`` rows.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+def converge_runner_images(
+    *,
+    job_id: str | None = None,
+    apply: bool = True,
+    retag: Callable[..., int] | None = None,
+) -> dict[str, Any]:
+    from hal0.runners import RUNNER_IMAGES, resolve_runner_image
+
+    detail = [
+        {"key": key, "image": resolve_runner_image(runner)}
+        for key, runner in sorted(RUNNER_IMAGES.items())
+    ]
+    result: dict[str, Any] = {"detail": detail}
+    if not apply:
+        return {**result, "status": "converged"}
+    if retag is None:
+        from hal0.updater.updater import retag_stale_slot_images
+
+        retag = retag_stale_slot_images
+    try:
+        retagged = retag(job_id=job_id)
+    except Exception as exc:
+        return {**result, "status": "build_failed", "error": f"retag failed: {exc}"}
+    return {**result, "status": "converged", "retagged": retagged}

--- a/src/hal0/components/state.py
+++ b/src/hal0/components/state.py
@@ -9,6 +9,7 @@ Writes are fail-soft: losing a breadcrumb must never fail an update.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import tempfile
@@ -53,9 +54,7 @@ def record_component_result(component_id: str, result: dict[str, Any]) -> None:
             tmp = None
         finally:
             if tmp is not None:
-                try:
+                with contextlib.suppress(OSError):
                     os.unlink(tmp)
-                except OSError:
-                    pass
     except OSError as exc:
         log.warning("components.state_persist_failed", component=component_id, error=str(exc))

--- a/src/hal0/components/state.py
+++ b/src/hal0/components/state.py
@@ -1,0 +1,61 @@
+"""Per-component converge bookkeeping: /var/lib/hal0/state/components.json.
+
+One JSON object keyed by component id; each value is the last converge
+status dict plus a ``ts`` stamp. Written atomically (same-dir tmp +
+replace); reads tolerate a missing or corrupt file by returning ``{}`` —
+this file is a courtesy cache over live probes, never load-bearing state.
+Writes are fail-soft: losing a breadcrumb must never fail an update.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from hal0.config.paths import var_lib
+
+log = structlog.get_logger(__name__)
+
+
+def components_state_path() -> Path:
+    return var_lib() / "state" / "components.json"
+
+
+def load_component_state() -> dict[str, dict[str, Any]]:
+    try:
+        raw = components_state_path().read_text(encoding="utf-8")
+        loaded = json.loads(raw)
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    return {str(k): v for k, v in loaded.items() if isinstance(v, dict)}
+
+
+def record_component_result(component_id: str, result: dict[str, Any]) -> None:
+    entry = {**result, "ts": time.time()}
+    current = load_component_state()
+    current[component_id] = entry
+    path = components_state_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(current, f)
+            os.replace(tmp, path)
+            tmp = None
+        finally:
+            if tmp is not None:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+    except OSError as exc:
+        log.warning("components.state_persist_failed", component=component_id, error=str(exc))

--- a/src/hal0/components/status.py
+++ b/src/hal0/components/status.py
@@ -12,7 +12,9 @@ from hal0.components.registry import COMPONENTS
 from hal0.components.state import load_component_state
 
 _FAILURE_STATUSES = frozenset({"build_failed", "snapshot_failed", "rolled_back"})
-_PENDING_STATUSES = frozenset({"pending", "stale", "build_failed", "snapshot_failed", "rolled_back"})
+_PENDING_STATUSES = frozenset(
+    {"pending", "stale", "build_failed", "snapshot_failed", "rolled_back"}
+)
 
 log = structlog.get_logger(__name__)
 

--- a/src/hal0/components/status.py
+++ b/src/hal0/components/status.py
@@ -1,0 +1,96 @@
+"""Merged component status: catalog × components.json × live probes."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Callable
+
+import structlog
+
+from hal0.components.registry import COMPONENTS
+from hal0.components.state import load_component_state
+
+_FAILURE_STATUSES = frozenset({"build_failed", "snapshot_failed", "rolled_back"})
+_PENDING_STATUSES = frozenset({"pending", "stale", "build_failed", "snapshot_failed", "rolled_back"})
+
+log = structlog.get_logger(__name__)
+
+
+def _resolve(fn: Callable[[], Any]) -> Callable[[], Any]:
+    """Re-resolve a probe callable by name in its defining module at call
+    time rather than trusting the reference ``ComponentDef.installed`` /
+    ``ComponentDef.pinned`` captured at catalog-build time.
+
+    Same trap as ``hal0.components.runner._resolve_converge``:
+    ``registry.COMPONENTS`` is a module-level tuple built once at import,
+    so its ``installed``/``pinned`` fields are bound to the function
+    OBJECTS that existed at that moment. ``unittest.mock.patch`` on the
+    module-level name (e.g. ``hal0.components.registry._hindsight_installed``)
+    reassigns that name in the module's namespace but cannot retroactively
+    change an already-captured reference. Looking the name up again here,
+    against the live module namespace, is what lets tests patch each
+    probe's module-level wrapper.
+    """
+    module = sys.modules.get(getattr(fn, "__module__", None))
+    name = getattr(fn, "__name__", None)
+    if module is not None and name is not None and hasattr(module, name):
+        return getattr(module, name)
+    return fn
+
+
+def _pin_label(component_id: str) -> str | None:
+    if component_id == "openwebui":
+        from hal0.openwebui.image_pin import OPENWEBUI_PIN_LABEL
+
+        return OPENWEBUI_PIN_LABEL
+    return None
+
+
+def component_status_snapshot() -> dict[str, Any]:
+    recorded = load_component_state()
+    rows: list[dict[str, Any]] = []
+    for comp in COMPONENTS:
+        last = recorded.get(comp.id) or {}
+        try:
+            installed = _resolve(comp.installed)()
+        except Exception as exc:
+            log.warning("components.installed_probe_failed", component=comp.id, error=str(exc))
+            installed = None
+        try:
+            pinned = _resolve(comp.pinned)()
+        except Exception as exc:
+            log.warning("components.pinned_probe_failed", component=comp.id, error=str(exc))
+            pinned = "unknown"
+
+        if last.get("status") in _FAILURE_STATUSES:
+            derived = last["status"]
+        elif installed is None:
+            derived = "not-installed"
+        elif installed == pinned:
+            derived = "converged"
+        else:
+            derived = "pending"
+            if comp.id == "openwebui":
+                from hal0.components.openwebui_arm import read_pin_override
+
+                if read_pin_override() == installed:
+                    derived = "override"
+
+        rows.append(
+            {
+                "id": comp.id,
+                "name": comp.name,
+                "kind": comp.kind,
+                "service_id": comp.service_id,
+                "installed": installed,
+                "pinned": pinned,
+                "pin_label": _pin_label(comp.id),
+                "status": derived,
+                "error": last.get("error"),
+                "remedy": last.get("remedy"),
+                "ts": last.get("ts"),
+                "detail": last.get("detail") or [],
+            }
+        )
+    pending = sum(1 for r in rows if r["status"] in _PENDING_STATUSES)
+    return {"components": rows, "pending": pending}

--- a/src/hal0/components/status.py
+++ b/src/hal0/components/status.py
@@ -1,9 +1,10 @@
-"""Merged component status: catalog × components.json × live probes."""
+"""Merged component status: catalog x components.json x live probes."""
 
 from __future__ import annotations
 
 import sys
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import structlog
 

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -2786,7 +2786,7 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
     "updater_channel_get": "Get the configured update channel.",
     "updater_slot_drift": "Report slots whose running argv has drifted from a fresh post-update render.",
     "updater_job_status": "Poll an update/prepare/commit job's state. Args: job_id.",
-    "component_status": "Per-component version/converge status — catalog x components.json x live probes (OpenWebUI, ComfyUI, Hermes, Hindsight, runner images).",
+    "component_status": "Per-component version/converge status — catalog x components.json x live probes (OpenWebUI, runner images [ComfyUI rides this component], Hermes, Hindsight).",
     "update_check": "Fetch the release manifest and diff it against the running version; includes components_pending (count of components needing converge).",
     "component_converge": "Re-run one component's converge arm — stops+restarts the companion service, may trigger a one-way DB migration (hindsight) (gated). Args: component_id.",
     "doctor_report": "Composed doctor verdict — health, URLs, system, memory, services, capabilities in one read.",

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -388,6 +388,12 @@ AUTONOMOUS_READ_TOOLS: frozenset[str] = frozenset(
         "updater_channel_get",
         "updater_slot_drift",
         "updater_job_status",
+        # Component updates (spec 2026-08-30 §1b). component_status reads
+        # components.json + live probes; update_check rides the existing
+        # GET /api/updates/check route (which now also carries
+        # components_pending).
+        "component_status",
+        "update_check",
         "doctor_report",
         "health_system",
         "feature_list",
@@ -516,6 +522,14 @@ GATED_TOOLS: frozenset[str] = frozenset(
         # target the slot everywhere else — gated so a rename can't
         # silently redirect a subsequent autonomous call (spec §4.3).
         "slot_rename",
+        # ── Updates (spec 2026-08-30 §1b). Converge stops+restarts companion
+        # services and (hindsight) can trigger a one-way DB migration —
+        # always owner-approval gated, mirroring slot_restart. update_apply
+        # deliberately NOT added: EXCLUDED_TOOLS["updater_apply"] stands —
+        # self-update needs its own POLICY_NO_LOOSEN + operator-confirmation
+        # design; the agent-facing update surface stays these three tools
+        # (component_status / update_check / component_converge). ─────────
+        "component_converge",
         # Capability / config
         "capability_set",
         "config_write",
@@ -748,10 +762,21 @@ TOOL_NAME_ALIASES: dict[str, tuple[str, ...]] = {
     # apply/commit/rollback/prepare/restart-slots/channel-PUT routes stay
     # unaliased (see EXCLUDED_TOOLS["updater_apply"]). ───────────────────────
     "GET:/api/updates/state": ("updater_state",),
-    "GET:/api/updates/check": ("updater_check",),
+    "GET:/api/updates/check": ("updater_check", "update_check"),
     "GET:/api/updates/channel": ("updater_channel_get",),
     "GET:/api/updates/slot-drift": ("updater_slot_drift",),
     "GET:/api/updates/status/{job_id}": ("updater_job_status",),
+    # ── Component updates (spec 2026-08-30 §1b). component_status is a
+    # read; component_converge stops+restarts companion services and
+    # (hindsight) can trigger a one-way DB migration — always
+    # owner-approval gated, see GATED_TOOLS. update_apply intentionally NOT
+    # aliased here: apply/commit/rollback/prepare/restart-slots/channel-PUT
+    # (incl. plain POST /apply) stay excluded per
+    # EXCLUDED_TOOLS["updater_apply"] — self-update needs its own
+    # POLICY_NO_LOOSEN + operator-confirmation design; this pass's
+    # agent-facing update surface is these three tools only. ─────────────
+    "GET:/api/updates/components": ("component_status",),
+    "POST:/api/updates/components/{component_id}/converge": ("component_converge",),
     "GET:/api/doctor": ("doctor_report",),
     "GET:/api/health/system": ("health_system",),
     "GET:/api/features": ("feature_list",),
@@ -2312,6 +2337,22 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     "updater_job_status": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
+    "component_status": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # Same route as updater_check — fetches the release manifest, open-world.
+    "update_check": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=True
+    ),
+    # Mirrors slot_restart's shape: mutating, reversible, non-idempotent
+    # (each call re-runs the converge arm). Not marked open-world itself —
+    # any network fetch a converge arm performs (e.g. an image pull) is the
+    # documented behavior of the already-open-world-classified tools that
+    # do that fetching directly (slot_pull_image/runner_image_sync), same
+    # treatment as comfyui_restart/comfyui_switchover.
+    "component_converge": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
     "doctor_report": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
@@ -2745,6 +2786,9 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
     "updater_channel_get": "Get the configured update channel.",
     "updater_slot_drift": "Report slots whose running argv has drifted from a fresh post-update render.",
     "updater_job_status": "Poll an update/prepare/commit job's state. Args: job_id.",
+    "component_status": "Per-component version/converge status — catalog x components.json x live probes (OpenWebUI, ComfyUI, Hermes, Hindsight, runner images).",
+    "update_check": "Fetch the release manifest and diff it against the running version; includes components_pending (count of components needing converge).",
+    "component_converge": "Re-run one component's converge arm — stops+restarts the companion service, may trigger a one-way DB migration (hindsight) (gated). Args: component_id.",
     "doctor_report": "Composed doctor verdict — health, URLs, system, memory, services, capabilities in one read.",
     "health_system": "Deep health check — disk, slot manager, event bus, MCP mount.",
     "feature_list": "Feature-flag map (comfyui_switchover, memory, memory_engine, npu, mcp_supervisor).",
@@ -2876,7 +2920,11 @@ EXCLUDED_TOOLS: dict[str, str] = {
         "dedicated lane rather than hand-added here. The READ half of the updater "
         "surface (state/check/channel-GET/slot-drift/status) IS classified now — see "
         "updater_state / updater_check / updater_channel_get / updater_slot_drift / "
-        "updater_job_status in TOOL_DESCRIPTIONS."
+        "updater_job_status in TOOL_DESCRIPTIONS. "
+        "Component-updates lane (2026-08-30, task 13): this exclusion stands "
+        "deliberately — spec §1b's `update_apply` row is superseded; the "
+        "agent-facing update surface is component_status / update_check / "
+        "component_converge only."
     ),
     "auth_rotate": (
         "Key rotation is a lockout-recovery / operator-console action — never "

--- a/src/hal0/openwebui/image_pin.py
+++ b/src/hal0/openwebui/image_pin.py
@@ -38,6 +38,18 @@ OPENWEBUI_DEFAULT_TAG = "main"
 #: systemd unit that runs the container.
 OPENWEBUI_UNIT_NAME = "hal0-openwebui.service"
 
+#: The digest every box converges on — the release-carried pin (spec
+#: 2026-08-30 §2, same single-owner posture as
+#: hal0.memory.engine_upgrade.HINDSIGHT_API_PIN). Must stay in lockstep
+#: with packaging/systemd/hal0-openwebui.service + installer/install.sh
+#: (tests/installer/test_owui_pin_lockstep.py enforces it). Bump via
+#: scripts/update-owui-digest.sh.
+OPENWEBUI_IMAGE_PIN = "sha256:7f1b0a1a50cfbac23da3b16f96bc968fd757b26dc9e54e93813d61768ea9184e"
+
+#: Human-readable label for the pin, shown next to the digest in status
+#: surfaces. Informational only — the digest is the authority.
+OPENWEBUI_PIN_LABEL = "7f1b0a1a50cf"
+
 #: Matches the pinned ref in the unit / install.sh, capturing the digest.
 #: e.g. ``ghcr.io/open-webui/open-webui@sha256:7f1b0a…`` → ``sha256:7f1b0a…``.
 _PINNED_REF_RE = re.compile(r"open-webui@(sha256:[0-9a-f]{64})")
@@ -126,7 +138,9 @@ def repin_unit_text(text: str, new_digest: str) -> tuple[str, int]:
 __all__ = [
     "OPENWEBUI_DEFAULT_TAG",
     "OPENWEBUI_GHCR_REPO",
+    "OPENWEBUI_IMAGE_PIN",
     "OPENWEBUI_IMAGE_REPO",
+    "OPENWEBUI_PIN_LABEL",
     "OPENWEBUI_UNIT_NAME",
     "find_owui_digests",
     "installed_unit_path",

--- a/src/hal0/openwebui/image_pin.py
+++ b/src/hal0/openwebui/image_pin.py
@@ -42,10 +42,12 @@ OPENWEBUI_UNIT_NAME = "hal0-openwebui.service"
 
 #: The digest every box converges on — the release-carried pin (spec
 #: 2026-08-30 §2, same single-owner posture as
-#: hal0.memory.engine_upgrade.HINDSIGHT_API_PIN). Must stay in lockstep
-#: with packaging/systemd/hal0-openwebui.service + installer/install.sh
-#: (tests/installer/test_owui_pin_lockstep.py enforces it). Bump via
-#: scripts/update-owui-digest.sh.
+#: hal0.memory.engine_upgrade.HINDSIGHT_API_PIN). Three declaration sites
+#: by design, and this is only one of them: this constant, the shipped
+#: unit (packaging/systemd/hal0-openwebui.service — pins the digest twice,
+#: ExecStartPre pull + ExecStart run), and installer/install.sh. Bump all
+#: three together; tests/installer/test_owui_pin_lockstep.py fails naming
+#: whichever site is stale.
 OPENWEBUI_IMAGE_PIN = "sha256:7f1b0a1a50cfbac23da3b16f96bc968fd757b26dc9e54e93813d61768ea9184e"
 
 #: Human-readable label for the pin, shown next to the digest in status

--- a/src/hal0/openwebui/image_pin.py
+++ b/src/hal0/openwebui/image_pin.py
@@ -32,7 +32,9 @@ OPENWEBUI_GHCR_REPO = "open-webui/open-webui"
 
 #: Tag we resolve against when checking for a newer image. OWUI publishes the
 #: multi-arch container under ``:main`` (the tag its own docs recommend for the
-#: self-hosted container). Overridable via ``hal0 update owui --tag``.
+#: self-hosted container). No longer operator-overridable — the pin now rides
+#: hal0 releases; use ``hal0 update owui --target`` for an explicit digest
+#: override instead.
 OPENWEBUI_DEFAULT_TAG = "main"
 
 #: systemd unit that runs the container.

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -4200,7 +4200,6 @@ _NON_FATAL_MIGRATION_FAILURE_EVENTS: tuple[str, ...] = (
     "updater.seed_profiles_prune_failed",
     "updater.mtp_migration_failed",
     "updater.vulkan_migration_failed",
-    "updater.image_retag_failed",
     "updater.extra_args_sanitize_failed",
     "updater.memory_engine_upgrade_failed",
     "updater.components_converge_failed",

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1868,6 +1868,7 @@ def run_post_activation_migrations(
     skip_image_retag: bool = False,
     repair_hermes_venv: bool = True,
     upgrade_memory_engine_venv: bool = True,
+    converge_companions: bool = True,
 ) -> tuple[int, int]:
     """Run every post-activation migration pass hal0 ships, in order.
 
@@ -1942,6 +1943,19 @@ def run_post_activation_migrations(
     post-swap subprocess (an actual update) always passes the default
     ``False``, so the pass still gets its shot every time a release ships.
 
+    ``converge_companions`` gates whether the component catalog
+    (:func:`hal0.components.runner.converge_components`, the final pass
+    below) is even allowed to mutate. It maps straight to that call's
+    ``apply`` kwarg: ``True`` (the default, what an actual update passes)
+    lets each arm converge; ``False`` (what :func:`check_outstanding_migrations`
+    passes) makes every arm diagnose-only, matching the boot-time posture
+    the other three flags (``skip_image_retag``, ``repair_hermes_venv``,
+    ``upgrade_memory_engine_venv``) already hold at boot. Without this flag
+    the openwebui arm — which has no dedicated "install" toggle of its own —
+    would still mutate at boot; adding an explicit kwarg here instead of
+    inferring "diagnose-only" from the other three being off keeps that
+    behaviour legible rather than implicit.
+
     Returns the ``(source, target)`` schema-version tuple for breadcrumb
     logging, the same shape ``commit()`` already returned.
     """
@@ -1983,13 +1997,6 @@ def run_post_activation_migrations(
         # Non-fatal: an affected slot keeps refusing to load (the #1923
         # preflight guard) until the operator manually relabels its device.
 
-    if not skip_image_retag:
-        try:
-            retag_stale_slot_images(job_id=job_id)
-        except Exception as exc:
-            log.warning("updater.image_retag_failed", job_id=job_id, error=str(exc))
-            # Non-fatal: a stale pin just keeps the previous runner image.
-
     try:
         sanitize_model_extra_args(job_id=job_id)
     except Exception as exc:
@@ -1997,16 +2004,28 @@ def run_post_activation_migrations(
         # Non-fatal: an affected model keeps failing to launch until the
         # operator removes the managed flag in the model drawer.
 
+    # ── Component convergence (spec 2026-08-30): the catalog runs LAST for
+    # the same reason the engine pass did — hindsight (inside it) is the
+    # slowest pass and stops a companion service; every cheap pass above
+    # must land even when a component wedges. Flags carry the callers'
+    # existing semantics: boot (check_outstanding_migrations) passes
+    # engine/hermes-install/retag all off, an actual update passes them on.
     try:
-        from hal0.memory.engine_upgrade import upgrade_memory_engine
+        from hal0.components.runner import converge_components
 
-        upgrade_memory_engine(job_id=job_id, upgrade=upgrade_memory_engine_venv)
+        converge_components(
+            job_id=job_id,
+            apply=converge_companions,
+            image_retag=not skip_image_retag,
+            engine=upgrade_memory_engine_venv,
+            hermes_install=repair_hermes_venv,
+        )
     except Exception as exc:
-        log.warning("updater.memory_engine_upgrade_failed", job_id=job_id, error=str(exc))
-        # Non-fatal: the pass itself reports operational failures as status
-        # dicts (and logs this same event with a remedy); reaching here means
-        # a genuine bug, and the box keeps its current working engine either
-        # way — never a reason to fail an update.
+        log.warning("updater.components_converge_failed", job_id=job_id, error=str(exc))
+        # Non-fatal: each arm reports operational failures as status dicts
+        # (and logs its own event with a remedy); reaching here means a
+        # genuine bug, and the box keeps its current working components
+        # either way — never a reason to fail an update.
 
     return migration_info
 
@@ -2065,6 +2084,7 @@ def check_outstanding_migrations(*, job_id: str | None = None) -> tuple[int, int
             skip_image_retag=True,
             repair_hermes_venv=False,
             upgrade_memory_engine_venv=False,
+            converge_companions=False,
         )
     except Exception as exc:
         log.warning("updater.boot_migration_check_failed", job_id=job_id, error=str(exc))
@@ -4183,6 +4203,7 @@ _NON_FATAL_MIGRATION_FAILURE_EVENTS: tuple[str, ...] = (
     "updater.image_retag_failed",
     "updater.extra_args_sanitize_failed",
     "updater.memory_engine_upgrade_failed",
+    "updater.components_converge_failed",
 )
 
 

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -1294,7 +1294,12 @@ def test_components_returns_catalog_rows(isolated_client: TestClient) -> None:
     resp = isolated_client.get("/api/updates/components")
     assert resp.status_code == 200
     body = resp.json()
-    assert {r["id"] for r in body["components"]} == {"openwebui", "runner-images", "hermes", "hindsight"}
+    assert {r["id"] for r in body["components"]} == {
+        "openwebui",
+        "runner-images",
+        "hermes",
+        "hindsight",
+    }
     assert isinstance(body["pending"], int)
 
 

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -1284,3 +1284,14 @@ def test_commit_convergence_is_durable_before_the_restart_that_can_kill_us(
         "convergence was not durable on disk before the restart that can kill this "
         f"process; convergence persisted by then was {convergence_at_restart_time!r}"
     )
+
+
+# ── /components (Task 8) ─────────────────────────────────────────────────────
+
+
+def test_components_returns_catalog_rows(isolated_client: TestClient) -> None:
+    resp = isolated_client.get("/api/updates/components")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert {r["id"] for r in body["components"]} == {"openwebui", "runner-images", "hermes", "hindsight"}
+    assert isinstance(body["pending"], int)

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -1330,3 +1330,12 @@ def test_component_converge_busy_409(isolated_client: TestClient) -> None:
     app.state.update_jobs = {"j1": {"id": "j1", "state": "running"}}
     resp = isolated_client.post("/api/updates/components/hindsight/converge")
     assert resp.status_code == 409
+
+
+# ── components_pending on /check (Task 10) ───────────────────────────────────
+
+
+def test_check_carries_components_pending(isolated_client: TestClient) -> None:
+    resp = isolated_client.get("/api/updates/check")
+    assert resp.status_code == 200
+    assert isinstance(resp.json()["components_pending"], int)

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -11,6 +11,7 @@ import time
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from fastapi import FastAPI
@@ -1295,3 +1296,37 @@ def test_components_returns_catalog_rows(isolated_client: TestClient) -> None:
     body = resp.json()
     assert {r["id"] for r in body["components"]} == {"openwebui", "runner-images", "hermes", "hindsight"}
     assert isinstance(body["pending"], int)
+
+
+# ── /components/{id}/converge (Task 9) ───────────────────────────────────────
+
+
+def test_component_converge_unknown_id_404(isolated_client: TestClient) -> None:
+    resp = isolated_client.post("/api/updates/components/nope/converge")
+    assert resp.status_code == 404
+
+
+def test_component_converge_returns_job_and_completes(isolated_client: TestClient) -> None:
+    with patch(
+        "hal0.components.runner.converge_component",
+        return_value={"status": "upgraded", "from": "a", "to": "b"},
+    ):
+        resp = isolated_client.post("/api/updates/components/openwebui/converge")
+        assert resp.status_code == 202
+        job_id = resp.json()["id"]
+        # in-process task: poll until terminal
+        for _ in range(50):
+            job = isolated_client.get(f"/api/updates/status/{job_id}").json()
+            if job["state"] in ("applied", "failed"):
+                break
+            time.sleep(0.05)
+    assert job["state"] == "applied"
+    assert job["component_result"]["status"] == "upgraded"
+
+
+def test_component_converge_busy_409(isolated_client: TestClient) -> None:
+    # Seed a running job into the registry the route reads.
+    app = isolated_client.app
+    app.state.update_jobs = {"j1": {"id": "j1", "state": "running"}}
+    resp = isolated_client.post("/api/updates/components/hindsight/converge")
+    assert resp.status_code == 409

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -878,7 +878,9 @@ def test_update_component_converges_and_prints_result(
         posted["json"] = json
         return {"id": "job1", "state": "queued"}
 
-    def fake_poll(job_id: str, *, terminal: tuple = ("applied", "failed"), **kwargs: object) -> dict:
+    def fake_poll(
+        job_id: str, *, terminal: tuple = ("applied", "failed"), **kwargs: object
+    ) -> dict:
         assert job_id == "job1"
         return {
             "id": job_id,
@@ -924,7 +926,9 @@ def test_update_owui_target_posts_normalized_digest(monkeypatch: pytest.MonkeyPa
         posted["json"] = json
         return {"id": "job2", "state": "queued"}
 
-    def fake_poll(job_id: str, *, terminal: tuple = ("applied", "failed"), **kwargs: object) -> dict:
+    def fake_poll(
+        job_id: str, *, terminal: tuple = ("applied", "failed"), **kwargs: object
+    ) -> dict:
         return {"id": job_id, "state": "applied", "component_result": {"status": "converged"}}
 
     monkeypatch.setattr(uc, "api_get", fake_get)

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -263,6 +263,55 @@ def test_post_apply_shows_drift_banner(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "--restart-slots" in result.output
 
 
+def test_bare_update_exits_2_when_a_component_is_still_pending_after_apply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The applied branch folds component convergence into its exit-2 rule.
+
+    A hal0 self-update can swap the tree cleanly while a component (e.g.
+    hindsight) is still mid-converge or stuck — that must not be reported as
+    a clean "update applied.", same as an outstanding ownership migration.
+    """
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+    monkeypatch.setattr(uc, "_interactive", lambda: False)
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
+
+    def fake_get(path: str, **kwargs: object) -> dict:
+        if path == "/api/updates/slot-drift":
+            return {"count": 0, "slots": []}
+        if path == "/api/updates/components":
+            return {"components": [_component_row(status="pending")], "pending": 1}
+        return {
+            "current": "0.0.0",
+            "latest": "9.9.9",
+            "channel": "stable",
+            "update_available": True,
+            "manifest": {},
+        }
+
+    def fake_post(path: str, *, json: object = None, **kwargs: object) -> dict:
+        if path == "/api/updates/prepare":
+            return {"id": "p1", "state": "queued"}
+        if path == "/api/updates/commit":
+            return {"id": "c1", "state": "queued"}
+        return {}
+
+    def fake_poll(
+        job_id: str, *, terminal: tuple = ("applied", "failed"), **kwargs: object
+    ) -> dict:
+        if "prepared" in terminal:
+            return {"id": job_id, "state": "prepared", "resolved_version": "9.9.9", "notes": {}}
+        return {"id": job_id, "state": "applied"}
+
+    monkeypatch.setattr(uc, "api_get", fake_get)
+    monkeypatch.setattr(uc, "api_post", fake_post)
+    monkeypatch.setattr(uc, "_poll_job", fake_poll)
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 2, result.output
+    assert "NOT fully converged" in result.output
+    assert "update applied." not in result.output
+
+
 def test_target_strips_leading_v(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:
     """``--target v0.1.1`` is normalized to ``0.1.1`` before hitting /prepare."""
     result = runner.invoke(app, ["update", "--target", "v0.1.1"])
@@ -750,3 +799,143 @@ def test_print_check_real_manifest_renders_normally(capsys: pytest.CaptureFixtur
     out = capsys.readouterr().out
     assert "no release published" not in out
     assert "1.0.0" in out
+
+
+# ── `hal0 update status` / `hal0 update component` (spec 2026-08-30 §3) ────────
+
+
+def _component_row(**overrides: object) -> dict:
+    row = {
+        "id": "hindsight",
+        "name": "Hindsight",
+        "installed": "1.0.0",
+        "pinned": "1.1.0",
+        "pin_label": None,
+        "status": "pending",
+        "error": None,
+        "remedy": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_update_status_exits_2_when_a_component_is_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+
+    def fake_get(path: str, **kwargs: object) -> dict:
+        if path == "/api/updates/components":
+            return {"components": [_component_row(status="pending")], "pending": 1}
+        return {
+            "current": "1.0.0",
+            "latest": "1.0.0",
+            "channel": "stable",
+            "update_available": False,
+            "manifest": {},
+        }
+
+    monkeypatch.setattr(uc, "api_get", fake_get)
+    result = runner.invoke(app, ["update", "status"])
+    assert result.exit_code == 2, result.output
+    assert "Hindsight" in result.output
+
+
+def test_update_status_exits_0_when_all_components_converged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+
+    def fake_get(path: str, **kwargs: object) -> dict:
+        if path == "/api/updates/components":
+            return {"components": [_component_row(status="converged")], "pending": 0}
+        return {
+            "current": "1.0.0",
+            "latest": "1.0.0",
+            "channel": "stable",
+            "update_available": False,
+            "manifest": {},
+        }
+
+    monkeypatch.setattr(uc, "api_get", fake_get)
+    result = runner.invoke(app, ["update", "status"])
+    assert result.exit_code == 0, result.output
+    assert "Hindsight" in result.output
+
+
+def test_update_component_converges_and_prints_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+    posted: dict = {}
+
+    def fake_get(path: str, **kwargs: object) -> dict:
+        assert path == "/api/updates/components"
+        return {"components": [_component_row(id="hindsight", status="pending")], "pending": 1}
+
+    def fake_post(path: str, *, json: object = None, **kwargs: object) -> dict:
+        posted["path"] = path
+        posted["json"] = json
+        return {"id": "job1", "state": "queued"}
+
+    def fake_poll(job_id: str, *, terminal: tuple = ("applied", "failed"), **kwargs: object) -> dict:
+        assert job_id == "job1"
+        return {
+            "id": job_id,
+            "state": "applied",
+            "component_result": {"status": "converged", "from": "1.0.0", "to": "1.1.0"},
+        }
+
+    monkeypatch.setattr(uc, "api_get", fake_get)
+    monkeypatch.setattr(uc, "api_post", fake_post)
+    monkeypatch.setattr(uc, "_poll_job", fake_poll)
+    result = runner.invoke(app, ["update", "component", "hindsight"])
+    assert result.exit_code == 0, result.output
+    assert posted["path"] == "/api/updates/components/hindsight/converge"
+    assert "converged" in result.output
+
+
+def test_update_component_unknown_id_dies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+
+    def fake_get(path: str, **kwargs: object) -> dict:
+        return {"components": [_component_row(id="hindsight")], "pending": 1}
+
+    monkeypatch.setattr(uc, "api_get", fake_get)
+    result = runner.invoke(app, ["update", "component", "nope"])
+    assert result.exit_code == 1, result.output
+    assert "nope" in result.output
+
+
+# ── `hal0 update owui` (thin client rework; --tag GONE) ─────────────────────────
+
+
+def test_update_owui_target_posts_normalized_digest(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+    monkeypatch.setattr(uc, "_interactive", lambda: False)
+    posted: dict = {}
+    digest_hex = "a" * 64
+
+    def fake_get(path: str, **kwargs: object) -> dict:
+        return {"components": [_component_row(id="openwebui", status="pending")], "pending": 1}
+
+    def fake_post(path: str, *, json: object = None, **kwargs: object) -> dict:
+        posted["path"] = path
+        posted["json"] = json
+        return {"id": "job2", "state": "queued"}
+
+    def fake_poll(job_id: str, *, terminal: tuple = ("applied", "failed"), **kwargs: object) -> dict:
+        return {"id": job_id, "state": "applied", "component_result": {"status": "converged"}}
+
+    monkeypatch.setattr(uc, "api_get", fake_get)
+    monkeypatch.setattr(uc, "api_post", fake_post)
+    monkeypatch.setattr(uc, "_poll_job", fake_poll)
+    result = runner.invoke(app, ["update", "owui", "--target", digest_hex])
+    assert result.exit_code == 0, result.output
+    assert posted["path"] == "/api/updates/components/openwebui/converge"
+    assert posted["json"] == {"target": f"sha256:{digest_hex}"}
+
+
+def test_update_owui_tag_flag_no_longer_parses() -> None:
+    result = runner.invoke(app, ["update", "owui", "--tag", "x"])
+    assert result.exit_code == 2, result.output

--- a/tests/components/test_hermes_arm.py
+++ b/tests/components/test_hermes_arm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -81,3 +82,59 @@ def test_deprovisioned_with_stale_stamp_reads_none(tmp_path) -> None:
     hermes_arm.stamp_path().parent.mkdir(parents=True, exist_ok=True)
     hermes_arm.stamp_path().write_text("v2026.7.7.2\n", encoding="utf-8")
     assert hermes_arm.installed_hermes_pin() is None
+
+
+# ── I3: provision.json checkpoint fallback (final-review) ────────────────────
+#
+# No box provisioned before the venv.pin stamp existed has one, so a bare
+# "no stamp -> not installed" read would misreport a working provision and
+# trigger a needless venv rebuild on the first `hal0 update`. The fallback
+# reads hermes_version out of the provisioner's last-run report instead.
+
+
+def _write_checkpoint(hermes_version) -> None:
+    path = var_lib() / "state" / "agents" / "hermes" / "provision.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"hermes_version": hermes_version}), encoding="utf-8")
+
+
+def test_stamp_absent_checkpoint_present_falls_back_to_checkpoint(tmp_path) -> None:
+    venv = _venv(tmp_path)
+    _write_checkpoint("v2026.7.7.2")
+    assert hermes_arm.installed_hermes_pin(venv) == "v2026.7.7.2"
+
+
+def test_stamp_and_checkpoint_both_absent_reads_none(tmp_path) -> None:
+    venv = _venv(tmp_path)
+    assert hermes_arm.installed_hermes_pin(venv) is None
+
+
+def test_stamp_wins_over_checkpoint_when_both_present(tmp_path) -> None:
+    venv = _venv(tmp_path)
+    hermes_arm.stamp_path().parent.mkdir(parents=True, exist_ok=True)
+    hermes_arm.stamp_path().write_text("stamp-value\n", encoding="utf-8")
+    _write_checkpoint("checkpoint-value")
+    assert hermes_arm.installed_hermes_pin(venv) == "stamp-value"
+
+
+def test_checkpoint_malformed_json_reads_none(tmp_path) -> None:
+    venv = _venv(tmp_path)
+    path = var_lib() / "state" / "agents" / "hermes" / "provision.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    assert hermes_arm.installed_hermes_pin(venv) is None
+
+
+def test_checkpoint_missing_hermes_version_key_reads_none(tmp_path) -> None:
+    venv = _venv(tmp_path)
+    path = var_lib() / "state" / "agents" / "hermes" / "provision.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"hal0_version": "1.0"}), encoding="utf-8")
+    assert hermes_arm.installed_hermes_pin(venv) is None
+
+
+def test_checkpoint_venv_absent_still_reads_none_regardless_of_checkpoint(tmp_path) -> None:
+    # No venv -> installed_hermes_pin short-circuits to None before ever
+    # consulting the stamp or the checkpoint (deprovisioned-box semantics).
+    _write_checkpoint("v2026.7.7.2")
+    assert hermes_arm.installed_hermes_pin(tmp_path / "nope") is None

--- a/tests/components/test_hermes_arm.py
+++ b/tests/components/test_hermes_arm.py
@@ -1,0 +1,68 @@
+"""Hermes converge arm: stamp-tracked venv rebuild at the requirements pin."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hal0.components import hermes_arm
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+
+
+def _venv(tmp_path, with_python=True):
+    venv = tmp_path / "venvs" / "hermes"
+    (venv / "bin").mkdir(parents=True)
+    if with_python:
+        (venv / "bin" / "python").write_text("", encoding="utf-8")
+    return venv
+
+
+def test_unprovisioned_skips(tmp_path) -> None:
+    res = hermes_arm.converge_hermes(venv=tmp_path / "nope")
+    assert res["status"] == "skipped"
+
+
+def test_stamped_at_pin_converges(tmp_path) -> None:
+    venv = _venv(tmp_path)
+    with patch("hal0.agents.hermes_provision._hermes_version_pin", return_value="v2026.7.7.2"):
+        hermes_arm.stamp_path().parent.mkdir(parents=True, exist_ok=True)
+        hermes_arm.stamp_path().write_text("v2026.7.7.2\n", encoding="utf-8")
+        res = hermes_arm.converge_hermes(venv=venv)
+    assert res["status"] == "converged"
+
+
+def test_drift_diagnose_only(tmp_path) -> None:
+    venv = _venv(tmp_path)
+    with patch("hal0.agents.hermes_provision._hermes_version_pin", return_value="v2"):
+        res = hermes_arm.converge_hermes(venv=venv, apply=False)
+    assert res["status"] == "stale"
+
+
+def test_drift_rebuilds_probes_and_stamps(tmp_path) -> None:
+    venv = _venv(tmp_path)
+    with (
+        patch("hal0.agents.hermes_provision._hermes_version_pin", return_value="v2"),
+        patch("hal0.agents.hermes_provision._install_venv") as install,
+        patch("hal0.agents.hermes_provision._probe_mcp_client", return_value={"ok": True}),
+    ):
+        res = hermes_arm.converge_hermes(venv=venv, runner=MagicMock(return_value=MagicMock(returncode=0)), is_hal0_user=lambda: False)
+    assert res["status"] == "upgraded"
+    install.assert_called_once()
+    assert hermes_arm.installed_hermes_pin() == "v2"
+
+
+def test_failed_probe_is_build_failed_and_unstamped(tmp_path) -> None:
+    venv = _venv(tmp_path)
+    with (
+        patch("hal0.agents.hermes_provision._hermes_version_pin", return_value="v2"),
+        patch("hal0.agents.hermes_provision._install_venv"),
+        patch("hal0.agents.hermes_provision._probe_mcp_client", return_value={"ok": False, "error": "no mcp"}),
+    ):
+        res = hermes_arm.converge_hermes(venv=venv, is_hal0_user=lambda: False)
+    assert res["status"] == "build_failed"
+    assert hermes_arm.installed_hermes_pin() is None

--- a/tests/components/test_hermes_arm.py
+++ b/tests/components/test_hermes_arm.py
@@ -56,7 +56,11 @@ def test_drift_rebuilds_probes_and_stamps(tmp_path) -> None:
         patch("hal0.agents.hermes_provision._install_venv") as install,
         patch("hal0.agents.hermes_provision._probe_mcp_client", return_value={"ok": True}),
     ):
-        res = hermes_arm.converge_hermes(venv=venv, runner=MagicMock(return_value=MagicMock(returncode=0)), is_hal0_user=lambda: False)
+        res = hermes_arm.converge_hermes(
+            venv=venv,
+            runner=MagicMock(return_value=MagicMock(returncode=0)),
+            is_hal0_user=lambda: False,
+        )
     assert res["status"] == "upgraded"
     install.assert_called_once()
     assert hermes_arm.installed_hermes_pin() == "v2"
@@ -67,7 +71,10 @@ def test_failed_probe_is_build_failed_and_unstamped(tmp_path) -> None:
     with (
         patch("hal0.agents.hermes_provision._hermes_version_pin", return_value="v2"),
         patch("hal0.agents.hermes_provision._install_venv"),
-        patch("hal0.agents.hermes_provision._probe_mcp_client", return_value={"ok": False, "error": "no mcp"}),
+        patch(
+            "hal0.agents.hermes_provision._probe_mcp_client",
+            return_value={"ok": False, "error": "no mcp"},
+        ),
     ):
         res = hermes_arm.converge_hermes(venv=venv, is_hal0_user=lambda: False)
     assert res["status"] == "build_failed"

--- a/tests/components/test_hermes_arm.py
+++ b/tests/components/test_hermes_arm.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hal0.components import hermes_arm
+from hal0.config.paths import var_lib
 
 
 @pytest.fixture(autouse=True)
@@ -15,7 +16,11 @@ def _home(tmp_path, monkeypatch):
 
 
 def _venv(tmp_path, with_python=True):
-    venv = tmp_path / "venvs" / "hermes"
+    # Built at installed_hermes_pin()'s HAL0_HOME-aware default
+    # (var_lib() / "venvs" / "hermes") rather than an arbitrary tmp_path
+    # location, so the no-arg calls below (mirroring the registry's own
+    # usage) resolve to the same venv these helpers just built.
+    venv = var_lib() / "venvs" / "hermes"
     (venv / "bin").mkdir(parents=True)
     if with_python:
         (venv / "bin" / "python").write_text("", encoding="utf-8")
@@ -65,4 +70,14 @@ def test_failed_probe_is_build_failed_and_unstamped(tmp_path) -> None:
     ):
         res = hermes_arm.converge_hermes(venv=venv, is_hal0_user=lambda: False)
     assert res["status"] == "build_failed"
+    assert hermes_arm.installed_hermes_pin() is None
+
+
+def test_deprovisioned_with_stale_stamp_reads_none(tmp_path) -> None:
+    # State (var_lib()) is preserved across an uninstall unless --keep-data
+    # is dropped, so a stamp file can outlive the venv it describes. That
+    # must read as "not installed", not as a stale converged/pending
+    # verdict (Task 8's status derivation depends on this).
+    hermes_arm.stamp_path().parent.mkdir(parents=True, exist_ok=True)
+    hermes_arm.stamp_path().write_text("v2026.7.7.2\n", encoding="utf-8")
     assert hermes_arm.installed_hermes_pin() is None

--- a/tests/components/test_openwebui_arm.py
+++ b/tests/components/test_openwebui_arm.py
@@ -89,6 +89,26 @@ def test_target_digest_writes_override_marker(tmp_path) -> None:
     assert res2["status"] == "override"
 
 
+def test_target_digest_matching_installed_persists_override(tmp_path) -> None:
+    # Installed digest is already the operator's --target — distinct from
+    # the release pin (NEW), so this can't be mistaken for the plain
+    # already-converged-to-the-release-pin case.
+    other = "sha256:" + "2" * 64
+    unit = tmp_path / "u.service"
+    unit.write_text(UNIT.replace(OLD, other), encoding="utf-8")
+    runner = _ok_runner()
+    res = openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=runner, is_hal0_user=lambda: False, target_digest=other
+    )
+    assert res["status"] == "override"
+    assert openwebui_arm.read_pin_override() == other
+    runner.assert_not_called()
+    # A subsequent un-targeted converge holds the box at the override
+    # (NEW would otherwise pull it back to the release pin).
+    res2 = openwebui_arm.converge_openwebui(unit_path=unit, runner=_ok_runner(), is_hal0_user=lambda: False)
+    assert res2["status"] == "override"
+
+
 def test_clear_override(tmp_path) -> None:
     other = "sha256:" + "2" * 64
     unit = _unit(tmp_path)

--- a/tests/components/test_openwebui_arm.py
+++ b/tests/components/test_openwebui_arm.py
@@ -1,0 +1,102 @@
+"""OpenWebUI converge arm: pull-first repin with override marker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from hal0.components import openwebui_arm
+from hal0.openwebui.image_pin import OPENWEBUI_IMAGE_PIN
+
+OLD = "sha256:" + "1" * 64
+NEW = OPENWEBUI_IMAGE_PIN
+UNIT = (
+    "[Service]\n"
+    f"ExecStartPre=podman pull ghcr.io/open-webui/open-webui@{OLD}\n"
+    f"ExecStart=podman run ghcr.io/open-webui/open-webui@{OLD}\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+
+
+def _unit(tmp_path) -> Path:
+    unit = tmp_path / "hal0-openwebui.service"
+    unit.write_text(UNIT, encoding="utf-8")
+    return unit
+
+
+def _ok_runner():
+    r = MagicMock()
+    r.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    return r
+
+
+def test_no_unit_skips(tmp_path) -> None:
+    res = openwebui_arm.converge_openwebui(unit_path=tmp_path / "missing.service")
+    assert res["status"] == "skipped"
+
+
+def test_already_pinned_converges(tmp_path) -> None:
+    unit = tmp_path / "u.service"
+    unit.write_text(UNIT.replace(OLD, NEW), encoding="utf-8")
+    res = openwebui_arm.converge_openwebui(unit_path=unit, runner=_ok_runner())
+    assert res["status"] == "converged"
+
+
+def test_drift_diagnose_only_reports_stale(tmp_path) -> None:
+    res = openwebui_arm.converge_openwebui(unit_path=_unit(tmp_path), apply=False, runner=_ok_runner())
+    assert res["status"] == "stale"
+    assert res["installed"] == OLD and res["pinned"] == NEW
+
+
+def test_drift_pull_ok_repins_and_restarts(tmp_path) -> None:
+    runner = _ok_runner()
+    unit = _unit(tmp_path)
+    res = openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=runner, is_hal0_user=lambda: False
+    )
+    assert res["status"] == "upgraded"
+    text = unit.read_text(encoding="utf-8")
+    assert NEW in text and OLD not in text
+    pulled = [c.args[0] for c in runner.call_args_list if "pull" in c.args[0]]
+    assert pulled, "must pull before repinning"
+
+
+def test_pull_failure_leaves_unit_untouched(tmp_path) -> None:
+    runner = MagicMock()
+    runner.return_value = MagicMock(returncode=1, stdout="", stderr="no route")
+    unit = _unit(tmp_path)
+    res = openwebui_arm.converge_openwebui(unit_path=unit, runner=runner, is_hal0_user=lambda: False)
+    assert res["status"] == "build_failed"
+    assert OLD in unit.read_text(encoding="utf-8")
+
+
+def test_target_digest_writes_override_marker(tmp_path) -> None:
+    other = "sha256:" + "2" * 64
+    unit = _unit(tmp_path)
+    res = openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=_ok_runner(), is_hal0_user=lambda: False, target_digest=other
+    )
+    assert res["status"] == "upgraded"
+    assert openwebui_arm.read_pin_override() == other
+    # Subsequent pin-converge respects the override and reports it.
+    res2 = openwebui_arm.converge_openwebui(unit_path=unit, runner=_ok_runner(), is_hal0_user=lambda: False)
+    assert res2["status"] == "override"
+
+
+def test_clear_override(tmp_path) -> None:
+    other = "sha256:" + "2" * 64
+    unit = _unit(tmp_path)
+    openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=_ok_runner(), is_hal0_user=lambda: False, target_digest=other
+    )
+    res = openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=_ok_runner(), is_hal0_user=lambda: False, clear_override=True
+    )
+    assert openwebui_arm.read_pin_override() is None
+    assert res["status"] == "upgraded"  # back to the release pin

--- a/tests/components/test_openwebui_arm.py
+++ b/tests/components/test_openwebui_arm.py
@@ -49,7 +49,9 @@ def test_already_pinned_converges(tmp_path) -> None:
 
 
 def test_drift_diagnose_only_reports_stale(tmp_path) -> None:
-    res = openwebui_arm.converge_openwebui(unit_path=_unit(tmp_path), apply=False, runner=_ok_runner())
+    res = openwebui_arm.converge_openwebui(
+        unit_path=_unit(tmp_path), apply=False, runner=_ok_runner()
+    )
     assert res["status"] == "stale"
     assert res["installed"] == OLD and res["pinned"] == NEW
 
@@ -71,7 +73,9 @@ def test_pull_failure_leaves_unit_untouched(tmp_path) -> None:
     runner = MagicMock()
     runner.return_value = MagicMock(returncode=1, stdout="", stderr="no route")
     unit = _unit(tmp_path)
-    res = openwebui_arm.converge_openwebui(unit_path=unit, runner=runner, is_hal0_user=lambda: False)
+    res = openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=runner, is_hal0_user=lambda: False
+    )
     assert res["status"] == "build_failed"
     assert OLD in unit.read_text(encoding="utf-8")
 
@@ -85,7 +89,9 @@ def test_target_digest_writes_override_marker(tmp_path) -> None:
     assert res["status"] == "upgraded"
     assert openwebui_arm.read_pin_override() == other
     # Subsequent pin-converge respects the override and reports it.
-    res2 = openwebui_arm.converge_openwebui(unit_path=unit, runner=_ok_runner(), is_hal0_user=lambda: False)
+    res2 = openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=_ok_runner(), is_hal0_user=lambda: False
+    )
     assert res2["status"] == "override"
 
 
@@ -105,7 +111,9 @@ def test_target_digest_matching_installed_persists_override(tmp_path) -> None:
     runner.assert_not_called()
     # A subsequent un-targeted converge holds the box at the override
     # (NEW would otherwise pull it back to the release pin).
-    res2 = openwebui_arm.converge_openwebui(unit_path=unit, runner=_ok_runner(), is_hal0_user=lambda: False)
+    res2 = openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=_ok_runner(), is_hal0_user=lambda: False
+    )
     assert res2["status"] == "override"
 
 

--- a/tests/components/test_registry.py
+++ b/tests/components/test_registry.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from hal0.components.registry import COMPONENTS, component_by_id
 from hal0.services.registry import service_by_id
 
@@ -24,7 +22,6 @@ def test_service_joins_resolve() -> None:
             assert service_by_id(comp.service_id) is not None, comp.id
 
 
-@pytest.mark.xfail(reason="OPENWEBUI_IMAGE_PIN lands in the next commit", strict=True)
 def test_pinned_callables_return_strings() -> None:
     for comp in COMPONENTS:
         assert isinstance(comp.pinned(), str) and comp.pinned()

--- a/tests/components/test_registry.py
+++ b/tests/components/test_registry.py
@@ -1,0 +1,30 @@
+"""Catalog shape: ids, order, and service joins stay stable."""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.components.registry import COMPONENTS, component_by_id
+from hal0.services.registry import service_by_id
+
+
+def test_catalog_ids_and_order() -> None:
+    # Order is the converge order: hindsight LAST (slowest, service-stopping).
+    assert [c.id for c in COMPONENTS] == ["openwebui", "runner-images", "hermes", "hindsight"]
+
+
+def test_component_by_id() -> None:
+    assert component_by_id("hindsight").kind == "venv"
+    assert component_by_id("nope") is None
+
+
+def test_service_joins_resolve() -> None:
+    for comp in COMPONENTS:
+        if comp.service_id is not None:
+            assert service_by_id(comp.service_id) is not None, comp.id
+
+
+@pytest.mark.xfail(reason="OPENWEBUI_IMAGE_PIN lands in the next commit", strict=True)
+def test_pinned_callables_return_strings() -> None:
+    for comp in COMPONENTS:
+        assert isinstance(comp.pinned(), str) and comp.pinned()

--- a/tests/components/test_runner.py
+++ b/tests/components/test_runner.py
@@ -19,10 +19,14 @@ def _patch_arms(calls):
         def arm(**kwargs):
             calls.append((name, kwargs))
             return {"status": "converged"}
+
         return arm
+
     return (
         patch("hal0.components.registry._openwebui_converge", side_effect=make("openwebui")),
-        patch("hal0.components.registry._runner_images_converge", side_effect=make("runner-images")),
+        patch(
+            "hal0.components.registry._runner_images_converge", side_effect=make("runner-images")
+        ),
         patch("hal0.components.registry._hermes_converge", side_effect=make("hermes")),
         patch("hal0.components.registry._hindsight_converge", side_effect=make("hindsight")),
     )
@@ -34,7 +38,7 @@ def test_order_and_flags_update_path() -> None:
     with p1, p2, p3, p4:
         results = runner.converge_components(job_id="j1")
     assert [c[0] for c in calls] == ["openwebui", "runner-images", "hermes", "hindsight"]
-    assert calls[3][1] == {"job_id": "j1", "upgrade": True}   # hindsight kwarg spelling
+    assert calls[3][1] == {"job_id": "j1", "upgrade": True}  # hindsight kwarg spelling
     assert calls[0][1] == {"job_id": "j1", "apply": True}
     assert set(results) == {"openwebui", "runner-images", "hermes", "hindsight"}
 
@@ -44,9 +48,7 @@ def test_boot_path_is_diagnose_only() -> None:
     p1, p2, p3, p4 = _patch_arms(calls)
     with p1, p2, p3, p4:
         runner.converge_components(apply=False)
-    assert all(
-        kw.get("apply") is False or kw.get("upgrade") is False for _, kw in calls
-    )
+    assert all(kw.get("apply") is False or kw.get("upgrade") is False for _, kw in calls)
 
 
 def test_one_arm_crashing_never_blocks_the_next() -> None:
@@ -63,7 +65,12 @@ def test_results_recorded_to_state_store() -> None:
     p1, p2, p3, p4 = _patch_arms([])
     with p1, p2, p3, p4:
         runner.converge_components()
-    assert set(state.load_component_state()) == {"openwebui", "runner-images", "hermes", "hindsight"}
+    assert set(state.load_component_state()) == {
+        "openwebui",
+        "runner-images",
+        "hermes",
+        "hindsight",
+    }
 
 
 # ── M1: boot-time diagnose must not erase a recorded failure breadcrumb ──────
@@ -105,9 +112,7 @@ def test_boot_diagnose_still_records_when_no_prior_failure() -> None:
 def test_apply_true_converge_overwrites_a_prior_failure() -> None:
     # A retry / `hal0 update` pass (apply=True) is the freshest truth and
     # must always overwrite, whether curing the failure or reconfirming it.
-    state.record_component_result(
-        "openwebui", {"status": "build_failed", "error": "pull failed"}
-    )
+    state.record_component_result("openwebui", {"status": "build_failed", "error": "pull failed"})
     p1, p2, p3, p4 = _patch_arms([])
     with p1, p2, p3, p4:
         runner.converge_components(apply=True)

--- a/tests/components/test_runner.py
+++ b/tests/components/test_runner.py
@@ -64,3 +64,72 @@ def test_results_recorded_to_state_store() -> None:
     with p1, p2, p3, p4:
         runner.converge_components()
     assert set(state.load_component_state()) == {"openwebui", "runner-images", "hermes", "hindsight"}
+
+
+# ── M1: boot-time diagnose must not erase a recorded failure breadcrumb ──────
+
+
+def test_boot_diagnose_does_not_clobber_a_recorded_failure() -> None:
+    # Seed a real failure (as a prior apply=True converge would have
+    # recorded) — the error/remedy the dashboard Retry button reads.
+    state.record_component_result(
+        "openwebui",
+        {"status": "build_failed", "error": "pull failed", "remedy": "check registry creds"},
+    )
+    calls: list = []
+    p1, p2, p3, p4 = _patch_arms(calls)
+    with p1, p2, p3, p4:
+        results = runner.converge_components(apply=False)
+    # The arm still ran (diagnose is a real probe) and its own return value
+    # is handed back to the caller...
+    assert results["openwebui"]["status"] == "converged"
+    # ...but components.json keeps the prior failure breadcrumb rather than
+    # being overwritten with the diagnose-only result that has no
+    # error/remedy of its own.
+    stored = state.load_component_state()["openwebui"]
+    assert stored["status"] == "build_failed"
+    assert stored["error"] == "pull failed"
+    assert stored["remedy"] == "check registry creds"
+
+
+def test_boot_diagnose_still_records_when_no_prior_failure() -> None:
+    # No pre-existing entry at all — the common case (fresh box / first
+    # boot) — must still get recorded so the dashboard has something to show.
+    p1, p2, p3, p4 = _patch_arms([])
+    with p1, p2, p3, p4:
+        runner.converge_components(apply=False)
+    stored = state.load_component_state()
+    assert stored["openwebui"]["status"] == "converged"
+
+
+def test_apply_true_converge_overwrites_a_prior_failure() -> None:
+    # A retry / `hal0 update` pass (apply=True) is the freshest truth and
+    # must always overwrite, whether curing the failure or reconfirming it.
+    state.record_component_result(
+        "openwebui", {"status": "build_failed", "error": "pull failed"}
+    )
+    p1, p2, p3, p4 = _patch_arms([])
+    with p1, p2, p3, p4:
+        runner.converge_components(apply=True)
+    stored = state.load_component_state()["openwebui"]
+    assert stored["status"] == "converged"
+    assert "error" not in stored
+
+
+def test_converge_component_diagnose_only_flag_gates_recording_directly() -> None:
+    # Exercise converge_component() itself (not just via converge_components)
+    # since the retry route calls it directly.
+    from hal0.components.registry import COMPONENTS
+
+    comp = next(c for c in COMPONENTS if c.id == "openwebui")
+    state.record_component_result(
+        "openwebui", {"status": "snapshot_failed", "error": "boom", "remedy": "retry"}
+    )
+    with patch(
+        "hal0.components.registry._openwebui_converge",
+        side_effect=lambda **kw: {"status": "stale"},
+    ):
+        result = runner.converge_component(comp, diagnose_only=True, job_id=None, apply=False)
+    assert result["status"] == "stale"
+    stored = state.load_component_state()["openwebui"]
+    assert stored["status"] == "snapshot_failed"  # untouched

--- a/tests/components/test_runner.py
+++ b/tests/components/test_runner.py
@@ -1,0 +1,66 @@
+"""converge_components: order, flag fan-out, isolation, bookkeeping."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hal0.components import runner, state
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+
+
+def _patch_arms(calls):
+    def make(name):
+        def arm(**kwargs):
+            calls.append((name, kwargs))
+            return {"status": "converged"}
+        return arm
+    return (
+        patch("hal0.components.registry._openwebui_converge", side_effect=make("openwebui")),
+        patch("hal0.components.registry._runner_images_converge", side_effect=make("runner-images")),
+        patch("hal0.components.registry._hermes_converge", side_effect=make("hermes")),
+        patch("hal0.components.registry._hindsight_converge", side_effect=make("hindsight")),
+    )
+
+
+def test_order_and_flags_update_path() -> None:
+    calls: list = []
+    p1, p2, p3, p4 = _patch_arms(calls)
+    with p1, p2, p3, p4:
+        results = runner.converge_components(job_id="j1")
+    assert [c[0] for c in calls] == ["openwebui", "runner-images", "hermes", "hindsight"]
+    assert calls[3][1] == {"job_id": "j1", "upgrade": True}   # hindsight kwarg spelling
+    assert calls[0][1] == {"job_id": "j1", "apply": True}
+    assert set(results) == {"openwebui", "runner-images", "hermes", "hindsight"}
+
+
+def test_boot_path_is_diagnose_only() -> None:
+    calls: list = []
+    p1, p2, p3, p4 = _patch_arms(calls)
+    with p1, p2, p3, p4:
+        runner.converge_components(apply=False)
+    assert all(
+        kw.get("apply") is False or kw.get("upgrade") is False for _, kw in calls
+    )
+
+
+def test_one_arm_crashing_never_blocks_the_next() -> None:
+    calls: list = []
+    p1, p2, p3, p4 = _patch_arms(calls)
+    with p1 as owui, p2, p3, p4:
+        owui.side_effect = RuntimeError("bug")
+        results = runner.converge_components()
+    assert results["openwebui"]["status"] == "build_failed"
+    assert [c[0] for c in calls] == ["runner-images", "hermes", "hindsight"]
+
+
+def test_results_recorded_to_state_store() -> None:
+    p1, p2, p3, p4 = _patch_arms([])
+    with p1, p2, p3, p4:
+        runner.converge_components()
+    assert set(state.load_component_state()) == {"openwebui", "runner-images", "hermes", "hindsight"}

--- a/tests/components/test_runner_images_arm.py
+++ b/tests/components/test_runner_images_arm.py
@@ -1,0 +1,34 @@
+"""Runner-images arm: detail rows + retag pass wrapper."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from hal0.components import runner_images_arm
+from hal0.runners import RUNNER_IMAGES
+
+
+def test_detail_covers_every_runner() -> None:
+    res = runner_images_arm.converge_runner_images(retag=MagicMock(return_value=0))
+    assert {d["key"] for d in res["detail"]} == set(RUNNER_IMAGES)
+    assert all(d["image"] for d in res["detail"])
+
+
+def test_apply_runs_retag_and_converges() -> None:
+    retag = MagicMock(return_value=2)
+    res = runner_images_arm.converge_runner_images(retag=retag)
+    retag.assert_called_once()
+    assert res["status"] == "converged"
+    assert res["retagged"] == 2
+
+
+def test_diagnose_only_skips_retag() -> None:
+    retag = MagicMock()
+    res = runner_images_arm.converge_runner_images(apply=False, retag=retag)
+    retag.assert_not_called()
+    assert res["status"] == "converged"
+
+
+def test_retag_failure_is_build_failed() -> None:
+    res = runner_images_arm.converge_runner_images(retag=MagicMock(side_effect=OSError("disk")))
+    assert res["status"] == "build_failed"

--- a/tests/components/test_state.py
+++ b/tests/components/test_state.py
@@ -1,0 +1,53 @@
+"""components.json state store: atomic write, tolerant read."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hal0.components import state
+
+
+@pytest.fixture(autouse=True)
+def _isolated_var_lib(tmp_path, monkeypatch):
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+
+
+def test_record_then_load_roundtrip() -> None:
+    state.record_component_result("openwebui", {"status": "converged", "installed": "sha256:" + "a" * 64})
+    loaded = state.load_component_state()
+    assert loaded["openwebui"]["status"] == "converged"
+    assert "ts" in loaded["openwebui"]
+
+
+def test_record_preserves_other_components() -> None:
+    state.record_component_result("openwebui", {"status": "converged"})
+    state.record_component_result("hermes", {"status": "build_failed", "error": "pip died"})
+    loaded = state.load_component_state()
+    assert set(loaded) == {"openwebui", "hermes"}
+
+
+def test_load_missing_file_returns_empty() -> None:
+    assert state.load_component_state() == {}
+
+
+def test_load_corrupt_file_returns_empty() -> None:
+    path = state.components_state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    assert state.load_component_state() == {}
+
+
+def test_record_over_corrupt_file_recovers() -> None:
+    path = state.components_state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    state.record_component_result("hindsight", {"status": "upgraded"})
+    assert state.load_component_state()["hindsight"]["status"] == "upgraded"
+
+
+def test_record_never_raises_on_unwritable_dir(monkeypatch) -> None:
+    # Fail-soft posture: bookkeeping failure must not fail an update.
+    monkeypatch.setattr(state, "components_state_path", lambda: state.Path("/proc/nope/components.json"))
+    state.record_component_result("openwebui", {"status": "converged"})  # must not raise

--- a/tests/components/test_state.py
+++ b/tests/components/test_state.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from hal0.components import state

--- a/tests/components/test_state.py
+++ b/tests/components/test_state.py
@@ -13,7 +13,9 @@ def _isolated_var_lib(tmp_path, monkeypatch):
 
 
 def test_record_then_load_roundtrip() -> None:
-    state.record_component_result("openwebui", {"status": "converged", "installed": "sha256:" + "a" * 64})
+    state.record_component_result(
+        "openwebui", {"status": "converged", "installed": "sha256:" + "a" * 64}
+    )
     loaded = state.load_component_state()
     assert loaded["openwebui"]["status"] == "converged"
     assert "ts" in loaded["openwebui"]
@@ -47,5 +49,7 @@ def test_record_over_corrupt_file_recovers() -> None:
 
 def test_record_never_raises_on_unwritable_dir(monkeypatch) -> None:
     # Fail-soft posture: bookkeeping failure must not fail an update.
-    monkeypatch.setattr(state, "components_state_path", lambda: state.Path("/proc/nope/components.json"))
+    monkeypatch.setattr(
+        state, "components_state_path", lambda: state.Path("/proc/nope/components.json")
+    )
     state.record_component_result("openwebui", {"status": "converged"})  # must not raise

--- a/tests/components/test_status.py
+++ b/tests/components/test_status.py
@@ -1,4 +1,4 @@
-"""Snapshot merge: live probes × recorded results."""
+"""Snapshot merge: live probes x recorded results."""
 
 from __future__ import annotations
 

--- a/tests/components/test_status.py
+++ b/tests/components/test_status.py
@@ -1,0 +1,67 @@
+"""Snapshot merge: live probes × recorded results."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hal0.components import state, status
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+
+
+def _probe_patches(installed_map, pinned_map):
+    def fake_rows():
+        return installed_map, pinned_map
+    return fake_rows
+
+
+def test_converged_when_installed_equals_pinned() -> None:
+    with (
+        patch("hal0.components.registry._hindsight_installed", return_value="0.9.2"),
+        patch("hal0.components.registry._hindsight_pinned", return_value="0.9.2"),
+    ):
+        snap = status.component_status_snapshot()
+    row = next(r for r in snap["components"] if r["id"] == "hindsight")
+    assert row["status"] == "converged"
+
+
+def test_pending_when_versions_differ() -> None:
+    with (
+        patch("hal0.components.registry._hindsight_installed", return_value="0.8.4"),
+        patch("hal0.components.registry._hindsight_pinned", return_value="0.9.2"),
+    ):
+        snap = status.component_status_snapshot()
+    row = next(r for r in snap["components"] if r["id"] == "hindsight")
+    assert row["status"] == "pending"
+    assert snap["pending"] >= 1
+
+
+def test_recorded_failure_wins() -> None:
+    state.record_component_result("hindsight", {"status": "rolled_back", "error": "postcheck"})
+    with (
+        patch("hal0.components.registry._hindsight_installed", return_value="0.8.4"),
+        patch("hal0.components.registry._hindsight_pinned", return_value="0.9.2"),
+    ):
+        snap = status.component_status_snapshot()
+    row = next(r for r in snap["components"] if r["id"] == "hindsight")
+    assert row["status"] == "rolled_back"
+    assert row["error"] == "postcheck"
+
+
+def test_not_installed() -> None:
+    with patch("hal0.components.registry._hermes_installed", return_value=None):
+        snap = status.component_status_snapshot()
+    row = next(r for r in snap["components"] if r["id"] == "hermes")
+    assert row["status"] == "not-installed"
+
+
+def test_probe_crash_degrades_to_unknown() -> None:
+    with patch("hal0.components.registry._hindsight_installed", side_effect=OSError("boom")):
+        snap = status.component_status_snapshot()  # must not raise
+    row = next(r for r in snap["components"] if r["id"] == "hindsight")
+    assert row["installed"] is None

--- a/tests/components/test_status.py
+++ b/tests/components/test_status.py
@@ -17,6 +17,7 @@ def _home(tmp_path, monkeypatch):
 def _probe_patches(installed_map, pinned_map):
     def fake_rows():
         return installed_map, pinned_map
+
     return fake_rows
 
 

--- a/tests/installer/test_migration_convergence.py
+++ b/tests/installer/test_migration_convergence.py
@@ -62,12 +62,12 @@ def test_migration_sequence_runs_engine_pass_by_default_but_not_at_boot() -> Non
     assert "converge_components(" in seq_src
     assert "engine=upgrade_memory_engine_venv" in seq_src
     assert "updater.components_converge_failed" in seq_src
-    assert (
-        "updater.components_converge_failed" in updater._NON_FATAL_MIGRATION_FAILURE_EVENTS
-    ), "a swallowed component-convergence failure must surface in commit()'s convergence report"
-    assert (
-        "updater.memory_engine_upgrade_failed" in updater._NON_FATAL_MIGRATION_FAILURE_EVENTS
-    ), "a swallowed engine-pass failure must surface in commit()'s convergence report"
+    assert "updater.components_converge_failed" in updater._NON_FATAL_MIGRATION_FAILURE_EVENTS, (
+        "a swallowed component-convergence failure must surface in commit()'s convergence report"
+    )
+    assert "updater.memory_engine_upgrade_failed" in updater._NON_FATAL_MIGRATION_FAILURE_EVENTS, (
+        "a swallowed engine-pass failure must surface in commit()'s convergence report"
+    )
 
 
 def test_install_sh_no_longer_hand_picks_a_migration_subset() -> None:

--- a/tests/installer/test_migration_convergence.py
+++ b/tests/installer/test_migration_convergence.py
@@ -33,7 +33,20 @@ def test_migration_sequence_runs_engine_pass_by_default_but_not_at_boot() -> Non
     network op and the first start of a newer engine triggers its one-way DB
     migration, neither of which belongs outside an operator-visible update
     (the ``skip_image_retag``/``repair_hermes_venv`` posture, one step
-    further)."""
+    further).
+
+    Since the 2026-08-30 component-updates spec, the engine pass rides in
+    via the component catalog (:func:`hal0.components.runner.converge_components`,
+    ``engine=upgrade_memory_engine_venv``) rather than a direct
+    ``upgrade_memory_engine(...)`` call inline in the sequence — the
+    catalog also covers openwebui/runner-images/hermes convergence in one
+    best-effort pass. ``updater.memory_engine_upgrade_failed`` is now
+    logged from inside :func:`hal0.memory.engine_upgrade.upgrade_memory_engine`
+    itself, not from ``run_post_activation_migrations``, but stays in
+    :data:`updater._NON_FATAL_MIGRATION_FAILURE_EVENTS` for the stderr-relay
+    scan; the pass's own genuine-bug isolation now logs the new
+    ``updater.components_converge_failed`` event instead.
+    """
     import inspect
 
     from hal0.updater import updater
@@ -43,13 +56,18 @@ def test_migration_sequence_runs_engine_pass_by_default_but_not_at_boot() -> Non
 
     boot_src = inspect.getsource(updater.check_outstanding_migrations)
     assert "upgrade_memory_engine_venv=False" in boot_src
+    assert "converge_companions=False" in boot_src
 
     seq_src = inspect.getsource(updater.run_post_activation_migrations)
-    assert "upgrade_memory_engine(" in seq_src
-    assert "updater.memory_engine_upgrade_failed" in seq_src
-    assert "updater.memory_engine_upgrade_failed" in updater._NON_FATAL_MIGRATION_FAILURE_EVENTS, (
-        "a swallowed engine-pass failure must surface in commit()'s convergence report"
-    )
+    assert "converge_components(" in seq_src
+    assert "engine=upgrade_memory_engine_venv" in seq_src
+    assert "updater.components_converge_failed" in seq_src
+    assert (
+        "updater.components_converge_failed" in updater._NON_FATAL_MIGRATION_FAILURE_EVENTS
+    ), "a swallowed component-convergence failure must surface in commit()'s convergence report"
+    assert (
+        "updater.memory_engine_upgrade_failed" in updater._NON_FATAL_MIGRATION_FAILURE_EVENTS
+    ), "a swallowed engine-pass failure must surface in commit()'s convergence report"
 
 
 def test_install_sh_no_longer_hand_picks_a_migration_subset() -> None:

--- a/tests/installer/test_owui_pin_lockstep.py
+++ b/tests/installer/test_owui_pin_lockstep.py
@@ -1,0 +1,34 @@
+"""OPENWEBUI_IMAGE_PIN stays in lockstep with the shipped pin sites.
+
+Three declaration sites by design (spec §2): the python constant (read by
+the converge arm), packaging/systemd/hal0-openwebui.service (the shipped
+unit — pins the digest twice: ExecStartPre pull + ExecStart run), and
+installer/install.sh. Bump one and this fails naming the others.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hal0.openwebui.image_pin import OPENWEBUI_IMAGE_PIN, find_owui_digests
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _digests_in(rel: str) -> list[str]:
+    return find_owui_digests((_REPO_ROOT / rel).read_text(encoding="utf-8"))
+
+
+def test_packaging_unit_matches_constant() -> None:
+    digests = _digests_in("packaging/systemd/hal0-openwebui.service")
+    assert digests, "packaging unit no longer pins an OWUI digest"
+    assert set(digests) == {OPENWEBUI_IMAGE_PIN}, (
+        f"packaging unit pins {set(digests)} but OPENWEBUI_IMAGE_PIN is "
+        f"{OPENWEBUI_IMAGE_PIN!r} — update whichever side is stale"
+    )
+
+
+def test_install_sh_matches_constant() -> None:
+    digests = _digests_in("installer/install.sh")
+    assert digests, "installer/install.sh no longer pins an OWUI digest"
+    assert set(digests) == {OPENWEBUI_IMAGE_PIN}

--- a/tests/installer/test_systemctl_repin_owui.py
+++ b/tests/installer/test_systemctl_repin_owui.py
@@ -156,9 +156,7 @@ def test_a_malformed_digest_is_refused_and_the_unit_is_untouched(
         "sha256:aaaa; rm -rf /",  # shell metacharacters
     ],
 )
-def test_malformed_digests_are_all_refused(
-    seam: tuple[Path, Path, Path, Path], bad: str
-) -> None:
+def test_malformed_digests_are_all_refused(seam: tuple[Path, Path, Path, Path], bad: str) -> None:
     _, _, _, unit_dir = seam
     unit_path = unit_dir / "hal0-openwebui.service"
     unit_path.write_text(_UNIT_BODY, encoding="utf-8")

--- a/tests/installer/test_systemctl_repin_owui.py
+++ b/tests/installer/test_systemctl_repin_owui.py
@@ -1,0 +1,186 @@
+"""repin-owui: digest-validated single-purpose unit rewrite (component-updates
+task 3).
+
+``installer/wrappers/hal0-systemctl`` is the entire privileged surface a
+service-user ``hal0-api`` can reach for slot/systemd ops (see the module
+docstring at the top of the wrapper). ``hal0 update owui`` needs one more
+root-only action to repin the *installed* OpenWebUI companion unit: rewrite
+every ``open-webui@sha256:…`` occurrence in
+``/etc/systemd/system/hal0-openwebui.service`` to a new digest, then
+``daemon-reload`` so systemd picks it up. ``repin-owui`` is that verb.
+
+WHY THIS RUNS A COPY OF THE WRAPPER, AND WHY ``UNIT_DIR`` IS OVERRIDABLE.
+``tests/conftest.py``'s ``_no_real_systemctl`` guard hard-fails any test that
+executes a binary named ``hal0-systemctl`` with a mutating verb (real root,
+real polkit). This test copies the wrapper to a neutral filename and runs it
+directly — never through sudo — exactly like
+``tests/installer/test_systemctl_start_limit_recovery.py``. A ``systemctl``
+shim goes first on ``PATH`` so the arm's ``daemon-reload`` call never reaches
+the system bus. The wrapper has no pre-existing test-root convention for the
+unit directory it writes into (``UNIT_DIR`` was a hardcoded literal), so this
+verb's unit path is env-overridable (``${UNIT_DIR:-/etc/systemd/system}``,
+same fallback shape the brief specifies) and the test points it at a
+``tmp_path`` fixture instead of the real ``/etc/systemd/system``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+WRAPPER = REPO / "installer" / "wrappers" / "hal0-systemctl"
+
+_SHIM = """#!/bin/bash
+echo "$@" >> "$SYSTEMCTL_LOG"
+exit 0
+"""
+
+_OLD_DIGEST = "sha256:" + "a" * 64
+_NEW_DIGEST = "sha256:" + "b" * 64
+
+_UNIT_BODY = f"""[Unit]
+Description=hal0 OpenWebUI companion
+
+[Container]
+Image=ghcr.io/open-webui/open-webui@{_OLD_DIGEST}
+
+[Service]
+ExecStartPre=/usr/bin/podman pull ghcr.io/open-webui/open-webui@{_OLD_DIGEST}
+
+[Install]
+WantedBy=hal0.target
+"""
+
+
+@pytest.fixture
+def seam(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    """Recording ``systemctl`` + a neutrally-named wrapper copy + a fake unit dir."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    shim_path = bindir / "systemctl"
+    shim_path.write_text(_SHIM, encoding="utf-8")
+    shim_path.chmod(0o755)
+
+    # Byte-for-byte the shipped wrapper — only the filename differs, so the
+    # conftest guard (which matches on basename) doesn't trip on a call that
+    # provably cannot reach the real system bus. See the module docstring.
+    wrapper_copy = tmp_path / "seam-under-test"
+    shutil.copy2(WRAPPER, wrapper_copy)
+
+    unit_dir = tmp_path / "unit-dir"
+    unit_dir.mkdir()
+
+    return bindir, tmp_path / "systemctl.log", wrapper_copy, unit_dir
+
+
+def _run(
+    seam: tuple[Path, Path, Path, Path], *args: str
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    bindir, log, wrapper, unit_dir = seam
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["SYSTEMCTL_LOG"] = str(log)
+    env["UNIT_DIR"] = str(unit_dir)
+    proc = subprocess.run(
+        [str(wrapper), "repin-owui", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    lines = log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+    return proc, lines
+
+
+def test_wrapper_is_syntactically_valid() -> None:
+    proc = subprocess.run(["bash", "-n", str(WRAPPER)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_repin_owui_validates_before_writing() -> None:
+    """The digest must be checked before anything is touched — a
+    ``repin-owui`` arm that mutated the unit before validating it would be a
+    root-side confused-deputy hole at the same seam #1716/#1740 closed."""
+    text = WRAPPER.read_text()
+    arm = text.split("  repin-owui)", 1)[1].split("\n    ;;", 1)[0]
+    assert "die" in arm
+    assert "sha256" in arm
+
+
+def test_both_occurrences_are_rewritten_and_daemon_reloaded(
+    seam: tuple[Path, Path, Path, Path],
+) -> None:
+    _, _, _, unit_dir = seam
+    unit_path = unit_dir / "hal0-openwebui.service"
+    unit_path.write_text(_UNIT_BODY, encoding="utf-8")
+
+    proc, lines = _run(seam, _NEW_DIGEST)
+
+    assert proc.returncode == 0, proc.stderr
+    new_body = unit_path.read_text(encoding="utf-8")
+    assert new_body.count(_OLD_DIGEST) == 0
+    assert new_body.count(_NEW_DIGEST) == 2
+    assert lines == ["daemon-reload"]
+
+
+def test_a_malformed_digest_is_refused_and_the_unit_is_untouched(
+    seam: tuple[Path, Path, Path, Path],
+) -> None:
+    _, _, _, unit_dir = seam
+    unit_path = unit_dir / "hal0-openwebui.service"
+    unit_path.write_text(_UNIT_BODY, encoding="utf-8")
+
+    proc, lines = _run(seam, "not-a-digest")
+
+    assert proc.returncode == 64
+    assert "bad digest" in proc.stderr
+    assert unit_path.read_text(encoding="utf-8") == _UNIT_BODY
+    assert lines == [], "a rejected digest must never reach systemctl"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "sha256:" + "a" * 63,  # one hex char short
+        "sha256:" + "a" * 65,  # one hex char long
+        "sha256:" + "A" * 64,  # uppercase hex refused (unit stores lowercase)
+        "md5:" + "a" * 32,  # wrong algorithm prefix
+        "a" * 64,  # missing sha256: prefix
+        "sha256:" + "g" * 64,  # non-hex character
+        "sha256:aaaa; rm -rf /",  # shell metacharacters
+    ],
+)
+def test_malformed_digests_are_all_refused(
+    seam: tuple[Path, Path, Path, Path], bad: str
+) -> None:
+    _, _, _, unit_dir = seam
+    unit_path = unit_dir / "hal0-openwebui.service"
+    unit_path.write_text(_UNIT_BODY, encoding="utf-8")
+
+    proc, lines = _run(seam, bad)
+
+    assert proc.returncode == 64
+    assert unit_path.read_text(encoding="utf-8") == _UNIT_BODY
+    assert lines == []
+
+
+def test_a_missing_unit_file_is_refused(seam: tuple[Path, Path, Path, Path]) -> None:
+    proc, lines = _run(seam, _NEW_DIGEST)
+
+    assert proc.returncode == 64
+    assert "not found" in proc.stderr
+    assert lines == []
+
+
+def test_help_documents_the_verb() -> None:
+    proc = subprocess.run(
+        [str(WRAPPER), "help"], capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"}
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "repin-owui" in proc.stdout

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -129,6 +129,32 @@ def test_classification_buckets_match_adr_0004() -> None:
         assert t in read
 
 
+def test_component_update_tools_classified_per_spec_1b() -> None:
+    """Component-updates spec (2026-08-30 §1b): three MCP tools ride the
+    admin route-alias map — component_status/update_check (autonomous read)
+    and component_converge (gated). `update_apply` was ruled OUT during
+    implementation: EXCLUDED_TOOLS["updater_apply"] stands as-is (self-update
+    needs its own POLICY_NO_LOOSEN + operator-confirmation design), so no
+    tool or alias by that name should ever appear."""
+    alias_tools = {t for names in admin.TOOL_NAME_ALIASES.values() for t in names}
+    for t in ("component_status", "update_check", "component_converge"):
+        assert t in alias_tools, f"{t} missing a TOOL_NAME_ALIASES entry"
+
+    assert {"component_status", "update_check"} <= admin.AUTONOMOUS_READ_TOOLS
+    assert "component_converge" in admin.GATED_TOOLS
+
+    # No tool lives in two tiers.
+    assert admin.AUTONOMOUS_READ_TOOLS.isdisjoint(admin.GATED_TOOLS)
+    assert admin.AUTONOMOUS_READ_TOOLS.isdisjoint(admin.AUTONOMOUS_WRITE_TOOLS)
+    assert admin.GATED_TOOLS.isdisjoint(admin.AUTONOMOUS_WRITE_TOOLS)
+
+    # update_apply intentionally never shipped as a tool or a route alias.
+    catalog = admin.AUTONOMOUS_READ_TOOLS | admin.AUTONOMOUS_WRITE_TOOLS | admin.GATED_TOOLS
+    assert "update_apply" not in alias_tools
+    assert "update_apply" not in catalog
+    assert "updater_apply" in admin.EXCLUDED_TOOLS
+
+
 def test_is_gated_memory_delete_branches_on_id_count() -> None:
     assert admin.is_gated("memory_delete", {"ids": ["a"]}) is False
     assert admin.is_gated("memory_delete", {"ids": ["a", "b"]}) is True
@@ -248,6 +274,9 @@ def test_open_world_tools_are_the_documented_set() -> None:
     runner_image_sync (GHCR discovery probe), mcp_server_install
     (may fetch a manifest from an arbitrary URL), and profile_generate
     (reaches HuggingFace when given hf_repo, like model_inspect).
+    Component-updates spec (2026-08-30 §1b) adds update_check — same
+    GET /api/updates/check route as updater_check, so the same release-
+    manifest fetch applies.
     Anything else with openWorldHint=True needs a deliberate ADR update."""
     open_world = {name for name, ann in admin._ANNOTATIONS.items() if ann.openWorldHint}
     assert open_world == {
@@ -255,6 +284,7 @@ def test_open_world_tools_are_the_documented_set() -> None:
         "model_update",
         "model_inspect",
         "updater_check",
+        "update_check",
         "hf_search",
         "comfyui_models_fetch",
         "slot_pull_image",

--- a/tests/memory/test_engine_gate.py
+++ b/tests/memory/test_engine_gate.py
@@ -1,0 +1,373 @@
+"""Hindsight pin-bump evidence gate (spec §5). HAL0_ENGINE_GATE=1 only.
+
+Exercises upgrade_memory_engine against REAL engines: old pin installed
+fresh, seeded over HTTP, then converged to HINDSIGHT_API_PIN with a
+process-seam (no systemd in CI — svc stop/start map to killing/spawning
+the venv's own hindsight-api). Asserts version, data survival, rollback,
+and the client-call contract.
+
+Three jobs, in the order the module runs them (test order is execution
+order and matters here — the engine binds ONE loopback port, 9177, so at
+most one engine process may live at a time):
+
+1. ``test_upgrade_path_preserves_data`` — old pin → pin, data survives.
+2. ``test_client_contract_against_new_engine`` — HindsightRestClient's core
+   surface still answers on the NEW engine (catches removed/renamed
+   endpoints). Runs against the engine test 1 left upgraded and healthy.
+3. ``test_rollback_restores_old_engine`` — a forced postcheck failure must
+   restore both the old venv and the ``.pg0`` snapshot. Last, because it
+   stops the module engine and stands up a second one on the same port.
+
+Deviations from the design sketch, each against an authority in-tree:
+
+* REST paths/payloads come from ``hal0.memory.hindsight_client`` — the bank
+  surface is ``/v1/default/banks/{bank}/…`` (``retain`` at :130, ``recall``
+  at :177), NOT the bank-less ``/v1/default/memories``. Every call carries
+  the ``Authorization: Bearer`` header the client always sends (the engine
+  requires a non-empty key even with auth off).
+* The engine child process inherits the environment
+  ``installer/systemd/hindsight-api.service`` pins — ``HOME`` (embedded
+  postgres lives at ``$HOME/.pg0``), ``HF_HOME`` (writable embedder cache),
+  ``HINDSIGHT_API_SKIP_LLM_VERIFICATION`` (no LLM in CI; without it startup
+  blocks until the verification timeout and never binds) and the two
+  ``*_FORCE_CPU`` flags (no CUDA on a runner).
+* Data survival is asserted on **bank config + directives**, not on retained
+  documents or recall hits. Retain does not write a durable document row
+  synchronously: it queues an operation whose worker persists nothing until
+  LLM fact extraction succeeds. The gate has no LLM (see ``_engine_env``), so
+  a seeded document never lands — measured against hindsight-api 0.8.4, the
+  bank reports ``total_documents: 0`` and the operation carries
+  ``"Fact extraction failed: 1/1 chunks failed. First failures: chunk 0:
+  APIConnectionError"``. Bank config (``PUT /banks/{id}``, the installer's
+  seeding path) and directives (``POST /banks/{id}/directives``,
+  ``HindsightRestClient.create_directive``) are operator-authored rows
+  written synchronously with no LLM in the path — durable content that the
+  one-way alembic migration must carry across, and therefore the honest
+  survival evidence. Retain and recall are still called, for their contract.
+"""
+
+from __future__ import annotations
+
+import json as jsonlib
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from hal0.memory import engine_upgrade
+from hal0.memory.engine_upgrade import (
+    ENGINE_BASE_URL,
+    HINDSIGHT_API_PIN,
+    PY_MAX_MINOR,
+    PY_MIN_MINOR,
+    upgrade_memory_engine,
+)
+from hal0.memory.hindsight_client import DEFAULT_API_KEY, HindsightRestClient
+
+pytestmark = pytest.mark.engine_gate
+
+if os.environ.get("HAL0_ENGINE_GATE") != "1":
+    pytest.skip("engine gate: set HAL0_ENGINE_GATE=1", allow_module_level=True)
+
+OLD_PIN = os.environ["HAL0_GATE_OLD_PIN"]
+
+#: Interpreter the throwaway engine venvs are built from. Defaults to the one
+#: running pytest (CI pins it via setup-python); ``HAL0_GATE_PYTHON`` overrides
+#: it on a dev box whose default python sits outside the engine's supported
+#: band. Checked against engine_upgrade's own band constants rather than a
+#: second copy of the numbers.
+GATE_PYTHON = os.environ.get("HAL0_GATE_PYTHON") or sys.executable
+
+#: The global cross-agent bank (``namespace.DEFAULT_DATASET``). install.sh
+#: seeds it, but banks also lazy-create on first write, so the gate just
+#: writes to it.
+BANK = "shared"
+SEED_MISSION = "gate-seed retain mission marker"
+SEED_DIRECTIVE = "hal0-engine-gate-directive"
+SEED_DIRECTIVE_TEXT = "gate-seed durable directive"
+SEED_DOC_ID = "hal0-engine-gate-seed"
+SEED_TEXT = "gate-seed shared fact"
+
+_AUTH = {"Authorization": f"Bearer {DEFAULT_API_KEY}", "Content-Type": "application/json"}
+
+
+def _engine_env(hs_dir: Path) -> dict[str, str]:
+    """The subset of hindsight-api.service's Environment= lines CI needs.
+
+    The four ``*_LLM_*`` values are the unit's literals. They are not
+    optional: ``MemoryEngine.__init__`` raises ``ValueError("LLM API key is
+    required…")`` and the process dies before binding :9177 without a
+    NON-EMPTY key (the unit calls this out as "spike gotcha #1"). Nothing
+    listens on the unit's ``127.0.0.1:8080`` LLM base URL under the gate, so
+    extraction/reflect fail lazily exactly as they do on a fresh box with no
+    utility model loaded — which is why the gate asserts on retained
+    documents rather than on extracted/recalled content.
+    """
+    return {
+        **os.environ,
+        "HOME": str(hs_dir),
+        "HF_HOME": str(hs_dir / "hf-cache"),
+        "HINDSIGHT_API_LLM_PROVIDER": "openai",
+        "HINDSIGHT_API_LLM_BASE_URL": "http://127.0.0.1:8080/v1",
+        "HINDSIGHT_API_LLM_MODEL": "hal0/utility",
+        "HINDSIGHT_API_LLM_API_KEY": DEFAULT_API_KEY,
+        "HINDSIGHT_API_SKIP_LLM_VERIFICATION": "true",
+        "HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU": "true",
+        "HINDSIGHT_API_RERANKER_LOCAL_FORCE_CPU": "true",
+    }
+
+
+class EngineProc:
+    """Process-seam standing in for systemd: one engine process per venv."""
+
+    def __init__(self, hs_dir: Path) -> None:
+        self.hs_dir = hs_dir
+        self.proc: subprocess.Popen | None = None
+
+    def start(self) -> None:
+        binary = self.hs_dir / ".venv" / "bin" / "hindsight-api"
+        self.proc = subprocess.Popen(
+            [str(binary), "--host", "127.0.0.1", "--port", "9177"],
+            cwd=self.hs_dir,
+            env=_engine_env(self.hs_dir),
+        )
+
+    def stop(self) -> None:
+        if self.proc and self.proc.poll() is None:
+            self.proc.send_signal(signal.SIGTERM)
+            try:
+                self.proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+        self.proc = None
+
+    def seam(self):
+        """SystemCtlSeam stand-in matching engine_upgrade._svc's call shape."""
+        outer = self
+
+        class _Seam:
+            def systemctl(self, _bin, verb, _unit, *, check=True, timeout=0.0):
+                if verb == "stop":
+                    outer.stop()
+                elif verb == "start":
+                    outer.start()
+
+        return _Seam()
+
+
+def _wait_health(total_s: float = 240.0) -> None:
+    deadline = time.monotonic() + total_s
+    while time.monotonic() < deadline:
+        try:
+            urllib.request.urlopen(f"{ENGINE_BASE_URL}/health", timeout=3)
+            return
+        except OSError:
+            time.sleep(2)
+    raise AssertionError("engine never became healthy")
+
+
+def _http(method: str, path: str, body: dict | None = None) -> dict:
+    req = urllib.request.Request(
+        f"{ENGINE_BASE_URL}{path}",
+        method=method,
+        data=jsonlib.dumps(body).encode() if body is not None else None,
+        headers=_AUTH,
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return jsonlib.loads(resp.read().decode() or "{}")
+
+
+def _seed() -> None:
+    """Write the durable rows whose survival the gate asserts, then retain.
+
+    All three writes go through the REST shapes hal0 itself uses. The first
+    two land synchronously with no LLM involved and are what the survival
+    assertions read back; the retain is fired for its call contract only (its
+    document row needs extraction the gate cannot run — see module docstring).
+    """
+    # Creates the bank if absent — the installer's seeding path (install.sh
+    # `_seed_bank`), and the only reason a fresh .pg0 has a `shared` bank.
+    _http(
+        "PUT",
+        f"/v1/default/banks/{BANK}",
+        {"retain_mission": SEED_MISSION, "disposition_skepticism": 4},
+    )
+    # HindsightRestClient.create_directive's exact payload (:394).
+    _http(
+        "POST",
+        f"/v1/default/banks/{BANK}/directives",
+        {
+            "name": SEED_DIRECTIVE,
+            "content": SEED_DIRECTIVE_TEXT,
+            "priority": 7,
+            "is_active": True,
+            "tags": ["hal0-engine-gate"],
+        },
+    )
+    # HindsightRestClient.retain's exact payload (:130).
+    _http(
+        "POST",
+        f"/v1/default/banks/{BANK}/memories",
+        {"items": [{"content": SEED_TEXT, "document_id": SEED_DOC_ID}], "async": True},
+    )
+
+
+def _assert_seed_survives(when: str) -> None:
+    """The seeded bank config + directive must still be readable."""
+    config = _http("GET", f"/v1/default/banks/{BANK}/config").get("config", {})
+    assert config.get("retain_mission") == SEED_MISSION, f"{when}: bank config lost"
+
+    directives = _http("GET", f"/v1/default/banks/{BANK}/directives").get("items", [])
+    match = next((d for d in directives if d.get("name") == SEED_DIRECTIVE), None)
+    assert match is not None, f"{when}: directive {SEED_DIRECTIVE!r} lost — {directives}"
+    assert match.get("content") == SEED_DIRECTIVE_TEXT, f"{when}: directive body changed — {match}"
+    assert match.get("priority") == 7, f"{when}: directive priority changed — {match}"
+    assert match.get("tags") == ["hal0-engine-gate"], f"{when}: directive tags changed — {match}"
+
+
+def _reported_version() -> str | None:
+    return _http("GET", "/version").get("api_version")
+
+
+def _build_engine_dir(root: Path) -> EngineProc:
+    """Fresh venv at OLD_PIN under ``root``, started, healthy and seeded."""
+    # Same predicate the pass itself uses to accept an interpreter, so the gate
+    # can never build an engine venv the production path would have refused.
+    if not engine_upgrade._interpreter_in_band(subprocess.run, GATE_PYTHON):
+        pytest.fail(
+            f"gate interpreter {GATE_PYTHON} is outside the engine's supported "
+            f"3.{PY_MIN_MINOR}-3.{PY_MAX_MINOR} band; set HAL0_GATE_PYTHON"
+        )
+    subprocess.run([GATE_PYTHON, "-m", "venv", str(root / ".venv")], check=True)
+    pip = str(root / ".venv" / "bin" / "pip")
+    subprocess.run([pip, "install", "--upgrade", "pip", "wheel", "-q"], check=True, timeout=2400)
+    subprocess.run(
+        [pip, "install", f"hindsight-api=={OLD_PIN}", "-q"],
+        check=True,
+        timeout=2400,
+    )
+    proc = EngineProc(root)
+    proc.start()
+    _wait_health()
+    # Seed via the same REST surface hal0.memory.hindsight_client wraps.
+    _seed()
+    _assert_seed_survives("seed")
+    return proc
+
+
+@pytest.fixture(scope="module")
+def old_engine(tmp_path_factory):
+    """Fresh venv at OLD_PIN with an initialized .pg0 + seeded memories."""
+    hs = tmp_path_factory.mktemp("hindsight")
+    proc = _build_engine_dir(hs)
+    yield proc, hs
+    proc.stop()
+
+
+def test_upgrade_path_preserves_data(old_engine) -> None:
+    proc, hs = old_engine
+    result = upgrade_memory_engine(seam=proc.seam(), hs_dir=hs)
+    assert result["status"] == "upgraded", result
+    assert result["from"] == OLD_PIN, result
+    assert result["to"] == HINDSIGHT_API_PIN, result
+    _wait_health()
+    assert _reported_version() == HINDSIGHT_API_PIN
+    # The one-way alembic migration ran on the .pg0 that was snapshotted before
+    # the swap — the seeded rows must have come through it.
+    _assert_seed_survives("after upgrade")
+    # Recall answers on the migrated schema (content is LLM-dependent, so this
+    # asserts the call contract, not the ranking).
+    recalled = _http(
+        "POST",
+        f"/v1/default/banks/{BANK}/memories/recall",
+        {"query": "gate-seed", "max_tokens": 4096},
+    )
+    assert isinstance(recalled, dict), recalled
+    # The rollback snapshot is kept, not pruned, on a successful upgrade.
+    assert (hs / f".pg0.pre-{OLD_PIN}").is_dir()
+
+
+async def test_client_contract_against_new_engine(old_engine) -> None:
+    """Drive HindsightRestClient's core surface against the live new engine.
+
+    Spec §5 job 3: a pin bump that removed or renamed an endpoint hal0 calls
+    must fail here rather than in production. Each call raises
+    ``httpx.HTTPStatusError`` on non-2xx (``raise_for_status`` inside the
+    client), so reaching the assertion is itself the contract evidence.
+    """
+    _, _hs = old_engine
+    assert _reported_version() == HINDSIGHT_API_PIN, "job 1 must have upgraded the engine"
+
+    client = HindsightRestClient(base_url=ENGINE_BASE_URL)
+    try:
+        retained = await client.retain(
+            bank_id=BANK,
+            content="gate contract probe",
+            document_id="hal0-engine-gate-contract",
+        )
+        assert isinstance(retained, dict), retained
+
+        recalled = await client.recall(bank_id=BANK, query="gate-seed")
+        assert isinstance(recalled, dict), recalled
+
+        listed = await client.list_memories(bank_id=BANK, limit=10)
+        assert isinstance(listed, dict | list), listed
+
+        stats = await client.bank_stats(bank_id=BANK)
+        assert isinstance(stats, dict), stats
+
+        documents = await client.list_documents(bank_id=BANK, limit=100)
+        assert isinstance(documents, dict | list), documents
+
+        directives = await client.list_directives(bank_id=BANK)
+        assert SEED_DIRECTIVE in jsonlib.dumps(directives)
+    finally:
+        await client.aclose()
+
+
+def test_rollback_restores_old_engine(old_engine, tmp_path_factory) -> None:
+    """A failing postcheck must restore BOTH the old venv and the .pg0 snapshot.
+
+    Builds a SECOND old-pin engine dir (the first one is already converged),
+    then forces the postcheck to fail by stubbing ``http_get`` to report a
+    wrong ``/version`` while letting the real ``/health`` probe through — so
+    the new engine genuinely starts and genuinely gets rolled back.
+    """
+    module_proc, _module_hs = old_engine
+    # One loopback port: retire the converged engine before binding a second.
+    module_proc.stop()
+
+    hs = tmp_path_factory.mktemp("hindsight-rollback")
+    proc = _build_engine_dir(hs)
+    try:
+
+        def http_get(url: str) -> dict | None:
+            if url.endswith("/version"):
+                # Real /health, lying /version: the pass sees a healthy engine
+                # serving the wrong build — engine_upgrade.py:462's branch.
+                return {"api_version": "0.0.0-not-the-pin"}
+            return engine_upgrade._http_get_json(url)
+
+        result = upgrade_memory_engine(seam=proc.seam(), hs_dir=hs, http_get=http_get)
+        assert result["status"] == "rolled_back", result
+        assert result["from"] == OLD_PIN, result
+        assert "0.0.0-not-the-pin" in result["error"], result
+        assert result["old_engine_healthy"] is True, result
+
+        # Venv restored; the rejected build is kept for forensics.
+        assert (hs / f".venv.failed-{HINDSIGHT_API_PIN}").is_dir()
+        assert engine_upgrade._installed_version(subprocess.run, hs / ".venv") == OLD_PIN
+        # Snapshot survives the restore, so a retry still has a rollback.
+        assert (hs / f".pg0.pre-{OLD_PIN}").is_dir()
+
+        # The old engine is back on the restored .pg0, with its data.
+        _wait_health()
+        assert _reported_version() == OLD_PIN
+        _assert_seed_survives("after rollback")
+    finally:
+        proc.stop()

--- a/tests/updater/test_post_activation_migrations.py
+++ b/tests/updater/test_post_activation_migrations.py
@@ -59,7 +59,9 @@ def _stub_every_pass(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
         calls["hermes_venv"].append((job_id, install))
         return False
 
-    def _converge_components(*, job_id=None, apply=True, image_retag=True, engine=True, hermes_install=True):
+    def _converge_components(
+        *, job_id=None, apply=True, image_retag=True, engine=True, hermes_install=True
+    ):
         calls["converge_components"].append(
             {
                 "job_id": job_id,
@@ -145,7 +147,9 @@ def test_a_failing_non_fatal_pass_does_not_block_the_others(
     assert _stub_every_pass["seed_profiles"] == ["j2"]
     assert _stub_every_pass["vulkan_migration"] == ["j2"]  # ran despite mtp's failure
     assert _stub_every_pass["extra_args"] == ["j2"]
-    assert [c["job_id"] for c in _stub_every_pass["converge_components"]] == ["j2"]  # ran despite mtp's failure
+    assert [c["job_id"] for c in _stub_every_pass["converge_components"]] == [
+        "j2"
+    ]  # ran despite mtp's failure
 
 
 def test_schema_migration_failure_propagates(

--- a/tests/updater/test_post_activation_migrations.py
+++ b/tests/updater/test_post_activation_migrations.py
@@ -30,9 +30,9 @@ def _stub_every_pass(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
         "seed_profiles": [],
         "mtp": [],
         "vulkan_migration": [],
-        "image_retag": [],
         "extra_args": [],
         "hermes_venv": [],
+        "converge_components": [],
     }
 
     def _config_migrations(min_data_version, *, job_id=None, ceiling=None):
@@ -51,10 +51,6 @@ def _stub_every_pass(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
         calls["vulkan_migration"].append(job_id)
         return 0
 
-    def _image_retag(*, job_id=None):
-        calls["image_retag"].append(job_id)
-        return 0
-
     def _extra_args(*, job_id=None, registry=None):
         calls["extra_args"].append(job_id)
         return 0
@@ -63,13 +59,25 @@ def _stub_every_pass(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
         calls["hermes_venv"].append((job_id, install))
         return False
 
+    def _converge_components(*, job_id=None, apply=True, image_retag=True, engine=True, hermes_install=True):
+        calls["converge_components"].append(
+            {
+                "job_id": job_id,
+                "apply": apply,
+                "image_retag": image_retag,
+                "engine": engine,
+                "hermes_install": hermes_install,
+            }
+        )
+        return {}
+
     monkeypatch.setattr("hal0.updater.updater._maybe_run_config_migrations", _config_migrations)
     monkeypatch.setattr("hal0.updater.updater.ensure_seed_profiles", _seed_profiles)
     monkeypatch.setattr("hal0.updater.updater.clear_stale_mtp_overrides", _mtp)
     monkeypatch.setattr("hal0.updater.updater.relabel_stale_vulkan_slots", _vulkan_migration)
-    monkeypatch.setattr("hal0.updater.updater.retag_stale_slot_images", _image_retag)
     monkeypatch.setattr("hal0.updater.updater.sanitize_model_extra_args", _extra_args)
     monkeypatch.setattr("hal0.updater.updater.repair_hermes_mcp_client", _hermes_venv)
+    monkeypatch.setattr("hal0.components.runner.converge_components", _converge_components)
     return calls
 
 
@@ -80,21 +88,38 @@ def test_runs_all_six_passes(_stub_every_pass: dict[str, list[Any]]) -> None:
     assert _stub_every_pass["seed_profiles"] == ["j1"]
     assert _stub_every_pass["mtp"] == ["j1"]
     assert _stub_every_pass["vulkan_migration"] == ["j1"]
-    assert _stub_every_pass["image_retag"] == ["j1"]
     assert _stub_every_pass["extra_args"] == ["j1"]
+    assert _stub_every_pass["converge_components"] == [
+        {
+            "job_id": "j1",
+            "apply": True,
+            "image_retag": True,
+            "engine": True,
+            "hermes_install": True,
+        }
+    ]
 
 
 def test_skip_image_retag_omits_only_that_pass(_stub_every_pass: dict[str, list[Any]]) -> None:
     """#1960 N2: check_outstanding_migrations passes skip_image_retag=True
-    so the boot-time safety net never runs retag_stale_slot_images — every
-    OTHER pass must still run unaffected."""
+    so the boot-time safety net never runs retag_stale_slot_images (now the
+    runner-images arm inside converge_components) — every OTHER pass must
+    still run unaffected."""
     result = run_post_activation_migrations(job_id="j1", skip_image_retag=True)
     assert result == (1, 2)
     assert _stub_every_pass["seed_profiles"] == ["j1"]
     assert _stub_every_pass["mtp"] == ["j1"]
     assert _stub_every_pass["vulkan_migration"] == ["j1"]
-    assert _stub_every_pass["image_retag"] == []
     assert _stub_every_pass["extra_args"] == ["j1"]
+    assert _stub_every_pass["converge_components"] == [
+        {
+            "job_id": "j1",
+            "apply": True,
+            "image_retag": False,
+            "engine": True,
+            "hermes_install": True,
+        }
+    ]
 
 
 def test_min_data_version_defaults_to_1(_stub_every_pass: dict[str, list[Any]]) -> None:
@@ -119,8 +144,8 @@ def test_a_failing_non_fatal_pass_does_not_block_the_others(
     assert result == (1, 2)  # schema migration still reported
     assert _stub_every_pass["seed_profiles"] == ["j2"]
     assert _stub_every_pass["vulkan_migration"] == ["j2"]  # ran despite mtp's failure
-    assert _stub_every_pass["image_retag"] == ["j2"]  # ran despite mtp's failure
     assert _stub_every_pass["extra_args"] == ["j2"]
+    assert [c["job_id"] for c in _stub_every_pass["converge_components"]] == ["j2"]  # ran despite mtp's failure
 
 
 def test_schema_migration_failure_propagates(
@@ -143,8 +168,8 @@ def test_schema_migration_failure_propagates(
     assert _stub_every_pass["seed_profiles"] == []
     assert _stub_every_pass["mtp"] == []
     assert _stub_every_pass["vulkan_migration"] == []
-    assert _stub_every_pass["image_retag"] == []
     assert _stub_every_pass["extra_args"] == []
+    assert _stub_every_pass["converge_components"] == []
 
 
 def test_update_path_repairs_a_drifted_hermes_venv(
@@ -174,3 +199,31 @@ def test_boot_safety_net_diagnoses_the_venv_without_installing(
     check_outstanding_migrations(job_id="boot")
 
     assert _stub_every_pass["hermes_venv"] == [("boot", False)]
+    assert _stub_every_pass["converge_components"] == [
+        {
+            "job_id": "boot",
+            "apply": False,
+            "image_retag": False,
+            "engine": False,
+            "hermes_install": False,
+        }
+    ]
+
+
+def test_converge_companions_flag_gates_the_apply_kwarg(
+    _stub_every_pass: dict[str, list[Any]],
+) -> None:
+    """``converge_companions=False`` is the explicit, non-inferred way to
+    make the whole component catalog diagnose-only — see the controller
+    ruling in the component-updates spec: inferring "diagnose-only" from
+    the other three flags being off was rejected as fragile."""
+    run_post_activation_migrations(job_id="j4", converge_companions=False)
+    assert _stub_every_pass["converge_components"] == [
+        {
+            "job_id": "j4",
+            "apply": False,
+            "image_retag": True,
+            "engine": True,
+            "hermes_install": True,
+        }
+    ]

--- a/tests/updater/test_post_swap_migrations.py
+++ b/tests/updater/test_post_swap_migrations.py
@@ -302,6 +302,7 @@ def test_never_raises_on_internal_failure(monkeypatch: pytest.MonkeyPatch) -> No
         skip_image_retag=False,
         repair_hermes_venv=True,
         upgrade_memory_engine_venv=True,
+        converge_companions=True,
     ):
         raise RuntimeError("disk full")
 
@@ -342,6 +343,7 @@ def test_caps_the_ceiling_while_the_profile_catalog_reset_is_outstanding(
         skip_image_retag=False,
         repair_hermes_venv=True,
         upgrade_memory_engine_venv=True,
+        converge_companions=True,
     ):
         seen["ceiling"] = ceiling
         return (1, 1)
@@ -363,6 +365,7 @@ def test_no_ceiling_when_the_reset_is_not_due(monkeypatch: pytest.MonkeyPatch) -
         skip_image_retag=False,
         repair_hermes_venv=True,
         upgrade_memory_engine_venv=True,
+        converge_companions=True,
     ):
         seen["ceiling"] = ceiling
         return (1, 1)
@@ -409,6 +412,7 @@ def test_skips_the_image_retag_pass(monkeypatch: pytest.MonkeyPatch) -> None:
         skip_image_retag=False,
         repair_hermes_venv=True,
         upgrade_memory_engine_venv=True,
+        converge_companions=True,
     ):
         seen["skip_image_retag"] = skip_image_retag
         return (1, 1)

--- a/tests/updater/test_post_swap_migrations.py
+++ b/tests/updater/test_post_swap_migrations.py
@@ -316,7 +316,7 @@ def test_forwards_the_real_migration_result_on_success(monkeypatch: pytest.Monke
     monkeypatch.setattr(
         updater_module,
         "run_post_activation_migrations",
-        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True: (
+        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True, converge_companions=True: (
             1,
             2,
         ),
@@ -383,7 +383,7 @@ def test_never_calls_reset_profile_catalog(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(
         updater_module,
         "run_post_activation_migrations",
-        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True: (
+        lambda *, job_id=None, ceiling=None, skip_image_retag=False, repair_hermes_venv=True, upgrade_memory_engine_venv=True, converge_companions=True: (
             1,
             1,
         ),

--- a/ui/src/api/hooks/useComponents.ts
+++ b/ui/src/api/hooks/useComponents.ts
@@ -1,0 +1,43 @@
+// hal0 v3 dashboard — per-component version/converge hooks (Task 12, spec
+// 2026-08-30 component-updates §3/§4).
+//
+// `/api/updates/components` (Task 8, hal0.components.status) reports the
+// catalogue × recorded-state × live-probe status for each managed
+// component (openwebui, runner-images, hermes, hindsight, …), joined to
+// the Services page by `service_id`. `/api/updates/components/{id}/converge`
+// re-runs one component's converge arm — the retry surface for a failed row
+// (see components-pure.ts's RETRYABLE_STATUSES).
+//
+// Mirrors useUpdates.ts's fail-soft/poll conventions: an older daemon
+// without this route degrades to `null` (never throws), and the list polls
+// every 30s (slower than the 1.5s job-status poll — component convergence
+// is not time-critical the way an in-flight self-update is).
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiGet, apiPost } from '../client'
+import type { ComponentRow } from '@/dash/components-pure'
+
+type ComponentsResponse = { components: ComponentRow[]; pending: number }
+
+export function useComponents() {
+  return useQuery<ComponentsResponse | null>({
+    queryKey: ['updates', 'components'],
+    queryFn: async () => {
+      try {
+        return await apiGet<ComponentsResponse>('/api/updates/components')
+      } catch {
+        return null // fail-soft: older daemon without the route
+      }
+    },
+    refetchInterval: 30_000,
+  })
+}
+
+export function useComponentConverge() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiPost<{ id: string }>(`/api/updates/components/${id}/converge`),
+    onSettled: () => qc.invalidateQueries({ queryKey: ['updates', 'components'] }),
+  })
+}

--- a/ui/src/dash/__tests__/components-pure.test.ts
+++ b/ui/src/dash/__tests__/components-pure.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  componentCell,
+  componentForService,
+  pendingCount,
+  RETRYABLE_STATUSES,
+} from '../components-pure'
+
+const rows = [
+  { id: 'openwebui', service_id: 'openwebui', installed: 'sha256:aaa', pinned: 'sha256:bbb', pin_label: '0.6.9', status: 'pending' },
+  { id: 'hindsight', service_id: 'hindsight', installed: '0.9.2', pinned: '0.9.2', status: 'converged' },
+  { id: 'hermes', service_id: 'hermes', installed: null, pinned: 'v2026.7.7.2', status: 'not-installed' },
+  { id: 'runner-images', service_id: null, installed: '8 images', pinned: '8 images', status: 'rolled_back', error: 'x' },
+]
+
+describe('componentForService', () => {
+  it('joins by service_id', () => {
+    expect(componentForService(rows, 'hindsight')?.id).toBe('hindsight')
+    expect(componentForService(rows, 'comfyui')).toBeUndefined()
+  })
+})
+
+describe('componentCell', () => {
+  it('converged renders version + ok tone', () => {
+    expect(componentCell(rows[1])).toEqual({ label: '0.9.2 ✓', tone: 'ok' })
+  })
+  it('pending renders arrow with labels when present', () => {
+    const cell = componentCell(rows[0])
+    expect(cell.tone).toBe('pending')
+    expect(cell.label).toContain('0.6.9')
+  })
+  it('failure statuses render failed tone', () => {
+    expect(componentCell(rows[3]).tone).toBe('failed')
+  })
+  it('not-installed is muted', () => {
+    expect(componentCell(rows[2]).tone).toBe('muted')
+  })
+})
+
+describe('pendingCount', () => {
+  it('counts pending + failed rows', () => {
+    expect(pendingCount(rows)).toBe(2)
+  })
+})
+
+describe('RETRYABLE_STATUSES', () => {
+  it('retry only on failures, never on pending (spec §4)', () => {
+    expect(RETRYABLE_STATUSES).toEqual(['build_failed', 'snapshot_failed', 'rolled_back'])
+  })
+})

--- a/ui/src/dash/components-pure.ts
+++ b/ui/src/dash/components-pure.ts
@@ -1,0 +1,52 @@
+// hal0 dashboard — component-update pure helpers (Task 12, spec
+// 2026-08-30 component-updates §4).
+//
+// No React, no API imports — vitest exercises these without a DOM, mirroring
+// services-widget-pure.ts. Consumed by services.jsx (per-service version
+// cell + retry), services-card.jsx and UpdatesPage.jsx (pending badge).
+//
+// Row shape mirrors GET /api/updates/components (Task 8,
+// hal0.components.status.component_status_snapshot). `PENDING` below is
+// deliberately the same set as that route's `_PENDING_STATUSES` — pending +
+// stale + the three failure statuses all count toward the "N updates
+// pending" badge.
+
+export type ComponentRow = {
+  id: string
+  name?: string
+  service_id: string | null
+  installed: string | null
+  pinned: string | null
+  pin_label?: string | null
+  status: string
+  error?: string | null
+  remedy?: string | null
+  detail?: Array<{ key: string; image: string }>
+}
+
+// Failure statuses a retry (POST .../converge) makes sense for. Never
+// includes 'pending' — the spec (§4) is explicit that pending rows get no
+// update-now button, only a passive arrow label; retry is failure recovery.
+export const RETRYABLE_STATUSES = ['build_failed', 'snapshot_failed', 'rolled_back'] as const
+
+const PENDING = new Set(['pending', 'stale', ...RETRYABLE_STATUSES])
+
+const short = (v: string | null | undefined, label?: string | null) =>
+  label || (v && v.startsWith('sha256:') ? v.slice(7, 19) : v) || '—'
+
+export function componentForService(rows: ComponentRow[] | null | undefined, serviceId: string) {
+  return (rows ?? []).find(r => r.service_id === serviceId)
+}
+
+export function componentCell(row: ComponentRow): { label: string; tone: 'ok' | 'pending' | 'failed' | 'muted' } {
+  if ((RETRYABLE_STATUSES as readonly string[]).includes(row.status))
+    return { label: `${short(row.installed)} — ${row.status}`, tone: 'failed' }
+  if (row.status === 'not-installed') return { label: 'not installed', tone: 'muted' }
+  if (row.status === 'converged' || row.status === 'override')
+    return { label: `${short(row.installed, row.pin_label)} ✓`, tone: 'ok' }
+  return { label: `${short(row.installed)} → ${short(row.pinned, row.pin_label)} pending`, tone: 'pending' }
+}
+
+export function pendingCount(rows: ComponentRow[] | null | undefined): number {
+  return (rows ?? []).filter(r => PENDING.has(r.status)).length
+}

--- a/ui/src/dash/services-card.jsx
+++ b/ui/src/dash/services-card.jsx
@@ -15,6 +15,8 @@
 
 import { useServicesHealth } from '@/api/hooks/useServicesHealth'
 import { useComfyui, COMFYUI_FALLBACK } from '@/api/hooks/useComfyui'
+import { useComponents } from '@/api/hooks/useComponents'
+import { pendingCount } from './components-pure'
 import { ENDPOINTS } from '@/api/endpoints'
 
 const { useState, useEffect, useRef, useCallback } = React
@@ -300,13 +302,26 @@ export function ServicesCard() {
 
   const [comfyExpanded, setComfyExpanded] = useState(false)
 
+  // Task 12: "N updates pending" badge — fail-soft (older daemon without
+  // GET /api/updates/components → componentRows null → pendingCount 0, no
+  // badge, rest of the card unaffected).
+  const componentsQ = useComponents()
+  const componentRows = componentsQ.data?.components ?? null
+  const pendingN = pendingCount(componentRows)
+  const pendingBadge = pendingN > 0
+    ? <a className="chip" href="#services" data-testid="svc-pending-badge"
+        title={`${pendingN} component update${pendingN === 1 ? '' : 's'} pending`}>
+        {pendingN} update{pendingN === 1 ? '' : 's'} pending
+      </a>
+    : null
+
   // If services health pending (404 not built yet) but comfyui/status IS
   // reachable, we still show the ComfyUI row from what we know.
   const showPendingGate = pending && !comfyReachable
 
   if (showPendingGate) {
     return (
-      <DCard title="SERVICES">
+      <DCard title="SERVICES" right={pendingBadge}>
         <div className="svc-pending">source pending</div>
       </DCard>
     )
@@ -335,14 +350,14 @@ export function ServicesCard() {
 
   if (rows.length === 0 && pending) {
     return (
-      <DCard title="SERVICES">
+      <DCard title="SERVICES" right={pendingBadge}>
         <div className="svc-pending">source pending</div>
       </DCard>
     )
   }
 
   return (
-    <DCard title="SERVICES">
+    <DCard title="SERVICES" right={pendingBadge}>
       <div className="svc-list">
         {rows.map((svc) => {
           const isComfy = svc.id === 'comfyui'

--- a/ui/src/dash/services.jsx
+++ b/ui/src/dash/services.jsx
@@ -14,8 +14,11 @@
 
 import { useServices, useServiceAction, useMdnsAdvertise, useUnitLogs } from '@/api/hooks/useServices'
 import { useComfyui, COMFYUI_FALLBACK } from '@/api/hooks/useComfyui'
+import { useComponents, useComponentConverge } from '@/api/hooks/useComponents'
+import { useUpdateJob } from '@/api/hooks/useUpdates'
+import { componentForService, componentCell, RETRYABLE_STATUSES } from './components-pure'
 
-const { useState } = React
+const { useState, useEffect, useRef } = React
 
 // ── Inline SVG icons (16×16, 1.5px stroke — hal0 thin-line family) ───────────
 function SIc({ d, children, size = 14, sw = 1.5 }) {
@@ -73,6 +76,82 @@ function StatePill({ svc }) {
   )
 }
 
+// ── Component version cell + retry (Task 12, spec 2026-08-30 §4) ─────────────
+// Joins the Services page to GET /api/updates/components via componentForService
+// (services.jsx passes each row's matching component down by service_id).
+// Retry (POST .../converge) is offered ONLY on RETRYABLE_STATUSES — a pending
+// row never gets an update-now button, per spec §4's explicit decision that
+// convergence is scheduled server-side, not operator-triggered from a pending
+// state. A retry's job id is tracked with the same useUpdateJob poller the
+// self-update apply flow uses (same backend job map — see updater.py's
+// converge_component_route, which reuses _update_jobs()).
+const TONE_COLOR = {
+  ok: 'var(--ok)',
+  pending: 'var(--warn)',
+  failed: 'var(--err)',
+  muted: 'var(--fg-4)',
+}
+
+function useComponentRetry(component) {
+  const convergeMut = useComponentConverge()
+  const [jobId, setJobId] = useState(null)
+  const lastTerminalJobRef = useRef(null)
+  const { job, terminal } = useUpdateJob(jobId)
+
+  useEffect(() => {
+    if (!terminal || !job || lastTerminalJobRef.current === job.id) return
+    lastTerminalJobRef.current = job.id
+    const label = component?.name || component?.id || 'component'
+    if (job.state === 'applied') {
+      window.__hal0Toast && window.__hal0Toast(`${label} converged`, 'ok')
+    } else {
+      const detail = job.error || job.error_code || 'unknown'
+      window.__hal0Toast && window.__hal0Toast(`${label} retry failed: ${detail}`, 'err')
+    }
+  }, [terminal, job, component])
+
+  const jobBusy = !!(job && (job.state === 'queued' || job.state === 'running'))
+
+  const retry = () => {
+    if (!component) return
+    convergeMut.mutate(component.id, {
+      onSuccess: (snap) => setJobId(snap?.id || null),
+      onError: (err) => {
+        window.__hal0Toast && window.__hal0Toast(`Retry failed to start — ${err?.message || 'see logs'}`, 'err')
+      },
+    })
+  }
+
+  return { retry, jobBusy, starting: convergeMut.isPending }
+}
+
+function ComponentVersionLine({ component }) {
+  const { retry, jobBusy, starting } = useComponentRetry(component)
+  const cell = componentCell(component)
+  const retryable = RETRYABLE_STATUSES.includes(component.status)
+
+  return (
+    <div className="svcp-detail" data-testid={`svcp-component-${component.id}`}>
+      <span className="mono" style={{ color: TONE_COLOR[cell.tone] }}>{cell.label}</span>
+      {retryable && (
+        <button
+          className="btn ghost sm svcp-act"
+          data-testid={`svcp-component-retry-${component.id}`}
+          disabled={starting || jobBusy}
+          onClick={retry}
+          style={{ marginLeft: 8 }}
+        >{jobBusy ? 'Retrying…' : 'Retry'}</button>
+      )}
+      {retryable && (component.error || component.remedy) && (
+        <div className="mono" style={{ fontSize: 11, color: 'var(--fg-3)', marginTop: 2 }}>
+          {component.error && <div style={{ color: 'var(--err)' }}>{component.error}</div>}
+          {component.remedy && <div>{component.remedy}</div>}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ── Logs drawer (journald tail via /api/logs?unit=…) ─────────────────────────
 function LogsDrawer({ unit, open }) {
   const q = useUnitLogs(unit, open)
@@ -127,7 +206,7 @@ function ActionButtons({ svc, onAction, busy }) {
 }
 
 // ── One service card ──────────────────────────────────────────────────────────
-function ServiceCard({ svc, onAction, busyId, actionMsg, comfyReachable }) {
+function ServiceCard({ svc, onAction, busyId, actionMsg, comfyReachable, component }) {
   const [logsOpen, setLogsOpen] = useState(false)
   const [queueOpen, setQueueOpen] = useState(false)
   const busy = busyId === svc.id
@@ -155,6 +234,7 @@ function ServiceCard({ svc, onAction, busyId, actionMsg, comfyReachable }) {
 
       <div className="svcp-desc">{svc.description}</div>
       <div className="svcp-detail">{svc.detail}{svc.stat ? ` · ${svc.stat.value} ${svc.stat.label}` : ''}</div>
+      {component && <ComponentVersionLine component={component} />}
 
       <div className="svcp-meta mono">
         {svc.unit && <span className="svcp-meta-row">unit <b>{svc.unit}</b> · {svc.unit_state?.active_state ?? 'unknown'}{svc.unit_state?.unit_file_state && svc.unit_state.unit_file_state !== 'unknown' ? ` · ${svc.unit_state.unit_file_state}` : ''}</span>}
@@ -240,6 +320,50 @@ function DiscoveryCard({ mdns, services }) {
   )
 }
 
+// ── Runner images card (Task 12) ──────────────────────────────────────────────
+// `runner-images` is a component row with no `service_id` (it isn't a
+// systemd-managed service — see hal0.components.registry) so it never joins
+// to a ServiceCard. Its `detail[]` (per-runner-key resolved image, from
+// converge_runner_images) is rendered here instead, with the same retry
+// treatment as a per-service version cell.
+function RunnerImagesCard({ component }) {
+  if (!component) return null
+  const { retry, jobBusy, starting } = useComponentRetry(component)
+  const cell = componentCell(component)
+  const retryable = RETRYABLE_STATUSES.includes(component.status)
+  const detail = component.detail || []
+
+  return (
+    <DCard title="RUNNER IMAGES" data-testid="svcp-runner-images">
+      <div className="svcp-mdns">
+        <div className="svcp-mdns-row">
+          <span className="mono" style={{ color: TONE_COLOR[cell.tone] }}>{cell.label}</span>
+          <span className="vh-spacer" style={{ flex: 1 }} />
+          {retryable && (
+            <button
+              className="btn ghost sm svcp-act"
+              data-testid="svcp-component-retry-runner-images"
+              disabled={starting || jobBusy}
+              onClick={retry}
+            >{jobBusy ? 'Retrying…' : 'Retry'}</button>
+          )}
+        </div>
+        {detail.length > 0 && (
+          <div className="svcp-mdns-sub mono">
+            {detail.map(d => <div key={d.key}>{d.key} — {d.image}</div>)}
+          </div>
+        )}
+        {retryable && (component.error || component.remedy) && (
+          <div className="mono" style={{ fontSize: 11, marginTop: 4 }}>
+            {component.error && <div style={{ color: 'var(--err)' }}>{component.error}</div>}
+            {component.remedy && <div style={{ color: 'var(--fg-3)' }}>{component.remedy}</div>}
+          </div>
+        )}
+      </div>
+    </DCard>
+  );
+}
+
 // ── ServicesView (page) ───────────────────────────────────────────────────────
 function ServicesView() {
   const { services, mdns, pending } = useServices()
@@ -247,6 +371,17 @@ function ServicesView() {
   const comfyQ = useComfyui({ active: false })
   const comfyReachable = (comfyQ.data ?? COMFYUI_FALLBACK).reachable
   const [actionMsg, setActionMsg] = useState(null)
+
+  // Task 12: fail-soft — an older daemon without GET /api/updates/components
+  // resolves to `data: null`, so `componentRows` stays [] and every
+  // componentForService() lookup below returns undefined (no version cells,
+  // no runner-images card) rather than throwing.
+  const componentsQ = useComponents()
+  const componentRows = componentsQ.data?.components ?? null
+  // `runner-images` carries `service_id: null` (it isn't a systemd-managed
+  // service — hal0.components.registry) so it never joins via
+  // componentForService; look it up by id instead.
+  const runnerImagesComponent = (componentRows ?? []).find(r => r.id === 'runner-images')
 
   const busyId = actionMut.isPending ? actionMut.variables?.id ?? null : null
 
@@ -275,9 +410,11 @@ function ServicesView() {
             {services.map(svc => (
               <ServiceCard key={svc.id} svc={svc}
                 onAction={onAction} busyId={busyId} actionMsg={actionMsg}
-                comfyReachable={comfyReachable} />
+                comfyReachable={comfyReachable}
+                component={componentForService(componentRows, svc.id)} />
             ))}
           </div>
+          <RunnerImagesCard component={runnerImagesComponent} />
         </>
       )}
     </div>

--- a/ui/src/dash/services.jsx
+++ b/ui/src/dash/services.jsx
@@ -327,8 +327,15 @@ function DiscoveryCard({ mdns, services }) {
 // converge_runner_images) is rendered here instead, with the same retry
 // treatment as a per-service version cell.
 function RunnerImagesCard({ component }) {
-  if (!component) return null
+  // Hooks must run on every render regardless of `component` — the
+  // components query resolves after first paint, so `component` starts
+  // undefined and becomes defined on a later render of this same instance.
+  // An early return before useComponentRetry (which calls
+  // useMutation/useState/useUpdateJob) would change the hook count between
+  // renders and trigger React's "Rendered more hooks than during the
+  // previous render" crash. See C1 final-review finding.
   const { retry, jobBusy, starting } = useComponentRetry(component)
+  if (!component) return null
   const cell = componentCell(component)
   const retryable = RETRYABLE_STATUSES.includes(component.status)
   const detail = component.detail || []

--- a/ui/src/dash/settings/pages/diagnostics/UpdatesPage.jsx
+++ b/ui/src/dash/settings/pages/diagnostics/UpdatesPage.jsx
@@ -5,6 +5,8 @@
 // #settings/about aliases here.
 import { useState, useRef, useEffect } from 'react'
 import { useUpdateState, useUpdateCheck, useUpdateApply, useUpdateJob, useSetUpdateChannel, useUpdateRollback } from '@/api/hooks/useUpdates'
+import { useComponents } from '@/api/hooks/useComponents'
+import { pendingCount } from '@/dash/components-pure'
 import { ConfirmDialog } from '../../../primitives.jsx'
 import { Icons } from '../../../chrome.jsx'
 import { SRow } from '../../shared/SRow.jsx'
@@ -65,6 +67,12 @@ export function UpdatesPage() {
     ? (job.state === 'queued' ? 'queued…' : 'installing…')
     : null;
 
+  // Task 12: "N updates pending" badge next to the hal0 version line — the
+  // same per-component pending count the Services page badges surface,
+  // fail-soft on an older daemon (useComponents() -> null -> pendingCount 0).
+  const componentsQ = useComponents();
+  const componentPending = pendingCount(componentsQ.data?.components ?? null);
+
   return (
     <div className="s-section">
       <h2>Updates</h2>
@@ -95,6 +103,15 @@ export function UpdatesPage() {
               ? <><span style={{color: "var(--accent)"}}>{u.hal0.available} available</span> <span style={{color: "var(--fg-4)"}}>· current <span data-testid="updates-hal0-version">{u.hal0.current}</span></span></>
               : <span>current <span data-testid="updates-hal0-version">{u.hal0?.current || "—"}</span></span>}
             {jobLabel && <span style={{marginLeft: 8, color: "var(--warn)", fontFamily: "var(--jbm)", fontSize: 11}}>· {jobLabel}</span>}
+            {componentPending > 0 && (
+              <a
+                href="#services"
+                className="chip"
+                data-testid="updates-components-pending"
+                style={{marginLeft: 8}}
+                title={`${componentPending} component update${componentPending === 1 ? "" : "s"} pending — see Services`}
+              >{componentPending} update{componentPending === 1 ? "" : "s"} pending</a>
+            )}
           </>}
           actions={<>
             <button


### PR DESCRIPTION
Implements the component update system designed 2026-08-30: one `ComponentDef` catalog covering everything hal0 ships (OpenWebUI, runner images, Hermes, Hindsight), with release-carried pins, auto-converge as the final pass of `hal0 update`, and a per-component status/retry surface across CLI, Dashboard, and the admin MCP.

**What's in here**
- `src/hal0/components/`: declarative catalog, `components.json` state store, sequential best-effort converge runner wired as the last pass of `run_post_activation_migrations` (new `converge_companions` kwarg; boot path stays diagnose-only)
- Converge arms: OpenWebUI (pull-first repin via the new `hal0-systemctl repin-owui` seam verb + operator override marker), Hermes (stamp-tracked venv rebuild with provision-checkpoint fallback), runner-images (retag wrapper); Hindsight rides `upgrade_memory_engine`
- `OPENWEBUI_IMAGE_PIN`: OpenWebUI moves from floating upstream `:main` to a release-carried digest pin (lockstep-tested against packaging + install.sh); `hal0 update owui --tag` is removed, `--target`/`--clear-override` added
- API: `GET /api/updates/components`, `POST /api/updates/components/{id}/converge` (job-based retry), `components_pending` on `/check`
- CLI: `hal0 update status`, `hal0 update component <id>`, component summary + extended exit-2 contract on bare `hal0 update`
- Dashboard: version cells + failure retry on the services page, runner-images card, pending badges
- MCP: `component_status`/`update_check` (autonomous read) + `component_converge` (owner-approval gated); `update_apply` deliberately NOT exposed (existing `EXCLUDED_TOOLS` decision stands)
- CI: `hindsight-pin-gate.yml` + `tests/memory/test_engine_gate.py` — a `HINDSIGHT_API_PIN` bump runs a real old→new engine upgrade/rollback/contract suite. Its first live run caught #2147 (fixed in #2146); re-run green against the fix (3/3, 334s)

**Known deviations from the spec** (recorded in the design session):
- runner-images `installed` mirrors the pin summary rather than per-image podman inspect — drift only surfaces through the retag pass; follow-up if per-image drift display is wanted
- `update_apply` MCP tool dropped (standing exclusion of self-update from MCP)

**Operator actions after merge**
- Mark `engine-gate` as a required status check (the workflow now always reports; the gate job self-skips when the pin didn't change)
- First `hal0 update` on a provisioned box will stamp the Hermes venv pin (one-time; provision-checkpoint fallback prevents a gratuitous rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018H7JY5CY1wK2ZMypQiVeDp