### PR TITLE
docs(adr): renumber the memory-namespace ADR 0004 -> 0005

### DIFF
--- a/docs/adr/0005-memory-namespace-shared-private.md
+++ b/docs/adr/0005-memory-namespace-shared-private.md
@@ -1,4 +1,4 @@
-# ADR-0004: Memory namespace grammar cut to `shared` + `private:<agent>`
+# ADR-0005: Memory namespace grammar cut to `shared` + `private:<agent>`
 
 ## Status
 

--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -123,7 +123,7 @@ memory is inert only once you (or the installer) have written
 
 Every memory operation is scoped to a namespace, and the grammar is a closed
 two-value set: `shared` or the caller's own `private:<client_id>`
-([ADR-0004](/docs/adr/0004-memory-namespace-shared-private)). `shared` is the
+([ADR-0004](/docs/adr/0005-memory-namespace-shared-private)). `shared` is the
 default for every write; `private:<agent>` is for memories an agent — or the
 operator — explicitly wants scoped to one identity. Scoping *within* `shared`
 is done with tags (the agent identity cards carry `agent-identity`; project

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -3455,7 +3455,7 @@ def _phase_context_link(ctx: _StepCtx) -> PhaseResult:
 
 AGENT_IDENTITY_TAG = "agent-identity"
 # Identity cards live in the shared dataset, scoped by AGENT_IDENTITY_TAG —
-# the dedicated ``agents`` namespace was retired (ADR 0004).
+# the dedicated ``agents`` namespace was retired (ADR 0005).
 AGENTS_DATASET = "shared"
 
 

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -974,7 +974,7 @@ async def memory_delete(request: Request) -> dict[str, int]:
     deletes documents. See #1456.
 
     ``dataset`` optionally directs the engine's bank sweep (``shared`` or
-    the caller's own ``private:<client_id>``; ADR 0004). It goes through
+    the caller's own ``private:<client_id>``; ADR 0005). It goes through
     the same ``resolve_read_datasets`` closed-set
     resolver the MCP surface uses — a list that names no addressable
     namespace is a 400, never a silent widening to ``shared`` (#1451).

--- a/src/hal0/mcp/memory.py
+++ b/src/hal0/mcp/memory.py
@@ -473,7 +473,7 @@ async def _memory_delete(
 
     Returns the count of deleted rows. ``ids`` must be
     non-empty. ``dataset`` optionally directs the engine's bank sweep
-    (``shared`` or your own ``private:<client_id>``; ADR 0004).
+    (``shared`` or your own ``private:<client_id>``; ADR 0005).
 
     Approval-gating for bulk deletes (>1 id) is classified by
     :func:`hal0.mcp.admin.is_gated` and enforced one layer up — by

--- a/src/hal0/memory/namespace.py
+++ b/src/hal0/memory/namespace.py
@@ -19,7 +19,7 @@ The rule:
     without having to opt in per-call.
   - Requesting ``private`` without an authenticated ``client_id`` is
     a usage error — the namespace promotion has no identity to scope to.
-  - The namespace set is CLOSED and two-valued (ADR 0004): ``shared`` |
+  - The namespace set is CLOSED and two-valued (ADR 0005): ``shared`` |
     the caller's own ``private:<client_id>``. Free-form names used to
     pass through verbatim, which let any caller read/write arbitrary
     engine banks (and made the items undeletable through the id-scoped
@@ -28,7 +28,7 @@ The rule:
     least one addressable namespace, so a multi-namespace read keeps
     working instead of erroring.
   - ``agents`` and ``project:<id>`` were retired from the grammar
-    (ADR 0004): scoping within ``shared`` is done with tags (the
+    (ADR 0005): scoping within ``shared`` is done with tags (the
     agent-identity cards carry the ``agent-identity`` tag; project
     provenance is a ``project:<id>`` *tag*), and per-repository coding
     memory lives outside this namespace system entirely, in
@@ -53,7 +53,7 @@ from __future__ import annotations
 DEFAULT_DATASET = "shared"
 PRIVATE_PREFIX = "private:"
 
-# Retired namespaces (ADR 0004). Kept as named constants only so the
+# Retired namespaces (ADR 0005). Kept as named constants only so the
 # rejection messages and tests can refer to them without magic strings.
 RETIRED_AGENTS_DATASET = "agents"
 RETIRED_PROJECT_PREFIX = "project:"
@@ -72,7 +72,7 @@ class MemoryNamespaceError(ValueError):
 
 
 def is_known_namespace(name: str, *, client_id: str | None = None) -> bool:
-    """ADR 0004 table membership: ``shared`` | the caller's own
+    """ADR 0005 table membership: ``shared`` | the caller's own
     ``private:<client_id>``."""
     if name == DEFAULT_DATASET:
         return True
@@ -101,7 +101,7 @@ def resolve_write_dataset(
         namespace by passing the prefix in the body — the toggle is
         the only path in. Surfaces as 400 at the transport layer
         instead of silently being forwarded to the wrapper.
-      - ``requested`` outside the namespace table (ADR 0004) →
+      - ``requested`` outside the namespace table (ADR 0005) →
         ``MemoryNamespaceError`` (closed-set hardening; see module
         docstring).
     """
@@ -121,7 +121,7 @@ def resolve_write_dataset(
         if requested == RETIRED_AGENTS_DATASET or requested.startswith(RETIRED_PROJECT_PREFIX):
             hint = (
                 " ('agents' and 'project:<id>' were retired — write to 'shared' "
-                "with a scoping tag instead; see ADR 0004)"
+                "with a scoping tag instead; see ADR 0005)"
             )
         raise MemoryNamespaceError(
             f"unknown namespace {requested!r}; writes accept 'shared' "
@@ -141,7 +141,7 @@ def resolve_read_datasets(
     Mirrors the read branch from :func:`hal0.mcp.memory._memory_search`:
 
       - ``requested`` already a non-empty list → filtered against the
-        namespace table of ADR 0004 (unknown / foreign-private entries are
+        namespace table of ADR 0005 (unknown / foreign-private entries are
         dropped — the provider applies the same rule, this keeps the
         contract visible at the front door). If **every** entry is
         dropped the call raises ``MemoryNamespaceError`` rather than

--- a/tests/api/test_memory_rest_routes.py
+++ b/tests/api/test_memory_rest_routes.py
@@ -181,7 +181,7 @@ def test_add_private_mode_wins_over_body_dataset(
 def test_add_explicit_shared_dataset_passthrough_no_private(
     client: TestClient, stub_wrapper: StubWrapper
 ) -> None:
-    """Non-private callers can name ``shared`` explicitly (ADR 0004: the
+    """Non-private callers can name ``shared`` explicitly (ADR 0005: the
     only non-private namespace; the Hermes identity cards write here)."""
     r = client.post(
         "/api/memory/add",
@@ -195,7 +195,7 @@ def test_add_explicit_shared_dataset_passthrough_no_private(
 
 
 def test_add_retired_dataset_rejected(client: TestClient, stub_wrapper: StubWrapper) -> None:
-    """ADR 0004: writes naming the retired ``agents``/``project:<id>``
+    """ADR 0005: writes naming the retired ``agents``/``project:<id>``
     namespaces are a 400 with a pointed remedy, never a passthrough."""
     r = client.post(
         "/api/memory/add",

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -175,7 +175,7 @@ def test_is_gated_memory_delete_single_id_gates_on_dataset() -> None:
         admin.is_gated("memory_delete", {"ids": ["a"], "dataset": "shared"}, client_id="pi")
         is False
     )
-    # Retired namespaces (ADR 0004) are unknown now — they gate like any
+    # Retired namespaces (ADR 0005) are unknown now — they gate like any
     # foreign namespace instead of running unattended.
     assert (
         admin.is_gated("memory_delete", {"ids": ["a"], "dataset": "project:apollo"}, client_id="pi")

--- a/tests/mcp/test_memory.py
+++ b/tests/mcp/test_memory.py
@@ -169,7 +169,7 @@ async def test_memory_search_private_mode_reads_both_datasets(
 
 @pytest.mark.asyncio
 async def test_memory_search_accepts_dataset_list(wrapper: _FakeWrapper, dispatcher: Any) -> None:
-    """Known-namespace list entries (ADR 0004 closed table) pass through."""
+    """Known-namespace list entries (ADR 0005 closed table) pass through."""
     await dispatcher("memory_search", {"query": "x", "dataset": ["shared", "private:pi-coder"]})
     assert wrapper.search_calls[0]["dataset"] == ["shared", "private:pi-coder"]
 
@@ -310,7 +310,7 @@ async def test_memory_add_surfaces_async_operation_id(dispatcher_factory: Any = 
 
 @pytest.mark.asyncio
 async def test_memory_delete_dataset_directs_sweep(wrapper: _FakeWrapper, dispatcher: Any) -> None:
-    """An explicit dataset directs the engine's bank sweep (ADR 0004:
+    """An explicit dataset directs the engine's bank sweep (ADR 0005:
     ``shared`` or the caller's own private namespace)."""
     out = await dispatcher("memory_delete", {"ids": ["d1"], "dataset": "shared"})
     assert out["status"] == "ok"

--- a/tests/memory/test_namespace_policy.py
+++ b/tests/memory/test_namespace_policy.py
@@ -1,11 +1,11 @@
-"""Closed-namespace policy (ADR 0004) — :mod:`hal0.memory.namespace`.
+"""Closed-namespace policy (ADR 0005) — :mod:`hal0.memory.namespace`.
 
 Free-form dataset names used to pass through verbatim, which let any
 caller read/write arbitrary engine banks (live-verified on CT105:
 a probe wrote into a stale smoke-test bank, and the item was then
 unreachable by the id-scoped delete sweep). The namespace set is now
 closed and two-valued: ``shared`` | own private. ``agents`` and
-``project:<id>`` were retired (ADR 0004) — scoping inside ``shared``
+``project:<id>`` were retired (ADR 0005) — scoping inside ``shared``
 is done with tags, and per-repo coding memory lives in client-side
 ``coding-agent::<repo>`` banks outside this grammar.
 """
@@ -31,8 +31,8 @@ def test_known_namespaces_table() -> None:
 
 def test_unknown_namespaces_rejected() -> None:
     assert not is_known_namespace("smoke-gemma4-e4b-v2")
-    assert not is_known_namespace("agents")  # retired (ADR 0004)
-    assert not is_known_namespace("project:apollo")  # retired (ADR 0004)
+    assert not is_known_namespace("agents")  # retired (ADR 0005)
+    assert not is_known_namespace("project:apollo")  # retired (ADR 0005)
     assert not is_known_namespace("private:hermes", client_id="other")  # foreign private
     assert not is_known_namespace("private:hermes")  # private without identity
 
@@ -45,7 +45,7 @@ def test_write_allows_table_names() -> None:
 
 
 def test_write_rejects_retired_namespaces_with_hint() -> None:
-    # ADR 0004: the retired names get a pointed remedy, not just "unknown".
+    # ADR 0005: the retired names get a pointed remedy, not just "unknown".
     with pytest.raises(MemoryNamespaceError, match="retired"):
         resolve_write_dataset("agents", private=False, client_id="a")
     with pytest.raises(MemoryNamespaceError, match="retired"):


### PR DESCRIPTION
tests/mcp/test_admin.py already cites an ADR-0004 (the MCP admin tool classification spec, not in docs/adr/), so the namespace-grammar ADR merged in #2161 took a colliding number. This renames docs/adr/0004-memory-namespace-shared-private.md to 0005 and updates every reference (src, tests, docs). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAGHsKjpMPq15yyhjDNt7y