### PR TITLE
fix(slots): surface pinnable catalogue images and pin-declared image status

### DIFF
--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -728,15 +728,27 @@ async def container_enrichment(
         profile_name = str(cfg.get("profile") or "")
         entry["profile"] = profile_name
         image: str | None = None
-        if profile_name:
+        image_pin = str(cfg.get("image_pin") or "").strip()
+        if profile_name or image_pin:
             try:
-                if profiles is None:
-                    raise RuntimeError("profiles catalogue unreadable")
-                prof = profiles.get(profile_name)
-                if prof is not None:
-                    from hal0.providers.container import _resolve_image_ref
+                prof = None
+                if profile_name:
+                    if profiles is None:
+                        raise RuntimeError("profiles catalogue unreadable")
+                    prof = profiles.get(profile_name)
+                # Resolve through the SAME chain the launch uses (image_pin →
+                # [slots].default_images → runner default) — _resolve_image_ref
+                # tolerates prof=None, which is exactly the two cases that used
+                # to fall through to image=None here: a profile name the
+                # catalogue can't resolve (custom/stale id), and a profileless
+                # slot whose image_pin alone declares the image. Both launched
+                # a real ref while this view answered "not-configured" (#1226's
+                # no-expected-image state) — a claim about config the config
+                # contradicts. The truly-undeclared slot (no profile, no pin)
+                # still takes the else-branch below.
+                from hal0.providers.container import _resolve_image_ref
 
-                    image = _resolve_image_ref(cfg, prof)
+                image = _resolve_image_ref(cfg, prof)
                 entry["image"] = image
                 # Lift device_class + backend from the resolved profile so the
                 # UI groups by silicon class and colours by GPU runtime without

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -721,6 +721,37 @@ class TestContainerEnrichment:
         )
         assert out["gpu-chat"]["image_status"] == "not-configured"
 
+    async def test_pin_only_slot_reports_pin_and_probed_status(self) -> None:
+        # A profileless slot whose image_pin declares the image used to answer
+        # image=None / image_status="not-configured" while its unit launched
+        # the pin (observed live: a pinned slot rendering "IMAGE STATUS —").
+        # The view now resolves the same chain the launch does.
+        sv_mod._image_present_cache.clear()
+        out = await container_enrichment(
+            [_container_cfg(image_pin=_PINNED_IMAGE)],
+            pull_jobs={},
+            provider=FakeContainerProvider(active=False, present=True),
+        )
+        e = out["gpu-chat"]
+        assert e["image"] == _PINNED_IMAGE
+        assert e["image_status"] == "present"
+
+    async def test_unresolvable_profile_still_resolves_launch_image(
+        self, tmp_hal0_home: str
+    ) -> None:
+        # A profile id the catalogue can't resolve (custom/stale) doesn't stop
+        # the launch — _resolve_image_ref falls through to the pin/default —
+        # so it must not stop the view either.
+        sv_mod._image_present_cache.clear()
+        out = await container_enrichment(
+            [_container_cfg(profile="ghost-profile", image_pin=_PINNED_IMAGE)],
+            pull_jobs={},
+            provider=FakeContainerProvider(active=False, present=True),
+        )
+        e = out["gpu-chat"]
+        assert e["image"] == _PINNED_IMAGE
+        assert e["image_status"] == "present"
+
     # ── #1939: the four-state block is a five-state block ──────────────────
     #
     # `missing` is reserved for "podman was asked and said no". Every way of

--- a/ui/src/dash/__tests__/hw-cascade.test.ts
+++ b/ui/src/dash/__tests__/hw-cascade.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   applyBackendChoice,
   backendOptions,
+  cataloguePinOptions,
   optionValue,
   selectedBackendValue,
 } from '../hw-cascade.js'
@@ -163,5 +164,66 @@ describe('selectedBackendValue', () => {
   })
   it('returns empty string when no binary is pinned (auto)', () => {
     expect(selectedBackendValue({ binary: '', device: 'gpu-rocm', options: res.options })).toBe('')
+  })
+})
+
+describe('cataloguePinOptions — downloaded catalogue rows beyond the release catalog', () => {
+  // GET /api/runner-images rows (RunnerImage shape, the fields the helper reads).
+  const rows = [
+    // The motivating case (#2118): catalogued + downloaded, repo outside the
+    // release catalog — must surface as a pinnable option.
+    {
+      id: 'combined-upstream',
+      image: 'ghcr.io/hal0ai/hal0-combined-upstream',
+      tag: '0829',
+      downloaded: true,
+      notes: 'pin-only upstream variant',
+    },
+    // Same lineage the release catalog already lists (digest-pinned there) —
+    // offering it again would show one image under two spellings.
+    { id: 'cpu', image: 'ghcr.io/hal0ai/hal0-toolbox-cpu', tag: 'v1', downloaded: true },
+    // Catalogued but not on this box — a pin would just crash-loop.
+    { id: 'rocm', image: 'ghcr.io/hal0ai/hal0-toolbox-rocm', tag: 'v1', downloaded: false },
+  ]
+  // Release-catalog refs as system-info hands them out: tag AND digest shapes.
+  const catalogImages = [
+    'ghcr.io/hal0ai/hal0-combined:0826',
+    'ghcr.io/hal0ai/hal0-toolbox-cpu@sha256:eab70d0355981c08133a6fff28e472690c7091f6e968da1a2f269bdfa29311a1',
+  ]
+
+  it('offers downloaded rows the release catalog does not list, as repo:tag', () => {
+    const out = cataloguePinOptions({ rows, catalogImages, slotType: 'llm' })
+    expect(out).toEqual([
+      {
+        id: 'combined-upstream',
+        ref: 'ghcr.io/hal0ai/hal0-combined-upstream:0829',
+        notes: 'pin-only upstream variant',
+      },
+    ])
+  })
+
+  it('dedupes against catalog refs by repo, digest-pinned refs included', () => {
+    const out = cataloguePinOptions({ rows, catalogImages, slotType: 'llm' })
+    expect(out.some((o) => o.ref.includes('toolbox-cpu'))).toBe(false)
+  })
+
+  it('drops rows that are not downloaded', () => {
+    const out = cataloguePinOptions({ rows, catalogImages, slotType: 'llm' })
+    expect(out.some((o) => o.ref.includes('toolbox-rocm'))).toBe(false)
+  })
+
+  it('offers nothing for slot types llama-server does not serve', () => {
+    expect(cataloguePinOptions({ rows, catalogImages, slotType: 'tts' })).toEqual([])
+    expect(cataloguePinOptions({ rows, catalogImages, slotType: 'image' })).toEqual([])
+  })
+
+  it('serves every llama-server slot type', () => {
+    for (const t of ['llm', 'embedding', 'reranking']) {
+      expect(cataloguePinOptions({ rows, catalogImages, slotType: t }).length).toBe(1)
+    }
+  })
+
+  it('tolerates missing rows/catalog', () => {
+    expect(cataloguePinOptions({ rows: undefined, catalogImages: undefined, slotType: 'llm' })).toEqual([])
   })
 })

--- a/ui/src/dash/hw-cascade.js
+++ b/ui/src/dash/hw-cascade.js
@@ -141,6 +141,54 @@ export function backendOptions({ backends, pinnedImage, device, slotType }) {
 	};
 }
 
+// Repo part of an image ref — strips a @sha256 digest, then a trailing tag
+// (a ':' segment with no '/', so a registry port like localhost:5000/x
+// survives). FE mirror of the backend's `_repo_of` (api/routes/runner_images).
+function repoOfRef(ref) {
+	const body = String(ref || "").split("@")[0];
+	const i = body.lastIndexOf(":");
+	return i > -1 && !body.slice(i + 1).includes("/") ? body.slice(0, i) : body;
+}
+
+/**
+ * Catalogue rows offerable as an image pin beyond the release catalog.
+ *
+ * The Runner Image dropdown historically listed ONLY the RUNNER_IMAGES
+ * release-catalog refs (system-info `backends`), so a catalogued image with
+ * no runner family — e.g. hal0-combined-upstream, which #2118 says is wired
+ * to slots ONLY via per-slot image_pin — was reachable solely through the
+ * free-text "Custom image ref…" hatch. This enumerates the catalogue rows
+ * that are actually pinnable right now:
+ *
+ * - downloaded on this box (a pin to a missing image just crash-loops), and
+ * - not a repo the release catalog already lists (those rows are the same
+ *   lineage the catalog options resolve — offering both would show one image
+ *   twice under two spellings).
+ *
+ * Catalogue rows carry no runtime_family, so they're assumed llama-server
+ * (every uncatalogued-family row today is a llama.cpp fork) and offered only
+ * for the slot types that family serves. A wrong pick degrades to the
+ * existing out-of-catalog pin path (cascade fallback + caution), never a
+ * dead end.
+ *
+ * @param rows          GET /api/runner-images rows (RunnerImage[])
+ * @param catalogImages the release-catalog refs already in the dropdown
+ * @param slotType      slot.type — gates via FAMILY_SLOT_TYPES["llama-server"]
+ * @returns [{id, ref, notes}] — ref is the pinnable `repo:tag`
+ */
+export function cataloguePinOptions({ rows, catalogImages, slotType }) {
+	if (slotType && !FAMILY_SLOT_TYPES["llama-server"].includes(slotType))
+		return [];
+	const catalogRepos = new Set((catalogImages || []).map(repoOfRef));
+	const out = [];
+	for (const r of rows || []) {
+		if (!r || !r.downloaded || !r.image || !r.tag) continue;
+		if (catalogRepos.has(r.image)) continue;
+		out.push({ id: r.id, ref: `${r.image}:${r.tag}`, notes: r.notes || "" });
+	}
+	return out;
+}
+
 /**
  * Resolve a Backend dropdown pick to the state it drives.
  * Unknown values (the out-of-vocab persisted pair rendered as its own option)

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -22,9 +22,11 @@ import { useSystemInfo, deviceBackend } from "@/api/hooks/useRuntimes";
 import {
 	applyBackendChoice,
 	backendOptions,
+	cataloguePinOptions,
 	optionValue,
 	selectedBackendValue,
 } from "./hw-cascade.js";
+import { useRunnerImages } from "@/api/hooks/useRunnerImages";
 // llama.cpp build-provenance formatter (h0/runner-provenance) — shared with
 // the Runner Images page so option labels and the RunnerCard can't drift.
 import { formatProvenanceShort } from "./runner-images.jsx";
@@ -274,6 +276,12 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// it is the UI's only rocm↔vulkan switch, since BINARY is metadata-gated
 	// to the same image and profiles carry backend only as an inert fit hint.
 	const systemInfoQuery = useSystemInfo();
+	// Catalogue rows for the Runner Image dropdown's "downloaded · catalogue"
+	// group (cataloguePinOptions): images synced+downloaded on this box that
+	// the release catalog doesn't list — e.g. the per-slot-pin-only
+	// combined-upstream variant (#2118). useQuery dedupes against the Runner
+	// Images page's identical key, so an open drawer adds no extra polling.
+	const runnerImagesQuery = useRunnerImages();
 
 	// Seed from the PERSISTED context window (slot.ctx_max, from
 	// [model].context_size) first — NOT the live runtime metric, which is 0
@@ -1490,6 +1498,14 @@ function EditSlotDrawer({ open, slot, onClose }) {
 							imageKeysByRef.get(img).push(k);
 						}
 						const catalogImages = [...imageKeysByRef.keys()];
+						// Downloaded catalogue rows outside the release catalog —
+						// pinnable without the free-text hatch (see
+						// cataloguePinOptions in hw-cascade.js / #2118).
+						const cataloguePins = cataloguePinOptions({
+							rows: runnerImagesQuery.data?.images,
+							catalogImages,
+							slotType: slot.type,
+						});
 						// Image → Backend cascade (hw-cascade.js): one dropdown of
 						// (binary · backend) pairs enumerated from the pinned image (or
 						// the release-catalog union when nothing is pinned). Picking a
@@ -1618,7 +1634,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
 												{/* A persisted pin outside the catalog (older release,
 												    hand-edited TOML) keeps its own option so opening the
 												    drawer never silently rewrites it. */}
-												{pinnedImage && !catalogImages.includes(pinnedImage) && (
+												{pinnedImage &&
+													!catalogImages.includes(pinnedImage) &&
+													!cataloguePins.some((o) => o.ref === pinnedImage) && (
 													<option value={pinnedImage}>
 														{pinnedImage} · custom
 													</option>
@@ -1628,6 +1646,22 @@ function EditSlotDrawer({ open, slot, onClose }) {
 														{(imageKeysByRef.get(img) || []).join(" / ")} · {img}
 													</option>
 												))}
+												{/* Catalogued + downloaded images the release catalog
+												    doesn't list (e.g. combined-upstream, #2118) — the
+												    per-slot-pin lane without the free-text hatch. */}
+												{cataloguePins.length > 0 && (
+													<optgroup label="catalogued · downloaded">
+														{cataloguePins.map((o) => (
+															<option
+																key={o.ref}
+																value={o.ref}
+																title={o.notes || o.ref}
+															>
+																{o.id} · {o.ref}
+															</option>
+														))}
+													</optgroup>
+												)}
 												<option value="__custom__">Custom image ref…</option>
 											</select>
 										)}

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -339,6 +339,20 @@ test.describe('Slot edit controls (/slots)', () => {
         }),
       }),
     )
+    // Pin the catalogue empty via the #1498 passthrough hatch (forced-mock
+    // otherwise substitutes the baked fixture, whose downloaded catalogue
+    // row would add a "catalogued · downloaded" option and break the exact
+    // catalog-count assertion below — that lane has its own test).
+    await page.addInitScript(() => {
+      ;(window as unknown as { __hal0MockPassthrough: string[] }).__hal0MockPassthrough = ['/api/runner-images']
+    })
+    await page.route('**/api/runner-images', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ images: [], families: [] }),
+      }),
+    )
     await seedSlots(page, [{ ...PRIMARY, binary: 'rocmfpx', image_pin: null }, EMBED])
     await page.goto('/#slots/primary')
 
@@ -360,6 +374,81 @@ test.describe('Slot edit controls (/slots)', () => {
     await imageSel.selectOption('ghcr.io/hal0ai/tb:cuda')
     await expect(binarySel).toHaveValue('cuda::cuda')
     await expect(binarySel.locator('option')).toHaveCount(1)
+  })
+
+  test('HW grid — downloaded catalogue image outside the release catalog is offerable as a pin', async ({ page }) => {
+    // #2118: combined-upstream is wired to slots ONLY via per-slot
+    // image_pin — it has no RUNNER_IMAGES family, so it must surface in the
+    // "catalogued · downloaded" optgroup instead of hiding behind the
+    // free-text custom hatch.
+    await page.route('**/api/system-info', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          hardware: {},
+          features: {},
+          podman_context: 'rootless',
+          backends: {
+            rocmfpx: {
+              image: 'ghcr.io/hal0ai/tb:dual',
+              runtime_family: 'llamacpp',
+              device_class: 'gpu',
+              backend: 'rocm',
+              supported_backends: ['rocm', 'vulkan'],
+              format_arch: 'gguf',
+              state: 'installed',
+            },
+          },
+        }),
+      }),
+    )
+    await page.addInitScript(() => {
+      ;(window as unknown as { __hal0MockPassthrough: string[] }).__hal0MockPassthrough = ['/api/runner-images']
+    })
+    await page.route('**/api/runner-images', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          images: [
+            {
+              id: 'combined-upstream',
+              image: 'ghcr.io/hal0ai/hal0-combined-upstream',
+              tag: '0829',
+              downloaded: true,
+              store_state: 'present',
+              notes: 'pin-only upstream variant',
+            },
+            {
+              // Not downloaded — must NOT be offered.
+              id: 'rocm',
+              image: 'ghcr.io/hal0ai/hal0-toolbox-rocm',
+              tag: 'v1',
+              downloaded: false,
+              store_state: 'missing',
+              notes: '',
+            },
+          ],
+          families: [],
+        }),
+      }),
+    )
+    await seedSlots(page, [{ ...PRIMARY, binary: 'rocmfpx', image_pin: null }, EMBED])
+    await page.goto('/#slots/primary')
+
+    const imageSel = page.getByTestId('slot-hw-image-pin')
+    await expect(imageSel).toBeVisible()
+    // default + 1 catalog image + 1 catalogued·downloaded + custom hatch.
+    await expect(imageSel.locator('option')).toHaveCount(4)
+    const grouped = imageSel.locator('optgroup[label="catalogued · downloaded"] option')
+    await expect(grouped).toHaveCount(1)
+    await expect(grouped).toHaveText(/combined-upstream/)
+
+    // Picking it lands on the out-of-catalog pin path (fallback Backend
+    // union) — the form never dead-ends.
+    await imageSel.selectOption('ghcr.io/hal0ai/hal0-combined-upstream:0829')
+    await expect(imageSel).toHaveValue('ghcr.io/hal0ai/hal0-combined-upstream:0829')
   })
 
   test('HW grid — fit-check warns on a persisted pair the catalog does not offer (§4)', async ({ page }) => {


### PR DESCRIPTION
## What

Two fixes from live-debugging "can't run Qwen3.8 Flash Next" on ct105:

**1. Runner Image dropdown offers downloaded catalogue images** (`ui/src/dash/hw-cascade.js`, `slot-modals.jsx`)

The slot drawer's Runner Image dropdown listed only `RUNNER_IMAGES` release-catalog refs (`GET /api/system-info` backends). A catalogued, downloaded image outside the release catalog — `ghcr.io/hal0ai/hal0-combined-upstream:0829`, the only runner that loads `qwen4exp`-arch models and deliberately pin-only per #2118 — never appeared; the only route was pasting the ref into "Custom image ref…". New `cataloguePinOptions()` adds a `catalogued · downloaded` optgroup: rows from `GET /api/runner-images` that are downloaded on the box and whose repo the release catalog doesn't already list (dedupe handles digest-pinned catalog refs), gated to llama-server slot types. Picking one lands on the existing out-of-catalog pin path (cascade fallback + caution) — no new launch semantics.

**2. `image`/`image_status` honor `image_pin` and unresolvable profile ids** (`src/hal0/slot_view/__init__.py`)

The slot view computed `image`/`image_status` only when `slot.profile` resolved in the ProfileCatalog. Live on ct105, three slots with custom/stale profile ids (`vulkan-dense`, `rocm-dense-minicpm5`, `hy3-fpx`) and the pin-only `hy3` slot all reported `image=None` / `image_status="not-configured"` while their units launched real refs — the drawer rendered IMAGE STATUS "—". Resolution now goes through `_resolve_image_ref` (pin → `[slots].default_images` → runner default) whenever a profile name **or** pin is declared. A slot with neither still reports `not-configured` (#1226 semantics preserved).

## Verified

- `tests/slot_view/` 83 passed (2 new tests: pin-only slot, unresolvable-profile slot)
- `tests/api/test_slots_container_state.py` 12 passed
- ui: vitest 283 passed (6 new `cataloguePinOptions` tests), `tsc --noEmit`, eslint clean
- ruff check + format clean
- Live on ct105: `PUT /api/slots/code/config {"image_pin": "ghcr.io/hal0ai/hal0-combined-upstream:0829"}` + load of `qwen3.8-flash-next-ud-q2-k-xl` — the image accepts the qwen4exp arch and proceeds to weight allocation (fails there only for host RAM: 47.3 GiB weights vs 18 GiB free on the pve host). On `hal0-combined:0826` the same model dies at arch parse, which is the crash-loop / "trial pending" the dropdown gap forced operators into.

Note: `make test` fails on this dev box before and after this change (PATH `pytest` is a mise shim without the repo's plugins — collection errors on the `asyncio` marker); `.venv/bin/pytest` collects all 12521 tests cleanly.

Refs #2118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011o6Hur5YMz4RidLNtsAtN4