### PR TITLE
fix(install): bind the default brain model into an unbound slot on upgrade (#2131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,21 +26,33 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Fixed
 
-- **The brain slot is now verified bound, not assumed bound** (#2131). The
-  documented 0.9.8 → 1.0.0 upgrade downloaded the default brain model, left
+- **The 0.9.8 → 1.0.0 upgrade no longer blanks the brain model it just bound**
+  (#2131). The documented upgrade path downloaded the default brain model, left
   `/etc/hal0/slots/brain.toml` with a `[model]` table naming nothing, and ended
   at `Verify FAILED: structured-output probe failed` — with no hint that one
-  `hal0 slot edit brain --model <id>` recovered the box. The activation write
-  is best-effort by design (`_activate_slot_model` suppresses every exception
-  so a config rewrite can never abort a pull), so a write that never landed was
-  indistinguishable from one that did: the installer printed
-  `brain model ready: … bound to the 'brain' slot` and exited 0 either way.
-  `hal0.install.brain_model` now reads the slot back: an existing-but-UNBOUND
-  `[model]` table is the shipped seed state and gets the default bound into it,
-  a NON-EMPTY `[model].default` is an operator pick and is never touched (a
-  re-run can no longer revert one), and a binding that genuinely cannot be made
-  is reported with the exact remediation command instead of reported as
-  success. Still never fatal — the install continues. A failed
+  `hal0 slot edit brain --model <id>` recovered the box. The binding was not
+  missing, it was **reverted**: v0.9.8's installer ran `hal0 setup --auto`
+  before its curated seed loop, so every stable box carries the generic
+  scaffold's `enabled = false` beside a model-less `[model]` table; install.sh
+  bound the freshly pulled default into it, and the `SlotConfig.enabled` sweep
+  — which ran *after* the brain step — read `enabled = false` next to a bound
+  model and cleared it, exactly as that migration is designed to. The same
+  sweep runs at every `hal0-api` boot, so even a hand-repaired box lost the
+  binding again on the next restart. install.sh now runs that sweep **before**
+  the brain model step, which hits the migration's own "no model bound, just
+  drop the stale key" branch; the binding then survives every later boot sweep.
+  A slot an operator deliberately disabled (`enabled = false` *with* a model
+  bound) still has its model cleared, as before.
+- **The brain binding is now verified rather than assumed** (#2131). The
+  activation write is best-effort by design (`_activate_slot_model` suppresses
+  every exception so a config rewrite can never abort a pull), so the installer
+  printed `brain model ready: … bound to the 'brain' slot` and exited 0 whether
+  or not the write landed. `hal0.install.brain_model` now reads the slot back:
+  an existing-but-UNBOUND `[model]` table is the shipped seed state and gets
+  the default bound into it, a NON-EMPTY `[model].default` is an operator pick
+  and is never touched (a re-run can no longer revert one), and a binding that
+  cannot be made is reported with the exact remediation command instead of
+  reported as success. Still never fatal — the install continues. A failed
   structured-output probe now also names an unbound brain slot when that is the
   actual shape on disk.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Fixed
+
+- **The brain slot is now verified bound, not assumed bound** (#2131). The
+  documented 0.9.8 → 1.0.0 upgrade downloaded the default brain model, left
+  `/etc/hal0/slots/brain.toml` with a `[model]` table naming nothing, and ended
+  at `Verify FAILED: structured-output probe failed` — with no hint that one
+  `hal0 slot edit brain --model <id>` recovered the box. The activation write
+  is best-effort by design (`_activate_slot_model` suppresses every exception
+  so a config rewrite can never abort a pull), so a write that never landed was
+  indistinguishable from one that did: the installer printed
+  `brain model ready: … bound to the 'brain' slot` and exited 0 either way.
+  `hal0.install.brain_model` now reads the slot back: an existing-but-UNBOUND
+  `[model]` table is the shipped seed state and gets the default bound into it,
+  a NON-EMPTY `[model].default` is an operator pick and is never touched (a
+  re-run can no longer revert one), and a binding that genuinely cannot be made
+  is reported with the exact remediation command instead of reported as
+  success. Still never fatal — the install continues. A failed
+  structured-output probe now also names an unbound brain slot when that is the
+  actual shape on disk.
+
 ### Changed
 
 - **Removed** the `vulkanfpx` runner key — there was never a vulkanFPX

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -3278,6 +3278,22 @@ run_post_install_smoke() {
         SMOKE_FAILED+=("structured-output")
         warn "structured-output probe FAILED — a json_object request via the gateway (:${HAL0_PORT}/v1) did not return parseable JSON"
         warn "  extraction/structured-output consumers are likely broken even if plain chat works — check 'hal0 status' for a loaded model, then 'journalctl -u hal0-api -n 40'"
+        # #2131: on an upgraded box the commonest cause is a brain slot the
+        # seeding pass downloaded a model for but never bound — the gateway
+        # then has nothing to answer with, and a bare probe failure reads like
+        # a runner bug. `--check-binding` prints the exact fix, and prints
+        # NOTHING when the slot is bound (or when the venv/daemon can't be
+        # reached), so a fresh-install failure reads exactly as before.
+        # `${VENV_DIR:-}` + the -x test, not a bare expansion: this block runs
+        # under `set -euo pipefail`, where an unbound VENV_DIR would abort the
+        # install from inside a diagnostic.
+        _brain_hint=""
+        if [[ -n "${VENV_DIR:-}" && -x "${VENV_DIR}/bin/python" ]]; then
+            _brain_hint="$("${VENV_DIR}/bin/python" -m hal0.install.brain_model --check-binding 2>/dev/null || true)"
+        fi
+        if [[ -n "${_brain_hint}" ]]; then
+            warn "  ${_brain_hint}"
+        fi
     fi
     if smoke_update_check; then
         info "update-check probe ok ('hal0 update --check' exits cleanly)"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2166,14 +2166,26 @@ ui_step "Container slot seeds"
 # that touches installer/.
 #
 # ORDERING IS LOAD-BEARING (v1.0). This loop MUST run BEFORE the first-run
-# scaffold pass below. It used to run after it, and the two then fought:
-# the scaffold wrote a generic model-less `agent`/`brain` toml (with a
-# derived profile like plain "vulkan"), and this loop's `[[ -f ]]` guard
-# then said "exists — left alone" and silently discarded the CURATED seeds.
-# Net effect on every fresh box: agent.toml never got `profile =
-# "chadrock-moe"` and brain.toml never got `profile = "brain"` or its
-# `[model].default`. Seeding first inverts it correctly with no special
-# case — `build_auto_selections` already skips any slot whose config exists
+# scaffold pass below. It used to run after it (v0.9.8 install.sh:1249 ran
+# `hal0 setup --auto` at :1249 and reached this loop only at :1487), and the
+# two then fought: the scaffold wrote a generic model-less `agent`/`brain`
+# toml — `_build_slot_cfg`, which in v0.9.8 also stamped `enabled = false` —
+# and this loop's `[[ -f ]]` guard then said "exists — left alone" and
+# silently discarded the CURATED seeds. Net effect on every box installed
+# that way: agent.toml never got `profile = "chadrock-moe"`, and brain.toml
+# never got `profile = "brain"` — it kept the scaffold's derived profile
+# (plain "vulkan") and the scaffold's `enabled = false`.
+#
+# That is still the shape every stable-channel box carries into a 1.0
+# upgrade, and it is why the `enabled` sweep has to run before the brain
+# model step (#2131 — see the ordering note at that call site). The seeds
+# themselves no longer pin a `[model].default` at all: the brain's is stamped
+# by the installer only once the bytes land (installer/etc-hal0/slots/
+# brain.toml, "WHO SETS [model].default"), so a missing default is no longer
+# part of what this ordering protects.
+#
+# Seeding first inverts it correctly with no special case —
+# `build_auto_selections` already skips any slot whose config exists
 # (`existing_slots`, setup_command.py), so the scaffold pass sees the
 # curated files and leaves them alone, while still scaffolding the slots
 # that have NO static seed (e.g. `vision`).
@@ -2310,10 +2322,87 @@ else
         || warn "first-run seeding failed — slots can still be created from the dashboard; see the output above"
 fi
 
+# ── SlotConfig.enabled sweep (#1369) ──────────────────────────────────────────
+# `enabled` is gone — a non-empty [model].default IS the activation signal — and
+# `enabled = false` alongside a bound model would silently switch a deliberately
+# disabled slot back ON, so for that shape the sweep clears the model instead.
+# The identical idempotent sweep runs at hal0-api boot, but only into
+# `journalctl -u hal0-api`, which nobody watching an install ever sees. Run it
+# here so the result lands in the install transcript.
+#
+# ORDERING IS LOAD-BEARING (#2131). This MUST run BEFORE the brain model step
+# below. It used to run with the config-convergence migrations further down,
+# and on every 0.9.8 upgrade the two fought:
+#
+#   * v0.9.8's install.sh ran `hal0 setup --auto` (:1249) BEFORE its seed loop
+#     (:1487), so the generic scaffold won and the curated brain seed was
+#     skipped as "already present". `_build_slot_cfg(..., enabled=False)` wrote
+#     the shape every stable box therefore carries: `enabled = false` with a
+#     model-less `[model]` table.
+#   * the brain step below then bound the freshly pulled default into it, and
+#     THIS sweep — reading `enabled = false` next to a now-bound model — did
+#     exactly what it is designed to do and cleared the model again. The box
+#     ended the install with the 2.87 GB on disk and a model-less brain slot.
+#
+# Sweeping first restores the migration's OWN semantics for that shape: a
+# `enabled = false` slot with no model bound "already said off with both
+# signals", so the sweep drops the stale key and touches nothing else. The
+# brain step then binds into a clean slot, and every later boot-time sweep
+# (hal0.api._boot_slot_reconcile) finds no `enabled` key and no-ops, so the
+# binding is stable rather than reverted on the next restart.
+#
+# A slot an operator DELIBERATELY disabled (`enabled = false` WITH a model
+# bound) still has its model cleared here, exactly as before — that is the
+# deactivation the migration exists to carry forward. For the brain slot
+# specifically that then reads as model-less, which the step below re-binds:
+# the steward is not a normal user slot (it must work out of the box), and
+# re-running install.sh has re-bound a model-less brain since v1.0.0 anyway.
+#
+# This file runs under `set -euo pipefail` (:17), so a bare heredoc aborts the
+# WHOLE install on any raise — before start_or_restart_api is ever reached.
+# hal0_migration_step contains that: report the failure, keep going, let the
+# service start (`if ! cmd` also suppresses `set -e` for the call itself).
+# Defined HERE rather than with the other convergence steps further down
+# because the sweep below is the first migration step in the script (#2131);
+# the rest of the rationale lives at the "config-convergence migrations"
+# banner. Every heredoc-fed migration in this file must go through it —
+# tests/installer/test_migration_step_containment.py pins that.
+hal0_migration_step() {
+    # $1 = human label for the warning; python source arrives on stdin.
+    local label="$1"
+    if "${VENV_DIR}/bin/python" -; then
+        return 0
+    fi
+    warn "${label}: migration step failed — continuing with the install"
+    warn "  this is non-fatal; hal0-api still starts. Re-run 'sudo bash install.sh'"
+    warn "  after fixing the reported problem, or check 'journalctl -u hal0-api'."
+    return 0
+}
+
+if [[ "${DEV_MODE}" -eq 1 ]]; then
+    info "dev mode — skipping slot 'enabled' sweep (no system writes)"
+else
+    hal0_migration_step "slot 'enabled' key sweep" <<'PYEOF'
+from hal0.updater.updater import sweep_slot_enabled_keys
+swept = sweep_slot_enabled_keys()
+if swept:
+    print(f"  swept the removed 'enabled' key off {len(swept)} slot(s): {', '.join(swept)}")
+    print("    (a slot that was 'enabled = false' WITH a bound model is now model-less,")
+    print("     which is how 'off' is expressed in v1.0 — re-bind a model to turn it on)")
+else:
+    print("  no slot carries the removed 'enabled' key")
+PYEOF
+fi
+
 # ── hal0 brain model (v1.0) ─────────────────────────────────────────────────
 # The brain is the platform steward: the dashboard's sidebar chat targets the
 # virtual model `hal0/brain`, so unlike every other slot it must WORK out of
 # the box rather than ship as a grey model-less tile. Pull its weights here.
+#
+# The `enabled` sweep immediately above is a PREREQUISITE, not a neighbour:
+# binding a model into a slot that still carries a stale `enabled = false` is
+# undone by the next sweep, whether that is the one in this script or the one
+# hal0-api runs at every boot (#2131).
 #
 # Fail-soft by construction (ruling: never hard-fail an install over an
 # optional model pull) — no network, no disk, an unsupported device or a
@@ -2672,19 +2761,14 @@ fi
 #
 # Updater.commit() already wraps the identical calls in try/except-and-warn.
 # hal0_migration_step gives install.sh the same posture: report the failure,
-# keep going, let the service start. `if ! cmd` also suppresses `set -e` for the
-# call itself.
-hal0_migration_step() {
-    # $1 = human label for the warning; python source arrives on stdin.
-    local label="$1"
-    if "${VENV_DIR}/bin/python" -; then
-        return 0
-    fi
-    warn "${label}: migration step failed — continuing with the install"
-    warn "  this is non-fatal; hal0-api still starts. Re-run 'sudo bash install.sh'"
-    warn "  after fixing the reported problem, or check 'journalctl -u hal0-api'."
-    return 0
-}
+# keep going, let the service start.
+#
+# The helper itself is DEFINED EARLIER — just above the "Steward + agent
+# models" step — because the SlotConfig.enabled sweep has to run before the
+# brain model is bound (#2131) and needs the same containment. Every migration
+# heredoc in this file, there and here, goes through it; a stdin-fed python
+# invocation may appear exactly once in the whole script, inside the helper
+# body (tests/installer/test_migration_step_containment.py enforces that).
 
 # ── profile catalog: one-shot v1.0 reset ──────────────────────────────────────
 # v1.0 makes profiles tuning-only. A pre-v1.0 /etc/hal0/profiles.toml can hold
@@ -2821,26 +2905,10 @@ print("  seed-profile / stale-MTP / vulkan-slot / runner-image / extra-args clea
 PYEOF
 fi
 
-# ── SlotConfig.enabled sweep (#1369) ──────────────────────────────────────────
-# `enabled` is gone — a non-empty [model].default IS the activation signal — and
-# `enabled = false` alongside a bound model would silently switch a deliberately
-# disabled slot back ON. The identical idempotent sweep runs at hal0-api boot,
-# but only into `journalctl -u hal0-api`, which nobody watching an install ever
-# sees. Run it here so the result lands in the install transcript.
-if [[ "${DEV_MODE}" -eq 1 ]]; then
-    info "dev mode — skipping slot 'enabled' sweep (no system writes)"
-else
-    hal0_migration_step "slot 'enabled' key sweep" <<'PYEOF'
-from hal0.updater.updater import sweep_slot_enabled_keys
-swept = sweep_slot_enabled_keys()
-if swept:
-    print(f"  swept the removed 'enabled' key off {len(swept)} slot(s): {', '.join(swept)}")
-    print("    (a slot that was 'enabled = false' WITH a bound model is now model-less,")
-    print("     which is how 'off' is expressed in v1.0 — re-bind a model to turn it on)")
-else:
-    print("  no slot carries the removed 'enabled' key")
-PYEOF
-fi
+# The SlotConfig.enabled sweep (#1369) used to live HERE. It now runs in the
+# "Hardware probe" step, BEFORE the brain model is pulled and bound — see the
+# ordering note at that call site (#2131). Running it after the brain step is
+# what blanked the freshly bound brain model on every 0.9.8 upgrade.
 
 # Stale former-default runner-image pins and hal0-managed flags in model
 # defaults.extra_args (parity with Updater.commit() steps 7d/7e) are handled

--- a/src/hal0/install/brain_model.py
+++ b/src/hal0/install/brain_model.py
@@ -6,7 +6,7 @@ WORK out of the box instead of shipping as a grey model-less tile. This module
 is what makes that true — ``installer/install.sh`` runs it as
 ``python -m hal0.install.brain_model`` right after the first-run seeding step.
 
-Four properties are deliberate:
+Five properties are deliberate:
 
 **Never fatal.** No network, no disk, an unreadable ``hardware.json``, a
 missing curated entry — every failure path returns a non-zero exit code with a
@@ -36,6 +36,25 @@ already-on-disk short circuit — ``run_pull``/``_download_one`` stream from HF
 unconditionally, and a COMPLETED pull leaves no ``.part`` for the resume path
 to reuse. :func:`already_pulled` is the guard that stops a re-run from
 re-downloading gigabytes it already has.
+
+**An unbound ``[model]`` table is not operator config (#2131).** The activation
+gate above is *best-effort by construction*:
+:func:`~hal0.install.orchestrate._activate_slot_model` wraps its write in
+``contextlib.suppress(Exception)`` so a config-rewrite failure can never abort
+the pull driver. That is right for the driver and wrong for this module — a
+swallowed write left the brain slot MODEL-LESS while this module still printed
+"brain model ready" and exited 0, so install.sh had no signal, and the
+documented 0.9.8 → 1.0.0 path ended at "Verify FAILED: structured-output probe
+failed" with the 2.87 GB already on disk and nothing pointing at the cause.
+:func:`bind_brain_model` closes that: it reads the slot back and, when the
+``[model]`` table exists but names nothing, binds the default into it — a
+model-less slot is the shipped seed state (``installer/etc-hal0/slots/
+brain.toml`` ships no ``[model].default``), not a pick to protect. The guard is
+the other half of the rule: a NON-EMPTY ``[model].default`` is an operator pick
+and is never touched, even when it names something other than the default. When
+the binding genuinely cannot be made the failure is now *reported* (warning +
+exit 1 + the exact remediation command) instead of being reported as success —
+still never fatal, exactly as ruling 7 requires.
 """
 
 from __future__ import annotations
@@ -190,6 +209,112 @@ def already_pulled(model_id: str, *, capability: str = "chat") -> Path | None:
     return dest
 
 
+def remediation_command(model_id: str = BRAIN_MODEL_DEFAULT) -> str:
+    """The two commands that bind + start the brain slot by hand.
+
+    Verbatim from the #2131 report, where they were verified to recover the
+    box. Printed by :func:`main` when the seeding pass could not land the
+    binding itself, and by ``--check-binding`` when the installer's
+    structured-output probe fails with the model on disk but unbound — a bare
+    probe failure gave the operator no lead at all.
+    """
+    return (
+        f"hal0 slot edit {BRAIN_SLOT_NAME} --model {model_id} && hal0 slot load {BRAIN_SLOT_NAME}"
+    )
+
+
+async def current_brain_binding(slot_manager) -> str | None:
+    """What the brain slot's ``[model].default`` names right now.
+
+    Three outcomes, and the difference between the last two is the whole
+    point:
+
+      * a non-empty id — an operator pick (or a binding we already made),
+        which :func:`bind_brain_model` must not overwrite;
+      * ``""`` — the slot is readable and UNBOUND. That is the shipped seed
+        state, not a pick, so the default may be bound into it;
+      * ``None`` — the slot could not be read at all (no such slot, an
+        unreadable TOML, a slot manager with no read surface). "Unknown" is
+        deliberately not folded into "unbound": a caller must not treat an
+        unreadable slot as proof that a write failed to land.
+
+    Never raises — this is a read taken during an optional install step.
+    """
+    getter = getattr(slot_manager, "get_config", None)
+    if getter is None:
+        return None
+    try:
+        cfg = await getter(BRAIN_SLOT_NAME)
+    except Exception as exc:
+        log.info("install.brain_binding_unreadable slot=%s err=%s", BRAIN_SLOT_NAME, exc)
+        return None
+    try:
+        from hal0.slots._cfg_helpers import _model_default
+
+        return _model_default(cfg)
+    except Exception as exc:  # pragma: no cover — defensive
+        log.info("install.brain_binding_unparseable slot=%s err=%s", BRAIN_SLOT_NAME, exc)
+        return None
+
+
+async def bind_brain_model(slot_manager, model_id: str, *, already_stamped: bool = False) -> str:
+    """Ensure the brain slot names a model. Returns the id it names afterwards.
+
+    ``""`` means the slot is still model-less — the caller turns that into a
+    warning with :func:`remediation_command`, never into a failed install.
+
+    The semantics (#2131):
+
+      * a NON-EMPTY existing ``[model].default`` is operator config and wins,
+        even when it names something other than *model_id*. Nothing is
+        written, so a re-run of install.sh can never revert an operator's pick;
+      * an existing-but-EMPTY (or absent) ``[model].default`` is not a pick at
+        all — the seed ships model-less on purpose (#1369) — so *model_id* is
+        bound into it. This is the upgrade case: the 0.9.8 slot had no model
+        bound either, so there was nothing to protect;
+      * the write is NOT blanket-suppressed the way
+        :func:`~hal0.install.orchestrate._activate_slot_model` suppresses it.
+        A failure returns ``""`` so the caller can say so.
+
+    *already_stamped* says the activation gate already ran its own stamp for
+    this slot in this pass. It only matters when the slot cannot be READ
+    (``None``): with no evidence either way, a stamped slot is trusted rather
+    than written a second time, while an unstamped one still gets the single
+    write that is its only chance. A readable slot ignores the flag entirely —
+    what the file says beats what we think we did.
+
+    Idempotent: a second call reads the id it just bound and writes nothing.
+    """
+    existing = await current_brain_binding(slot_manager)
+    if existing:
+        if existing != model_id:
+            log.info(
+                "install.brain_model_operator_default_kept slot=%s bound=%s pulled=%s",
+                BRAIN_SLOT_NAME,
+                existing,
+                model_id,
+            )
+        return existing
+    if existing is None and already_stamped:
+        return model_id
+    try:
+        await slot_manager.update_config(BRAIN_SLOT_NAME, {"model": {"default": model_id}})
+    except Exception as exc:
+        log.warning(
+            "install.brain_bind_write_failed slot=%s id=%s err=%s", BRAIN_SLOT_NAME, model_id, exc
+        )
+        return ""
+    confirmed = await current_brain_binding(slot_manager)
+    if confirmed is None:
+        # Unreadable slot, successful write: trust the write. Failing here
+        # would turn "we cannot check" into "it did not work".
+        return model_id
+    if not confirmed:
+        log.warning("install.brain_bind_not_persisted slot=%s id=%s", BRAIN_SLOT_NAME, model_id)
+        return ""
+    return confirmed
+
+
 def _load_hardware() -> HardwareInfo:
     """Prefer the ``hardware.json`` the first-run seeding step just wrote.
 
@@ -222,6 +347,12 @@ async def provision_brain_model(
     Returns the curated id that landed. Raises on failure — the caller
     (:func:`main`) turns that into a warning + non-zero exit so install.sh's
     ``|| warn`` keeps the install alive.
+
+    "Bind it" is an assertion, not a hope (#2131): the pull's own activation
+    write is best-effort and silently suppressed, so this function reads the
+    slot back through :func:`bind_brain_model` and raises when the bytes
+    landed but the slot is still model-less. An operator's own
+    ``[model].default`` is left exactly where it is.
     """
     from hal0.install.orchestrate import PullPlan, run_pull_and_activate
     from hal0.registry.curated import get_curated
@@ -241,14 +372,18 @@ async def provision_brain_model(
     if hasattr(registry, "ensure"):
         registry.ensure(model_id)
 
+    # What (if anything) the slot already names, read BEFORE the pull. A
+    # non-empty id here is operator config and decides two things: the pull
+    # must not stamp over it, and a failed pull must not park a slot that is
+    # not model-less in the first place.
+    pre_existing = await current_brain_binding(slot_manager)
+
     # Already on disk from an earlier install run? Bind it and stop. Nothing
     # below dedupes, so without this a re-run re-downloads the whole file.
     existing = already_pulled(model_id)
     if existing is not None:
-        from hal0.install.orchestrate import _activate_slot_model
-
         log.info("install.brain_model_already_present id=%s path=%s", model_id, existing)
-        await _activate_slot_model(slot_manager, BRAIN_SLOT_NAME, model_id, failed=False)
+        _require_binding(await bind_brain_model(slot_manager, model_id), model_id)
         return model_id
 
     plan = PullPlan(
@@ -261,7 +396,12 @@ async def provision_brain_model(
             hf_token=hf_token or None,
             capability="chat",
         ),
-        slot_names=[BRAIN_SLOT_NAME],
+        # The activation gate applies to a MODEL-LESS slot: stamp on success,
+        # mark [meta].pull_failed on failure. A slot that already names an
+        # operator's model is not in that state machine — it is neither ours
+        # to stamp nor parked when the pull fails — so it rides the pull with
+        # no slot attached and bind_brain_model below leaves it alone.
+        slot_names=[BRAIN_SLOT_NAME] if not pre_existing else [],
     )
     # run_pull_and_activate stamps [model].default only on success and marks
     # [meta].pull_failed otherwise — the model-less-on-failure guarantee.
@@ -271,7 +411,64 @@ async def provision_brain_model(
             f"brain model pull ended in state {getattr(plan.job, 'state', '?')!r}: "
             f"{getattr(plan.job, 'error', None)}"
         )
+    # The bytes are on disk. Read the slot back: the stamp above is wrapped in
+    # contextlib.suppress, so "it did not raise" proves nothing (#2131).
+    _require_binding(
+        await bind_brain_model(slot_manager, model_id, already_stamped=bool(plan.slot_names)),
+        model_id,
+    )
     return model_id
+
+
+def _require_binding(bound: str, model_id: str) -> None:
+    """Raise when the bytes landed but the brain slot still names nothing.
+
+    Reported, never fatal: :func:`main` turns this into a warning + exit 1 and
+    install.sh's ``|| warn`` keeps the install alive. Before #2131 this state
+    was indistinguishable from success.
+    """
+    if bound:
+        return
+    raise RuntimeError(
+        f"{model_id} is on disk but the '{BRAIN_SLOT_NAME}' slot could not be bound to it "
+        f"— bind it by hand: {remediation_command(model_id)}"
+    )
+
+
+#: ``python -m hal0.install.brain_model --check-binding`` — the diagnosis
+#: install.sh prints next to a failed structured-output probe (#2131).
+CHECK_BINDING_FLAG = "--check-binding"
+
+
+def check_binding(argv: list[str] | None = None) -> int:
+    """``--check-binding``: is the brain model on disk but unbound?
+
+    Prints the remediation line and NOTHING else — an empty stdout means
+    "nothing to say here", which is what lets install.sh splice the hint into
+    its probe-failure warning with a plain ``[[ -n ... ]]`` test. Always exits
+    0: this is a diagnostic printed while the installer is already reporting a
+    failure, and a non-zero exit under ``set -euo pipefail`` would be a
+    diagnostic that breaks the install it is trying to explain.
+    """
+    del argv
+    try:
+        override = (os.environ.get("HAL0_BRAIN_MODEL") or "").strip() or None
+        chosen = brain_model_for_hardware(_load_hardware(), override=override)
+        if already_pulled(chosen) is None:
+            return 0  # no bytes on disk — an unbound slot is not the story
+        from hal0.cli.setup_command import _build_offline_deps
+
+        slot_manager, _ = _build_offline_deps()
+        if asyncio.run(current_brain_binding(slot_manager)):
+            return 0  # bound — the probe failed for some other reason
+        print(
+            f"the '{BRAIN_SLOT_NAME}' slot has no model bound although {chosen} is on disk "
+            f"— bind it and retry: {remediation_command(chosen)}"
+        )
+    except BaseException:
+        # A diagnostic must never become the problem it is describing.
+        return 0
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -282,11 +479,18 @@ def main(argv: list[str] | None = None) -> int:
     under ``set -euo pipefail``, and a traceback escaping this module would
     abort the whole install over an optional model — the exact failure mode
     ruling 7 forbids.
+
+    The only option is :data:`CHECK_BINDING_FLAG`; everything else is
+    configured via env (see install.sh).
     """
-    del argv  # no options; configuration is via env (see install.sh)
+    if argv is None:
+        argv = sys.argv[1:]
+    if CHECK_BINDING_FLAG in argv:
+        return check_binding(argv)
     logging.basicConfig(level=logging.WARNING, format="  %(message)s")
     override = (os.environ.get("HAL0_BRAIN_MODEL") or "").strip() or None
     hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN") or None
+    chosen = BRAIN_MODEL_DEFAULT
     try:
         from hal0.cli.setup_command import _build_offline_deps
 
@@ -317,8 +521,18 @@ def main(argv: list[str] | None = None) -> int:
     except BaseException as exc:
         print(f"  brain model pull failed ({type(exc).__name__}: {exc})", file=sys.stderr)
         print("  the brain slot stays model-less; the install continues", file=sys.stderr)
+        print(f"  once the model is on disk: {remediation_command(chosen)}", file=sys.stderr)
         return 1
-    print(f"  brain model ready: {landed} bound to the '{BRAIN_SLOT_NAME}' slot")
+    # Report what the slot ACTUALLY names, not what we pulled — the two differ
+    # when an operator's own [model].default was found and left alone.
+    bound = asyncio.run(current_brain_binding(slot_manager)) or landed
+    if bound != landed:
+        print(
+            f"  brain model ready: {landed} is on disk; the '{BRAIN_SLOT_NAME}' slot keeps "
+            f"its existing model {bound}"
+        )
+    else:
+        print(f"  brain model ready: {landed} bound to the '{BRAIN_SLOT_NAME}' slot")
     return 0
 
 

--- a/src/hal0/install/brain_model.py
+++ b/src/hal0/install/brain_model.py
@@ -10,9 +10,17 @@ Five properties are deliberate:
 
 **Never fatal.** No network, no disk, an unreadable ``hardware.json``, a
 missing curated entry — every failure path returns a non-zero exit code with a
-warning and leaves the brain slot MODEL-LESS. The install still succeeds. This
-mirrors the absent-``HF_TOKEN`` posture in install.sh: an optional model pull
-must not be able to fail a platform install.
+warning and leaves the brain slot NO WORSE THAN IT FOUND IT. The install still
+succeeds. This mirrors the absent-``HF_TOKEN`` posture in install.sh: an
+optional model pull must not be able to fail a platform install.
+
+"No worse", not "model-less": a failure only ever *withholds* a binding, it
+never removes one. ``_activate_slot_model``'s failure path writes
+``{"meta": {"pull_failed": True}}`` and no ``model`` key at all, and
+``merge_slot_config`` merges one level deep, so a slot that already carried a
+``[model].default`` keeps it. An already-model-less slot — the fresh-seed and
+0.9.8-scaffold case, and the only one this module ever binds into — does stay
+model-less, which is where the shorter phrasing came from.
 
 **One default, hardware-blind (rc.10).** The default is
 :data:`BRAIN_MODEL_DEFAULT` (LFM2.5-2.6B Q8_0) on every box: plain GGUF, no
@@ -37,24 +45,49 @@ unconditionally, and a COMPLETED pull leaves no ``.part`` for the resume path
 to reuse. :func:`already_pulled` is the guard that stops a re-run from
 re-downloading gigabytes it already has.
 
-**An unbound ``[model]`` table is not operator config (#2131).** The activation
-gate above is *best-effort by construction*:
+**An unbound ``[model]`` table is not operator config (#2131).** A NON-EMPTY
+``[model].default`` is an operator pick and is never touched, even when it
+names something other than the default — so an install.sh re-run can no longer
+revert one. An EMPTY or absent one is not a pick at all: the seed ships
+model-less on purpose (``installer/etc-hal0/slots/brain.toml``, "WHO SETS
+[model].default"), so :func:`bind_brain_model` binds the default into it.
+
+THE ORDERING THIS DEPENDS ON — read before moving anything in install.sh.
+The 0.9.8 → 1.0.0 upgrade ended at "Verify FAILED: structured-output probe
+failed" on every stable-channel box, with the 2.87 GB on disk and the brain
+slot model-less. The binding was not missing; it was **reverted**:
+
+  * v0.9.8's install.sh ran ``hal0 setup --auto`` (:1249) BEFORE its curated
+    seed loop (:1487), so the generic scaffold won and the curated brain seed
+    was skipped as already-present. ``_build_slot_cfg(..., enabled=False)``
+    therefore left ``enabled = false`` next to a model-less ``[model]`` table
+    on every one of those boxes;
+  * install.sh bound the freshly pulled default into that slot, and the
+    ``SlotConfig.enabled`` sweep — which ran AFTER the brain step — read
+    ``enabled = false`` beside a now-bound model and did exactly what it is
+    designed to do (:mod:`hal0.config.migrations.slot_enabled_removal`,
+    ``out["model"] = {**model, "default": ""}``). The same sweep runs at every
+    hal0-api boot (``hal0.api._boot_slot_reconcile``), so even a hand-repaired
+    box lost the binding again on the next restart.
+
+install.sh now runs that sweep BEFORE this module. For a model-less
+``enabled = false`` slot the migration's own rule is "both signals already said
+off — only the key needs dropping", so the stale key goes and the model is
+untouched; this module then binds into a clean slot and every later boot-time
+sweep no-ops. A slot an operator DELIBERATELY disabled (``enabled = false``
+WITH a model bound) still has its model cleared by that sweep, which is the
+deactivation the migration exists to carry forward.
+
+**Reported, not assumed.** Independently of the ordering above, the activation
+gate is *best-effort by construction*:
 :func:`~hal0.install.orchestrate._activate_slot_model` wraps its write in
 ``contextlib.suppress(Exception)`` so a config-rewrite failure can never abort
-the pull driver. That is right for the driver and wrong for this module — a
-swallowed write left the brain slot MODEL-LESS while this module still printed
-"brain model ready" and exited 0, so install.sh had no signal, and the
-documented 0.9.8 → 1.0.0 path ended at "Verify FAILED: structured-output probe
-failed" with the 2.87 GB already on disk and nothing pointing at the cause.
-:func:`bind_brain_model` closes that: it reads the slot back and, when the
-``[model]`` table exists but names nothing, binds the default into it — a
-model-less slot is the shipped seed state (``installer/etc-hal0/slots/
-brain.toml`` ships no ``[model].default``), not a pick to protect. The guard is
-the other half of the rule: a NON-EMPTY ``[model].default`` is an operator pick
-and is never touched, even when it names something other than the default. When
-the binding genuinely cannot be made the failure is now *reported* (warning +
-exit 1 + the exact remediation command) instead of being reported as success —
-still never fatal, exactly as ruling 7 requires.
+the pull driver. That is right for the driver and wrong for this module, which
+otherwise reports "brain model ready" and exits 0 whether or not the write
+landed. :func:`bind_brain_model` reads the slot back and, when the binding
+genuinely cannot be made, the failure is *reported* — warning, exit 1, and the
+exact remediation command — instead of being reported as success. Still never
+fatal, exactly as ruling 7 requires.
 """
 
 from __future__ import annotations

--- a/tests/install/test_brain_model.py
+++ b/tests/install/test_brain_model.py
@@ -21,6 +21,7 @@ huggingface.co.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -45,6 +46,8 @@ from hal0.install.brain_model import (
     rocmfpx_capable,
 )
 from hal0.registry.curated import get_curated
+
+_INSTALL_SH = Path(__file__).resolve().parents[2] / "installer" / "install.sh"
 
 # ── quant choice ────────────────────────────────────────────────────────────
 
@@ -694,6 +697,173 @@ def test_module_entry_point_routes_the_check_binding_flag(
     _stub_check_binding_deps(monkeypatch, _ConfiguredSlotManager(bound=""))
     assert main([bm.CHECK_BINDING_FLAG]) == 0
     assert remediation_command(BRAIN_MODEL_DEFAULT) in capsys.readouterr().out
+
+
+# ── the reverting sweep: what actually broke the 0.9.8 upgrade ──────────────
+#
+# The binding was never missing — it was REVERTED. v0.9.8's install.sh ran
+# `hal0 setup --auto` (:1249) BEFORE its curated seed loop (:1487), so the
+# generic scaffold won and `_build_slot_cfg(..., enabled=False)` left
+# `enabled = false` beside a model-less `[model]` table on every stable box.
+# install.sh then bound the pulled default into it and the SlotConfig.enabled
+# sweep, reading `enabled = false` next to a now-bound model, cleared the model
+# exactly as it is designed to (slot_enabled_removal.py:86). The same sweep runs
+# at every hal0-api boot, so even a hand-repaired box lost it again on restart.
+
+#: The shape every v0.9.8 stable box carries into the upgrade.
+_V098_SCAFFOLD_BRAIN_TOML = (
+    'name = "brain"\n'
+    'type = "llm"\n'
+    'device = "gpu-vulkan"\n'
+    'runtime = "container"\n'
+    'profile = "vulkan"\n'
+    "enabled = false\n"
+    "port = 8089\n"
+    "\n"
+    "[model]\n"
+    'default = ""\n'
+    "context_size = 65536\n"
+)
+
+
+@pytest.fixture()
+def upgraded_box(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """A v0.9.8 box mid-upgrade: scaffold brain.toml + the bytes already pulled.
+
+    Yields the path of the live ``brain.toml`` so a test can read back exactly
+    what the installer left on disk.
+    """
+    import hal0.config.store as store_mod
+
+    home = tmp_path / "home"
+    slots_dir = home / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True)
+    brain_toml = slots_dir / "brain.toml"
+    brain_toml.write_text(_V098_SCAFFOLD_BRAIN_TOML, encoding="utf-8")
+    monkeypatch.setenv("HAL0_HOME", str(home))
+    monkeypatch.setattr(store_mod, "store_root", lambda: tmp_path / "store")
+    _place(tmp_path / "store", BRAIN_MODEL_DEFAULT)
+    return brain_toml
+
+
+def _bind_step() -> str:
+    """install.sh's brain step: `python -m hal0.install.brain_model`."""
+    from hal0.cli.setup_command import _build_offline_deps
+
+    slot_manager, registry = _build_offline_deps()
+    return asyncio.run(
+        provision_brain_model(hw=_hw(), slot_manager=slot_manager, registry=registry)
+    )
+
+
+def _sweep_step() -> list[str]:
+    """install.sh's `enabled` sweep — the same call hal0-api makes at boot."""
+    from hal0.updater.updater import sweep_slot_enabled_keys
+
+    return sweep_slot_enabled_keys()
+
+
+def _model_default_on_disk(brain_toml) -> str:
+    import tomllib
+
+    raw = tomllib.loads(brain_toml.read_text(encoding="utf-8"))
+    return str(raw.get("model", {}).get("default") or "")
+
+
+def _install_sh_runs_sweep_before_the_brain_pull() -> bool:
+    """The order install.sh actually declares, read out of the script."""
+    text = _INSTALL_SH.read_text(encoding="utf-8")
+    pull = "-m hal0.install.brain_model \\"
+    assert text.count(pull) == 1, "expected exactly one brain-model pull invocation"
+    return text.index("sweep_slot_enabled_keys") < text.index(pull)
+
+
+def test_binding_survives_the_enabled_sweep_in_the_order_install_sh_runs_them(
+    upgraded_box,
+) -> None:
+    """Drives the REAL order — taken from install.sh, not hardcoded here.
+
+    This is the whole bug: with the sweep after the brain step the binding is
+    blanked minutes later, so the assertion below fails on the shipped order
+    that produced #2131 and passes on the corrected one.
+    """
+    steps = (
+        [_sweep_step, _bind_step]
+        if _install_sh_runs_sweep_before_the_brain_pull()
+        else [_bind_step, _sweep_step]
+    )
+    for step in steps:
+        step()
+    assert _model_default_on_disk(upgraded_box) == BRAIN_MODEL_DEFAULT, (
+        "the brain slot lost its binding to the SlotConfig.enabled sweep — "
+        "install.sh must run the sweep BEFORE the brain model step (#2131)"
+    )
+
+
+def test_the_binding_then_survives_every_later_api_boot_sweep(upgraded_box) -> None:
+    """`hal0.api._boot_slot_reconcile` runs the identical sweep on every start.
+
+    Sweeping first is what makes those boot passes no-ops: the stale `enabled`
+    key is already gone, so `migrate_slot_toml` returns None and the file is
+    left byte-identical. Without that, a hand-repaired box lost its binding
+    again at the next restart.
+    """
+    _sweep_step()
+    _bind_step()
+    assert _model_default_on_disk(upgraded_box) == BRAIN_MODEL_DEFAULT
+
+    for _ in range(3):  # three more service restarts
+        assert _sweep_step() == [], "a converged slot must not be rewritten again"
+        assert _model_default_on_disk(upgraded_box) == BRAIN_MODEL_DEFAULT
+
+
+def test_the_sweep_only_drops_the_key_on_the_model_less_scaffold(upgraded_box) -> None:
+    """Why sweeping first is the migration's OWN semantics, not a workaround.
+
+    `enabled = false` with NO model bound is the documented "both signals
+    already said off" case — the key is dropped and nothing else changes. The
+    model-clearing branch is for a slot that had a model to deactivate.
+    """
+    import tomllib
+
+    assert _sweep_step() == ["brain"]
+    raw = tomllib.loads(upgraded_box.read_text(encoding="utf-8"))
+    assert "enabled" not in raw
+    assert raw["model"]["context_size"] == 65536
+
+
+def test_a_deliberately_disabled_slot_still_has_its_model_cleared(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The carve-out the reorder must not break: `enabled = false` WITH a bound
+    model is an operator deactivation, and the sweep still carries it forward.
+
+    The brain step also declines to touch it — a non-empty `[model].default` is
+    operator config — so the two passes agree instead of fighting.
+    """
+    import tomllib
+
+    import hal0.config.store as store_mod
+
+    home = tmp_path / "home"
+    slots_dir = home / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True)
+    brain_toml = slots_dir / "brain.toml"
+    brain_toml.write_text(
+        _V098_SCAFFOLD_BRAIN_TOML.replace('default = ""', 'default = "operator-pick"'),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HAL0_HOME", str(home))
+    monkeypatch.setattr(store_mod, "store_root", lambda: tmp_path / "store")
+    _place(tmp_path / "store", BRAIN_MODEL_DEFAULT)
+
+    raw_before = tomllib.loads(brain_toml.read_text(encoding="utf-8"))
+    assert raw_before["model"]["default"] == "operator-pick"
+
+    _sweep_step()
+    raw = tomllib.loads(brain_toml.read_text(encoding="utf-8"))
+    assert raw["model"]["default"] == "", "a deliberate deactivation must survive the upgrade"
+    assert "enabled" not in raw
 
 
 # ── end to end on a real slot TOML: the shape the box actually had ───────────

--- a/tests/install/test_brain_model.py
+++ b/tests/install/test_brain_model.py
@@ -35,9 +35,13 @@ from hal0.install.brain_model import (
     BRAIN_MODEL_SMALL,
     BRAIN_SLOT_NAME,
     already_pulled,
+    bind_brain_model,
     brain_model_for_hardware,
+    check_binding,
+    current_brain_binding,
     main,
     provision_brain_model,
+    remediation_command,
     rocmfpx_capable,
 )
 from hal0.registry.curated import get_curated
@@ -402,3 +406,336 @@ def test_provisioning_still_pulls_when_the_prior_file_is_untrustworthy(
     sm, reg = _FakeSlotManager(), _FakeRegistry()
     landed = asyncio.run(provision_brain_model(hw=_hw(), slot_manager=sm, registry=reg))
     assert landed == BRAIN_MODEL_DEFAULT
+
+
+# ── #2131: the 0.9.8 → 1.0.0 upgrade — model on disk, slot never bound ──────
+#
+# The documented upgrade path ended at "Verify FAILED: structured-output probe
+# failed" on every stable-channel box: the 2.87 GB default landed and was
+# registered, but `/etc/hal0/slots/brain.toml` kept a `[model]` table naming
+# nothing, so the gateway had nothing to answer with. The seeding pass reported
+# success throughout — `_activate_slot_model` wraps its write in
+# `contextlib.suppress(Exception)`, so a write that never landed is
+# indistinguishable from one that did.
+#
+# The semantics these pin: an existing-but-UNBOUND `[model]` table is the
+# shipped seed state, not operator config, so the default is bound into it; a
+# NON-EMPTY `[model].default` is an operator pick and is never touched; and a
+# binding that genuinely cannot be made is REPORTED (exit 1 + the exact
+# remediation command) instead of reported as success.
+
+
+class _ConfiguredSlotManager:
+    """A slot manager backed by one in-memory brain config.
+
+    Unlike :class:`_FakeSlotManager` it can be READ, which is what the binding
+    contract turns on: "" (an empty ``[model].default``) is the seed state,
+    a non-empty one is an operator pick.
+    """
+
+    def __init__(self, bound: str = "", *, persist: bool = True) -> None:
+        self.cfg: dict[str, Any] = {
+            "name": BRAIN_SLOT_NAME,
+            "type": "llm",
+            "device": "gpu-vulkan",
+            "port": 8089,
+            "model": {"default": bound, "context_size": 65536},
+        }
+        self.updates: list[tuple[str, dict[str, Any]]] = []
+        self._persist = persist
+
+    async def get_config(self, slot: str) -> dict[str, Any]:
+        assert slot == BRAIN_SLOT_NAME
+        return {**self.cfg, "model": dict(self.cfg["model"])}
+
+    async def update_config(self, slot: str, updates: dict[str, Any]) -> None:
+        self.updates.append((slot, updates))
+        if not self._persist:  # a write that silently does not land
+            return
+        model = updates.get("model")
+        if isinstance(model, dict):
+            self.cfg["model"] = {**self.cfg["model"], **model}
+
+
+class _WriteFailsSlotManager(_ConfiguredSlotManager):
+    """Every config write raises — a read-only /etc, a lock we lost, a
+    validation refusal on a config shape this release no longer accepts."""
+
+    async def update_config(self, slot: str, updates: dict[str, Any]) -> None:
+        self.updates.append((slot, updates))
+        raise RuntimeError("failed to rewrite /etc/hal0/slots/brain.toml")
+
+
+def test_an_unbound_model_table_is_seed_state_and_gets_the_default_bound(
+    store, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The exact #2131 shape: brain.toml exists, `[model]` names nothing, and
+    the bytes are already on disk (the upgrade re-run / already-pulled path)."""
+    _place(store, BRAIN_MODEL_DEFAULT)
+    sm, reg = _ConfiguredSlotManager(bound=""), _FakeRegistry()
+    landed = asyncio.run(provision_brain_model(hw=_hw(), slot_manager=sm, registry=reg))
+    assert landed == BRAIN_MODEL_DEFAULT
+    assert sm.cfg["model"]["default"] == BRAIN_MODEL_DEFAULT
+    # Binding is a merge, never a reset of the slot's tuning.
+    assert sm.cfg["model"]["context_size"] == 65536
+
+
+def test_an_unbound_model_table_gets_bound_on_the_pull_path_too(
+    store, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_run_pull(monkeypatch, state="completed")
+    sm, reg = _ConfiguredSlotManager(bound=""), _FakeRegistry()
+    landed = asyncio.run(provision_brain_model(hw=_hw(), slot_manager=sm, registry=reg))
+    assert landed == BRAIN_MODEL_DEFAULT
+    assert sm.cfg["model"]["default"] == BRAIN_MODEL_DEFAULT
+
+
+def test_an_operator_set_default_is_never_overwritten(
+    store, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other half of the rule. A non-empty `[model].default` is a pick —
+    a re-run of install.sh must not revert it to the shipped default."""
+    _place(store, BRAIN_MODEL_DEFAULT)
+    sm, reg = _ConfiguredSlotManager(bound="my-own-brain"), _FakeRegistry()
+    landed = asyncio.run(provision_brain_model(hw=_hw(), slot_manager=sm, registry=reg))
+    assert landed == BRAIN_MODEL_DEFAULT  # the pull still reports what it has
+    assert sm.cfg["model"]["default"] == "my-own-brain"
+    assert sm.updates == [], "an operator's pick must not be written over"
+
+
+def test_an_operator_set_default_survives_the_pull_path(
+    store, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_run_pull(monkeypatch, state="completed")
+    sm, reg = _ConfiguredSlotManager(bound="my-own-brain"), _FakeRegistry()
+    asyncio.run(provision_brain_model(hw=_hw(), slot_manager=sm, registry=reg))
+    assert sm.cfg["model"]["default"] == "my-own-brain"
+    assert sm.updates == []
+
+
+def test_binding_is_idempotent_across_re_runs(store, monkeypatch: pytest.MonkeyPatch) -> None:
+    _place(store, BRAIN_MODEL_DEFAULT)
+    sm, reg = _ConfiguredSlotManager(bound=""), _FakeRegistry()
+    asyncio.run(provision_brain_model(hw=_hw(), slot_manager=sm, registry=reg))
+    first = len(sm.updates)
+    asyncio.run(provision_brain_model(hw=_hw(), slot_manager=sm, registry=reg))
+    assert len(sm.updates) == first, "a converged slot must be re-read, not re-written"
+    assert sm.cfg["model"]["default"] == BRAIN_MODEL_DEFAULT
+
+
+def test_a_binding_write_that_fails_is_reported_not_swallowed(
+    store, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The #2131 silence. Before this, the suppressed write left the slot
+    model-less while the module printed "brain model ready" and exited 0."""
+    _place(store, BRAIN_MODEL_DEFAULT)
+    sm, reg = _WriteFailsSlotManager(bound=""), _FakeRegistry()
+    with pytest.raises(RuntimeError, match="could not be bound"):
+        asyncio.run(provision_brain_model(hw=_hw(), slot_manager=sm, registry=reg))
+
+
+def test_a_binding_write_that_does_not_land_is_reported_not_swallowed(
+    store, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A write that raises nothing but changes nothing is the same failure —
+    "it did not raise" is not proof the slot is bound."""
+    _place(store, BRAIN_MODEL_DEFAULT)
+    sm, reg = _ConfiguredSlotManager(bound="", persist=False), _FakeRegistry()
+    with pytest.raises(RuntimeError, match="could not be bound"):
+        asyncio.run(provision_brain_model(hw=_hw(), slot_manager=sm, registry=reg))
+
+
+def test_an_unbindable_slot_exits_nonzero_with_the_remediation(
+    store, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """install.sh's ``|| warn`` needs a non-zero exit to fire at all, and the
+    operator needs the command that recovers the box (ruling 7: still not
+    fatal — the install continues)."""
+    import hal0.install.brain_model as bm
+
+    _place(store, BRAIN_MODEL_DEFAULT)
+    monkeypatch.setattr(bm, "_load_hardware", lambda: _hw())
+    monkeypatch.setattr(
+        "hal0.cli.setup_command._build_offline_deps",
+        lambda: (_WriteFailsSlotManager(bound=""), _FakeRegistry()),
+    )
+    assert main([]) == 1
+    err = capsys.readouterr().err
+    assert f"hal0 slot edit {BRAIN_SLOT_NAME} --model {BRAIN_MODEL_DEFAULT}" in err
+    assert f"hal0 slot load {BRAIN_SLOT_NAME}" in err
+
+
+def test_main_reports_the_model_the_slot_actually_names(
+    store, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A transcript that says "bound to the 'brain' slot" while the slot names
+    the operator's own model is exactly the misreport #2131 was made of."""
+    import hal0.install.brain_model as bm
+
+    _place(store, BRAIN_MODEL_DEFAULT)
+    monkeypatch.setattr(bm, "_load_hardware", lambda: _hw())
+    monkeypatch.setattr(
+        "hal0.cli.setup_command._build_offline_deps",
+        lambda: (_ConfiguredSlotManager(bound="my-own-brain"), _FakeRegistry()),
+    )
+    assert main([]) == 0
+    out = capsys.readouterr().out
+    assert "keeps its existing model my-own-brain" in out
+
+
+# ── the binding helpers, directly ───────────────────────────────────────────
+
+
+def test_current_binding_distinguishes_unbound_from_unreadable() -> None:
+    """`""` (readable, unbound → bindable) must never be confused with `None`
+    (unreadable → we know nothing, so a write is trusted)."""
+    assert asyncio.run(current_brain_binding(_ConfiguredSlotManager(bound=""))) == ""
+    assert asyncio.run(current_brain_binding(_ConfiguredSlotManager(bound="x"))) == "x"
+    assert asyncio.run(current_brain_binding(_FakeSlotManager())) is None
+
+
+def test_bind_trusts_a_clean_write_on_an_unreadable_slot() -> None:
+    """A slot manager with no read surface must not turn "cannot check" into
+    "did not work" — that would fail every install for a missing accessor."""
+    sm = _FakeSlotManager()
+    assert asyncio.run(bind_brain_model(sm, BRAIN_MODEL_DEFAULT)) == BRAIN_MODEL_DEFAULT
+    assert sm.updates == [(BRAIN_SLOT_NAME, {"model": {"default": BRAIN_MODEL_DEFAULT}})]
+
+
+def test_bind_does_not_restamp_an_unreadable_slot_the_gate_already_stamped() -> None:
+    """The pull path's activation gate writes first. When the slot cannot be
+    read there is no evidence to act on, so re-writing would just be a second
+    identical stamp — the readable case is where the repair earns its keep."""
+    sm = _FakeSlotManager()
+    bound = asyncio.run(bind_brain_model(sm, BRAIN_MODEL_DEFAULT, already_stamped=True))
+    assert bound == BRAIN_MODEL_DEFAULT
+    assert sm.updates == []
+
+
+def test_remediation_command_names_the_id_that_was_pulled() -> None:
+    assert remediation_command(BRAIN_MODEL_ROCMFPX).startswith(
+        f"hal0 slot edit {BRAIN_SLOT_NAME} --model {BRAIN_MODEL_ROCMFPX}"
+    )
+
+
+# ── --check-binding: the hint install.sh prints beside a failed probe ────────
+
+
+def _stub_check_binding_deps(monkeypatch: pytest.MonkeyPatch, slot_manager) -> None:
+    import hal0.install.brain_model as bm
+
+    monkeypatch.setattr(bm, "_load_hardware", lambda: _hw())
+    monkeypatch.setattr(
+        "hal0.cli.setup_command._build_offline_deps",
+        lambda: (slot_manager, _FakeRegistry()),
+    )
+
+
+def test_check_binding_names_the_fix_when_the_model_is_on_disk_but_unbound(
+    store, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _place(store, BRAIN_MODEL_DEFAULT)
+    _stub_check_binding_deps(monkeypatch, _ConfiguredSlotManager(bound=""))
+    assert check_binding([]) == 0
+    out = capsys.readouterr().out
+    assert remediation_command(BRAIN_MODEL_DEFAULT) in out
+
+
+def test_check_binding_is_silent_when_the_slot_is_bound(
+    store, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Empty stdout is the contract — install.sh splices the hint in with a
+    plain `[[ -n ... ]]`, so a bound slot must add nothing to the transcript."""
+    _place(store, BRAIN_MODEL_DEFAULT)
+    _stub_check_binding_deps(monkeypatch, _ConfiguredSlotManager(bound=BRAIN_MODEL_DEFAULT))
+    assert check_binding([]) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_check_binding_is_silent_when_no_model_is_on_disk(
+    store, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No bytes means the unbound slot is not the story — a failed pull has
+    already printed its own warning."""
+    _stub_check_binding_deps(monkeypatch, _ConfiguredSlotManager(bound=""))
+    assert check_binding([]) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_check_binding_never_fails_the_installer(
+    store, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """It runs while install.sh is ALREADY reporting a failure, under
+    `set -euo pipefail`. A diagnostic that aborts the install it is explaining
+    is worse than no diagnostic."""
+    import hal0.install.brain_model as bm
+
+    def _boom() -> None:
+        raise RuntimeError("hardware probe exploded")
+
+    monkeypatch.setattr(bm, "_load_hardware", _boom)
+    assert check_binding([]) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_module_entry_point_routes_the_check_binding_flag(
+    store, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """install.sh invokes it as `python -m hal0.install.brain_model
+    --check-binding`, which lands in ``main`` — it must not run a pull."""
+    import hal0.install.brain_model as bm
+    import hal0.registry.pull as pull_mod
+
+    async def _explode(job, **kwargs):
+        raise AssertionError("--check-binding must never pull")
+
+    monkeypatch.setattr(pull_mod, "run_pull", _explode)
+    _place(store, BRAIN_MODEL_DEFAULT)
+    _stub_check_binding_deps(monkeypatch, _ConfiguredSlotManager(bound=""))
+    assert main([bm.CHECK_BINDING_FLAG]) == 0
+    assert remediation_command(BRAIN_MODEL_DEFAULT) in capsys.readouterr().out
+
+
+# ── end to end on a real slot TOML: the shape the box actually had ───────────
+
+
+def test_the_upgrade_shape_binds_against_a_real_slot_manager(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fakes cannot prove the TOML on disk changed. This drives the REAL
+    SlotManager over a real `/etc/hal0/slots/brain.toml` in the 0.9.8 shape
+    the reporter found: `[model]` present, nothing bound."""
+    import hal0.config.store as store_mod
+
+    home = tmp_path / "home"
+    slots_dir = home / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True)
+    (slots_dir / "brain.toml").write_text(
+        'name = "brain"\n'
+        'type = "llm"\n'
+        'device = "gpu-vulkan"\n'
+        'runtime = "container"\n'
+        'profile = "vulkan"\n'
+        "port = 8089\n"
+        "\n"
+        "[model]\n"
+        "context_size = 65536\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HAL0_HOME", str(home))
+    monkeypatch.setattr(store_mod, "store_root", lambda: tmp_path / "store")
+    _place(tmp_path / "store", BRAIN_MODEL_DEFAULT)  # bytes already on disk
+
+    from hal0.cli.setup_command import _build_offline_deps
+
+    slot_manager, registry = _build_offline_deps()
+    landed = asyncio.run(
+        provision_brain_model(hw=_hw(), slot_manager=slot_manager, registry=registry)
+    )
+    assert landed == BRAIN_MODEL_DEFAULT
+
+    import tomllib
+
+    raw = tomllib.loads((slots_dir / "brain.toml").read_text(encoding="utf-8"))
+    assert raw["model"]["default"] == BRAIN_MODEL_DEFAULT
+    assert raw["model"]["context_size"] == 65536, "binding must not reset the slot's tuning"

--- a/tests/installer/test_install_smoke_probes.py
+++ b/tests/installer/test_install_smoke_probes.py
@@ -179,6 +179,66 @@ def test_memory_engine_probe_skips_when_engine_not_installed(tmp_path: Path) -> 
     assert res.returncode == 0, res.stderr
 
 
+# ── #2131: a failed probe must name the unbound brain slot, not just fail ───
+#
+# The 0.9.8 → 1.0.0 upgrade ended at a bare "structured-output probe failed"
+# while the cause — the default brain model downloaded but never bound — was
+# one command away from a fix and mentioned nowhere. The probe's failure branch
+# now asks `brain_model --check-binding`, which prints the remediation when
+# (and only when) that is actually the shape on disk.
+
+
+def test_probe_failure_asks_for_the_brain_binding_diagnosis() -> None:
+    func = _extract("run_post_install_smoke")
+    assert "hal0.install.brain_model --check-binding" in func, (
+        "a failed structured-output probe must check for the #2131 unbound-brain "
+        "shape instead of leaving 'check hal0 status' as the only lead"
+    )
+
+
+def _fake_venv(tmp_path: Path, body: str) -> Path:
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True, exist_ok=True)
+    _write_exec(venv / "bin" / "python", body)
+    return venv
+
+
+def test_probe_failure_prints_the_brain_remediation_when_one_is_offered(
+    tmp_path: Path,
+) -> None:
+    venv = _fake_venv(tmp_path, "echo 'bind it: hal0 slot edit brain --model lfm2.5-2.6b'")
+    _write_exec(tmp_path / "curl", "exit 7")
+    _write_exec(tmp_path / "hal0", "exit 0")
+    res = _drive(tmp_path, f'VENV_DIR="{venv}"\nrun_post_install_smoke\nexit 0')
+    assert res.returncode == 0, res.stderr
+    assert "hal0 slot edit brain --model lfm2.5-2.6b" in res.stderr
+
+
+def test_probe_failure_says_nothing_extra_when_the_slot_is_bound(tmp_path: Path) -> None:
+    """`--check-binding` prints nothing when the binding is fine, so a
+    fresh-install probe failure reads exactly as it did before."""
+    venv = _fake_venv(tmp_path, "exit 0")
+    _write_exec(tmp_path / "curl", "exit 7")
+    _write_exec(tmp_path / "hal0", "exit 0")
+    res = _drive(tmp_path, f'VENV_DIR="{venv}"\nrun_post_install_smoke\nexit 0')
+    assert res.returncode == 0, res.stderr
+    assert "slot edit brain" not in res.stderr
+
+
+def test_probe_failure_survives_a_missing_venv(tmp_path: Path) -> None:
+    """The hint runs under `set -euo pipefail` while the installer is ALREADY
+    reporting a failure — an absent venv (or an unset VENV_DIR) must not turn
+    a warning into an aborted install."""
+    _write_exec(tmp_path / "curl", "exit 7")
+    _write_exec(tmp_path / "hal0", "exit 0")
+    res = _drive(
+        tmp_path,
+        'set -e\nrun_post_install_smoke\nprintf "%s\\n" "${SMOKE_FAILED[@]}"\nexit 0',
+    )
+    assert res.returncode == 0, res.stderr
+    assert "structured-output" in res.stdout
+
+
 def test_smoke_failures_surface_in_the_summary_box() -> None:
     """The summary builder must fold SMOKE_FAILED into SUMMARY_LINES so an
     rc-validate run catches failures without scrolling the warn stream."""

--- a/tests/installer/test_migration_convergence.py
+++ b/tests/installer/test_migration_convergence.py
@@ -70,6 +70,31 @@ def test_migration_sequence_runs_engine_pass_by_default_but_not_at_boot() -> Non
     )
 
 
+def test_the_enabled_sweep_runs_before_the_brain_model_is_bound() -> None:
+    """#2131 — the ordering the 0.9.8 upgrade turns on.
+
+    Every v0.9.8 box carries `enabled = false` on a model-less brain.toml (its
+    install.sh ran `hal0 setup --auto` at :1249 before the curated seed loop at
+    :1487, so `_build_slot_cfg(..., enabled=False)`'s scaffold won). With the
+    sweep AFTER the brain step, install.sh bound the freshly pulled default and
+    the sweep then read `enabled = false` beside a bound model and cleared it —
+    the documented upgrade path finished with the model on disk and the slot
+    model-less.
+
+    Sweeping FIRST hits the migration's own "no model bound, just drop the key"
+    branch, so the brain step binds into a clean slot and the identical
+    boot-time sweep (`hal0.api._boot_slot_reconcile`) no-ops forever after.
+    """
+    text = _INSTALL_SH.read_text(encoding="utf-8")
+    pull = "-m hal0.install.brain_model \\"
+    assert text.count(pull) == 1, "expected exactly one brain-model pull invocation"
+    assert "sweep_slot_enabled_keys" in text, "install.sh no longer runs the enabled sweep"
+    assert text.index("sweep_slot_enabled_keys") < text.index(pull), (
+        "the SlotConfig.enabled sweep must run BEFORE the brain model step — "
+        "after it, the sweep blanks the binding it just made (#2131)"
+    )
+
+
 def test_install_sh_no_longer_hand_picks_a_migration_subset() -> None:
     """The old two-heredoc block imported ensure_seed_profiles and
     clear_stale_mtp_overrides directly, skipping _maybe_run_config_migrations,


### PR DESCRIPTION
Closes #2131

> **Revised after review.** The first push named the wrong root cause (a
> suppressed activation write). Review was right: the binding **lands and is
> then reverted**. The hardening from that commit is kept — it is good, it is
> just not the cause. See "What actually broke" below.

## What broke

The documented 0.9.8 → 1.0.0 path pulled the 2.87 GB default brain model,
registered it, and left `/etc/hal0/slots/brain.toml` carrying a `[model]` table
that named nothing, so the install ended at:

```
  Verify FAILED:
    structured-output probe failed — see the warnings above
```

Every stable-channel upgrader hits it; fresh 1.0.0 installs do not.

## What actually broke: the bind lands, then a migration reverts it

Verified at the source, not inferred:

1. **v0.9.8 left `enabled = false` on a model-less brain slot, on every box.**
   Its install.sh ran `hal0 setup --auto` (v0.9.8 `install.sh:1249`) *before*
   its curated seed loop (`:1487`), so the generic scaffold won and the curated
   brain seed was skipped as "already present".
   `_build_slot_cfg(..., enabled=False)` (v0.9.8 `install/orchestrate.py:121`)
   wrote `enabled = false` beside an empty `[model].default`. That asymmetry is
   exactly why fresh 1.0.0 installs (no `enabled` key) bind fine.
2. **The `enabled` sweep ran after the brain step and cleared the fresh bind.**
   `install.sh:2341` bound the pulled default; `install.sh:2834` then called
   `sweep_slot_enabled_keys` (`updater.py:2822`), which for `enabled = false`
   beside a *now-bound* model does
   `out["model"] = {**model, "default": ""}` (`slot_enabled_removal.py:86`) —
   precisely what it is designed to do. The identical sweep runs at every
   `hal0-api` boot (`api/__init__.py:1369`), so even a hand-repaired box lost
   the binding again on the next restart.

Reproduced end to end against a real `SlotManager` and a real 0.9.8-shaped
`brain.toml`:

```
STEP 1 install.sh:2341 brain_model  -> lfm2.5-2.6b
   [model].default = 'lfm2.5-2.6b'
STEP 2 install.sh:2834 enabled sweep -> ['brain']
   [model].default = ''
VERDICT: REVERTED
```

## The fix: ordering — and it restores the migration's own semantics

For a **model-less** `enabled = false` slot the migration's documented rule is
"both signals already said off — every other shape only needs the key dropped".
It is only our fresh bind, landing first, that retroactively turns that into the
model-clearing branch. So this is not a workaround for the migration; it is
letting the migration see the input it was written for.

install.sh now runs the sweep **before** the brain model step. The stale key is
dropped, the brain step binds into a clean slot, and every later boot-time sweep
finds no `enabled` key and no-ops:

```
STEP 1  enabled sweep (now BEFORE the brain step) -> ['brain']
        [model].default = ''
STEP 2  brain_model -> lfm2.5-2.6b
        [model].default = 'lfm2.5-2.6b'
BOOT 1  api sweep -> []   [model].default = 'lfm2.5-2.6b'
BOOT 2  api sweep -> []   [model].default = 'lfm2.5-2.6b'
BOOT 3  api sweep -> []   [model].default = 'lfm2.5-2.6b'
VERDICT: BINDING SURVIVES
```

**The deliberate-disable carve-out is preserved.** A slot an operator really did
disable (`enabled = false` *with* a model bound) still has its model cleared by
that sweep — that deactivation is what the migration exists to carry forward —
and the brain step declines to touch it, because a non-empty `[model].default`
is operator config. The two passes now agree instead of fighting. Pinned by
`test_a_deliberately_disabled_slot_still_has_its_model_cleared`.

`hal0_migration_step` moves up with the sweep rather than the sweep being
inlined: `tests/installer/test_migration_step_containment.py` requires every
heredoc-fed migration to go through that helper (a bare heredoc under
`set -euo pipefail` aborts the install on any raise). My first attempt inlined
it and that test caught it — the guard works.

## Kept from the first commit

Still correct, still wanted, no longer claimed as the cause:

* the binding write is no longer blanket-suppressed, and the slot is read back —
  `_activate_slot_model` wraps its write in `contextlib.suppress(Exception)`, so
  the module otherwise reports "brain model ready" and exits 0 whether or not
  the write landed;
* a **non-empty** `[model].default` is an operator pick and is never touched, so
  an install.sh re-run can no longer revert one (it previously did,
  unconditionally, on the already-pulled path);
* `--check-binding` prints the exact remediation next to a failed
  structured-output probe when — and only when — the model is on disk with the
  slot unbound.

## Red first

The new ordering tests fail on the previous PR head (307f99b7) and pass here:

```
FAILED tests/install/test_brain_model.py::test_binding_survives_the_enabled_sweep_in_the_order_install_sh_runs_them
FAILED tests/installer/test_migration_convergence.py::test_the_enabled_sweep_runs_before_the_brain_model_is_bound
2 failed, 55 passed
```

The behavioural one is the real proof: it does not hardcode an order, it **reads
the order out of install.sh** and executes the two steps in that sequence, so it
fails on the shipped order that produced #2131 and passes on the corrected one.
It is joined by `test_the_binding_then_survives_every_later_api_boot_sweep`
(three simulated restarts), `test_the_sweep_only_drops_the_key_on_the_model_less_scaffold`
(why sweeping first is the migration's own semantics), and the
deliberate-disable carve-out above.

## Docstring corrections (both flagged in review)

* `brain_model.py` claimed a failed pull "leaves the brain slot MODEL-LESS".
  Only true for an already-model-less slot: the failure path writes
  `{"meta": {"pull_failed": True}}` with no `model` key, and
  `merge_slot_config` merges one level deep, so an existing default survives.
  Now states "no worse than it found it" and explains the distinction.
* install.sh's seed-order justification cited "brain.toml never got `profile =
  "brain"` or its `[model].default`". The shipped seed has not pinned a
  `[model].default` since rc.10 (`installer/etc-hal0/slots/brain.toml`, "WHO
  SETS [model].default"), so half that rationale was dead. It now cites the
  `enabled = false` the scaffold really left behind — which is what the ordering
  protects today, and the direct cause of this bug.

## Contract properties preserved

| Property | Preserved by | Test |
| --- | --- | --- |
| **Never fatal** | the sweep goes through `hal0_migration_step` (report + continue); every brain-step failure is warning + exit 1 behind `\|\| warn` | `test_migration_step_containment.py` (whole file), `test_an_unbindable_slot_exits_nonzero_with_the_remediation`, `test_check_binding_never_fails_the_installer` |
| **One hardware-blind default** | untouched | existing `TestHardwareDecisionMatrix` |
| **Reuses the activation gate** | `run_pull_and_activate` still stamps on success / marks `[meta].pull_failed` for a model-less slot; a slot already naming an operator's model rides with `slot_names=[]` | existing `test_failed_pull_leaves_the_slot_model_less_and_marked`, `test_an_operator_set_default_survives_the_pull_path` |
| **Idempotent** | `already_pulled` unchanged; converged slot re-read not re-written; the sweep no-ops once the key is gone | `test_binding_is_idempotent_across_re_runs`, `test_the_binding_then_survives_every_later_api_boot_sweep` |

## Checks

`.venv/bin/python -m pytest tests/install/ tests/installer/test_install_smoke_probes.py tests/installer/test_migration_convergence.py -q`
→ **1 failed, 339 passed, 1 skipped** (baseline: 1 failed, 311 passed). The one
failure is the pre-existing macOS AppleDouble `UnicodeDecodeError` in
`test_perms_converge.py`, identical before and after.

Whole `tests/installer/`: the failing set is **byte-identical to the baseline**
at PR head (`diff` of the sorted FAILED lists is empty) — 215 pre-existing
environment failures, no new ones.

`ruff check src tests` → all checks passed. `ruff format --check src tests` →
1239 files already formatted. `bash -n installer/install.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcGmVXzvn28MJhtZwGd5f3
