### PR TITLE
ci(release): give the installer mirror and the stable pointer an owner (#2057, #2101)

### DIFF
--- a/.github/workflows/bootstrap-parity.yml
+++ b/.github/workflows/bootstrap-parity.yml
@@ -11,6 +11,16 @@ name: Bootstrap parity (daily)
 #   installer team can reconcile hal0-web in a follow-up. The header of
 #   bootstrap.sh promises the two stay mirrored; this is the safety net.
 #
+# Why a red run is not enough (#2057):
+#   It was. Parity went red every day from 2026-08-16 to 2026-08-28 and nobody
+#   noticed, because a red run in a list of workflow runs pages no one. The
+#   obvious watch — "alert when `mirror-bootstrap` fails" — can never fire:
+#   mirror-bootstrap concludes green and declines to publish, by design. This
+#   daily check is therefore the only signal that actually tracks the live
+#   installer rotting, so it is the one that has to carry an owner. The `alert`
+#   job below opens (and later closes) exactly one tracking issue once the red
+#   streak reaches ALERT_STREAK.
+#
 # The script is the contract (scripts/check-bootstrap-parity.sh):
 #   exit 0 — in sync.   exit 1 — drift (unified diff printed).
 #   exit 2 — operational error (fetch failed / empty) — NOT read as drift.
@@ -34,6 +44,8 @@ jobs:
     name: Diff in-tree bootstrap.sh against live install.sh
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      rc: ${{ steps.parity.outputs.rc }}
 
     steps:
       - name: Checkout hal0
@@ -43,12 +55,15 @@ jobs:
         id: parity
         # Exit 0 = in sync, 1 = drift, 2 = operational error. We surface the
         # script's stdout/stderr (the unified diff lives there) into the step
-        # summary so a glance at the run page tells the whole story.
+        # summary so a glance at the run page tells the whole story, and export
+        # the raw code so the `alert` job can tell drift from a fetch blip.
         run: |
           set +e
           bash scripts/check-bootstrap-parity.sh > parity.out 2>&1
           rc=$?
           set -e
+
+          echo "rc=${rc}" >> "$GITHUB_OUTPUT"
 
           {
             echo "## Bootstrap parity check"
@@ -72,3 +87,158 @@ jobs:
               ;;
           esac
           exit "$rc"
+
+  # ── Give the daily red an owner ─────────────────────────────────────────
+  # One open tracking issue for the whole drift episode: opened when the red
+  # streak reaches ALERT_STREAK, commented on each further red, and closed
+  # when parity comes back green. The loop has to end as well as start, or the
+  # next episode files on top of a stale issue nobody trusts.
+  alert:
+    name: Open/update the parity drift issue
+    needs: [parity]
+    if: always() && needs.parity.result != 'cancelled' && needs.parity.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Open, update, or close the parity tracking issue
+        uses: actions/github-script@v9
+        env:
+          # Three consecutive daily reds ≈ 48 h of a stale front door. One red
+          # is routinely a same-day sync still in flight; three is an episode.
+          ALERT_STREAK: "3"
+          PARITY_RC: ${{ needs.parity.outputs.rc }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Body marker, not a bespoke label: CLAUDE.md asks for the five
+            // canonical triage labels used unmodified rather than new ones.
+            const MARKER = '<!-- hal0:bootstrap-parity-drift -->';
+            const labels = ['bug'];
+            const streakThreshold = Number(process.env.ALERT_STREAK);
+            const runUrl = process.env.RUN_URL;
+            const today = new Date().toISOString().slice(0, 10);
+
+            // An empty rc means the parity job died before the check ran (bad
+            // checkout, runner loss). `Number('')` is 0, so parsing it naively
+            // would read an infrastructure failure as "green" and close a
+            // live drift issue. Treat a missing code as no evidence at all.
+            const rawRc = (process.env.PARITY_RC || '').trim();
+            const rc = rawRc === '' ? NaN : Number(rawRc);
+
+            // exit 2 is a fetch failure, not drift (see the script's exit-code
+            // contract). Counting it would page the installer team for a
+            // transient Cloudflare blip, so this run is simply not evidence.
+            if (rc === 2 || Number.isNaN(rc)) {
+              core.info(`parity rc='${rawRc}' is not a drift verdict; ignoring this run.`);
+              return;
+            }
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const tracking = openIssues.find(
+              (issue) => !issue.pull_request && (issue.body || '').includes(MARKER),
+            );
+
+            if (rc === 0) {
+              if (!tracking) {
+                core.info('parity is green and no tracking issue is open.');
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking.number,
+                body: [
+                  `Parity is green again as of ${today}: \`installer/bootstrap.sh\` matches`,
+                  `the live \`hal0.dev/install.sh\`.`,
+                  ``,
+                  `- Run: ${runUrl}`,
+                  ``,
+                  `Closing automatically. A future drift episode opens a fresh issue.`,
+                ].join('\n'),
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking.number,
+                state: 'closed',
+              });
+              core.info(`closed issue #${tracking.number}`);
+              return;
+            }
+
+            // rc === 1 — drift. Count how far back the reds run, this run
+            // included, so a single red does not file an issue.
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'bootstrap-parity.yml',
+              status: 'completed',
+              per_page: 50,
+            });
+            let streak = 1;
+            for (const run of runs.data.workflow_runs) {
+              if (run.id === context.runId) continue;
+              if (run.conclusion === 'failure') {
+                streak += 1;
+              } else if (run.conclusion === 'success') {
+                break;
+              }
+              // Cancelled/skipped runs are not evidence; step over them.
+            }
+            core.info(`consecutive parity reds (this run included): ${streak}`);
+
+            if (streak < streakThreshold && !tracking) {
+              core.info(`streak ${streak} < ${streakThreshold}; not filing yet.`);
+              return;
+            }
+
+            const detail = [
+              `- Consecutive red parity runs: **${streak}**`,
+              `- Latest run: ${runUrl}`,
+              ``,
+              `\`mirror-bootstrap\` will not publish while the stable channel has no`,
+              `sibling Sigstore bundle, and it reports that refusal as a *skipped*`,
+              `mirror job rather than a failure — so this check is the signal that`,
+              `the live one-liner is stale. See #2057 and #2101 gate 4.`,
+            ].join('\n');
+
+            if (tracking) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking.number,
+                body: [`Still drifting on ${today}.`, ``, detail].join('\n'),
+              });
+              core.info(`updated issue #${tracking.number}`);
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `installer: hal0.dev/install.sh has drifted from installer/bootstrap.sh (${streak} consecutive parity reds)`,
+              labels,
+              body: [
+                MARKER,
+                `The daily bootstrap-parity check has been red for ${streak} consecutive runs.`,
+                `The audited in-tree \`installer/bootstrap.sh\` and the live one-liner served`,
+                `at \`https://hal0.dev/install.sh\` have diverged, so a fresh install today`,
+                `does not run the code this repository reviewed.`,
+                ``,
+                detail,
+                ``,
+                `This issue is opened, updated, and closed automatically by`,
+                `\`.github/workflows/bootstrap-parity.yml\`.`,
+              ].join('\n'),
+            });
+            core.info(`opened issue #${created.data.number}`);

--- a/.github/workflows/mirror-bootstrap.yml
+++ b/.github/workflows/mirror-bootstrap.yml
@@ -18,6 +18,27 @@
 #   (v1.0.0) is published, and `release: published` re-runs it at that instant.
 #   Override with the `force` input only if you know the gate is stale.
 #
+# Why the gate and the publish are separate jobs (#2057):
+#   They used to be one job, and a closed gate was a `::warning::` annotation
+#   on a run that still concluded `success`. The workflow list therefore looked
+#   healthy for weeks while the served installer sat at its 2026-07-11 copy and
+#   `bootstrap-parity` went red daily. Splitting them makes the refusal a
+#   `skipped` conclusion on the `mirror` job — a distinguishable outcome in the
+#   run's job list, in `gh run view`, and in the Actions API — and the `gate`
+#   job writes what it decided, and why, into the run summary.
+#
+#   The gate is *correct* and stays. The alarm for a rotting front door is not
+#   this workflow going red; it is `bootstrap-parity` alerting on N consecutive
+#   reds (see .github/workflows/bootstrap-parity.yml).
+#
+# Rehearsing the publish path before GA (#2101 gate 4):
+#   GA day should not be the first execution of the push path. Dispatch this
+#   workflow with `gate_channel: preview` (already signed) and `dry_run: true`
+#   to run checkout → sync → `bash -n` → diff and stop short of the push. A
+#   rehearsal channel is refused outside a dry run: bootstrap.sh installs from
+#   `stable` by default, so publishing on the strength of a signed *preview*
+#   manifest would break the one-liner exactly as publishing unsigned would.
+#
 # `release: published` never actually fires for a release hal0 cuts itself:
 # release.yml creates the release via `gh release create` running under the
 # default GITHUB_TOKEN, and GitHub suppresses workflow-triggering events
@@ -38,13 +59,29 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: "Publish even if the stable manifest has no sibling Sigstore bundle"
+        description: "Publish even if the gate channel manifest has no sibling Sigstore bundle"
+        type: boolean
+        default: false
+      gate_channel:
+        description: "Channel manifest the gate probes (rehearsal only; non-stable requires dry_run)"
+        type: string
+        default: stable
+      dry_run:
+        description: "Run the whole publish path but stop before pushing to hal0-web"
         type: boolean
         default: false
   workflow_call:
     inputs:
       force:
-        description: "Publish even if the stable manifest has no sibling Sigstore bundle"
+        description: "Publish even if the gate channel manifest has no sibling Sigstore bundle"
+        type: boolean
+        default: false
+      gate_channel:
+        description: "Channel manifest the gate probes (rehearsal only; non-stable requires dry_run)"
+        type: string
+        default: stable
+      dry_run:
+        description: "Run the whole publish path but stop before pushing to hal0-web"
         type: boolean
         default: false
 
@@ -52,40 +89,135 @@ concurrency:
   group: mirror-bootstrap
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
-  mirror:
+  # ── 1. Decide, and say so out loud ──────────────────────────────────────
+  gate:
+    name: Gate the mirror on a signed channel manifest
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      publish: ${{ steps.gate.outputs.publish }}
+      outcome: ${{ steps.gate.outputs.outcome }}
+      channel: ${{ steps.gate.outputs.channel }}
+      status_code: ${{ steps.gate.outputs.status_code }}
+
+    steps:
+      # `inputs` is null for `push` and `release`, so these collapse to the
+      # documented defaults on the two automatic triggers.
+      - name: Reject a rehearsal channel outside a dry run
+        env:
+          CHANNEL: ${{ inputs.gate_channel || 'stable' }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
+        run: |
+          set -euo pipefail
+
+          case "${CHANNEL}" in
+            stable | preview | nightly) ;;
+            *)
+              echo "::error::unsupported gate_channel '${CHANNEL}' (stable|preview|nightly)"
+              exit 1
+              ;;
+          esac
+
+          # `stable` is the only channel bootstrap.sh installs from by default,
+          # so it is the only channel whose signature authorizes a real push.
+          if [[ "${CHANNEL}" != "stable" && "${DRY_RUN}" != "true" ]]; then
+            echo "::error::gate_channel '${CHANNEL}' is a rehearsal channel and requires dry_run: true. Publishing the canonical fail-closed bootstrap on the strength of a non-stable manifest would break the one-line install."
+            exit 1
+          fi
+
+      - name: Gate on a signed channel manifest
+        id: gate
+        env:
+          CHANNEL: ${{ inputs.gate_channel || 'stable' }}
+          FORCE: ${{ inputs.force || false }}
+        run: |
+          set -euo pipefail
+
+          bundle_url="https://releases.hal0.dev/${CHANNEL}.json.bundle"
+          code="$(curl -sS -o /dev/null -w '%{http_code}' -L --retry 3 --retry-delay 2 "${bundle_url}" || echo 000)"
+
+          {
+            echo "channel=${CHANNEL}"
+            echo "status_code=${code}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "${code}" = "200" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "outcome=published" >> "$GITHUB_OUTPUT"
+            echo "${bundle_url} -> 200. The ${CHANNEL} channel is signed; publishing."
+            exit 0
+          fi
+
+          if [ "${FORCE}" = "true" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "outcome=forced" >> "$GITHUB_OUTPUT"
+            echo "::warning::${bundle_url} -> ${code}, but force=true. Publishing anyway."
+            exit 0
+          fi
+
+          # Deliberately NOT a ::warning:: (#2057). The refusal is reported by
+          # the `mirror` job's `skipped` conclusion and by the run summary
+          # below; an annotation on a green run is what hid this for weeks.
+          echo "publish=false" >> "$GITHUB_OUTPUT"
+          echo "outcome=skipped" >> "$GITHUB_OUTPUT"
+          printf '::notice::%s\n' "${bundle_url} -> ${code}. The ${CHANNEL} channel is not signed yet, so publishing the canonical fail-closed bootstrap would break the one-line install. The mirror job is skipped. This gate opens by itself once a signed stable release is published."
+
+      - name: Record the gate outcome
+        if: always()
+        env:
+          OUTCOME: ${{ steps.gate.outputs.outcome }}
+          CHANNEL: ${{ steps.gate.outputs.channel }}
+          CODE: ${{ steps.gate.outputs.status_code }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
+        run: |
+          set -euo pipefail
+
+          case "${OUTCOME:-unknown}" in
+            published) headline="PUBLISHING — the ${CHANNEL} channel manifest is signed." ;;
+            forced)    headline="PUBLISHING (forced) — the gate was closed and \`force\` overrode it." ;;
+            skipped)   headline="SKIPPED — the ${CHANNEL} channel has no sibling Sigstore bundle. hal0.dev/install.sh stays at its previous copy." ;;
+            *)         headline="UNKNOWN — the gate did not complete." ;;
+          esac
+
+          {
+            echo "## mirror-bootstrap"
+            echo ""
+            echo "**Outcome: ${OUTCOME:-unknown}** — ${headline}"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Gate channel | \`${CHANNEL:-?}\` |"
+            echo "| \`${CHANNEL:-?}.json.bundle\` | HTTP \`${CODE:-?}\` |"
+            echo "| Dry run | \`${DRY_RUN}\` |"
+            echo ""
+            if [ "${OUTCOME:-}" = "skipped" ]; then
+              echo "The publish gate is working as designed — see the workflow header."
+              echo "The alarm for a stale live installer is \`bootstrap-parity\`, which"
+              echo "opens a tracking issue after N consecutive reds."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── 2. Publish (or rehearse the publish) ────────────────────────────────
+  mirror:
+    name: Mirror bootstrap.sh to hal0-web
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [gate]
+    # A closed gate leaves this job `skipped`, which is the distinguishable
+    # outcome #2057 asked for. Do not turn it into an `always()` job.
+    if: needs.gate.outputs.publish == 'true'
+
     steps:
       - name: Checkout hal0 (source)
         uses: actions/checkout@v4
         with:
           path: hal0
 
-      - name: Gate on a signed stable manifest
-        id: gate
-        env:
-          FORCE: ${{ inputs.force }}
-        run: |
-          bundle_url="https://releases.hal0.dev/stable.json.bundle"
-          code="$(curl -sS -o /dev/null -w '%{http_code}' -L --retry 3 --retry-delay 2 "${bundle_url}" || echo 000)"
-
-          if [ "${code}" = "200" ]; then
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-            echo "Stable manifest is signed (${bundle_url} → 200). Publishing."
-            exit 0
-          fi
-
-          if [ "${FORCE}" = "true" ]; then
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::${bundle_url} → ${code}, but force=true. Publishing anyway."
-            exit 0
-          fi
-
-          echo "publish=false" >> "$GITHUB_OUTPUT"
-          printf '::warning::%s\n' "${bundle_url} -> ${code}. The stable channel is not signed yet, so publishing the canonical fail-closed bootstrap would break the one-line install. Skipping. This gate opens by itself once a signed stable release is published."
-
       - name: Checkout Hal0ai/hal0-web (target)
-        if: steps.gate.outputs.publish == 'true'
         uses: actions/checkout@v4
         with:
           repository: Hal0ai/hal0-web
@@ -93,29 +225,55 @@ jobs:
           path: hal0-web
 
       - name: Sync bootstrap.sh → public/install.sh
-        if: steps.gate.outputs.publish == 'true'
         run: |
+          set -euo pipefail
           install -m 0644 hal0/installer/bootstrap.sh hal0-web/public/install.sh
           # A syntax error here is served to every new user's shell.
           bash -n hal0-web/public/install.sh
 
       - name: Commit + push
-        if: steps.gate.outputs.publish == 'true'
         working-directory: hal0-web
+        env:
+          DRY_RUN: ${{ inputs.dry_run || false }}
+          OUTCOME: ${{ needs.gate.outputs.outcome }}
+          SOURCE_SHA: ${{ github.sha }}
         run: |
+          set -euo pipefail
+
           git config user.name  "hal0-docs-mirror[bot]"
           git config user.email "hal0-docs-mirror@users.noreply.github.com"
 
           if [ -z "$(git status --porcelain public/install.sh)" ]; then
             echo "public/install.sh already matches bootstrap.sh. Nothing to push."
+            {
+              echo ""
+              echo "Mirror result: **already in sync** — no push was needed."
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          source_sha="${{ github.sha }}"
-          git add public/install.sh
-          git commit -m "chore: mirror install.sh from hal0@${source_sha:0:7}
+          git --no-pager diff --stat -- public/install.sh
 
-          Auto-synced from Hal0ai/hal0:installer/bootstrap.sh at ${source_sha}.
+          # The rehearsal exit. Everything above this line — checkout of both
+          # repos, the copy, `bash -n`, and the diff — is the real publish path.
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "::notice::dry_run=true — the publish path ran to completion; stopping before the push."
+            {
+              echo ""
+              echo "Mirror result: **dry run** — the publish path executed and stopped before \`git push\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          git add public/install.sh
+          git commit -m "chore: mirror install.sh from hal0@${SOURCE_SHA:0:7}
+
+          Auto-synced from Hal0ai/hal0:installer/bootstrap.sh at ${SOURCE_SHA}.
           See .github/workflows/mirror-bootstrap.yml in hal0."
 
           git push origin HEAD:master
+
+          {
+            echo ""
+            echo "Mirror result: **pushed** (\`${OUTCOME}\`) from hal0@\`${SOURCE_SHA:0:7}\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/stable-pointer-watch.yml
+++ b/.github/workflows/stable-pointer-watch.yml
@@ -1,0 +1,334 @@
+name: Stable pointer watch
+
+# Tagging `v1.0.0` is not the release. The tag publishes immutable assets; it
+# does not advance the `stable` channel pointer. Nothing in this repository
+# ever noticed the difference, so "GA tagged, stable channel never moved" was a
+# silent and indefinite failure mode (#2101 gate 2). This workflow makes it
+# finite: once a GA tag is older than GRACE_HOURS, the live stable manifest is
+# expected to name that version, and a mismatch fails loudly and files an
+# issue that someone owns.
+#
+# Why this is not a job inside release.yml:
+#   1. release.yml completes in minutes; the condition it would need to assert
+#      is only meaningful hours later. A job cannot outlive its run.
+#   2. release.yml's executable surface deliberately never names an external
+#      pointer system — its `authorize-pointer` job is read-only
+#      re-verification of what GitHub and PyPI already hold, and
+#      `tests/release/test_workflow_contract.py::
+#      test_global_executable_surface_has_no_external_pointer_or_mutation_markers`
+#      enforces that. Reaching out to releases.hal0.dev from the workflow that
+#      cuts the tag would erase the very boundary that test protects.
+#
+# This workflow OBSERVES the pointer. It never advances it. Advancing the
+# stable pointer is an owned human step — see "Release delivery" in
+# CONTRIBUTING.md for who does it and how it is verified.
+
+on:
+  schedule:
+    # 07:00 UTC daily, an hour after bootstrap-parity, so the two delivery
+    # checks report within the same window at the start of the day.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: stable-pointer-watch
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  watch:
+    name: Compare the newest GA tag against the live stable pointer
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      status: ${{ steps.probe.outputs.status }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+      detail: ${{ steps.probe.outputs.detail }}
+
+    steps:
+      - name: Checkout hal0 (full tag history)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve the newest GA tag
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # How long a GA tag may exist before its stable pointer is overdue.
+          # Long enough for a human to finish the runbook in one sitting;
+          # short enough that "nobody looked" is caught the next morning.
+          GRACE_HOURS: "6"
+        run: |
+          set -euo pipefail
+
+          # `ReleasePolicy.manifest_targets` is the single authority on which
+          # tags emit stable.json. Read it; do not restate it here.
+          TAG="$(git tag --list 'v*' --sort=-creatordate | PYTHONPATH=src python3 -c '
+          import sys
+
+          from hal0.release.policy import ReleasePolicy, ReleaseTagError
+
+          for line in sys.stdin:
+              tag = line.strip()
+              if not tag:
+                  continue
+              try:
+                  policy = ReleasePolicy.from_tag(tag)
+              except ReleaseTagError:
+                  continue
+              if "stable" in policy.manifest_targets and policy.kind == "stable":
+                  print(tag)
+                  break
+          ')"
+
+          if [ -z "${TAG}" ]; then
+            echo "::notice::no GA tag emits a stable manifest yet; nothing to watch."
+            {
+              echo "expected=false"
+              echo "tag="
+              echo "version="
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          VERSION="${TAG#v}"
+          echo "newest GA tag: ${TAG} (version ${VERSION})"
+
+          # The release publication time is the clock that matters — a tag can
+          # be pushed long after its commit was authored.
+          PUBLISHED_AT="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            --jq '.published_at // empty' 2>/dev/null || true)"
+          if [ -z "${PUBLISHED_AT}" ]; then
+            PUBLISHED_AT="$(git log -1 --format=%cI "${TAG}")"
+            echo "::notice::no published GitHub release for ${TAG}; using the tagged commit date ${PUBLISHED_AT}."
+          fi
+
+          AGE_HOURS="$(PUBLISHED_AT="${PUBLISHED_AT}" python3 -c '
+          import datetime as dt
+          import os
+
+          published = dt.datetime.fromisoformat(os.environ["PUBLISHED_AT"].replace("Z", "+00:00"))
+          now = dt.datetime.now(dt.timezone.utc)
+          print(f"{(now - published).total_seconds() / 3600:.2f}")
+          ')"
+          echo "release age: ${AGE_HOURS}h (grace ${GRACE_HOURS}h)"
+
+          {
+            echo "tag=${TAG}"
+            echo "version=${VERSION}"
+            echo "age_hours=${AGE_HOURS}"
+          } >> "$GITHUB_OUTPUT"
+
+          if python3 -c "import sys; sys.exit(0 if float('${AGE_HOURS}') >= float('${GRACE_HOURS}') else 1)"; then
+            echo "expected=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "expected=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::${TAG} is ${AGE_HOURS}h old, still inside the ${GRACE_HOURS}h grace window."
+          fi
+
+      - name: Probe the live stable pointer
+        id: probe
+        if: steps.resolve.outputs.expected == 'true'
+        env:
+          EXPECTED_VERSION: ${{ steps.resolve.outputs.version }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+          AGE_HOURS: ${{ steps.resolve.outputs.age_hours }}
+        run: |
+          set -uo pipefail
+
+          MANIFEST_URL="https://releases.hal0.dev/stable.json"
+          BUNDLE_URL="https://releases.hal0.dev/stable.json.bundle"
+
+          BODY="$(mktemp)"
+          MANIFEST_CODE="$(curl -sS -L --retry 3 --retry-delay 2 --max-time 30 \
+            -o "${BODY}" -w '%{http_code}' "${MANIFEST_URL}" || echo 000)"
+          BUNDLE_CODE="$(curl -sS -L --retry 3 --retry-delay 2 --max-time 30 \
+            -o /dev/null -w '%{http_code}' "${BUNDLE_URL}" || echo 000)"
+
+          SERVED_VERSION=""
+          if [ "${MANIFEST_CODE}" = "200" ]; then
+            SERVED_VERSION="$(python3 -c '
+          import json
+          import sys
+
+          try:
+              print(json.load(open(sys.argv[1])).get("version", ""))
+          except Exception:
+              print("")
+          ' "${BODY}")"
+          fi
+          rm -f "${BODY}"
+
+          echo "${MANIFEST_URL} -> ${MANIFEST_CODE} (version '${SERVED_VERSION}')"
+          echo "${BUNDLE_URL} -> ${BUNDLE_CODE}"
+
+          # bootstrap.sh is fail-closed: it authenticates the manifest against
+          # its sibling bundle before parsing it. A manifest without a bundle
+          # is not a delivered channel — it breaks every one-line install.
+          PROBLEMS=()
+          [ "${MANIFEST_CODE}" = "200" ] || PROBLEMS+=("\`stable.json\` returned HTTP ${MANIFEST_CODE}")
+          [ "${BUNDLE_CODE}" = "200" ] || PROBLEMS+=("\`stable.json.bundle\` returned HTTP ${BUNDLE_CODE}")
+          if [ "${MANIFEST_CODE}" = "200" ] && [ "${SERVED_VERSION}" != "${EXPECTED_VERSION}" ]; then
+            PROBLEMS+=("\`stable.json\` serves \`${SERVED_VERSION:-<unparseable>}\`, expected \`${EXPECTED_VERSION}\`")
+          fi
+
+          {
+            echo "## Stable pointer watch"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Newest GA tag | \`${TAG}\` (${AGE_HOURS}h old) |"
+            echo "| \`stable.json\` | HTTP ${MANIFEST_CODE}, version \`${SERVED_VERSION:-—}\` |"
+            echo "| \`stable.json.bundle\` | HTTP ${BUNDLE_CODE} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${#PROBLEMS[@]}" -eq 0 ]; then
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+            echo "detail=" >> "$GITHUB_OUTPUT"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**The stable channel points at ${TAG}.**" >> "$GITHUB_STEP_SUMMARY"
+            echo "::notice::stable channel is delivering ${TAG}."
+            exit 0
+          fi
+
+          DETAIL="$(printf '%s; ' "${PROBLEMS[@]}")"
+          DETAIL="${DETAIL%; }"
+          echo "status=stale" >> "$GITHUB_OUTPUT"
+          echo "detail=${DETAIL}" >> "$GITHUB_OUTPUT"
+          {
+            echo ""
+            echo "**The stable pointer has NOT been advanced to ${TAG}:** ${DETAIL}"
+            echo ""
+            echo "See \"Release delivery\" in CONTRIBUTING.md — advancing the stable"
+            echo "pointer is an owned step, not a consequence of tagging."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::${TAG} was published ${AGE_HOURS}h ago and the stable channel still does not deliver it: ${DETAIL}"
+          exit 1
+
+  # ── Give the overdue pointer an owner ───────────────────────────────────
+  alert:
+    name: Open/update the stable-pointer issue
+    needs: [watch]
+    if: always() && needs.watch.result != 'cancelled' && needs.watch.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Open, update, or close the stable-pointer issue
+        uses: actions/github-script@v9
+        env:
+          WATCH_STATUS: ${{ needs.watch.outputs.status }}
+          WATCH_RESULT: ${{ needs.watch.result }}
+          TAG: ${{ needs.watch.outputs.tag }}
+          DETAIL: ${{ needs.watch.outputs.detail }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Body marker, not a bespoke label: CLAUDE.md asks for the five
+            // canonical triage labels used unmodified rather than new ones.
+            const MARKER = '<!-- hal0:stable-pointer-overdue -->';
+            const labels = ['bug'];
+            const status = process.env.WATCH_STATUS || '';
+            const result = process.env.WATCH_RESULT;
+            const tag = process.env.TAG;
+            const detail = process.env.DETAIL || 'see the run log';
+            const runUrl = process.env.RUN_URL;
+            const today = new Date().toISOString().slice(0, 10);
+
+            // No probe ran (no GA tag yet, or still inside the grace window),
+            // or the job broke for an unrelated reason. Neither is evidence.
+            if (status === '') {
+              core.info(`no probe verdict (job result: ${result}); nothing to report.`);
+              return;
+            }
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const tracking = openIssues.find(
+              (issue) => !issue.pull_request && (issue.body || '').includes(MARKER),
+            );
+
+            if (status === 'ok') {
+              if (!tracking) {
+                core.info(`stable channel delivers ${tag}; nothing open.`);
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking.number,
+                body: [
+                  `The stable channel now delivers \`${tag}\` as of ${today}:`,
+                  `\`stable.json\` and \`stable.json.bundle\` both return 200 and the`,
+                  `manifest names the GA version.`,
+                  ``,
+                  `- Run: ${runUrl}`,
+                  ``,
+                  `Closing automatically.`,
+                ].join('\n'),
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking.number,
+                state: 'closed',
+              });
+              core.info(`closed issue #${tracking.number}`);
+              return;
+            }
+
+            const detailBlock = [
+              `- Newest GA tag: \`${tag}\``,
+              `- Problem: ${detail}`,
+              `- Run: ${runUrl}`,
+              ``,
+              `Tagging does not advance the channel pointer — \`release.yml\`'s`,
+              `\`authorize-pointer\` job is read-only re-verification by design. The`,
+              `advance is an owned step: see "Release delivery" in CONTRIBUTING.md.`,
+              ``,
+              `Until \`stable.json.bundle\` returns 200, \`mirror-bootstrap\` also`,
+              `refuses to publish the canonical installer, so \`hal0.dev/install.sh\``,
+              `stays stale as well (#2057).`,
+            ].join('\n');
+
+            if (tracking) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking.number,
+                body: [`Still overdue on ${today}.`, ``, detailBlock].join('\n'),
+              });
+              core.info(`updated issue #${tracking.number}`);
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `release: ${tag} is tagged but the stable channel pointer has not been advanced`,
+              labels,
+              body: [
+                MARKER,
+                `\`${tag}\` has been published longer than the grace window and the live`,
+                `stable channel still does not deliver it. Every box on the stable`,
+                `channel is therefore not being offered the GA release.`,
+                ``,
+                detailBlock,
+                ``,
+                `This issue is opened, updated, and closed automatically by`,
+                `\`.github/workflows/stable-pointer-watch.yml\`.`,
+              ].join('\n'),
+            });
+            core.info(`opened issue #${created.data.number}`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,6 +215,94 @@ tag. It walks the per-release gate:
 
 If any of these fail, fix and re-run before `git tag`.
 
+## Release delivery
+
+Tagging is not delivering. The tag publishes immutable, signed assets;
+what reaches a user is a *channel pointer* and a *live installer*, and
+both have sat stale behind a green tag before (#2057, #2101). This
+section is the post-tag half of the ritual: who owns each step, and the
+probe that says it worked.
+
+**Owner: whoever cut the tag**, until every probe below passes. It is
+not the CI system's job — `release.yml`'s `authorize-pointer` job
+(`.github/workflows/release.yml:773`) is deliberately read-only
+re-verification of what GitHub and PyPI already hold, and it mutates no
+external pointer. Nothing in this repository can advance a channel on
+your behalf.
+
+### 1. The stable pointer
+
+`releases.hal0.dev` is not a file you edit. `hal0-web`'s middleware
+resolves each channel by scanning GitHub releases for an asset of that
+name, so **publishing `stable.json` + `stable.json.bundle` as assets on
+the GA release is the pointer advance.** `release.yml` uploads exactly
+the manifests that `ReleasePolicy.manifest_targets` names
+(`src/hal0/release/policy.py:92` — a final `vX.Y.Z` emits `stable` and
+`preview`), generated at `release.yml:436`, signed at `:501`, uploaded
+at `:637`.
+
+So the *mechanism* is automatic and the *verification* is yours:
+
+```
+curl -s  https://releases.hal0.dev/stable.json | jq -r .version   # → X.Y.Z
+curl -sI https://releases.hal0.dev/stable.json.bundle             # → 200
+```
+
+Both must pass. `stable.json` alone is not a delivered channel:
+`installer/bootstrap.sh` is fail-closed and authenticates the manifest
+against its sibling bundle before parsing it, so a manifest without a
+bundle breaks every one-line install exactly as a 404 would.
+
+If the manifest 404s or serves an older version, the release did not
+emit it — check `manifest_targets` for the tag you actually cut
+(a `-rc.N` tag emits `preview` only, by design; do not widen it to make
+a probe pass) and confirm the assets are on the GitHub release.
+
+`.github/workflows/stable-pointer-watch.yml` runs these two probes daily
+and opens a tracking issue once a GA tag is more than six hours old with
+no matching pointer. It is a backstop for a forgotten release, not a
+substitute for checking on the day.
+
+### 2. The live installer
+
+`https://hal0.dev/install.sh` must become byte-identical to
+`installer/bootstrap.sh` at the GA tag. `mirror-bootstrap` publishes it,
+but only once `stable.json.bundle` returns 200 — publishing the
+canonical fail-closed script against an unsigned channel would break
+every new install, so the gate refuses until step 1 is done. It opens by
+itself: `release.yml:1137` re-arms the mirror after the release is
+verified.
+
+```
+bash scripts/check-bootstrap-parity.sh    # exit 0 = in sync
+```
+
+A closed gate shows up as a **skipped** `mirror` job, not a failure —
+read the run summary, which names the outcome. If the gate is genuinely
+stale, dispatch `mirror-bootstrap` with `force: true`.
+
+Daily drift is watched by `.github/workflows/bootstrap-parity.yml`,
+which opens one tracking issue after three consecutive reds and closes
+it when parity returns.
+
+### 3. Rehearse the mirror before GA day
+
+GA day should not be the first execution of the push path. Dispatch
+`mirror-bootstrap` with `gate_channel: preview` (already signed) and
+`dry_run: true`: it runs checkout → sync → `bash -n` → diff and stops
+short of the push. A non-`stable` gate channel is *refused* outside a
+dry run, because bootstrap.sh installs from `stable` by default.
+
+### 4. From a user's position
+
+The probes above prove the infrastructure moved. They do not prove an
+upgrade works. Before calling a release delivered, on a real box:
+
+- a fresh install using the published one-liner verbatim, on the stable
+  channel, with no `HAL0_RELEASES_URL` override and no pinned asset URL
+- `hal0 update --check` from the *previous* stable release reports the
+  new version rather than "up to date"
+
 ## E2E tests
 
 The `ui/tests/e2e/` Playwright suite covers the seven critical paths

--- a/tests/release/test_workflow_contract.py
+++ b/tests/release/test_workflow_contract.py
@@ -409,3 +409,314 @@ def test_release_tree_pins_installer_and_updater_runtime_inputs() -> None:
     assert 'cp -a ui/dist            "${STAGE}/ui/dist"' in stage
     assert '"${STAGE}/ui/package.json"' in stage
     assert '"${STAGE}/ui/node_modules"' in stage
+
+
+# ── Delivery gates: the installer mirror and the stable channel pointer ──
+#
+# Two failure modes stayed invisible for weeks (#2057, #2101 gates 2 and 4):
+#
+#   1. `mirror-bootstrap` refuses to publish while the stable channel has no
+#      sibling Sigstore bundle. That refusal was a `::warning::` on an
+#      otherwise-green run, so the workflow list looked healthy while the live
+#      one-liner rotted. The gate is correct; only its reporting was not.
+#   2. Tagging a GA release does not advance the stable channel pointer, and
+#      nothing ever noticed that it had not. `release.yml` deliberately cannot
+#      look — its `authorize-pointer` job is read-only, and its executable
+#      surface may not name an external pointer system at all (see
+#      `test_global_executable_surface_has_no_external_pointer_or_mutation_markers`).
+#      A post-tag deadline is also not something a job in the tagging run can
+#      observe: it completes in minutes and the deadline is hours out. The
+#      watch therefore lives in its own scheduled workflow.
+
+MIRROR = Path(".github/workflows/mirror-bootstrap.yml")
+PARITY = Path(".github/workflows/bootstrap-parity.yml")
+POINTER = Path(".github/workflows/stable-pointer-watch.yml")
+
+MIRROR_INPUTS = {"force", "gate_channel", "dry_run"}
+
+CANONICAL_LABELS = {
+    "bug",
+    "needs-triage",
+    "needs-info",
+    "ready-for-agent",
+    "ready-for-human",
+    "wontfix",
+}
+
+
+def _load(path: Path) -> Any:
+    return yaml.safe_load(path.read_text())
+
+
+def _on(path: Path) -> Any:
+    # PyYAML resolves a bare `on:` key to the boolean True.
+    return _load(path)[True]
+
+
+def _named_step(job: dict[str, Any], name: str) -> dict[str, Any]:
+    return next(step for step in job["steps"] if step.get("name") == name)
+
+
+def _alert_script(path: Path, job: str, step: str) -> str:
+    return _named_step(_load(path)["jobs"][job], step)["with"]["script"]
+
+
+def _script_labels(script: str) -> set[str]:
+    match = re.search(r"const labels = \[([^\]]*)\]", script)
+    assert match is not None, "alert script must declare `const labels = [...]`"
+    return {label.strip().strip("'\"") for label in match.group(1).split(",") if label.strip()}
+
+
+# ── mirror-bootstrap: the skip must be a distinguishable outcome ─────────
+
+
+def test_mirror_gate_and_publish_are_separate_jobs_so_a_skip_is_visible() -> None:
+    """A closed gate must not read as a green publish.
+
+    Splitting the probe from the publish makes the refusal show up as a
+    `skipped` job conclusion in the run's job list and in the Actions API,
+    instead of a `::warning::` annotation buried inside a successful run.
+    """
+    jobs = _load(MIRROR)["jobs"]
+    assert set(jobs) == {"gate", "mirror"}
+    assert jobs["mirror"]["needs"] == ["gate"]
+    assert "needs.gate.outputs.publish == 'true'" in jobs["mirror"]["if"]
+    for output in ("publish", "outcome", "channel", "status_code"):
+        assert output in jobs["gate"]["outputs"], output
+
+
+def test_mirror_gate_records_every_outcome_in_the_job_summary() -> None:
+    gate = _load(MIRROR)["jobs"]["gate"]
+    summary = _named_step(gate, "Record the gate outcome")["run"]
+    assert "$GITHUB_STEP_SUMMARY" in summary
+    assert "## mirror-bootstrap" in summary
+    probe = _named_step(gate, "Gate on a signed channel manifest")["run"]
+    for outcome in ("outcome=published", "outcome=forced", "outcome=skipped"):
+        assert outcome in probe, outcome
+    skip_branch = probe.split("outcome=skipped")[1]
+    assert "::warning::" not in skip_branch
+    assert "::notice::" in skip_branch
+
+
+def test_mirror_publish_gate_still_refuses_an_unsigned_stable_channel() -> None:
+    """The gate itself is correct and has to survive this change."""
+    probe = _named_step(_load(MIRROR)["jobs"]["gate"], "Gate on a signed channel manifest")["run"]
+    assert "https://releases.hal0.dev/${CHANNEL}.json.bundle" in probe
+    assert 'echo "publish=false"' in probe
+    assert 'echo "publish=true"' in probe
+
+
+def test_mirror_force_and_rehearsal_inputs_are_wired_to_both_entrypoints() -> None:
+    """GA day must not be the first execution of the publish path.
+
+    `gate_channel` lets an operator point the probe at an already-signed
+    channel (`preview`), and `dry_run` runs the whole publish path — checkout,
+    sync, `bash -n`, diff — while stopping short of the push.
+    """
+    triggers = _on(MIRROR)
+    for entrypoint in ("workflow_dispatch", "workflow_call"):
+        assert set(triggers[entrypoint]["inputs"]) == MIRROR_INPUTS, entrypoint
+        assert triggers[entrypoint]["inputs"]["gate_channel"]["default"] == "stable"
+        assert triggers[entrypoint]["inputs"]["force"]["default"] is False
+        assert triggers[entrypoint]["inputs"]["dry_run"]["default"] is False
+
+
+def test_mirror_rehearsal_channel_cannot_publish_for_real() -> None:
+    """`gate_channel: preview` proves the path works; it must never push.
+
+    bootstrap.sh installs from `stable` by default, so mirroring the canonical
+    fail-closed script on the strength of a signed *preview* manifest would
+    break the one-line install exactly as publishing against an unsigned
+    stable channel would.
+    """
+    gate = _load(MIRROR)["jobs"]["gate"]
+    guard = _named_step(gate, "Reject a rehearsal channel outside a dry run")["run"]
+    assert '"${CHANNEL}" != "stable"' in guard
+    assert '"${DRY_RUN}" != "true"' in guard
+    assert "::error::" in guard
+    assert "exit 1" in guard
+
+
+def test_mirror_dry_run_stops_before_the_push() -> None:
+    mirror = _load(MIRROR)["jobs"]["mirror"]
+    push = _named_step(mirror, "Commit + push")["run"]
+    assert '"${DRY_RUN}" == "true"' in push
+    assert "git push" in push
+    assert push.index('"${DRY_RUN}" == "true"') < push.index("git push")
+
+
+# ── bootstrap-parity: N consecutive reds must page someone ──────────────
+
+
+def test_parity_exports_its_exit_code_for_the_alerting_job() -> None:
+    parity = _load(PARITY)["jobs"]["parity"]
+    assert parity["outputs"]["rc"] == "${{ steps.parity.outputs.rc }}"
+    run = _named_step(parity, "Run bootstrap-parity check")["run"]
+    assert 'echo "rc=${rc}" >> "$GITHUB_OUTPUT"' in run
+
+
+def test_parity_alert_job_files_an_owned_issue_after_n_consecutive_reds() -> None:
+    """Watching `mirror-bootstrap` for red never fires — it goes green and
+    skips. The daily parity red is the signal that actually tracks the live
+    installer rotting, so that is the one that has to grow an owner.
+    """
+    alert = _load(PARITY)["jobs"]["alert"]
+    assert alert["needs"] == ["parity"]
+    assert "always()" in alert["if"]
+    assert alert["permissions"]["issues"] == "write"
+    assert alert["permissions"]["contents"] == "read"
+    step = _named_step(alert, "Open, update, or close the parity tracking issue")
+    assert step["uses"] == "actions/github-script@v9"
+    assert step["env"]["ALERT_STREAK"] == "3"
+    script = step["with"]["script"]
+    assert "MARKER" in script
+    assert "issues.createComment" in script
+    assert "issues.create" in script
+    assert "state: 'closed'" in script
+
+
+def test_parity_alert_never_counts_an_operational_error_as_drift() -> None:
+    """exit 2 is a fetch failure, not drift (scripts/check-bootstrap-parity.sh
+    exit-code contract). Counting it would page the installer team for a
+    transient Cloudflare blip."""
+    script = _alert_script(PARITY, "alert", "Open, update, or close the parity tracking issue")
+    assert "rc === 2" in script
+    assert "conclusion === 'failure'" in script
+
+
+def test_parity_alert_does_not_read_a_missing_exit_code_as_green() -> None:
+    """If the parity job dies before running the check, `outputs.rc` is the
+    empty string — and `Number('')` is 0, the *success* code. Parsing it
+    naively would close a live drift issue on the strength of a bad checkout,
+    which is the exact class of silent failure this whole change is about."""
+    script = _alert_script(PARITY, "alert", "Open, update, or close the parity tracking issue")
+    assert "rawRc === '' ? NaN" in script
+    assert "Number.isNaN(rc)" in script
+    # ...and the naive parse must not survive anywhere in the script.
+    assert "Number(process.env.PARITY_RC)" not in script
+
+
+def test_parity_alert_uses_only_canonical_labels() -> None:
+    """CLAUDE.md: use the canonical labels unmodified rather than inventing new
+    ones. The tracking issue is located by a body marker, not a bespoke label."""
+    script = _alert_script(PARITY, "alert", "Open, update, or close the parity tracking issue")
+    assert _script_labels(script) <= CANONICAL_LABELS
+
+
+# ── stable-pointer-watch: a GA tag with no pointer must not stay silent ──
+
+
+def test_pointer_watch_runs_on_a_schedule_and_on_demand() -> None:
+    triggers = _on(POINTER)
+    assert set(triggers) == {"schedule", "workflow_dispatch"}
+    assert triggers["schedule"][0]["cron"]
+
+
+def test_pointer_watch_derives_the_expected_channel_from_release_policy() -> None:
+    """`ReleasePolicy.manifest_targets` is the authority on which tags emit
+    stable.json. The watch reads it; it does not restate it."""
+    resolve = _named_step(_load(POINTER)["jobs"]["watch"], "Resolve the newest GA tag")["run"]
+    assert "hal0.release.policy" in resolve
+    assert "manifest_targets" in resolve
+    assert '"stable" in' in resolve
+
+
+def test_pointer_watch_probes_both_the_manifest_and_its_sibling_bundle() -> None:
+    """`stable.json` alone is not delivery: bootstrap.sh is fail-closed and
+    authenticates the manifest against `stable.json.bundle` before parsing it,
+    so a manifest without a bundle still breaks every one-line install."""
+    probe = _named_step(_load(POINTER)["jobs"]["watch"], "Probe the live stable pointer")["run"]
+    assert "https://releases.hal0.dev/stable.json" in probe
+    assert "https://releases.hal0.dev/stable.json.bundle" in probe
+    assert "EXPECTED_VERSION" in probe
+    assert "::error::" in probe
+
+
+def test_pointer_watch_grace_window_is_explicit_and_bounded() -> None:
+    """'Silent and indefinite' is the defect. A named grace window makes the
+    wait finite, rather than nobody ever looking."""
+    resolve = _named_step(_load(POINTER)["jobs"]["watch"], "Resolve the newest GA tag")
+    assert resolve["env"]["GRACE_HOURS"] == "6"
+    assert "GRACE_HOURS" in resolve["run"]
+
+
+def test_pointer_watch_failure_has_an_owner_not_just_a_red_run() -> None:
+    alert = _load(POINTER)["jobs"]["alert"]
+    assert alert["needs"] == ["watch"]
+    assert "always()" in alert["if"]
+    assert alert["permissions"]["issues"] == "write"
+    step = _named_step(alert, "Open, update, or close the stable-pointer issue")
+    assert step["uses"] == "actions/github-script@v9"
+    script = step["with"]["script"]
+    assert "MARKER" in script
+    assert "issues.create" in script
+    assert "state: 'closed'" in script
+    assert _script_labels(script) <= CANONICAL_LABELS
+
+
+def test_pointer_watch_observes_the_pointer_and_never_advances_it() -> None:
+    """Advancing the stable pointer stays an owned human step in the runbook
+    (CONTRIBUTING.md, "Release delivery"). This workflow only observes it."""
+    workflow = _load(POINTER)
+    assert workflow["permissions"] == {"contents": "read"}
+    surface = "\n".join(value for _, value in _executable_scalars(workflow)).lower()
+    for marker in (
+        r"\bcloudflare\b",
+        r"\bwrangler\b",
+        r"\b(?:aws\s+s3|gsutil|rclone)\b",
+        r"\bgh release (?:create|upload|edit|delete)\b",
+        r"\bgit push\b",
+        r"\bcurl -x\b",
+    ):
+        assert re.search(marker, surface) is None, marker
+
+
+# ── the runbook step itself (#2101 gate 2) ──────────────────────────────
+
+
+def test_release_delivery_runbook_names_an_owner_and_both_probes() -> None:
+    """#2101 gate 2: "Runbook states who performs the pointer advance and how
+    it is verified." A runbook that names neither is decoration, so the two
+    load-bearing facts are pinned here.
+
+    The runbook lives in CONTRIBUTING.md rather than docs/operate/: everything
+    under the five published `docs/` sections is auto-synced to the public
+    forum by sync-docs-discourse.yml, and #2116 deliberately moved
+    operator-internal material out of the published tree.
+    """
+    runbook = Path("CONTRIBUTING.md").read_text()
+    assert "## Release delivery" in runbook
+    section = runbook.split("## Release delivery", 1)[1].split("\n## ", 1)[0]
+
+    # Who.
+    assert "Owner: whoever cut the tag" in section
+    assert "authorize-pointer" in section and "read-only" in section
+
+    # How it is verified — both halves, because a manifest without its
+    # sibling bundle still breaks every fail-closed one-line install.
+    assert "https://releases.hal0.dev/stable.json" in section
+    assert "https://releases.hal0.dev/stable.json.bundle" in section
+    assert "scripts/check-bootstrap-parity.sh" in section
+
+    # The automated backstops point back at the owned step, not away from it.
+    assert "stable-pointer-watch.yml" in section
+    assert "bootstrap-parity.yml" in section
+
+    # And the pre-GA rehearsal of the publish path (#2101 gate 4).
+    assert "gate_channel: preview" in section
+    assert "dry_run: true" in section
+
+
+def test_runbook_does_not_widen_which_tags_emit_a_stable_manifest() -> None:
+    """`ReleasePolicy.manifest_targets` stays the one authority. A runbook that
+    told an operator to hand-publish `stable.json` for an rc would route around
+    it, so the section says the opposite in as many words."""
+    from hal0.release.policy import ReleasePolicy
+
+    assert ReleasePolicy.from_tag("v1.0.0").manifest_targets == ("stable", "preview")
+    assert ReleasePolicy.from_tag("v1.0.0-rc.1").manifest_targets == ("preview",)
+
+    section = (
+        Path("CONTRIBUTING.md").read_text().split("## Release delivery", 1)[1].split("\n## ", 1)[0]
+    )
+    assert "do not widen it" in section


### PR DESCRIPTION
Release-gating observability for the two delivery failures behind the 1.0 gate. Both were **silent, not broken** — the mechanisms worked, nothing watched them, and the one obvious watch could never fire.

> ⚠️ **This PR changes CI workflow files and needs a human merge.** Workflow edits are not exercised by PR checks on the PR itself; `bootstrap-parity`, `stable-pointer-watch`, and the `mirror-bootstrap` job split only run from `main`.

## Measured state at time of writing (2026-08-30)

Worth recording, because the world moved between the issues being filed and this branch: **the root unblock resolved itself at the GA cut, exactly as the gate design predicted.**

| Probe | Result |
|---|---|
| `releases.hal0.dev/stable.json` | 200, version **1.0.0** |
| `releases.hal0.dev/stable.json.bundle` | **200** |
| `hal0.dev/install.sh` | 28,438 bytes — byte-identical to `installer/bootstrap.sh` |
| `scripts/check-bootstrap-parity.sh` | exit 0 |
| `bootstrap-parity` daily run | **green** 2026-08-30 11:28 UTC, after 14 consecutive reds |
| v1.0.0 release assets | include `stable.json` + `stable.json.bundle` |
| Release run 33282658574 → `Re-arm mirror-bootstrap / mirror` | success |

So `v1.0.0` (published 2026-08-30T00:10:39Z) emitted the signed stable manifest, the mirror gate opened by itself, and the installer published. No operator action was needed for the unblock. What was still missing is everything this PR adds: the part that *notices* next time.

## #2057 — the observability half

The issue body's diagnosis ("mirror-bootstrap has not fired") is wrong and its own correction comment says so. `mirror-bootstrap` fires; it declines to publish while `stable.json.bundle` 404s, because `installer/bootstrap.sh` is fail-closed and authenticates the manifest against that sibling bundle before parsing it. **That gate is correct and is unchanged here.** The defect was that the refusal was a `::warning::` on a run that still concluded `success` — so "alert when mirror-bootstrap fails" was never going to fire, and the workflow list looked healthy while the front door rotted.

**`mirror-bootstrap.yml` — the skip becomes a distinguishable outcome.** Split into `gate` and `mirror` jobs. A closed gate now leaves `mirror` **`skipped`** — a real conclusion in the job list, in `gh run view`, and in the Actions API — and `gate` writes the outcome (`published` / `forced` / `skipped`), the channel, and the HTTP code into the run summary. The closed-gate branch emits `::notice::`, not `::warning::`.

**`bootstrap-parity.yml` — the alarm moves to where a signal exists.** The daily parity red is the only thing that actually tracks the live installer rotting, so that is what grows an owner: an `alert` job opens **one** tracking issue after three consecutive reds, comments on each further red, and **closes it when parity returns**. `exit 2` (fetch failure) is explicitly not counted as drift, per the script's exit-code contract. Located by a body marker rather than a bespoke label, per CLAUDE.md's canonical-label rule.

**The `force` path is exercisable before GA day.** `mirror-bootstrap` gains `gate_channel` and `dry_run` inputs on both `workflow_dispatch` and `workflow_call`. `gate_channel: preview` + `dry_run: true` runs checkout → sync → `bash -n` → diff and stops short of the push. A non-`stable` gate channel is **refused** outside a dry run, since `bootstrap.sh` installs from `stable` by default — a signed *preview* manifest does not authorize publishing the canonical script.

`installer/bootstrap.sh` is untouched: it is the parity source of truth, not the thing to edit to close the diff.

## #2101 — Gate 2

Gate 1's pagination fix (hal0-web `a5af7db`) is not touched.

**The runbook step.** `CONTRIBUTING.md` grows a `## Release delivery` section — the post-tag half of the ritual it never had. It names the **owner** (whoever cut the tag, until every probe passes), states that the pointer advance *is* publishing `stable.json` + `stable.json.bundle` on the GA release, and gives both acceptance probes. It explicitly says not to widen `manifest_targets` to make a probe pass.

*Placement note:* the task suggested `docs/operate/`. Everything under the five published `docs/` sections is auto-synced to the public Discourse forum by `sync-docs-discourse.yml` (`scripts/docs_discourse_sync/discovery.py:27,192` — no manifest, a new `.mdx` publishes itself), and #2116 deliberately moved operator-internal material *out* of the published tree. Maintainer release mechanics belong next to the pre-tag ritual in `CONTRIBUTING.md`.

**The post-release check.** New `.github/workflows/stable-pointer-watch.yml`: daily + dispatch. Resolves the newest GA tag *through* `ReleasePolicy.manifest_targets` (read, not restated — an `-rc.N` tag emits `preview` only and is correctly ignored), and once that tag is older than `GRACE_HOURS: 6`, requires `stable.json` to return 200 naming that version **and** `stable.json.bundle` to return 200. The manifest alone is not a delivered channel. A mismatch fails loudly and files/updates/closes a tracking issue.

*Placement note:* the task suggested putting this in `release.yml`. It cannot go there, for two independent reasons:

1. `release.yml` finishes in minutes; the condition is only meaningful hours later. A job cannot outlive its run.
2. `release.yml`'s executable surface may not name an external pointer system at all — `test_global_executable_surface_has_no_external_pointer_or_mutation_markers` enforces exactly that, and weakening an anti-scar guard to add a read that cannot work inline would be the wrong trade.

`authorize-pointer` stays read-only and untouched. The new workflow observes; it never advances — pinned by a test asserting `permissions: {contents: read}` and no push/mutation verbs anywhere in its executable surface.

## Still open, tracked not vendored

- `hal0-web:functions/_middleware.ts` static-backstop fallthrough (#2101 Gate 1) — out of tree.
- Gate 3 (0.9.8 → 1.0.0 rehearsal) and Gate 5 (fresh install from the published one-liner) are box work, not repo work.

`Part of #2057` rather than `Closes` — the in-repo half is complete, but the acceptance line "the failure mode has an owner" is only proven once `bootstrap-parity`'s `alert` job runs from `main`.

## Verification

- `tests/release/` — **135 passed**, including 18 new contract tests
- `actionlint` 1.7.12 **+ shellcheck** 0.10.0 — clean on all three workflows
- `node --check` on both `github-script` bodies; `bash -n` on every `run:` block
- `stable-pointer-watch`'s probe step executed against production in both directions: exit 0 at `v1.0.0`, exit 1 with the right diagnostic on a forced version mismatch
- `ruff check` + `ruff format --check` clean on the touched test file
- The 60 `tests/installer/test_bootstrap_contract.py` failures on the dev machine are the pre-existing Darwin gate in `bootstrap.sh` (`hal0 only supports Linux right now`) and are **identical with and without this change** (60 failed / 6 passed, verified by stashing)

### One bug found while writing it

The alert script's first draft parsed `needs.parity.outputs.rc` with `Number()`. If the parity job dies *before* the check runs, that output is the empty string — and `Number('')` is `0`, the **success** code. It would have closed a live drift issue on the strength of a bad checkout: the same class of silent failure this whole PR is about. Guarded, and pinned by `test_parity_alert_does_not_read_a_missing_exit_code_as_green`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcGmVXzvn28MJhtZwGd5f3
