### PR TITLE
fix(updater): apply install.sh's HAL0_PREFIX venv rewrite to hal0-gpu-perms.service

### DIFF
--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -3796,6 +3796,18 @@ def _restore_service_ownership(root: Path, *, job_id: str | None = None) -> None
         log.warning("updater.cache_chown_failed", job_id=job_id, path=str(root), error=str(exc))
 
 
+#: Where the enabled unit lives. A module-level constant (not inlined in the
+#: function) so tests can redirect it the same way ``seam_dirs`` redirects
+#: :data:`hal0.system.seam_check.SEAM_BIN_DIR` — the real path needs root to
+#: write and must never be touched by a unit test.
+GPU_PERMS_UNIT_DST = Path("/etc/systemd/system/hal0-gpu-perms.service")
+
+#: The FHS default venv path baked into the bundled unit (matches
+#: ``installer/systemd/hal0-gpu-perms.service``'s ``ExecStart`` and
+#: ``install.sh``'s own ``VENV_DIR`` default — installer/install.sh:184).
+_DEFAULT_VENV_DIR = "/usr/lib/hal0/venv"
+
+
 def refresh_gpu_perms_unit(target: Path, *, job_id: str | None = None) -> str:
     """Install/refresh ``hal0-gpu-perms.service`` from the activated release (#1953).
 
@@ -3812,6 +3824,16 @@ def refresh_gpu_perms_unit(target: Path, *, job_id: str | None = None) -> str:
     failed ``systemctl enable`` is logged rather than raised. A missing
     permissions tidy-up must never fail an otherwise-successful activate.
 
+    #1982: a non-default ``HAL0_PREFIX`` moves the venv, and the bundled unit
+    hardcodes the FHS ``ExecStart`` interpreter path — copying it verbatim
+    clobbers the rewrite ``install.sh`` performs at install time
+    (installer/install.sh:1630-1645) and the unit dies ``203/EXEC`` on the
+    next activation. This process is itself running from the ACTUAL venv
+    (``sys.prefix`` — the same signal :func:`_is_editable_install` already
+    trusts for "where does this venv live"), so the same string rewrite
+    ``install.sh`` does is applied here before the unit is written, keeping
+    every subsequent update self-healing instead of re-breaking the box.
+
     Returns one of ``"installed"``, ``"unchanged"``, ``"skipped"``, ``"failed"``.
     """
     if os.geteuid() != 0:
@@ -3820,9 +3842,12 @@ def refresh_gpu_perms_unit(target: Path, *, job_id: str | None = None) -> str:
     if not src.is_file():
         log.info("updater.gpu_perms_unit_absent", job_id=job_id, src=str(src))
         return "skipped"
-    dst = Path("/etc/systemd/system/hal0-gpu-perms.service")
+    dst = GPU_PERMS_UNIT_DST
     try:
         desired = src.read_text(encoding="utf-8")
+        venv_dir = sys.prefix
+        if venv_dir != _DEFAULT_VENV_DIR:
+            desired = desired.replace(_DEFAULT_VENV_DIR, venv_dir)
         # NOT an early return on identical content: enable/start still re-run
         # below so a previously-failed enable self-heals on the next activate.
         up_to_date = dst.is_file() and dst.read_text(encoding="utf-8") == desired

--- a/tests/updater/test_gpu_perms_unit.py
+++ b/tests/updater/test_gpu_perms_unit.py
@@ -11,12 +11,28 @@ Two gaps this closes:
 from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 import hal0.updater.updater as updater_mod
 from hal0.install import gpu_perms
+
+
+class FakeRun:
+    """Recording stand-in for ``subprocess.run`` — never touches the real OS."""
+
+    def __init__(self, *, returncode: int = 0, stdout: str = "", stderr: bytes = b"") -> None:
+        self.calls: list[list[str]] = []
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __call__(self, argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        self.calls.append(list(argv))
+        return subprocess.CompletedProcess(argv, self.returncode, self.stdout, self.stderr)
 
 
 class TestGpuPermsEntryPoint:
@@ -61,6 +77,81 @@ class TestGpuPermsUnitRefresh:
     ) -> None:
         monkeypatch.setattr(os, "geteuid", lambda: 0)
         assert updater_mod.refresh_gpu_perms_unit(tmp_path) == "skipped"
+
+
+def _release_tree_with_unit(tmp_path: Path) -> Path:
+    target = tmp_path / "hal0-1.0.0"
+    unit_dir = target / "installer" / "systemd"
+    unit_dir.mkdir(parents=True)
+    (unit_dir / "hal0-gpu-perms.service").write_text(
+        "[Unit]\n"
+        "Description=hal0 GPU device permissions\n"
+        "\n"
+        "[Service]\n"
+        "Type=oneshot\n"
+        "ExecStart=/usr/lib/hal0/venv/bin/python -m hal0.install.gpu_perms\n"
+        "\n"
+        "[Install]\n"
+        "WantedBy=hal0.target\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+class TestGpuPermsUnitPrefixRewrite:
+    """#1982 — the update-path refresh must apply the same HAL0_PREFIX venv
+    rewrite ``install.sh`` performs at install time, or a custom-prefix box's
+    ``hal0-gpu-perms.service`` dies ``203/EXEC`` on every subsequent update.
+    """
+
+    @pytest.fixture
+    def unit_dst(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        dst_dir = tmp_path / "etc-systemd-system"
+        dst_dir.mkdir()
+        dst = dst_dir / "hal0-gpu-perms.service"
+        monkeypatch.setattr("hal0.updater.updater.GPU_PERMS_UNIT_DST", dst)
+        return dst
+
+    def test_default_prefix_is_written_verbatim(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, unit_dst: Path
+    ) -> None:
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        monkeypatch.setattr("hal0.updater.updater.sys.prefix", "/usr/lib/hal0/venv")
+        monkeypatch.setattr("hal0.updater.updater.subprocess.run", FakeRun())
+        target = _release_tree_with_unit(tmp_path)
+
+        result = updater_mod.refresh_gpu_perms_unit(target)
+
+        assert result == "installed"
+        assert "ExecStart=/usr/lib/hal0/venv/bin/python" in unit_dst.read_text()
+
+    def test_custom_prefix_rewrites_the_interpreter_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, unit_dst: Path
+    ) -> None:
+        """Mirrors install.sh's ``VENV_DIR`` rewrite (installer/install.sh:1630-1645):
+        the ExecStart interpreter must point at the ACTUAL venv this process
+        is running from, not the FHS default baked into the bundled unit.
+        """
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        custom_venv = tmp_path / "opt" / "hal0" / "venv"
+        (custom_venv / "bin").mkdir(parents=True)
+        (custom_venv / "bin" / "python").write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setattr("hal0.updater.updater.sys.prefix", str(custom_venv))
+        monkeypatch.setattr("hal0.updater.updater.subprocess.run", FakeRun())
+        target = _release_tree_with_unit(tmp_path)
+
+        result = updater_mod.refresh_gpu_perms_unit(target)
+
+        assert result == "installed"
+        written = unit_dst.read_text()
+        assert "/usr/lib/hal0/venv" not in written
+        exec_line = next(ln for ln in written.splitlines() if ln.startswith("ExecStart="))
+        interpreter = exec_line.removeprefix("ExecStart=").split()[0]
+        assert Path(interpreter).is_file(), (
+            f"rewritten ExecStart interpreter {interpreter!r} does not exist — "
+            "the unit would die 203/EXEC on activation"
+        )
+        assert interpreter == str(custom_venv / "bin" / "python")
 
 
 class TestUnitFileContract:


### PR DESCRIPTION
## Summary

Closes #1982

- `refresh_gpu_perms_unit` (`src/hal0/updater/updater.py`) copied the bundled `hal0-gpu-perms.service` unit verbatim on every activate, clobbering the `ExecStart` interpreter-path rewrite `install.sh` performs at install time for a non-default `HAL0_PREFIX` (`installer/install.sh:1630-1645`). On a custom-prefix or `--dev`-style box the unit then dies `203/EXEC` — and unlike a one-time install defect, this **re-breaks on every subsequent `hal0 update`**, silently defeating the boot-time `/dev/kfd` group convergence #1953/#1955 shipped.
- Fix mirrors `install.sh`'s own remedy exactly: the updater process is itself running from the actual venv (`sys.prefix` — the same signal `_is_editable_install` already trusts for "where does this venv live"), so the same `/usr/lib/hal0/venv` → real-venv string rewrite is applied before the unit is written.
- `GPU_PERMS_UNIT_DST` is now a module-level constant (mirroring the `SEAM_BIN_DIR`/`SUDOERS_DIR` pattern `refresh_privileged_wrappers` already uses) so tests can redirect the write target instead of touching the real `/etc/systemd/system`.

**This installs a root-side privileged unit, so it needs human merge** — `refresh_gpu_perms_unit` only runs at `os.geteuid() == 0` (the real seam path on a shipped box / an operator's direct `sudo hal0 update`), same privileged-side-only posture as its #1689 sibling `refresh_privileged_wrappers`.

## Root cause

`refresh_gpu_perms_unit` (previously `src/hal0/updater/updater.py:3799-3871`) read the release tree's bundled unit and wrote it to `/etc/systemd/system/hal0-gpu-perms.service` byte-for-byte. `install.sh` (`installer/install.sh:1630-1645`) instead rewrites the hardcoded `/usr/lib/hal0/venv` `ExecStart` interpreter path to the actual `VENV_DIR` whenever `HAL0_PREFIX` is non-default — a rewrite the updater never replicated, so every `hal0 update` on such a box reverted the unit back to the (nonexistent-on-that-box) default path.

## TDD proof

New tests in `tests/updater/test_gpu_perms_unit.py::TestGpuPermsUnitPrefixRewrite`:

**Red** (fix reverted via `git apply -R` on the source-only diff):
```
AttributeError: module 'hal0.updater.updater' has no attribute 'GPU_PERMS_UNIT_DST'
ERROR tests/updater/test_gpu_perms_unit.py::TestGpuPermsUnitPrefixRewrite::test_default_prefix_is_written_verbatim
ERROR tests/updater/test_gpu_perms_unit.py::TestGpuPermsUnitPrefixRewrite::test_custom_prefix_rewrites_the_interpreter_path
11 passed, 2 errors in 6.16s
```

**Green** (fix reapplied):
```
tests/updater/test_gpu_perms_unit.py tests/updater/test_wrapper_refresh.py tests/updater/test_kfd_group_converge.py
27 passed in 10.17s
```

Full `tests/updater/` tier: `379 passed, 1 failed` — the one failure (`test_convergence_report.py::test_the_only_caller_is_the_operator_facing_cli`) is a pre-existing environment artifact of this sandbox's NFS mount (AppleDouble `._*.py` shadow files under `src/`, e.g. `src/hal0/omni_router/._dispatch.py`, trip the test's `rglob("*.py")` + UTF-8 read), unrelated to this change and present in directories this PR never touches.

`ruff check` and `ruff format --check` both pass clean on the touched files.

## Overlap note

PR #2150 (`feat: component update system`, merged into `main` as `b0d5a357` after this branch was cut) touches `src/hal0/updater/updater.py` broadly. Verified via `gh pr diff 2150 | grep refresh_gpu_perms_unit` that it does not touch this function, and `git merge-tree` against current `main` shows no conflicts — this branch is 1 commit behind `main` but cleanly mergeable.

## Test plan

- [x] `tests/updater/test_gpu_perms_unit.py` — new prefix-rewrite tests, red→green
- [x] `tests/updater/test_wrapper_refresh.py` — precedent suite, still green
- [x] `tests/updater/test_kfd_group_converge.py` — still green (source-inspection assertions this PR doesn't touch)
- [x] `ruff check` / `ruff format --check` on touched files
- [ ] Human: confirm on a real custom-`HAL0_PREFIX` box that `hal0-gpu-perms.service` survives `hal0 update` with a working `ExecStart` interpreter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcGmVXzvn28MJhtZwGd5f3