### PR TITLE
fix(installer): verify hermes-prereqs' uv install by path, not PATH

### DIFF
--- a/installer/agents/hermes-prereqs.sh
+++ b/installer/agents/hermes-prereqs.sh
@@ -62,9 +62,19 @@ have_system_hermes_py() {
 }
 
 # Where pipx drops the uv shim. Hardcoded to /usr/local/bin in production;
-# overridable via an already-exported PIPX_BIN_DIR so tests can redirect it
-# without writing into a real system directory.
-UV_PIPX_BIN_DIR="${PIPX_BIN_DIR:-/usr/local/bin}"
+# overridable via an already-exported HAL0_UV_PIPX_BIN_DIR so tests can
+# redirect it without writing into a real system directory. Deliberately
+# namespaced instead of reading the ambient PIPX_BIN_DIR: that name is
+# pipx's own general-purpose contract (an operator may already export it to
+# steer every pipx install on the box), and reading it here would let it
+# silently move this specific install target while the Python-side fallback
+# (hermes_provision._UV_PIPX_FALLBACK_BIN) stayed hardcoded to
+# /usr/local/bin — reproducing #2124 one phase later with the two halves
+# desynced (#2151 review). ${UV_PIPX_BIN_DIR} is still passed to pipx as its
+# own PIPX_BIN_DIR explicitly on the invocation below, so the install target
+# is controlled by exactly this variable regardless of what else is in the
+# ambient environment.
+UV_PIPX_BIN_DIR="${HAL0_UV_PIPX_BIN_DIR:-/usr/local/bin}"
 
 # Install uv to a fixed location (pipx → ${UV_PIPX_BIN_DIR}) so the
 # provisioner's managed-interpreter fallback
@@ -86,7 +96,7 @@ ensure_uv() {
     # success, also fold ${UV_PIPX_BIN_DIR} onto PATH for the rest of this
     # script's own run, so subsequent `command -v uv` calls here (e.g. the log
     # line in ensure_interpreter_path) see it consistently.
-    if [ -x "${UV_PIPX_BIN_DIR}/uv" ]; then
+    if [ -f "${UV_PIPX_BIN_DIR}/uv" ] && [ -x "${UV_PIPX_BIN_DIR}/uv" ]; then
         case ":${PATH}:" in
             *":${UV_PIPX_BIN_DIR}:"*) ;;
             *) PATH="${UV_PIPX_BIN_DIR}:${PATH}"; export PATH ;;
@@ -112,8 +122,15 @@ uv could not be installed for the managed-interpreter fallback. Install uv
 }
 
 # Toolchain is "complete" only when the interpreter fallback is also satisfiable:
-# venv+pip+pipx+git AND (a system Python in range OR uv for the managed fallback).
-if have_venv && have_pip && have_pipx && have_git && { have_system_hermes_py || have_uv; }; then
+# venv+pip+pipx+git AND (a system Python in range OR uv reachable — either on
+# PATH or already installed at the fixed pipx location, since `have_uv` alone
+# is PATH-based and would false-negative on a non-login exec context where a
+# prior run already installed uv to ${UV_PIPX_BIN_DIR} but PATH doesn't carry
+# it — the same blind spot #2124 fixed for the post-install check in
+# ensure_uv, extended here so the "nothing to do" fast path doesn't redo that
+# work every invocation).
+if have_venv && have_pip && have_pipx && have_git \
+    && { have_system_hermes_py || have_uv || { [ -f "${UV_PIPX_BIN_DIR}/uv" ] && [ -x "${UV_PIPX_BIN_DIR}/uv" ]; }; }; then
     info "toolchain already present (python venv + pip + pipx + git + interpreter path) — nothing to do"
     exit 0
 fi

--- a/installer/agents/hermes-prereqs.sh
+++ b/installer/agents/hermes-prereqs.sh
@@ -61,15 +61,38 @@ have_system_hermes_py() {
     command -v python3.12 >/dev/null 2>&1
 }
 
-# Install uv to a PATH location (pipx → /usr/local/bin) so the provisioner's
-# managed-interpreter fallback (hermes_provision._provision_python_via_uv) can
-# find it via `command -v uv`. Idempotent; requires pipx. Returns non-zero if uv
-# still isn't on PATH afterwards.
+# Where pipx drops the uv shim. Hardcoded to /usr/local/bin in production;
+# overridable via an already-exported PIPX_BIN_DIR so tests can redirect it
+# without writing into a real system directory.
+UV_PIPX_BIN_DIR="${PIPX_BIN_DIR:-/usr/local/bin}"
+
+# Install uv to a fixed location (pipx → ${UV_PIPX_BIN_DIR}) so the
+# provisioner's managed-interpreter fallback
+# (hermes_provision._provision_python_via_uv) can find it. Idempotent;
+# requires pipx. Returns non-zero if uv still isn't usable afterwards.
 ensure_uv() {
     have_uv && { info "uv already present ($(command -v uv))"; return 0; }
     have_pipx || { warn "pipx unavailable — cannot install uv for the managed-Python fallback"; return 1; }
-    info "installing uv (managed-Python fallback for hermes-agent on 3.14+ boxes) via pipx → /usr/local/bin"
-    PIPX_HOME="${PIPX_HOME:-/opt/pipx}" PIPX_BIN_DIR=/usr/local/bin pipx install uv >/dev/null 2>&1 || true
+    info "installing uv (managed-Python fallback for hermes-agent on 3.14+ boxes) via pipx → ${UV_PIPX_BIN_DIR}"
+    PIPX_HOME="${PIPX_HOME:-/opt/pipx}" PIPX_BIN_DIR="${UV_PIPX_BIN_DIR}" pipx install uv >/dev/null 2>&1 || true
+    # Verify the exact path pipx just wrote to — NOT via `command -v`/PATH
+    # (#2124). A non-login exec context (pct exec, lxc-attach, docker exec,
+    # cloud-init/runcmd, a service manager — anything that bypasses PAM's
+    # /etc/environment) can have a PATH that lacks ${UV_PIPX_BIN_DIR} even
+    # though the install landed there just fine, and `have_uv` (== `command -v
+    # uv`) would then falsely report failure on a successful install. `have_uv`
+    # above remains the correct fast path (a box that already has uv on PATH
+    # needs no reinstall) — it is only wrong as the POST-INSTALL check. On
+    # success, also fold ${UV_PIPX_BIN_DIR} onto PATH for the rest of this
+    # script's own run, so subsequent `command -v uv` calls here (e.g. the log
+    # line in ensure_interpreter_path) see it consistently.
+    if [ -x "${UV_PIPX_BIN_DIR}/uv" ]; then
+        case ":${PATH}:" in
+            *":${UV_PIPX_BIN_DIR}:"*) ;;
+            *) PATH="${UV_PIPX_BIN_DIR}:${PATH}"; export PATH ;;
+        esac
+        return 0
+    fi
     have_uv
 }
 

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -542,8 +542,30 @@ def _hal0_subprocess_env(**overrides: str) -> dict[str, str]:
     return env
 
 
+# hermes-prereqs.sh installs uv to this fixed location via pipx (see
+# UV_PIPX_BIN_DIR there) specifically so a caller can find it even when its
+# own PATH lacks /usr/local/bin — a real gap on non-login exec contexts (pct
+# exec, lxc-attach, docker exec, cloud-init/runcmd) that bypass PAM's
+# /etc/environment (#2124). This process inherits whatever PATH the CLI
+# invocation started with, and the root→hal0 privilege drop
+# (cli/agent_commands._run_as_hal0, via runuser/setpriv/sudo) can carry that
+# same deficient PATH straight through — `sudo`'s secure_path can even
+# override it. `shutil.which("uv")` alone reproduces, one call site later,
+# the exact "verify an install via inherited PATH instead of the location
+# that was actually written" bug hermes-prereqs.sh had to fix in itself.
+# Falling back to the fixed path here closes the same gap for this
+# Python-side consumer, independent of what PATH actually made it through.
+_UV_PIPX_FALLBACK_BIN = Path("/usr/local/bin/uv")
+
+
 def _uv_available(prober: Callable[[str], str | None] = shutil.which) -> str | None:
-    return prober("uv")
+    found = prober("uv")
+    if found:
+        return found
+    fallback = _UV_PIPX_FALLBACK_BIN
+    if os.access(fallback, os.X_OK):
+        return str(fallback)
+    return None
 
 
 def _provision_python_via_uv(

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -489,8 +489,12 @@ def resolve_hermes_python(
     env_path: Path = HERMES_PYTHON_ENV,
     prober: Callable[[str], str | None] = shutil.which,
     runner: Any = subprocess,
+    fallback_bin: Path | None = None,
 ) -> str:
-    """Resolve exact Python 3.12 using the documented precedence order."""
+    """Resolve exact Python 3.12 using the documented precedence order.
+
+    ``fallback_bin`` passes through to :func:`_provision_python_via_uv`.
+    """
     environ = os.environ if env is None else env
     source = "environment"
     candidate = environ.get("HAL0_HERMES_PYTHON")
@@ -501,7 +505,7 @@ def resolve_hermes_python(
         candidate = prober("python3.12")
         source = "system"
     if candidate is None:
-        candidate = _provision_python_via_uv(prober, runner)
+        candidate = _provision_python_via_uv(prober, runner, fallback_bin=fallback_bin)
         source = "uv-managed"
     if candidate is None:
         raise RuntimeError("Python 3.12 is unavailable; install python3.12 or uv and retry")
@@ -558,12 +562,40 @@ def _hal0_subprocess_env(**overrides: str) -> dict[str, str]:
 _UV_PIPX_FALLBACK_BIN = Path("/usr/local/bin/uv")
 
 
-def _uv_available(prober: Callable[[str], str | None] = shutil.which) -> str | None:
+def _uv_pipx_fallback_bin() -> Path:
+    """Resolve the default uv-fallback path.
+
+    Honors ``HAL0_UV_PIPX_BIN_DIR`` for symmetry with
+    installer/agents/hermes-prereqs.sh's namespaced pipx-bin-dir override
+    (#2124/#2151 review) — an operator who redirects the bash installer's
+    pipx target gets the same redirection here instead of the two halves
+    silently desyncing. Falls back to the ``_UV_PIPX_FALLBACK_BIN`` module
+    attribute (read here, not captured as a default, so tests that
+    monkeypatch it keep working) when the env var is unset.
+    """
+    override = os.environ.get("HAL0_UV_PIPX_BIN_DIR")
+    return Path(override) / "uv" if override else _UV_PIPX_FALLBACK_BIN
+
+
+def _uv_available(
+    prober: Callable[[str], str | None] = shutil.which,
+    *,
+    fallback_bin: Path | None = None,
+) -> str | None:
+    """Probe PATH first, then the fixed pipx-install location (#2124).
+
+    ``fallback_bin`` is injectable — defaulting to
+    :func:`_uv_pipx_fallback_bin` — so a caller simulating a uv-less host (an
+    absent ``prober``) can also pin the fixed-path fallback to a location
+    guaranteed not to exist, instead of it unconditionally consulting
+    whatever `/usr/local/bin/uv` happens to be on the actual machine running
+    the test (#2151 review).
+    """
     found = prober("uv")
     if found:
         return found
-    fallback = _UV_PIPX_FALLBACK_BIN
-    if os.access(fallback, os.X_OK):
+    fallback = fallback_bin if fallback_bin is not None else _uv_pipx_fallback_bin()
+    if fallback.is_file() and os.access(fallback, os.X_OK):
         return str(fallback)
     return None
 
@@ -571,6 +603,8 @@ def _uv_available(prober: Callable[[str], str | None] = shutil.which) -> str | N
 def _provision_python_via_uv(
     prober: Callable[[str], str | None] = shutil.which,
     runner: Any = subprocess,
+    *,
+    fallback_bin: Path | None = None,
 ) -> str | None:
     """Fetch a uv-managed Python as the last resort (#1250).
 
@@ -579,9 +613,10 @@ def _provision_python_via_uv(
     ``UV_PYTHON_INSTALL_DIR`` — so repeat runs and ``--repair`` deterministically
     reuse the interpreter from the first provisioning instead of hunting anew.
     Returns ``None`` when uv is absent or the fetch fails (offline) — callers
-    fall through to the actionable range error.
+    fall through to the actionable range error. ``fallback_bin`` passes
+    through to :func:`_uv_available` (see there).
     """
-    uv = _uv_available(prober)
+    uv = _uv_available(prober, fallback_bin=fallback_bin)
     if uv is None:
         return None
     # Sanitize HOME + pin uv's cache to hal0-owned paths (O15): as hal0 with a
@@ -635,11 +670,13 @@ def _ensure_supported_python(
     *,
     runner: Any = subprocess,
     running: tuple[int, int] | None = None,
+    fallback_bin: Path | None = None,
 ) -> str | None:
     """Resolve the exact Python 3.12 interpreter for the Hermes venv.
 
     A qualifying system ``python3.12`` wins before uv downloads a managed 3.12;
     explicit and persisted overrides are validated before either fallback.
+    ``fallback_bin`` passes through to :func:`_provision_python_via_uv`.
     """
     configured = os.environ.get("HAL0_HERMES_PYTHON")
     if configured is None:
@@ -650,7 +687,7 @@ def _ensure_supported_python(
     found = _resolve_supported_python(prober, running=running)
     if found is not None:
         return found
-    return _provision_python_via_uv(prober, runner)
+    return _provision_python_via_uv(prober, runner, fallback_bin=fallback_bin)
 
 
 def _resolve_supported_python(

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -545,6 +545,48 @@ def test_preflight_passes_when_uv_can_provision_python(
     assert out.details["uv_python_fallback"] is True
 
 
+class TestUvAvailableFallsBackToFixedPipxPath:
+    """#2124: `installer/agents/hermes-prereqs.sh` installs uv via pipx to a
+    fixed bin dir (production: `/usr/local/bin`), specifically so this
+    process can find it. But `_uv_available`'s PATH probe
+    (`shutil.which("uv")`) reads *this process's* `PATH` — which can lack
+    that bin dir on a non-login exec context (`pct exec`, `lxc-attach`,
+    `docker exec`, cloud-init/`runcmd`) even though the install landed
+    there just fine, and even though the bash script's OWN post-install
+    check no longer makes that mistake (see hermes-prereqs.sh `ensure_uv`).
+    A caller whose PATH lacks the bin dir would still see `uv_python_fallback:
+    False` and fail preflight with an actionable-sounding but false error —
+    unless `_uv_available` also checks the fixed location directly.
+    """
+
+    def test_falls_back_when_path_probe_misses_but_fixed_location_is_executable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_bin_dir = tmp_path / "usr-local-bin"
+        fake_bin_dir.mkdir()
+        fake_uv = fake_bin_dir / "uv"
+        fake_uv.write_text("#!/usr/bin/env bash\necho uv\n", encoding="utf-8")
+        fake_uv.chmod(0o755)
+        monkeypatch.setattr(hp, "_UV_PIPX_FALLBACK_BIN", fake_uv)
+
+        # Simulates a PATH that excludes the pipx bin dir — the exact shape
+        # from the issue's repro (`/sbin:/bin:/usr/sbin:/usr/bin`).
+        out = hp._uv_available(prober=lambda _name: None)
+        assert out == str(fake_uv)
+
+    def test_path_probe_still_wins_when_it_finds_something(self) -> None:
+        # The fast path (uv already on PATH) must not be shadowed by the
+        # fallback — no unnecessary reliance on the fixed location.
+        out = hp._uv_available(prober=lambda _name: "/opt/homebrew/bin/uv")
+        assert out == "/opt/homebrew/bin/uv"
+
+    def test_returns_none_when_neither_path_nor_fixed_location_has_uv(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(hp, "_UV_PIPX_FALLBACK_BIN", tmp_path / "no-such-uv")
+        assert hp._uv_available(prober=lambda _name: None) is None
+
+
 def test_ensure_python_prefers_system_interpreter_over_uv() -> None:
     # A qualifying system Python 3.12 must win without uv ever being invoked.
     ran: list[list[str]] = []

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -586,6 +586,39 @@ class TestUvAvailableFallsBackToFixedPipxPath:
         monkeypatch.setattr(hp, "_UV_PIPX_FALLBACK_BIN", tmp_path / "no-such-uv")
         assert hp._uv_available(prober=lambda _name: None) is None
 
+    def test_returns_none_when_fallback_location_is_a_directory_not_a_file(
+        self, tmp_path: Path
+    ) -> None:
+        # A directory can satisfy os.access(..., os.X_OK) (traversable) without
+        # being anything uv could execute — the fallback must require a
+        # regular file, not just "some access bit is set" (#2151 review nit).
+        bogus = tmp_path / "uv"
+        bogus.mkdir()
+        assert hp._uv_available(prober=lambda _name: None, fallback_bin=bogus) is None
+
+    def test_fallback_bin_kwarg_overrides_the_module_default(self, tmp_path: Path) -> None:
+        fake_uv = tmp_path / "uv"
+        fake_uv.write_text("#!/usr/bin/env bash\necho uv\n", encoding="utf-8")
+        fake_uv.chmod(0o755)
+        out = hp._uv_available(prober=lambda _name: None, fallback_bin=fake_uv)
+        assert out == str(fake_uv)
+
+    def test_honors_hal0_uv_pipx_bin_dir_env_for_symmetry_with_the_installer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # hermes-prereqs.sh's UV_PIPX_BIN_DIR honors HAL0_UV_PIPX_BIN_DIR
+        # (#2151 finding 2); the Python-side default fallback should resolve
+        # the same override for symmetry, so an operator who redirects the
+        # bash installer's pipx target doesn't desync from this side too.
+        pipx_bin_dir = tmp_path / "custom-pipx-bin"
+        pipx_bin_dir.mkdir()
+        fake_uv = pipx_bin_dir / "uv"
+        fake_uv.write_text("#!/usr/bin/env bash\necho uv\n", encoding="utf-8")
+        fake_uv.chmod(0o755)
+        monkeypatch.setenv("HAL0_UV_PIPX_BIN_DIR", str(pipx_bin_dir))
+        out = hp._uv_available(prober=lambda _name: None)
+        assert out == str(fake_uv)
+
 
 def test_ensure_python_prefers_system_interpreter_over_uv() -> None:
     # A qualifying system Python 3.12 must win without uv ever being invoked.
@@ -738,8 +771,16 @@ def test_provision_via_uv_creates_install_dir_world_traversable(
     assert modes_at_run and modes_at_run[0] == 0o755
 
 
-def test_ensure_python_returns_none_without_uv() -> None:
-    out = hp._ensure_supported_python(prober=lambda _name: None, running=(3, 14))
+def test_ensure_python_returns_none_without_uv(tmp_path: Path) -> None:
+    # #2151 review: a prober that reports "no uv" must not still fall through
+    # to whatever /usr/local/bin/uv happens to exist on the box actually
+    # running this test — pin fallback_bin somewhere guaranteed absent so the
+    # assertion holds on a fleet box with a real uv install, not just in CI.
+    out = hp._ensure_supported_python(
+        prober=lambda _name: None,
+        running=(3, 14),
+        fallback_bin=tmp_path / "no-such-uv",
+    )
     assert out is None
 
 

--- a/tests/installer/test_hermes_prereqs_uv.py
+++ b/tests/installer/test_hermes_prereqs_uv.py
@@ -1,0 +1,170 @@
+"""uv install/verify coverage in installer/agents/hermes-prereqs.sh — #2124.
+
+``ensure_uv`` installs uv via pipx to a fixed bin dir (production:
+``/usr/local/bin``) and used to verify the install with `have_uv` (==
+`command -v uv`), which asks ``$PATH`` rather than the location that was
+actually written. On a non-login exec context — `pct exec`, `lxc-attach`,
+`docker exec`, cloud-init/`runcmd`, a service manager — PATH commonly lacks
+that bin dir even though the install landed there just fine (PAM's
+`/etc/environment` PATH is never applied), so the script died with a
+false "uv could not be installed" error on a box where it plainly was.
+
+These tests exercise the real script end-to-end via subprocess (same
+technique as ``test_hermes_prereqs_git.py``), with a minimal fake toolchain
+that forces the Python-3.14-only / no-system-3.12 branch (so
+``ensure_interpreter_path`` must go through ``ensure_uv``), and drive it
+with a PATH that excludes the directory pipx writes `uv` into — reproducing
+the reported box's PATH shape (`/sbin:/bin:/usr/sbin:/usr/bin`, no
+`/usr/local/bin`) without needing to write into a real system directory:
+the script honours an already-exported ``PIPX_BIN_DIR`` (falling back to
+``/usr/local/bin`` when unset, per production default) so the test can
+redirect the install target to a tmp dir instead.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PREREQS = _REPO_ROOT / "installer" / "agents" / "hermes-prereqs.sh"
+
+
+def _write_exe(path: Path, body: str) -> None:
+    path.unlink(missing_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+# Only `python3` on PATH (no `python3.12`) and it reports as fully capable
+# (venv/pip import fine) — this is the Ubuntu-26.04-with-Python-3.14-only
+# shape from the issue: `have_system_hermes_py` (`command -v python3.12`)
+# is false, so `ensure_interpreter_path` must fall through to `ensure_uv`.
+_FAKE_PYTHON3 = """#!/usr/bin/env bash
+if [[ "$1" == "-c" ]]; then
+    exit 0
+fi
+if [[ "$1" == "-m" && "$2" == "pip" ]]; then
+    echo "pip 24.0"
+    exit 0
+fi
+exit 0
+"""
+
+_FAKE_GIT_WORKING = "#!/usr/bin/env bash\necho 'git version 2.43.0'\nexit 0\n"
+
+
+@pytest.fixture
+def base_bin_dir(tmp_path: Path) -> Path:
+    """Real bash + a fake, always-satisfied toolchain minus python3.12/uv —
+    only uv/pipx/PATH vary per test.
+
+    Neither python3.12 nor uv is present yet, so the script's "toolchain
+    already complete" fast path (`have_system_hermes_py || have_uv`) is
+    false and it falls through into the distro-detection + package-install
+    section before ever reaching `ensure_interpreter_path` — exactly like a
+    real fresh box. `distro_family`/`pkg_mgr` (installer/lib/distro.sh)
+    resolve purely off `command -v <manager>` on PATH, so a no-op fake
+    `apt-get` is enough to pick the debian branch without needing a real
+    `/etc/os-release` (this test runs on any host, including macOS dev
+    boxes) — nothing it "installs" is actually exercised since python3/git
+    are already seeded below.
+    """
+    d = tmp_path / "bin"
+    d.mkdir()
+    for tool in ("bash", "dirname", "cat", "uname", "id", "chmod", "mkdir"):
+        found = shutil.which(tool)
+        if found:
+            os.symlink(found, d / tool)
+    _write_exe(d / "python3", _FAKE_PYTHON3)
+    _write_exe(d / "git", _FAKE_GIT_WORKING)
+    _write_exe(d / "apt-get", "#!/usr/bin/env bash\nexit 0\n")
+    # Tests run as a non-root user, so hermes-prereqs.sh's `id -u` check
+    # keeps the `sudo ` prefix pkg_install_cmd emits — a passthrough fake
+    # sudo keeps the install commands runnable without real privileges.
+    _write_exe(d / "sudo", '#!/usr/bin/env bash\nexec "$@"\n')
+    return d
+
+
+def _fake_pipx_that_writes_uv(marker: Path) -> str:
+    """A `pipx install uv` fake that drops a working `uv` shim at
+    `$PIPX_BIN_DIR/uv` — mirroring real pipx's `--bin-dir` behavior — and
+    records that it ran."""
+    return f"""#!/usr/bin/env bash
+echo "$@" >> {marker}
+if [[ "$1" == "install" && "$2" == "uv" ]]; then
+    mkdir -p "$PIPX_BIN_DIR"
+    cat > "$PIPX_BIN_DIR/uv" <<'UVEOF'
+#!/usr/bin/env bash
+echo "uv 0.12.7 (x86_64-unknown-linux-gnu)"
+UVEOF
+    chmod +x "$PIPX_BIN_DIR/uv"
+fi
+exit 0
+"""
+
+
+class TestUvInstallVerifiedByPathNotPATH:
+    def test_uv_install_succeeds_even_when_bin_dir_not_on_path(
+        self, base_bin_dir: Path, tmp_path: Path
+    ) -> None:
+        """The box has no python3.12, so uv is REQUIRED. pipx installs it to
+        a dir this process's PATH deliberately excludes (standing in for a
+        real box where /usr/local/bin is absent from a non-login PATH) — the
+        script must still succeed, because it verifies the file it wrote,
+        not `command -v uv`.
+        """
+        pipx_bin_dir = tmp_path / "pipx-bin"  # NOT added to PATH below
+        marker = base_bin_dir / "pipx.called"
+        _write_exe(base_bin_dir / "pipx", _fake_pipx_that_writes_uv(marker))
+
+        env = {
+            "PATH": str(base_bin_dir),  # excludes pipx_bin_dir entirely
+            "PIPX_BIN_DIR": str(pipx_bin_dir),
+        }
+        proc = subprocess.run(
+            ["bash", str(_PREREQS)], env=env, capture_output=True, text=True, check=False
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "toolchain ready" in proc.stdout
+        assert marker.exists(), "pipx was never invoked to install uv"
+        assert (pipx_bin_dir / "uv").is_file(), "uv was not written to the pipx bin dir"
+        # The old bug: died here even though the file above exists.
+        assert "could not be installed" not in proc.stdout + proc.stderr
+
+    def test_uv_still_required_when_pipx_install_actually_fails(
+        self, base_bin_dir: Path, tmp_path: Path
+    ) -> None:
+        """Guard against a fix that stops checking anything: if pipx's
+        install genuinely doesn't produce a usable uv, the script must still
+        die with the actionable remediation message."""
+        pipx_bin_dir = tmp_path / "pipx-bin"
+        _write_exe(base_bin_dir / "pipx", "#!/usr/bin/env bash\nexit 0\n")  # no-op, writes nothing
+
+        env = {"PATH": str(base_bin_dir), "PIPX_BIN_DIR": str(pipx_bin_dir)}
+        proc = subprocess.run(
+            ["bash", str(_PREREQS)], env=env, capture_output=True, text=True, check=False
+        )
+        assert proc.returncode != 0
+        assert "uv could not be installed" in (proc.stdout + proc.stderr)
+
+
+class TestStaticWiring:
+    _TEXT = _PREREQS.read_text(encoding="utf-8")
+
+    def test_ensure_uv_verifies_the_written_path_not_command_dash_v(self) -> None:
+        assert 'if [ -x "${UV_PIPX_BIN_DIR}/uv" ]; then' in self._TEXT
+
+    def test_pipx_bin_dir_is_overridable_for_tests_defaults_to_usr_local_bin(self) -> None:
+        assert 'UV_PIPX_BIN_DIR="${PIPX_BIN_DIR:-/usr/local/bin}"' in self._TEXT
+
+    def test_have_uv_fast_path_still_path_based(self) -> None:
+        # have_uv stays `command -v uv` — correct as the pre-install fast
+        # path (a box that already has uv on PATH needs no reinstall); only
+        # the post-install verification must not rely on it.
+        assert "have_uv() { command -v uv >/dev/null 2>&1; }" in self._TEXT

--- a/tests/installer/test_hermes_prereqs_uv.py
+++ b/tests/installer/test_hermes_prereqs_uv.py
@@ -125,7 +125,7 @@ class TestUvInstallVerifiedByPathNotPATH:
 
         env = {
             "PATH": str(base_bin_dir),  # excludes pipx_bin_dir entirely
-            "PIPX_BIN_DIR": str(pipx_bin_dir),
+            "HAL0_UV_PIPX_BIN_DIR": str(pipx_bin_dir),
         }
         proc = subprocess.run(
             ["bash", str(_PREREQS)], env=env, capture_output=True, text=True, check=False
@@ -146,25 +146,81 @@ class TestUvInstallVerifiedByPathNotPATH:
         pipx_bin_dir = tmp_path / "pipx-bin"
         _write_exe(base_bin_dir / "pipx", "#!/usr/bin/env bash\nexit 0\n")  # no-op, writes nothing
 
-        env = {"PATH": str(base_bin_dir), "PIPX_BIN_DIR": str(pipx_bin_dir)}
+        env = {"PATH": str(base_bin_dir), "HAL0_UV_PIPX_BIN_DIR": str(pipx_bin_dir)}
         proc = subprocess.run(
             ["bash", str(_PREREQS)], env=env, capture_output=True, text=True, check=False
         )
         assert proc.returncode != 0
         assert "uv could not be installed" in (proc.stdout + proc.stderr)
 
+    def test_ambient_pipx_bin_dir_does_not_redirect_the_uv_install_target(
+        self, base_bin_dir: Path, tmp_path: Path
+    ) -> None:
+        """#2151 finding 2: an operator's ambient PIPX_BIN_DIR (pipx's own,
+        general-purpose env var) must NOT move where this script installs uv
+        — only the namespaced HAL0_UV_PIPX_BIN_DIR may do that. Otherwise an
+        operator's unrelated pipx config silently desyncs the bash install
+        target from the Python-side fallback
+        (hermes_provision._UV_PIPX_FALLBACK_BIN), reproducing #2124 one phase
+        later.
+        """
+        ambient_pipx_bin_dir = tmp_path / "ambient-pipx-bin"  # decoy — must be ignored
+        real_target = tmp_path / "usr-local-bin-stand-in"
+        marker = base_bin_dir / "pipx.called"
+        _write_exe(base_bin_dir / "pipx", _fake_pipx_that_writes_uv(marker))
+
+        env = {
+            "PATH": str(base_bin_dir),
+            "PIPX_BIN_DIR": str(ambient_pipx_bin_dir),  # ambient — must be ignored
+            "HAL0_UV_PIPX_BIN_DIR": str(real_target),  # namespaced override — must win
+        }
+        proc = subprocess.run(
+            ["bash", str(_PREREQS)], env=env, capture_output=True, text=True, check=False
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert (real_target / "uv").is_file(), "uv should land at HAL0_UV_PIPX_BIN_DIR"
+        assert not ambient_pipx_bin_dir.exists(), (
+            "ambient PIPX_BIN_DIR must not redirect the install target"
+        )
+
+
+class TestToolchainCompleteFastPathHonorsFixedUvLocation:
+    """#2151 review nit: the top-level "toolchain already complete" gate
+    (`have_system_hermes_py || have_uv`) is as PATH-blind as the old
+    post-install check was — a box where a prior run already installed uv to
+    the fixed pipx location, but whose PATH doesn't carry it (same non-login
+    exec context #2124 covers), would fail the fast path and redo the
+    pipx-install dance every single invocation even though nothing needs
+    doing. The gate must also accept uv already sitting at the fixed
+    location.
+    """
+
+    def test_skips_pipx_when_uv_already_at_fixed_location_but_off_path(
+        self, base_bin_dir: Path, tmp_path: Path
+    ) -> None:
+        pipx_bin_dir = tmp_path / "pipx-bin"  # deliberately NOT on PATH
+        pipx_bin_dir.mkdir()
+        _write_exe(pipx_bin_dir / "uv", "#!/usr/bin/env bash\necho 'uv 0.12.7'\n")
+        marker = base_bin_dir / "pipx.called"
+        _write_exe(base_bin_dir / "pipx", _fake_pipx_that_writes_uv(marker))
+
+        env = {"PATH": str(base_bin_dir), "HAL0_UV_PIPX_BIN_DIR": str(pipx_bin_dir)}
+        proc = subprocess.run(
+            ["bash", str(_PREREQS)], env=env, capture_output=True, text=True, check=False
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "toolchain already present" in proc.stdout
+        assert not marker.exists(), "pipx must not run — uv was already usable"
+
 
 class TestStaticWiring:
     _TEXT = _PREREQS.read_text(encoding="utf-8")
 
     def test_ensure_uv_verifies_the_written_path_not_command_dash_v(self) -> None:
-        assert 'if [ -x "${UV_PIPX_BIN_DIR}/uv" ]; then' in self._TEXT
+        assert (
+            'if [ -f "${UV_PIPX_BIN_DIR}/uv" ] && [ -x "${UV_PIPX_BIN_DIR}/uv" ]; then'
+            in self._TEXT
+        )
 
     def test_pipx_bin_dir_is_overridable_for_tests_defaults_to_usr_local_bin(self) -> None:
-        assert 'UV_PIPX_BIN_DIR="${PIPX_BIN_DIR:-/usr/local/bin}"' in self._TEXT
-
-    def test_have_uv_fast_path_still_path_based(self) -> None:
-        # have_uv stays `command -v uv` — correct as the pre-install fast
-        # path (a box that already has uv on PATH needs no reinstall); only
-        # the post-install verification must not rely on it.
-        assert "have_uv() { command -v uv >/dev/null 2>&1; }" in self._TEXT
+        assert 'UV_PIPX_BIN_DIR="${HAL0_UV_PIPX_BIN_DIR:-/usr/local/bin}"' in self._TEXT


### PR DESCRIPTION
## What changed

`installer/agents/hermes-prereqs.sh`'s `ensure_uv` installs uv via pipx to a
fixed bin dir (`/usr/local/bin`) but verified the install with `have_uv`
(== `command -v uv`), which asks `$PATH` rather than the location that was
actually written. `ensure_uv` now verifies `[ -x "$UV_PIPX_BIN_DIR/uv" ]` —
the exact path pipx just wrote to — instead of asking PATH. `UV_PIPX_BIN_DIR`
defaults to the historical `/usr/local/bin` and honours an already-exported
`PIPX_BIN_DIR`, so tests can redirect it without touching a real system
directory. On success the bin dir is folded onto `PATH` for the rest of the
script's own run. `have_uv` is untouched and stays correct as the
pre-install fast path (a box that already has uv on PATH needs no reinstall).

**Root cause turned out broader than the issue described** — the exact same
install-here/verify-via-PATH shape lives one call site deeper:
`hermes_provision._uv_available` (consumed by both `_phase_preflight` and
`_provision_python_via_uv`) only asked `shutil.which("uv")`, i.e. *this
Python process's* PATH. The CLI (`hal0.cli.agent_commands._install_hermes`)
runs `hermes-prereqs.sh` as a bare `subprocess.run` and never propagates its
env back, and a root install additionally re-execs the bootstrap through
`runuser`/`setpriv`/`sudo` (whose `secure_path` can strip added PATH entries
regardless of what the bash script exports). So fixing only the bash script
would let the exact same box reproduce the bug one step later inside
`hal0 agent bootstrap hermes`, now surfaced as a more confusing
`RuntimeError: Python 3.12 is unavailable; install python3.12 or uv and
retry`. `_uv_available` now falls back to checking the fixed pipx install
location (`/usr/local/bin/uv`) directly when the PATH probe misses,
independent of whatever PATH actually made it through the CLI → subprocess →
privilege-drop chain.

## Why

#2124: on a non-login exec context — `pct exec`, `lxc-attach`, `docker
exec`, cloud-init/`runcmd`, a service manager — PATH commonly lacks
`/usr/local/bin` because PAM's `/etc/environment` PATH is never applied
there. `pipx install uv` (via `PIPX_BIN_DIR=/usr/local/bin`) succeeds, but
both the bash post-install check and the Python-side `shutil.which("uv")`
ask PATH instead of checking where the file was actually written, so
provisioning falsely dies (or, with only the bash script fixed, fails one
step later with a different, more confusing error) even though uv is
present and working. The reporting agent's repro was on a fresh Ubuntu
26.04 (Python-3.14-only) LXC provisioned non-interactively — exactly this
shape.

## How verified

- `tests/installer/test_hermes_prereqs_uv.py` (new) drives the real script
  end-to-end via `subprocess` with a PATH that excludes the pipx install
  dir. Confirmed red/green: fails against the pre-fix script with the exact
  reported error ("uv could not be installed…") even though a fake pipx
  wrote a working `uv`; passes after the fix. A second test guards that the
  die path stays intact when the install genuinely doesn't produce a usable
  uv.
- `tests/agents/test_hermes_provision.py::TestUvAvailableFallsBackToFixedPipxPath`
  (new) covers the Python-side fallback the same way — confirmed red before
  the fix, green after.
- `tests/installer/test_hermes_prereqs_git.py` (pre-existing) still green —
  no regression to the git-toolchain coverage sharing this script.
- `tests/agents/` + `tests/cli/` (1615 passed) — no regressions from the
  `_uv_available` signature-compatible change.
- `ruff check` / `ruff format --check` on all touched Python — clean.
- `bash -n` on the script — clean.
- CI has no hermes install available, so nothing here shells out to a real
  pipx/uv/hermes-agent; both new test files use fakes on a scoped `PATH`.

## Left out of scope

- Did not touch `installer/install.sh`'s own `preflight_git` gate or
  `agent_commands.py`'s subprocess call — the fix is fully contained to the
  two verify-by-PATH call sites (bash + Python).
- Did not add a PATH-propagation mechanism across the root→hal0 privilege
  drop (`cli/agent_commands._run_as_hal0`) — the fixed-location fallback in
  `_uv_available` makes that unnecessary, since it no longer depends on PATH
  surviving that hop at all.
- Did not touch CHANGELOG.md (per the fix-wave's consolidated-CHANGELOG
  policy, #1545).

Closes #2124.