### PR TITLE
feat(memory): cut the namespace grammar to shared + private (ADR 0004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,40 @@ applying. Add those subsections to a version's section to surface them; see
   honored forever via a permanent alias (warned at load; TOML is never
   rewritten in place).
 
+### Fixed
+
+- **A freshly booted box could finish the installer with Hermes silently
+  unprovisioned.** If `unattended-upgrades` or `apt-daily` still held the
+  dpkg lock — routine in the first minutes after boot — the preflight
+  install of git failed immediately rather than waiting, and Hermes
+  provisioning was skipped without a hard error. Every `apt-get` in the
+  preflight library now waits for the lock
+  (`-o DPkg::Lock::Timeout=120`), the convention `install.sh` already
+  applied to its own calls. The git install was the reported case, but all
+  six package installs preflight performs — the Python floor, the venv,
+  podman, git and Node — had the same gap and all six are fixed (#2125).
+- **The installer could abort with "uv could not be installed" on a box
+  where uv had installed perfectly.** `hermes-prereqs.sh` installed uv with
+  pipx and then looked for it on `PATH`; in a non-login exec context
+  (`pct exec`, `lxc-attach`, `docker exec`, cloud-init) `PATH` can lack
+  `/usr/local/bin`, so a successful install read as a failure. The script
+  now checks the location it just wrote to. The same install-here,
+  verify-through-`PATH` shape sat one step downstream in the provisioner,
+  where the root privilege drop through `runuser`/`setpriv`/`sudo` can
+  replace `PATH` outright; that path falls back to the fixed location too,
+  so a box that got past the script no longer fails a step later with a
+  more confusing error (#2124).
+- **A post-install seam check could report a working permission grant as
+  broken.** The verifier probed each grant once, so a probe that lost a
+  race with the grant becoming live was reported as a permanent fault —
+  and named a cause it had never actually observed, because it discarded
+  the probe's own stderr. The probe now retries (three attempts, a second
+  apart, each bounded by a 20-second timeout), says so plainly when a grant
+  only came up on a later attempt instead of passing silently, and on a
+  genuine failure reports the command it actually ran, its exit code, the
+  attempt count and the probe's last stderr line rather than asserting a
+  diagnosis (#2084).
+
 ## [1.0.0] — 2026-08-29
 
 The first stable release. hal0 stops being a box you configure and starts

--- a/docs/adr/0004-memory-namespace-shared-private.md
+++ b/docs/adr/0004-memory-namespace-shared-private.md
@@ -1,0 +1,64 @@
+# ADR-0004: Memory namespace grammar cut to `shared` + `private:<agent>`
+
+## Status
+
+**ACCEPTED (operator decision, 2026-08-31).** Shipped together with the
+server-side bank consolidation performed the same night.
+
+## Context
+
+The memory namespace grammar was a closed four-value set: `shared` |
+`agents` | `project:<id>` | the caller's own `private:<client_id>`
+(`src/hal0/memory/namespace.py`). In practice:
+
+- `agents` held only the agent identity cards written by Hermes
+  provisioning (`hermes_provision.py`) and read back by
+  `agent_commands.py` — always scoped by the `agent-identity` tag, so
+  the dedicated namespace added a bank without adding a boundary.
+- `project:<id>` had no writer anywhere in the tree. Under the default
+  `unified_bank = true` it was already implemented as a tag inside
+  `shared` (#1300), not a real bank; per-repository **coding** memory
+  had meanwhile moved outside the namespace system entirely, into
+  `coding-agent::<repo>` banks written directly against the Hindsight
+  engine by the coding-agent clients (hindsight-coding-agents plugin).
+- Each extra namespace was one more bank for consolidation to pay for
+  and one more place for operators to lose facts. A live audit
+  (2026-08-31, CT105) found 14 banks across three generations of naming
+  conventions; see issues #2153/#2154.
+
+## Decision
+
+The grammar is two-valued:
+
+- **`shared`** — the default for every write. Scoping *within* shared is
+  done with tags (`agent-identity` for the identity cards; `project:<id>`
+  as a provenance tag where wanted).
+- **`private:<client_id>`** — reachable only through the private-mode
+  toggle, for memories an agent or the user explicitly wants scoped to
+  one identity.
+
+Per-repository coding memory stays outside the namespace grammar in
+`coding-agent::<repo>` engine banks, owned by the coding-agent clients.
+
+Writes naming `agents` or `project:<id>` now fail with a
+`MemoryNamespaceError` carrying a pointed remedy; reads keep the
+established degrade contract (unknown entries dropped from a list,
+all-unknown lists fail closed per #1451).
+
+## Consequences
+
+- `hermes_provision.py` / `agent_commands.py` identity cards moved to
+  `shared` (the `AGENT_IDENTITY_TAG` scoping they already had is the
+  boundary).
+- The provider-side `project:<id>` **tag** ACL in
+  `hindsight_provider.py` is kept as defense-in-depth for pre-existing
+  tagged data; only the front-door grammar shrank.
+- Existing `agents` / `hal0:projects` / `hal0:system` banks on the
+  operator's box were transferred into `coding-agent::hal0-mono` (with
+  `origin:` tags) or archived, then deleted, the night this was decided.
+  Other deployments upgrading past this change with data still in an
+  `agents` bank must migrate it by hand (document-transfer to `shared`);
+  nothing recreates or reads that bank after this change.
+- A rejected write to a retired namespace is loud (400 with remedy), so
+  any out-of-tree caller still naming `agents` surfaces immediately
+  rather than silently forking a bank.

--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -122,9 +122,16 @@ memory is inert only once you (or the installer) have written
 ## Namespaces and banks: who a fact belongs to
 
 Every memory operation is scoped to a namespace, and the grammar is a closed
-set: `shared`, `agents`, `project:<id>`, or the caller's own
-`private:<client_id>`. A write with no explicit namespace defaults to
-`shared`. Setting the `X-hal0-Private` header over REST (or `private=true`
+two-value set: `shared` or the caller's own `private:<client_id>`
+([ADR-0004](/docs/adr/0004-memory-namespace-shared-private)). `shared` is the
+default for every write; `private:<agent>` is for memories an agent — or the
+operator — explicitly wants scoped to one identity. Scoping *within* `shared`
+is done with tags (the agent identity cards carry `agent-identity`; project
+provenance is a `project:<id>` tag), and per-repository **coding** memory
+lives outside this grammar entirely, in `coding-agent::<repo>` engine banks
+written by the coding-agent clients. The retired `agents` and `project:<id>`
+namespaces are rejected on write with a pointed remedy. A write with no
+explicit namespace defaults to `shared`. Setting the `X-hal0-Private` header over REST (or `private=true`
 over MCP) promotes the write to `private:<client_id>` and **wins over an
 explicit `dataset` field in the request body** — so a private-mode client
 can't smuggle data into `shared` by naming it directly in the payload. An
@@ -146,8 +153,8 @@ Namespaces map onto Hindsight **banks** — `shared` is the `shared` bank,
 forking a separate `private:<agent>` bank, the write still lands in `shared`
 but is stamped with a `visibility:private` tag plus an `agent:<id>` tag, and
 recall stays single-bank (no cross-bank fan-out). Set it `false` to restore
-the pre-unified model — real `private:<agent>` / `project:<id>` banks and
-fan-out recall across them.
+the pre-unified model — real `private:<agent>` banks and fan-out recall
+across them.
 
 ## Fact types: world, experience, observation
 

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -3395,7 +3395,9 @@ def _phase_context_link(ctx: _StepCtx) -> PhaseResult:
 
 
 AGENT_IDENTITY_TAG = "agent-identity"
-AGENTS_DATASET = "agents"
+# Identity cards live in the shared dataset, scoped by AGENT_IDENTITY_TAG —
+# the dedicated ``agents`` namespace was retired (ADR 0004).
+AGENTS_DATASET = "shared"
 
 
 def _hermes_version_pin() -> str:
@@ -3770,7 +3772,8 @@ def _build_brain_identity_card() -> dict[str, Any]:
 def _phase_brain_profile_seed(ctx: _StepCtx) -> PhaseResult:
     """Register the hal0-brain profile as a first-class agent identity.
 
-    Writes the brain identity card to the ``agents`` dataset (search → delete
+    Writes the brain identity card to the ``shared`` dataset under the
+    ``agent-identity`` tag (search → delete
     stale → add), keyed on the ``hermes__hal0-brain`` agent-id so its private
     bank is provisioned rather than left to lazy first-write. Idempotent;
     warn-as-OK so bootstrap never blocks on the memory layer.

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -973,9 +973,9 @@ async def memory_delete(request: Request) -> dict[str, int]:
     an alias and resolved to its owning document; the engine only ever
     deletes documents. See #1456.
 
-    ``dataset`` optionally directs the engine's bank sweep (e.g.
-    ``project:<id>`` items live outside the default shared + own-private
-    sweep). It goes through the same ``resolve_read_datasets`` closed-set
+    ``dataset`` optionally directs the engine's bank sweep (``shared`` or
+    the caller's own ``private:<client_id>``; ADR 0004). It goes through
+    the same ``resolve_read_datasets`` closed-set
     resolver the MCP surface uses — a list that names no addressable
     namespace is a 400, never a silent widening to ``shared`` (#1451).
 

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -1071,7 +1071,7 @@ def _uninstall_hermes_memory() -> MemoryUninstallOutcome:
             {
                 "query": agent_id,
                 "tags": ["agent-identity"],
-                "dataset": "agents",
+                "dataset": "shared",
                 "limit": 50,
             }
         ).encode("utf-8")
@@ -1364,7 +1364,7 @@ def agent_peers() -> None:
         {
             "query": "agent identity",
             "tags": ["agent-identity"],
-            "dataset": "agents",
+            "dataset": "shared",
             "limit": 50,
         }
     ).encode("utf-8")

--- a/src/hal0/mcp/memory.py
+++ b/src/hal0/mcp/memory.py
@@ -473,8 +473,7 @@ async def _memory_delete(
 
     Returns the count of deleted rows. ``ids`` must be
     non-empty. ``dataset`` optionally directs the engine's bank sweep
-    (e.g. ``project:<id>`` items live outside the default
-    shared + own-private sweep).
+    (``shared`` or your own ``private:<client_id>``; ADR 0004).
 
     Approval-gating for bulk deletes (>1 id) is classified by
     :func:`hal0.mcp.admin.is_gated` and enforced one layer up — by
@@ -1540,7 +1539,7 @@ def build_server(
             "Delete one or more memory items by id. Deleting >1 id is a bulk "
             "delete and returns {status: pending_approval} — it runs only "
             "after the operator approves it. dataset optionally directs the "
-            "sweep (e.g. project:<id>)."
+            "sweep (shared or your own private:<client_id>)."
         ),
         annotations=_ANNOTATIONS["memory_delete"],
     )

--- a/src/hal0/memory/namespace.py
+++ b/src/hal0/memory/namespace.py
@@ -19,14 +19,20 @@ The rule:
     without having to opt in per-call.
   - Requesting ``private`` without an authenticated ``client_id`` is
     a usage error — the namespace promotion has no identity to scope to.
-  - The namespace set is CLOSED (spec §3 table): ``shared`` | ``agents``
-    | ``project:<id>`` | the caller's own ``private:<client_id>``.
-    Free-form names used to pass through verbatim, which let any caller
-    read/write arbitrary engine banks (and made the items undeletable
-    through the id-scoped delete sweep). Writes to unknown namespaces
-    now raise; reads *degrade* — an unaddressable entry is dropped from a
-    list that still names at least one addressable namespace, so a
-    multi-namespace read keeps working instead of erroring.
+  - The namespace set is CLOSED and two-valued (ADR 0004): ``shared`` |
+    the caller's own ``private:<client_id>``. Free-form names used to
+    pass through verbatim, which let any caller read/write arbitrary
+    engine banks (and made the items undeletable through the id-scoped
+    delete sweep). Writes to unknown namespaces raise; reads *degrade* —
+    an unaddressable entry is dropped from a list that still names at
+    least one addressable namespace, so a multi-namespace read keeps
+    working instead of erroring.
+  - ``agents`` and ``project:<id>`` were retired from the grammar
+    (ADR 0004): scoping within ``shared`` is done with tags (the
+    agent-identity cards carry the ``agent-identity`` tag; project
+    provenance is a ``project:<id>`` *tag*), and per-repository coding
+    memory lives outside this namespace system entirely, in
+    ``coding-agent::<repo>`` banks written by the coding-agent clients.
   - A read request that names namespaces and resolves to NONE of them
     fails CLOSED (#1451). Dropping the last entry used to yield ``[]``,
     which every downstream ``requested or [DEFAULT_DATASET]`` read back
@@ -44,23 +50,19 @@ in the active provider — this layer is for transport-side resolution.
 
 from __future__ import annotations
 
-import re
-
 DEFAULT_DATASET = "shared"
-AGENTS_DATASET = "agents"
 PRIVATE_PREFIX = "private:"
-PROJECT_PREFIX = "project:"
+
+# Retired namespaces (ADR 0004). Kept as named constants only so the
+# rejection messages and tests can refer to them without magic strings.
+RETIRED_AGENTS_DATASET = "agents"
+RETIRED_PROJECT_PREFIX = "project:"
 
 # Sentinel the MCP/REST identity resolvers emit for an absent/malformed
 # ``X-hal0-Agent`` header. It is NOT a real identity: a private write under it
 # must be rejected, not mis-scoped into a ``private:anonymous`` bank. See
 # ``mcp_mount.client_id_resolver`` whose contract delegates that rejection here.
 ANONYMOUS_CLIENT_ID = "anonymous"
-
-# Spec §3 namespace grammar — the scoped suffix after ``project:`` follows
-# the same identity rules as agent ids: alnum + ``-`` + ``_``,
-# ≤64 chars, so bank names derived from it stay path-traversal-free.
-_SCOPED_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_\-]{1,64}$")
 
 
 class MemoryNamespaceError(ValueError):
@@ -70,12 +72,10 @@ class MemoryNamespaceError(ValueError):
 
 
 def is_known_namespace(name: str, *, client_id: str | None = None) -> bool:
-    """Spec §3 table membership: ``shared`` | ``agents`` | ``project:<id>``
-    | the caller's own ``private:<client_id>``."""
-    if name in (DEFAULT_DATASET, AGENTS_DATASET):
+    """ADR 0004 table membership: ``shared`` | the caller's own
+    ``private:<client_id>``."""
+    if name == DEFAULT_DATASET:
         return True
-    if name.startswith(PROJECT_PREFIX):
-        return bool(_SCOPED_ID_PATTERN.match(name[len(PROJECT_PREFIX) :]))
     if name.startswith(PRIVATE_PREFIX):
         return client_id is not None and name == f"{PRIVATE_PREFIX}{client_id}"
     return False
@@ -101,7 +101,7 @@ def resolve_write_dataset(
         namespace by passing the prefix in the body — the toggle is
         the only path in. Surfaces as 400 at the transport layer
         instead of silently being forwarded to the wrapper.
-      - ``requested`` outside the spec §3 namespace table →
+      - ``requested`` outside the namespace table (ADR 0004) →
         ``MemoryNamespaceError`` (closed-set hardening; see module
         docstring).
     """
@@ -117,9 +117,15 @@ def resolve_write_dataset(
             "send X-hal0-Private: 1 (REST) or private=true (MCP) instead"
         )
     if not is_known_namespace(requested, client_id=client_id):
+        hint = ""
+        if requested == RETIRED_AGENTS_DATASET or requested.startswith(RETIRED_PROJECT_PREFIX):
+            hint = (
+                " ('agents' and 'project:<id>' were retired — write to 'shared' "
+                "with a scoping tag instead; see ADR 0004)"
+            )
         raise MemoryNamespaceError(
-            f"unknown namespace {requested!r}; writes accept 'shared', 'agents', "
-            "or 'project:<id>' (private goes through the private-mode toggle)"
+            f"unknown namespace {requested!r}; writes accept 'shared' "
+            f"(private goes through the private-mode toggle){hint}"
         )
     return requested
 
@@ -135,7 +141,7 @@ def resolve_read_datasets(
     Mirrors the read branch from :func:`hal0.mcp.memory._memory_search`:
 
       - ``requested`` already a non-empty list → filtered against the
-        spec §3 namespace table (unknown / foreign-private entries are
+        namespace table of ADR 0004 (unknown / foreign-private entries are
         dropped — the provider applies the same rule, this keeps the
         contract visible at the front door). If **every** entry is
         dropped the call raises ``MemoryNamespaceError`` rather than
@@ -146,7 +152,7 @@ def resolve_read_datasets(
       - ``requested`` an empty list → no namespace was named at all, so it
         is treated exactly like ``None`` (below), not as a rejection.
       - ``requested`` empty/``None`` + ``private`` + ``client_id`` →
-        expand to ``[shared, private:<client_id>]`` per §3.
+        expand to ``[shared, private:<client_id>]``.
       - ``requested`` empty/``None`` otherwise → :data:`DEFAULT_DATASET`.
       - ``requested`` non-empty string → resolved via
         :func:`resolve_write_dataset` (same rule applies; e.g. an explicit
@@ -169,8 +175,7 @@ def resolve_read_datasets(
         if not kept:
             raise MemoryNamespaceError(
                 "no addressable namespace in the requested scope "
-                f"{names!r}; reads accept 'shared', 'agents', 'project:<id>', "
-                "or your own 'private:<client_id>'"
+                f"{names!r}; reads accept 'shared' or your own 'private:<client_id>'"
             )
         return kept
     if requested is None or isinstance(requested, list) or not requested.strip():
@@ -181,10 +186,10 @@ def resolve_read_datasets(
 
 
 __all__ = [
-    "AGENTS_DATASET",
     "DEFAULT_DATASET",
     "PRIVATE_PREFIX",
-    "PROJECT_PREFIX",
+    "RETIRED_AGENTS_DATASET",
+    "RETIRED_PROJECT_PREFIX",
     "MemoryNamespaceError",
     "is_known_namespace",
     "resolve_read_datasets",

--- a/tests/api/test_memory_rest_routes.py
+++ b/tests/api/test_memory_rest_routes.py
@@ -178,20 +178,33 @@ def test_add_private_mode_wins_over_body_dataset(
     assert call["dataset"] == "private:hermes-agent"
 
 
-def test_add_custom_dataset_passthrough_no_private(
+def test_add_explicit_shared_dataset_passthrough_no_private(
     client: TestClient, stub_wrapper: StubWrapper
 ) -> None:
-    """Non-private callers can address custom datasets (e.g. the
-    Hermes bootstrap ``agents`` dataset) explicitly."""
+    """Non-private callers can name ``shared`` explicitly (ADR 0004: the
+    only non-private namespace; the Hermes identity cards write here)."""
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "ident card", "dataset": "shared"},
+        headers={"X-hal0-Agent": "hermes-agent"},
+    )
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.add_calls[0]
+    assert call["dataset"] == "shared"
+    assert call["source"] == "hermes-agent"
+
+
+def test_add_retired_dataset_rejected(client: TestClient, stub_wrapper: StubWrapper) -> None:
+    """ADR 0004: writes naming the retired ``agents``/``project:<id>``
+    namespaces are a 400 with a pointed remedy, never a passthrough."""
     r = client.post(
         "/api/memory/add",
         json={"text": "ident card", "dataset": "agents"},
         headers={"X-hal0-Agent": "hermes-agent"},
     )
-    assert r.status_code == 200, r.text
-    call = stub_wrapper.add_calls[0]
-    assert call["dataset"] == "agents"
-    assert call["source"] == "hermes-agent"
+    assert r.status_code == 400, r.text
+    assert "retired" in r.text
+    assert not stub_wrapper.add_calls
 
 
 def test_add_private_without_agent_header_rejected(
@@ -310,10 +323,10 @@ def test_list_private_mode_expands_to_both_namespaces(
 
 def test_list_explicit_dataset_query_param(client: TestClient, stub_wrapper: StubWrapper) -> None:
     """The ``?dataset=`` query param still wins for non-private listers."""
-    r = client.get("/api/memory/list?dataset=agents")
+    r = client.get("/api/memory/list?dataset=shared")
     assert r.status_code == 200, r.text
     call = stub_wrapper.list_calls[0]
-    assert call["dataset"] == "agents"
+    assert call["dataset"] == "shared"
 
 
 # ── /api/memory/list?bank= (#1669) ───────────────────────────────────────────
@@ -644,11 +657,11 @@ def test_add_unknown_namespace_rejected(client: TestClient, stub_wrapper: StubWr
 def test_delete_dataset_directs_sweep(client: TestClient, stub_wrapper: StubWrapper) -> None:
     r = client.post(
         "/api/memory/delete",
-        json={"ids": ["d1"], "dataset": "project:apollo"},
+        json={"ids": ["d1"], "dataset": "shared"},
         headers={"X-hal0-Agent": "hermes-agent"},
     )
     assert r.status_code == 200, r.text
-    assert stub_wrapper.delete_calls[0]["dataset"] == "project:apollo"
+    assert stub_wrapper.delete_calls[0]["dataset"] == "shared"
 
 
 def test_delete_without_dataset_keeps_default_sweep(

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -144,14 +144,16 @@ def test_is_gated_memory_delete_single_id_gates_on_dataset() -> None:
     # No dataset at all — unaffected, stays autonomous.
     assert admin.is_gated("memory_delete", {"ids": ["a"]}) is False
     # Known, closed-set namespace (not private) — autonomous regardless of
-    # client_id ownership (shared/agents/project are not identity-scoped).
+    # client_id ownership (shared is not identity-scoped).
     assert (
         admin.is_gated("memory_delete", {"ids": ["a"], "dataset": "shared"}, client_id="pi")
         is False
     )
+    # Retired namespaces (ADR 0004) are unknown now — they gate like any
+    # foreign namespace instead of running unattended.
     assert (
         admin.is_gated("memory_delete", {"ids": ["a"], "dataset": "project:apollo"}, client_id="pi")
-        is False
+        is True
     )
     # The caller's own private namespace — autonomous.
     assert (

--- a/tests/mcp/test_memory.py
+++ b/tests/mcp/test_memory.py
@@ -169,9 +169,9 @@ async def test_memory_search_private_mode_reads_both_datasets(
 
 @pytest.mark.asyncio
 async def test_memory_search_accepts_dataset_list(wrapper: _FakeWrapper, dispatcher: Any) -> None:
-    """Known-namespace list entries (spec §3 closed table) pass through."""
-    await dispatcher("memory_search", {"query": "x", "dataset": ["agents", "project:apollo"]})
-    assert wrapper.search_calls[0]["dataset"] == ["agents", "project:apollo"]
+    """Known-namespace list entries (ADR 0004 closed table) pass through."""
+    await dispatcher("memory_search", {"query": "x", "dataset": ["shared", "private:pi-coder"]})
+    assert wrapper.search_calls[0]["dataset"] == ["shared", "private:pi-coder"]
 
 
 @pytest.mark.asyncio
@@ -310,11 +310,11 @@ async def test_memory_add_surfaces_async_operation_id(dispatcher_factory: Any = 
 
 @pytest.mark.asyncio
 async def test_memory_delete_dataset_directs_sweep(wrapper: _FakeWrapper, dispatcher: Any) -> None:
-    """An explicit dataset narrows/widens the engine's bank sweep (e.g.
-    project items live outside the default shared+own-private sweep)."""
-    out = await dispatcher("memory_delete", {"ids": ["d1"], "dataset": "project:apollo"})
+    """An explicit dataset directs the engine's bank sweep (ADR 0004:
+    ``shared`` or the caller's own private namespace)."""
+    out = await dispatcher("memory_delete", {"ids": ["d1"], "dataset": "shared"})
     assert out["status"] == "ok"
-    assert wrapper.delete_calls[0]["dataset"] == "project:apollo"
+    assert wrapper.delete_calls[0]["dataset"] == "shared"
 
 
 @pytest.mark.asyncio
@@ -324,10 +324,10 @@ async def test_memory_delete_dataset_list_filters_foreign_namespace(
     """Diagnosis #8: same closed-namespace filtering as memory_search/
     memory_recall applies to memory_delete's dataset list."""
     out = await dispatcher(
-        "memory_delete", {"ids": ["d1"], "dataset": ["agents", "not-a-real-bank"]}
+        "memory_delete", {"ids": ["d1"], "dataset": ["shared", "not-a-real-bank"]}
     )
     assert out["status"] == "ok"
-    assert wrapper.delete_calls[0]["dataset"] == ["agents"]
+    assert wrapper.delete_calls[0]["dataset"] == ["shared"]
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_memory_extended_tools.py
+++ b/tests/mcp/test_memory_extended_tools.py
@@ -385,9 +385,9 @@ async def test_tags_list_happy_path(wrapper: _FakeWrapper, dispatcher: Any) -> N
 
 @pytest.mark.asyncio
 async def test_bank_stats_happy_path(wrapper: _FakeWrapper, dispatcher: Any) -> None:
-    out = await dispatcher("memory_bank_stats", {"dataset": "agents"})
+    out = await dispatcher("memory_bank_stats", {"dataset": "shared"})
     assert out["status"] == "ok"
-    assert wrapper._last("bank_stats")["dataset"] == "agents"
+    assert wrapper._last("bank_stats")["dataset"] == "shared"
 
 
 @pytest.mark.asyncio

--- a/tests/memory/test_namespace_policy.py
+++ b/tests/memory/test_namespace_policy.py
@@ -1,10 +1,13 @@
-"""Spec §3 closed-namespace policy — :mod:`hal0.memory.namespace`.
+"""Closed-namespace policy (ADR 0004) — :mod:`hal0.memory.namespace`.
 
 Free-form dataset names used to pass through verbatim, which let any
 caller read/write arbitrary engine banks (live-verified on CT105:
 a probe wrote into a stale smoke-test bank, and the item was then
 unreachable by the id-scoped delete sweep). The namespace set is now
-closed: ``shared`` | ``agents`` | ``project:<id>`` | own private.
+closed and two-valued: ``shared`` | own private. ``agents`` and
+``project:<id>`` were retired (ADR 0004) — scoping inside ``shared``
+is done with tags, and per-repo coding memory lives in client-side
+``coding-agent::<repo>`` banks outside this grammar.
 """
 
 from __future__ import annotations
@@ -23,17 +26,13 @@ from hal0.memory.namespace import (
 
 def test_known_namespaces_table() -> None:
     assert is_known_namespace("shared")
-    assert is_known_namespace("agents")
-    assert is_known_namespace("project:apollo")
-    assert is_known_namespace("project:a-b_c42")
     assert is_known_namespace("private:hermes", client_id="hermes")
 
 
 def test_unknown_namespaces_rejected() -> None:
     assert not is_known_namespace("smoke-gemma4-e4b-v2")
-    assert not is_known_namespace("project:")  # empty scoped id
-    assert not is_known_namespace("project:has space")
-    assert not is_known_namespace("project:" + "x" * 65)  # over identity bound
+    assert not is_known_namespace("agents")  # retired (ADR 0004)
+    assert not is_known_namespace("project:apollo")  # retired (ADR 0004)
     assert not is_known_namespace("private:hermes", client_id="other")  # foreign private
     assert not is_known_namespace("private:hermes")  # private without identity
 
@@ -41,10 +40,16 @@ def test_unknown_namespaces_rejected() -> None:
 # ── resolve_write_dataset ────────────────────────────────────────────────────
 
 
-def test_write_allows_spec_table_names() -> None:
+def test_write_allows_table_names() -> None:
     assert resolve_write_dataset("shared", private=False, client_id="a") == "shared"
-    assert resolve_write_dataset("agents", private=False, client_id="a") == "agents"
-    assert resolve_write_dataset("project:apollo", private=False, client_id="a") == "project:apollo"
+
+
+def test_write_rejects_retired_namespaces_with_hint() -> None:
+    # ADR 0004: the retired names get a pointed remedy, not just "unknown".
+    with pytest.raises(MemoryNamespaceError, match="retired"):
+        resolve_write_dataset("agents", private=False, client_id="a")
+    with pytest.raises(MemoryNamespaceError, match="retired"):
+        resolve_write_dataset("project:apollo", private=False, client_id="a")
 
 
 def test_write_rejects_free_form_names() -> None:
@@ -75,13 +80,13 @@ def test_write_private_rejects_missing_or_anonymous_client_id() -> None:
 # ── resolve_read_datasets ────────────────────────────────────────────────────
 
 
-def test_read_list_drops_unknown_and_foreign_private() -> None:
+def test_read_list_drops_unknown_retired_and_foreign_private() -> None:
     out = resolve_read_datasets(
         ["shared", "agents", "project:apollo", "private:me", "private:other", "junk-bank"],
         private=False,
         client_id="me",
     )
-    assert out == ["shared", "agents", "project:apollo", "private:me"]
+    assert out == ["shared", "private:me"]
 
 
 def test_read_default_expansion_unchanged() -> None:

--- a/tests/security/test_memory_namespace_fail_closed.py
+++ b/tests/security/test_memory_namespace_fail_closed.py
@@ -3,7 +3,7 @@ to the default shared sweep.
 
 The defect. ``resolve_read_datasets`` documented its list branch as
 "fail-open-empty": unknown / foreign-private entries are dropped. That is
-right for a *partial* list (``["agents", "nope"]`` → ``["agents"]``) and
+right for a *partial* list (``["shared", "nope"]`` → ``["shared"]``) and
 catastrophically wrong for a list that filters to nothing, because every
 downstream consumer read ``[]`` as falsy and substituted the default:
 
@@ -104,8 +104,8 @@ def test_partial_list_still_fails_open_on_the_dropped_entries() -> None:
     """Unchanged behaviour: a list with at least one addressable namespace
     keeps degrading rather than erroring (the multi-namespace read contract)."""
     assert resolve_read_datasets(
-        ["agents", "not-a-real-bank"], private=False, client_id="agent-x"
-    ) == ["agents"]
+        ["shared", "not-a-real-bank"], private=False, client_id="agent-x"
+    ) == ["shared"]
 
 
 def test_empty_list_is_an_unspecified_request_not_a_foreign_one() -> None:
@@ -226,9 +226,9 @@ async def test_rest_delete_still_forwards_an_addressable_list() -> None:
             captured["dataset"] = dataset
             return {"deleted": len(ids)}
 
-    request = _FakeRequest({"ids": ["d1"], "dataset": ["agents", "nope"]}, wrapper=_Wrapper())
+    request = _FakeRequest({"ids": ["d1"], "dataset": ["shared", "nope"]}, wrapper=_Wrapper())
     assert await memory_routes.memory_delete(request) == {"deleted": 1}
-    assert captured["dataset"] == ["agents"]
+    assert captured["dataset"] == ["shared"]
 
 
 class _FakeRequest:


### PR DESCRIPTION
## What

Shrinks the closed memory-namespace set from `shared` | `agents` | `project:<id>` | `private:<client_id>` to just **`shared` | `private:<client_id>`** (operator decision 2026-08-31, recorded as ADR-0004).

- `shared` is the default for every write; `private:<agent>` stays behind the private-mode toggle, for memories an agent or the user explicitly wants identity-scoped.
- Scoping *within* shared is tags: the agent identity cards (`hermes_provision.py`, `agent_commands.py`) keep their `agent-identity` tag and move from the retired `agents` dataset to `shared`; project provenance is a `project:<id>` tag.
- Per-repo coding memory already lives outside this grammar in `coding-agent::<repo>` engine banks (hindsight-coding-agents clients).

## Behavior changes

- Writes naming `agents` / `project:<id>` → 400 `MemoryNamespaceError` with a pointed remedy (retired, use shared + tags).
- Reads keep the established contract: unknown entries dropped from a list, all-unknown lists fail closed (#1451).
- A single-id `memory_delete` directed at a retired namespace now **gates for operator approval** like any foreign namespace (it used to run unattended).
- Provider-side `project:<id>` tag ACL (`hindsight_provider.py`, #1300) kept as defense-in-depth for pre-existing tagged data.

## Migration note

The operator's box was consolidated the same night (agents/hal0:projects transferred into `coding-agent::hal0-mono` with `origin:` tags, hal0:system archived, banks deleted). Other deployments with data still in an `agents` bank must document-transfer it to `shared` by hand; nothing recreates or reads that bank after this change.

## Tests

`tests/memory`, `tests/mcp`, `tests/api/test_memory_rest_routes.py`, `tests/agents/test_hermes_provision.py` — all green locally (988 passed across the affected sweeps); ruff clean.

Related: #2153, #2154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAGHsKjpMPq15yyhjDNt7y