### PR TITLE
feat(slots): surface the decisive crash line to the slot card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+
+- The dashboard now surfaces the decisive crash line when a slot container
+  dies during model load. On a load failure the slot manager tails the
+  unit's journal, extracts the one line that names the fault (e.g.
+  `llama_model_load: error loading model: unknown model architecture`,
+  `unable to allocate ROCm0 buffer`, or the hal0-runner death summary from
+  #2037/#2126) and stamps it on the slot state (`metadata.last_crash_line`);
+  the crash-breaker chip's tooltip carries it, so "trial pending" finally
+  says why instead of pointing at `journalctl -u hal0-slot@<name>`.
+
 ## [1.1.0] — 2026-08-31
 
 ### Highlights

--- a/src/hal0/slots/logs.py
+++ b/src/hal0/slots/logs.py
@@ -12,6 +12,10 @@ Interface contract:
 
     is_log_noise(line) -> bool
         True for high-frequency heartbeat lines with no diagnostic value.
+    extract_crash_line(text) -> str | None
+        Pure: the single decisive error line out of a journal tail, or None.
+    read_crash_line(unit, lines=120) -> str | None
+        One-shot tail + extraction + redaction. Never raises.
     read_tail(unit, lines, quiet=True) -> tuple[str, str | None]
         One-shot ``journalctl -n`` tail. Returns ``(logs_text, hint)`` where
         ``hint`` is a non-None reason string when the tail is empty/best-effort
@@ -33,6 +37,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import re
 import shutil
 from collections.abc import AsyncIterator
 
@@ -50,6 +55,104 @@ LOG_NOISE_MARKERS: tuple[str, ...] = (
 def is_log_noise(line: str) -> bool:
     """True for high-frequency heartbeat lines with no diagnostic value."""
     return any(marker in line for marker in LOG_NOISE_MARKERS)
+
+
+# ── decisive crash line extraction ───────────────────────────────────────────
+#
+# When a slot container dies during model load, the WHY lives only in
+# ``journalctl -u hal0-slot@<name>`` — the dashboard showed a crash-breaker
+# chip with no reason. On a load failure the manager tails the unit's journal
+# and stamps the single decisive line onto the slot's state extra
+# (``last_crash_line``), which rides slot metadata to ``GET /api/slots`` and
+# the breaker chip's tooltip. Everything here is best-effort: an unreadable
+# journal yields ``None``, never an exception.
+
+#: ``journalctl -o short-iso`` line prefix: ``<iso-ts> <host> <ident>[pid]: ``
+#: (the pid suffix is optional — kernel/systemd lines omit it).
+_JOURNAL_PREFIX_RE = re.compile(r"^\S+ \S+ \S+?(?:\[\d+\])?: ")
+
+#: Substrings (matched case-insensitively on the prefix-stripped message) that
+#: mark an ENGINE error line — the actual reason a model load died. Ordered
+#: for readers, not priority: the LAST matching line in the tail wins, since
+#: the tail ends at the death.
+_CRASH_LINE_MARKERS: tuple[str, ...] = (
+    "error loading model",  # llama_model_load: error loading model: …
+    "failed to load model",
+    "error while loading",
+    "unable to allocate",  # unable to allocate ROCm0 buffer
+    "failed to allocate",
+    "out of memory",
+)
+
+#: The in-container hal0-runner wrapper's own summary lines (#2037/#2126/#1936)
+#: are a good FALLBACK when the engine printed no recognisable error — but its
+#: exit-translation/remediation boilerplate is not the reason itself.
+_RUNNER_PREFIX = "hal0-runner: "
+_RUNNER_BOILERPLATE: tuple[str, ...] = (
+    "translating to exit 64",
+    "refusing to start rather than crashing",
+    "expected /dev/kfd",
+    "pass the devices through",
+)
+
+#: Stored-line cap. One journal line can be a multi-KB dump (llama.cpp prints
+#: whole tensor lists); the state extra / API payload only needs the head.
+CRASH_LINE_MAX = 300
+
+
+def _strip_journal_prefix(line: str) -> str:
+    """Drop the ``short-iso`` timestamp/host/ident prefix, if present."""
+    return _JOURNAL_PREFIX_RE.sub("", line, count=1)
+
+
+def extract_crash_line(text: str) -> str | None:
+    """The single decisive error line out of a journal tail, or ``None``. Pure.
+
+    Preference order:
+
+      1. the LAST engine error line (``error loading model``, ``unable to
+         allocate …``, or an explicit ``E ``-level line) — the engine names
+         the actual fault;
+      2. else the last ``hal0-runner:`` summary line that isn't exit-code
+         translation boilerplate — the wrapper at least names the failure
+         shape (died during load, killed by SIGILL, no GPU devices, …);
+      3. else ``None`` — no line is better than a guessed one.
+    """
+    messages = [_strip_journal_prefix(ln).strip() for ln in text.splitlines()]
+    messages = [m for m in messages if m]
+    for msg in reversed(messages):
+        lowered = msg.lower()
+        if msg.startswith("E ") or any(marker in lowered for marker in _CRASH_LINE_MARKERS):
+            return msg[:CRASH_LINE_MAX]
+    for msg in reversed(messages):
+        if msg.startswith(_RUNNER_PREFIX) and not any(
+            marker in msg for marker in _RUNNER_BOILERPLATE
+        ):
+            return msg[:CRASH_LINE_MAX]
+    return None
+
+
+async def read_crash_line(unit: str, lines: int = 120) -> str | None:
+    """Tail *unit*'s journal and return the decisive crash line, redacted.
+
+    Best-effort by contract — the caller is a load-failure path that must
+    never fail harder because the journal is unreadable: any problem here
+    (journalctl missing/timed out, empty journal, no recognisable line)
+    answers ``None``. Redacted with the same text scrubber the ``/api/logs``
+    surfaces use, since the line lands in state.json and the slots API.
+    """
+    try:
+        text, _hint = await read_tail(unit, lines, quiet=True)
+        if not text:
+            return None
+        line = extract_crash_line(text)
+        if line is None:
+            return None
+        from hal0.redaction import redact_log_line
+
+        return redact_log_line(line)
+    except Exception:
+        return None
 
 
 def _suppress_proc():

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1287,6 +1287,10 @@ class SlotManager:
             self._load_failures.pop(key, None)
             carried_extra.pop("parked", None)
             carried_extra.pop("load_failures", None)
+            # …and the crash-line evidence: it explains the failures the
+            # breaker counted, so it retires with them.
+            carried_extra.pop("last_crash_line", None)
+            carried_extra.pop("last_crash_line_at", None)
             # …and the output-sanity verdict (#1922). Reaching READY/IDLE means
             # a load ran the gate and the model answered (or the operator
             # switched the gate off for this slot) — the one piece of evidence
@@ -1508,6 +1512,34 @@ class SlotManager:
         # stamping a healthy slot ERROR with "<MagicMock ...>" as the operator-
         # facing message. Only a real ``str`` is evidence.
         return reason if isinstance(reason, str) else ""
+
+    async def _read_last_crash_line(self, slot_name: str, cfg: Any) -> str | None:
+        """Decisive crash line from the slot unit's journal, or ``None``.
+
+        Called on the load-failure path so the WHY (``llama_model_load: error
+        loading model: …``, ``unable to allocate ROCm0 buffer``, or the
+        hal0-runner death summary) reaches the dashboard instead of living
+        only in ``journalctl -u hal0-slot@<name>``. Best-effort by contract:
+        any problem reading or parsing the journal answers ``None`` — a
+        diagnostic capture must never make the failure it is diagnosing worse.
+        The unit name goes through the naming seam (#1417), so id-keyed boxes
+        tail the journal of the unit that actually ran.
+        """
+        try:
+            cfg_dict = _cfg_to_dict(cfg) if cfg else {"name": slot_name}
+            if is_npu_trio_shadow(cfg_dict):
+                return None  # no unit (and so no journal) of its own
+            from hal0.slots import logs as slot_logs
+            from hal0.slots.naming import slot_instance_token, slot_unit_name
+
+            unit = slot_unit_name(slot_instance_token(cfg_dict))
+            return await slot_logs.read_crash_line(unit)
+        except Exception as exc:
+            log.debug(
+                "slot.crash_line_capture_failed",
+                extra={"slot": slot_name, "error": str(exc)},
+            )
+            return None
 
     # ── crash-loop breaker (issue i4) ────────────────────────────────────────
 
@@ -1891,6 +1923,17 @@ class SlotManager:
                 err_extra: dict[str, Any] = {"load_failures": failures, **gate_extra}
                 if failures >= _CRASH_LOOP_PARK_AFTER:
                     err_extra["parked"] = True
+                # Surface the decisive crash line: the reason a container died
+                # during model load (unknown architecture, buffer alloc, …)
+                # lives only in the unit's journal, so tail it now and stamp
+                # the one line that names the fault onto the state extra —
+                # metadata carries it to /api/slots and the breaker chip.
+                # Best-effort: an unreadable journal answers None and the
+                # failure path proceeds exactly as before.
+                crash_line = await self._read_last_crash_line(slot_name, cfg)
+                if crash_line:
+                    err_extra["last_crash_line"] = crash_line
+                    err_extra["last_crash_line_at"] = time.time()
                 # TIER1: never swallow — record ERROR with details, re-raise.
                 await self._transition(
                     slot_name,

--- a/tests/slots/test_crash_line.py
+++ b/tests/slots/test_crash_line.py
@@ -1,0 +1,236 @@
+"""Decisive crash line surfacing: journal tail → slot metadata → breaker chip.
+
+When a slot container dies during model load, the reason (e.g.
+``llama_model_load: error loading model: unknown model architecture`` or
+``unable to allocate ROCm0 buffer``) used to live only in
+``journalctl -u hal0-slot@<name>`` while the dashboard showed a bare
+crash-breaker chip. The manager now tails the unit's journal on a load
+failure and stamps the one decisive line onto the state extra
+(``last_crash_line`` + ``last_crash_line_at``), which rides slot metadata to
+``GET /api/slots``. Everything is best-effort: an unreadable journal must
+never make the load failure worse.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.slots import logs as slot_logs
+from hal0.slots.logs import CRASH_LINE_MAX, extract_crash_line, read_crash_line
+from hal0.slots.manager import SlotManager
+from hal0.slots.state import SlotState
+from tests.slots.conftest import FakeContainerProvider
+
+# ── extract_crash_line: pure extraction over real journal shapes ─────────────
+
+_PREFIX = "2026-08-30T01:02:03+0200 ct150 hal0-slot-chat[4242]: "
+
+
+def _journal(*messages: str) -> str:
+    return "\n".join(_PREFIX + m for m in messages)
+
+
+def test_extracts_unknown_architecture_line() -> None:
+    text = _journal(
+        "llama_model_loader: loaded meta data with 29 key-value pairs",
+        "llama_model_load: error loading model: unknown model architecture",
+        "hal0-runner: llama-server exited (rc=1) before /health ever answered "
+        "— died during model load.",
+        "hal0-runner: translating to exit 64 so systemd can fail-fast instead "
+        "of burning the restart ramp (hal0 issue #2037).",
+    )
+    assert (
+        extract_crash_line(text)
+        == "llama_model_load: error loading model: unknown model architecture"
+    )
+
+
+def test_extracts_rocm_buffer_alloc_line() -> None:
+    text = _journal(
+        "llm_load_tensors: offloading 48 repeating layers to GPU",
+        "ggml_backend_alloc: unable to allocate ROCm0 buffer",
+        "hal0-runner: llama-server exited (rc=1) before /health ever answered "
+        "— died during model load.",
+    )
+    assert extract_crash_line(text) == "ggml_backend_alloc: unable to allocate ROCm0 buffer"
+
+
+def test_last_engine_error_wins_over_earlier_ones() -> None:
+    text = _journal(
+        "llama_model_load: error loading model: first attempt",
+        "main: retrying",
+        "llama_model_load: error loading model: second attempt",
+    )
+    assert extract_crash_line(text) == "llama_model_load: error loading model: second attempt"
+
+
+def test_e_level_line_counts_as_engine_error() -> None:
+    text = _journal(
+        "I model loading started",
+        "E failed opening tensor stream",
+    )
+    assert extract_crash_line(text) == "E failed opening tensor stream"
+
+
+def test_runner_summary_is_the_fallback_not_the_boilerplate() -> None:
+    # SIGILL death (#2126): the engine printed nothing recognisable, so the
+    # hal0-runner summary/hint is the best available line — but never the
+    # "translating to exit 64" boilerplate that follows it.
+    text = _journal(
+        "load: loading model /models/chadrock-35b.gguf",
+        "hal0-runner: llama-server was killed by SIGILL (illegal instruction) "
+        "(rc=132) before /health ever answered.",
+        "hal0-runner: this image's llama-server contains CPU instructions this "
+        "host cannot execute — an image/hardware mismatch, not a model problem.",
+        "hal0-runner: translating to exit 64 — restarting reproduces this "
+        "fault exactly (hal0 issue #2126).",
+    )
+    line = extract_crash_line(text)
+    assert line is not None
+    assert line.startswith("hal0-runner: this image's llama-server contains CPU instructions")
+
+
+def test_no_recognisable_line_answers_none() -> None:
+    assert extract_crash_line("") is None
+    assert (
+        extract_crash_line(
+            _journal(
+                "main: build info",
+                "srv update_slots: all slots are idle",
+            )
+        )
+        is None
+    )
+
+
+def test_prefix_stripping_tolerates_bare_lines() -> None:
+    # A --output=cat style line (no journal prefix) must still match.
+    assert (
+        extract_crash_line("llama_model_load: error loading model: unknown model architecture")
+        == "llama_model_load: error loading model: unknown model architecture"
+    )
+
+
+def test_long_line_is_truncated() -> None:
+    text = _journal("llama_model_load: error loading model: " + "x" * 2000)
+    line = extract_crash_line(text)
+    assert line is not None
+    assert len(line) == CRASH_LINE_MAX
+
+
+# ── read_crash_line: fail-soft wrapper ───────────────────────────────────────
+
+
+async def test_read_crash_line_empty_tail_answers_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_tail(unit: str, lines: int, quiet: bool = True) -> tuple[str, str | None]:
+        return "", "journalctl not available on this host"
+
+    monkeypatch.setattr(slot_logs, "read_tail", fake_tail)
+    assert await read_crash_line("hal0-slot@chat.service") is None
+
+
+async def test_read_crash_line_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def boom(unit: str, lines: int, quiet: bool = True) -> tuple[str, str | None]:
+        raise RuntimeError("journal exploded")
+
+    monkeypatch.setattr(slot_logs, "read_tail", boom)
+    assert await read_crash_line("hal0-slot@chat.service") is None
+
+
+async def test_read_crash_line_redacts_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_tail(unit: str, lines: int, quiet: bool = True) -> tuple[str, str | None]:
+        return _journal("llama_model_load: error loading model: api_key=sk-hunter2-secret"), None
+
+    monkeypatch.setattr(slot_logs, "read_tail", fake_tail)
+    line = await read_crash_line("hal0-slot@chat.service")
+    assert line is not None
+    assert "hunter2" not in line
+
+
+# ── manager: load failure stamps the line; success clears it ─────────────────
+
+
+async def _fail_load(sm: SlotManager, container_stub: FakeContainerProvider) -> None:
+    container_stub.fail_load = RuntimeError("spawn boom")
+    with pytest.raises(RuntimeError):
+        await sm.load("chat")
+    assert sm._current_state("chat") == SlotState.ERROR
+
+
+async def test_load_failure_stamps_last_crash_line(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_units: list[str] = []
+
+    async def fake_read_crash_line(unit: str, lines: int = 120) -> str | None:
+        seen_units.append(unit)
+        return "llama_model_load: error loading model: unknown model architecture"
+
+    monkeypatch.setattr(slot_logs, "read_crash_line", fake_read_crash_line)
+    sm = SlotManager()
+    await _fail_load(sm, container_stub)
+
+    rec = sm._states[sm._key("chat")]
+    assert (
+        rec.extra["last_crash_line"]
+        == "llama_model_load: error loading model: unknown model architecture"
+    )
+    assert rec.extra["last_crash_line_at"] > 0
+    # The unit name went through the naming seam (name-keyed box → name token).
+    assert seen_units == ["hal0-slot@chat.service"]
+
+    # …and it surfaces on the status metadata, i.e. GET /api/slots payloads.
+    snap = await sm.status("chat")
+    assert (
+        snap.metadata["last_crash_line"]
+        == "llama_model_load: error loading model: unknown model architecture"
+    )
+
+
+async def test_unreadable_journal_never_breaks_the_failure_path(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def boom(unit: str, lines: int = 120) -> str | None:
+        raise RuntimeError("journal exploded")
+
+    monkeypatch.setattr(slot_logs, "read_crash_line", boom)
+    sm = SlotManager()
+    # The original spawn error propagates (not the journal one) and ERROR is
+    # stamped without any crash-line keys.
+    await _fail_load(sm, container_stub)
+    rec = sm._states[sm._key("chat")]
+    assert "last_crash_line" not in rec.extra
+    assert rec.extra["load_failures"] == 1
+
+
+async def test_healthy_convergence_clears_the_crash_line(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_read_crash_line(unit: str, lines: int = 120) -> str | None:
+        return "ggml_backend_alloc: unable to allocate ROCm0 buffer"
+
+    monkeypatch.setattr(slot_logs, "read_crash_line", fake_read_crash_line)
+    sm = SlotManager()
+    await _fail_load(sm, container_stub)
+    # Open the backoff window, fix the fault, reload.
+    key = sm._key("chat")
+    count, ts = sm._load_failures[key]
+    sm._load_failures[key] = (count, ts - 10_000.0)
+    container_stub.fail_load = None
+
+    await sm.load("chat")
+
+    assert sm._current_state("chat") == SlotState.READY
+    rec = sm._states[key]
+    assert "last_crash_line" not in rec.extra
+    assert "last_crash_line_at" not in rec.extra

--- a/ui/src/dash/__tests__/breaker-chip.test.ts
+++ b/ui/src/dash/__tests__/breaker-chip.test.ts
@@ -82,3 +82,53 @@ describe('breakerChip', () => {
     ).toBeNull()
   })
 })
+
+// The backend stamps metadata.last_crash_line — the decisive journal line a
+// failed model load died on — alongside the breaker view. The chip's tooltip
+// carries it so the operator sees WHY, not just "trial pending".
+describe('breakerChip crash line', () => {
+  const CRASH =
+    'llama_model_load: error loading model: unknown model architecture'
+
+  function withCrash(state: string, line: unknown): Slot {
+    return {
+      ...BASE,
+      metadata: {
+        breaker: { state, failures: 2, retry_after_s: 30 },
+        last_crash_line: line,
+      },
+    } as Slot
+  }
+
+  it('appends the decisive line to every breaker tooltip', () => {
+    for (const state of ['backoff', 'parked', 'half-open']) {
+      const chip = breakerChip(withCrash(state, CRASH))
+      expect(chip).not.toBeNull()
+      expect(chip!.tooltip).toContain(`Last crash: ${CRASH}`)
+      // one line in the label area is untouched — the reason is tooltip-only
+      expect(chip!.label).not.toContain('llama_model_load')
+    }
+  })
+
+  it('truncates a long crash line to one readable line', () => {
+    const long = 'unable to allocate ROCm0 buffer ' + 'x'.repeat(400)
+    const chip = breakerChip(withCrash('parked', long))
+    expect(chip).not.toBeNull()
+    const suffix = chip!.tooltip.split('Last crash: ')[1]
+    expect(suffix.length).toBeLessThanOrEqual(161) // 160 + ellipsis
+    expect(suffix.endsWith('…')).toBe(true)
+  })
+
+  it('tolerates an absent, empty, or non-string crash line', () => {
+    expect(
+      breakerChip(withBreaker({ state: 'parked', failures: 2, retry_after_s: 30 }))!
+        .tooltip
+    ).not.toContain('Last crash')
+    expect(breakerChip(withCrash('parked', '   '))!.tooltip).not.toContain(
+      'Last crash'
+    )
+    expect(breakerChip(withCrash('parked', 42))!.tooltip).not.toContain(
+      'Last crash'
+    )
+  })
+})

--- a/ui/src/dash/slot-status.js
+++ b/ui/src/dash/slot-status.js
@@ -293,10 +293,32 @@ export function imageStatusChip(slot) {
  *   parked    → err     (red — refusing loads until the trial; needs an eye)
  *   half-open → neutral (a trial will run on the next request; nothing to fix)
  *
+ * The backend also stamps `metadata.last_crash_line` — the decisive line the
+ * manager pulled from the slot unit's journal when the load died (e.g.
+ * `llama_model_load: error loading model: unknown model architecture`).
+ * When present, it is appended to the tooltip (one line, truncated) so the
+ * chip finally answers WHY instead of only "trial pending".
+ *
  * @param {object|null|undefined} slot
  * @param {number} [elapsedS] - seconds since the snapshot was fetched
  * @returns {{tone: string, label: string, tooltip: string}|null}
  */
+
+// Tooltip budget for the crash line — one readable line, not a log dump.
+const CRASH_LINE_TOOLTIP_MAX = 160;
+
+function crashLineSuffix(slot) {
+  const raw = slot?.metadata?.last_crash_line;
+  if (typeof raw !== "string") return "";
+  const line = raw.trim();
+  if (!line) return "";
+  const shown =
+    line.length > CRASH_LINE_TOOLTIP_MAX
+      ? `${line.slice(0, CRASH_LINE_TOOLTIP_MAX - 1)}…`
+      : line;
+  return ` Last crash: ${shown}`;
+}
+
 export function breakerChip(slot, elapsedS = 0) {
   const b = slot?.metadata?.breaker;
   if (!b || typeof b !== "object") return null;
@@ -306,6 +328,7 @@ export function breakerChip(slot, elapsedS = 0) {
     0,
     Math.round((Number(b.retry_after_s) || 0) - elapsedS),
   );
+  const crash = crashLineSuffix(slot);
   switch (b.state) {
     case "backoff":
       return {
@@ -313,7 +336,8 @@ export function breakerChip(slot, elapsedS = 0) {
         label: `retry in ${remaining}s`,
         tooltip:
           `Crash-loop breaker: the last load failed (${failTxt} in a row). ` +
-          `Next automatic retry in ${remaining}s.`,
+          `Next automatic retry in ${remaining}s.` +
+          crash,
       };
     case "parked":
       return {
@@ -322,7 +346,8 @@ export function breakerChip(slot, elapsedS = 0) {
         tooltip:
           `Crash-loop breaker: parked after ${failTxt} — the slot is ` +
           `deliberately refusing loads. Next automatic trial in ${remaining}s; ` +
-          `a manual Start/Restart attempts a load immediately.`,
+          `a manual Start/Restart attempts a load immediately.` +
+          crash,
       };
     case "half-open":
       return {
@@ -330,7 +355,8 @@ export function breakerChip(slot, elapsedS = 0) {
         label: "trial pending",
         tooltip:
           "Crash-loop breaker half-open: the next load request runs a single " +
-          "trial. Success closes the breaker; failure parks it again.",
+          "trial. Success closes the breaker; failure parks it again." +
+          crash,
       };
     default:
       // Unknown state (schema drift): render nothing rather than guess a


### PR DESCRIPTION
## Summary

When a slot container dies during model load (e.g. `llama_model_load: error loading model: unknown model architecture`, `unable to allocate ROCm0 buffer`, or a hal0-runner exit-64 death summary from #2037/#2126), the reason lived only in `journalctl -u hal0-slot@<name>` while the dashboard showed a bare crash-breaker chip ("trial pending") with no why. This PR carries that decisive line all the way to the breaker chip's tooltip.

## How

**Capture (backend)** — `src/hal0/slots/logs.py` gains a pure `extract_crash_line()` plus a fail-soft `read_crash_line()` wrapper over the existing `read_tail` journal seam. Extraction prefers the last engine error line (`error loading model`, `unable to allocate`, `out of memory`, `E `-level) and falls back to the hal0-runner death summary, skipping the exit-translation boilerplate. The result is redacted with the shared log scrubber and capped at 300 chars.

**Stamp (manager)** — on the `load()` failure path, `SlotManager._read_last_crash_line()` resolves the unit through the naming seam (#1417-safe on id-keyed boxes) and stamps `last_crash_line` + `last_crash_line_at` onto the ERROR state extra, next to the crash-loop bookkeeping. Cleared on healthy convergence alongside `load_failures`/`parked`. Fail-soft everywhere: an unreadable journal answers `None` and the failure path proceeds exactly as before — it can never break the load path or the slots endpoint.

**API** — no new plumbing: state extra already rides slot metadata through `SlotManager.status()` into `GET /api/slots` payloads (`slot_view.serialize_slot` passes metadata verbatim), so entries now carry `metadata.last_crash_line`.

**FE** — `breakerChip()` (shared by the slot cards and the edit drawer) appends `Last crash: <line>` to the tooltip for all three breaker states — one line, truncated at 160 chars.

## Tests

- `tests/slots/test_crash_line.py` (14 new): pure extraction over real journal shapes (both sample lines above, SIGILL runner summary vs boilerplate, E-level, truncation, prefix stripping, no-match → None), `read_crash_line` fail-soft + redaction, and manager integration (stamp on failure, surface via `status()` metadata, unreadable journal never breaks the failure path, healthy convergence clears).
- `ui/src/dash/__tests__/breaker-chip.test.ts` (3 new): tooltip carries the line for every breaker state, truncation, tolerance of absent/empty/non-string values.

## Verification

- `pytest tests/slots/test_crash_line.py` → 14 passed
- Regression: `tests/slots/test_crash_loop_breaker.py test_crash_loop_lifecycle.py test_logs_keepalive.py test_state_transitions.py tests/slot_view` → 138 passed
- `ruff check` + `ruff format --check` clean on touched files
- `vitest run breaker-chip.test.ts` → 10 passed; `node --test` slot-status suites pass; `eslint` 0 errors; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011o6Hur5YMz4RidLNtsAtN4