### PR TITLE
feat(catalogue): runtime_family + supported_backends metadata for runner-image catalogue rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ applying. Add those subsections to a version's section to surface them; see
   #2037/#2126) and stamps it on the slot state (`metadata.last_crash_line`);
   the crash-breaker chip's tooltip carries it, so "trial pending" finally
   says why instead of pointing at `journalctl -u hal0-slot@<name>`.
+- Runner-image catalogue rows now carry `runtime_family` and
+  `supported_backends` runtime metadata merged from the
+  `hal0.runner-images.v1` manifest, and the slot drawer's
+  "catalogued · downloaded" pin lane gates each row on its declared
+  runtime family instead of assuming every catalogue row is a
+  llama-server fork (#2174).
 
 ## [1.1.0] — 2026-08-31
 

--- a/src/hal0/db/migrations/010_runner_image_runtime_metadata.sql
+++ b/src/hal0/db/migrations/010_runner_image_runtime_metadata.sql
@@ -1,0 +1,15 @@
+-- 010_runner_image_runtime_metadata.sql  (schema version 10)
+--
+-- Catalogue runtime metadata (feat/catalogue-runtime-metadata): images.json
+-- (hal0.runner-images.v1) entries may now declare which runtime the image's
+-- entrypoint serves (`runtime_family`, same vocabulary as
+-- hal0.runners.RuntimeFamily) and which backends its runner binary can
+-- execute (`supported_backends`, same semantics as
+-- hal0.runners.Runner.supported_backends — metadata, not a selector).
+-- The slot drawer's "catalogued · downloaded" pin lane gates on these
+-- instead of assuming every catalogue row is a llama-server fork.
+-- NULL means the manifest entry predates the fields (or no entry matched);
+-- readers fall back rather than treating absence as a veto.
+
+ALTER TABLE runner_image ADD COLUMN runtime_family TEXT;
+ALTER TABLE runner_image ADD COLUMN supported_backends_json TEXT;

--- a/src/hal0/registry/runner_image.py
+++ b/src/hal0/registry/runner_image.py
@@ -63,6 +63,16 @@ class RunnerImage(BaseModel):
     publish: str | None = None  # "ci" | "external" | "manual"
     notes: str | None = None
     build: dict[str, Any] | None = None
+    #: Runtime the image's entrypoint serves — same vocabulary as
+    #: ``hal0.runners.RuntimeFamily`` (``"llama-server"``, ``"comfyui"``, …).
+    #: ``None`` when the matched ``images.json`` entry predates the field (or
+    #: no entry matched at all) — consumers fall back to their own assumption
+    #: rather than treating absence as a veto.
+    runtime_family: str | None = None
+    #: Backends the image's runner binary can execute (``"rocm"``/``"vulkan"``/
+    #: ``"cpu"``/…). Same semantics as ``hal0.runners.Runner.supported_backends``:
+    #: metadata, not a selector, and ``[]`` means "not declared" (no veto).
+    supported_backends: list[str] = Field(default_factory=list)
 
     # Local download state — set by hal0.registry.runner_pull once an
     # image has actually been pulled onto this host.

--- a/src/hal0/registry/runner_image_store.py
+++ b/src/hal0/registry/runner_image_store.py
@@ -41,6 +41,7 @@ _SCALAR_FIELDS = (
     "ownership",
     "publish",
     "notes",
+    "runtime_family",
     "local_path",
     "downloaded_at",
     "discovered_at",
@@ -52,11 +53,13 @@ def _row_to_runner_image(row: sqlite3.Row) -> RunnerImage:
     build_raw = row["build_json"]
     extra_raw = row["extra"]
     tags_raw = row["available_tags_json"]
+    backends_raw = row["supported_backends_json"]
     return RunnerImage(
         **{k: row[k] for k in _SCALAR_FIELDS},
         build=json.loads(build_raw) if build_raw else None,
         extra=json.loads(extra_raw) if extra_raw else {},
         available_tags=json.loads(tags_raw) if tags_raw else [],
+        supported_backends=json.loads(backends_raw) if backends_raw else [],
     )
 
 
@@ -102,6 +105,9 @@ def _runner_image_to_row(image: RunnerImage, *, discovered_at: str | None = None
     row["build_json"] = json.dumps(image.build) if image.build is not None else None
     row["extra"] = json.dumps(image.extra) if image.extra else None
     row["available_tags_json"] = json.dumps(image.available_tags) if image.available_tags else None
+    row["supported_backends_json"] = (
+        json.dumps(image.supported_backends) if image.supported_backends else None
+    )
     return row
 
 

--- a/src/hal0/registry/runner_image_sync.py
+++ b/src/hal0/registry/runner_image_sync.py
@@ -20,8 +20,9 @@ see PR description):
 2. **``images.json`` fetch.** ``raw.githubusercontent.com/Hal0ai/hal0-runner-images/main/images.json``
    (schema ``hal0.runner-images.v1``) — anonymous, CDN-backed, no auth. Gives
    display metadata (``ownership``/``publish``/``manifest_key``/``build``/
-   ``notes``) per image. Fetched live at sync time, never baked into a
-   release.
+   ``notes``) plus runtime metadata (``runtime_family``/
+   ``supported_backends``) per image. Fetched live at sync time, never baked
+   into a release.
 
 Fetch failures degrade gracefully at every layer: a malformed/unreachable
 ``images.json`` still lets already-known GHCR packages sync (tag/digest/size
@@ -496,13 +497,22 @@ def _match_key(entry: dict[str, Any]) -> str | None:
 def _apply_manifest_metadata(image: RunnerImage, entry: dict[str, Any]) -> RunnerImage:
     """Overlay images.json display metadata onto a GHCR-discovered row."""
     update: dict[str, Any] = {}
-    for field_name in ("manifest_key", "ownership", "publish", "notes"):
+    for field_name in ("manifest_key", "ownership", "publish", "notes", "runtime_family"):
         val = entry.get(field_name)
         if isinstance(val, str) and val.strip():
             update[field_name] = val.strip()
     build = entry.get("build")
     if isinstance(build, dict):
         update["build"] = build
+    # Runtime metadata (feat/catalogue-runtime-metadata): a list of backend
+    # strings, filtered fail-soft — a malformed value (non-list, or non-string
+    # members) degrades to "not declared" rather than failing the row, same
+    # discipline as every other images.json field here.
+    backends = entry.get("supported_backends")
+    if isinstance(backends, list):
+        cleaned = [b.strip() for b in backends if isinstance(b, str) and b.strip()]
+        if cleaned:
+            update["supported_backends"] = cleaned
     tag = entry.get("tag")
     if isinstance(tag, str) and tag.strip():
         update["tag"] = tag.strip()

--- a/tests/api/test_runner_images_routes.py
+++ b/tests/api/test_runner_images_routes.py
@@ -66,6 +66,8 @@ def test_sync_route_populates_catalogue(
                 "ownership": "owned",
                 "publish": "ci",
                 "notes": "CPU-only toolbox image.",
+                "runtime_family": "llama-server",
+                "supported_backends": ["cpu"],
             }
         ],
     }
@@ -101,10 +103,16 @@ def test_sync_route_populates_catalogue(
     assert listed[0]["id"] == "hal0ai/hal0-toolbox-cpu"
     assert listed[0]["digest"] == "sha256:abc"
     assert listed[0]["notes"] == "CPU-only toolbox image."
+    # Runtime metadata (feat/catalogue-runtime-metadata) flows through
+    # _image_to_dict (model_dump) into every row untouched.
+    assert listed[0]["runtime_family"] == "llama-server"
+    assert listed[0]["supported_backends"] == ["cpu"]
 
     detail = client.get("/api/runner-images/hal0ai/hal0-toolbox-cpu")
     assert detail.status_code == 200
     assert detail.json()["ownership"] == "owned"
+    assert detail.json()["runtime_family"] == "llama-server"
+    assert detail.json()["supported_backends"] == ["cpu"]
 
 
 def test_pull_unknown_image_404s(client: TestClient) -> None:

--- a/tests/registry/test_runner_image_store.py
+++ b/tests/registry/test_runner_image_store.py
@@ -62,6 +62,25 @@ class TestUpsert:
         assert got.build == {"context": ".", "dockerfile": "Dockerfile"}
         assert got.extra == {"foo": "bar"}
 
+    def test_runtime_metadata_round_trips(self, store: RunnerImageStore) -> None:
+        # feat/catalogue-runtime-metadata: runtime_family is a scalar column,
+        # supported_backends a JSON column (supported_backends_json,
+        # migration 010) — both must survive a write/read cycle.
+        store.upsert(_image(runtime_family="comfyui", supported_backends=["rocm"]))
+        got = store.get("hal0ai/hal0-toolbox-cpu")
+        assert got is not None
+        assert got.runtime_family == "comfyui"
+        assert got.supported_backends == ["rocm"]
+
+    def test_runtime_metadata_defaults_when_absent(self, store: RunnerImageStore) -> None:
+        # A row written without the fields (pre-010 shape) reads back as
+        # "not declared", never as a veto.
+        store.upsert(_image())
+        got = store.get("hal0ai/hal0-toolbox-cpu")
+        assert got is not None
+        assert got.runtime_family is None
+        assert got.supported_backends == []
+
     def test_persists_across_instances(self, store: RunnerImageStore, tmp_path: Path) -> None:
         store.upsert(_image())
         store2 = RunnerImageStore(db_path=tmp_path / "hal0.db")

--- a/tests/registry/test_runner_image_sync.py
+++ b/tests/registry/test_runner_image_sync.py
@@ -32,6 +32,8 @@ _IMAGES_JSON = {
             "publish": "ci",
             "build": {"context": ".", "dockerfile": "Dockerfile.cpu"},
             "notes": "CPU-only toolbox image.",
+            "runtime_family": "llama-server",
+            "supported_backends": ["cpu"],
         },
         {
             # no "id" — exercises the repo-path fallback
@@ -172,11 +174,63 @@ async def test_sync_merges_ghcr_and_images_json(tmp_path: Path) -> None:
     assert cpu.publish == "ci"
     assert cpu.notes == "CPU-only toolbox image."
     assert cpu.build == {"context": ".", "dockerfile": "Dockerfile.cpu"}
+    assert cpu.runtime_family == "llama-server"
+    assert cpu.supported_backends == ["cpu"]
 
     flm = store.get("hal0ai/hal0-toolbox-flm")  # no "id" — repo-path fallback
     assert flm is not None
     assert flm.tag == "v2"
     assert flm.ownership == "referenced"
+    # Entry carries no runtime metadata — reads back as "not declared".
+    assert flm.runtime_family is None
+    assert flm.supported_backends == []
+
+
+@pytest.mark.asyncio
+async def test_malformed_runtime_metadata_degrades_to_not_declared(tmp_path: Path) -> None:
+    """Bad runtime_family/supported_backends shapes never fail the row.
+
+    Same fail-soft discipline as every other images.json field: a non-string
+    runtime_family is dropped; a non-list supported_backends (or one whose
+    members aren't non-empty strings) degrades to [].
+    """
+    images_json = {
+        "schema": "hal0.runner-images.v1",
+        "images": [
+            {
+                "id": "cpu",
+                "image": "ghcr.io/hal0ai/hal0-toolbox-cpu",
+                "tag": "latest",
+                "runtime_family": 42,
+                "supported_backends": "rocm,vulkan",
+            },
+            {
+                "id": "flm",
+                "image": "ghcr.io/hal0ai/hal0-toolbox-flm",
+                "tag": "v2",
+                "runtime_family": "flm",
+                "supported_backends": [None, "", "  ", "npu"],
+            },
+        ],
+    }
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_route_handler(images_json=images_json))
+    )
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.probe_errors == {}
+    cpu = store.get("cpu")
+    assert cpu is not None
+    assert cpu.runtime_family is None
+    assert cpu.supported_backends == []
+    flm = store.get("flm")
+    assert flm is not None
+    assert flm.runtime_family == "flm"
+    assert flm.supported_backends == ["npu"]  # junk members filtered, order kept
 
 
 @pytest.mark.asyncio

--- a/ui/src/api/hooks/useRunnerImages.ts
+++ b/ui/src/api/hooks/useRunnerImages.ts
@@ -34,6 +34,15 @@ export interface RunnerImage {
   publish: 'ci' | 'external' | 'manual' | string | null
   notes: string | null
   build: Record<string, unknown> | null
+  // Catalogue runtime metadata (feat/catalogue-runtime-metadata): which
+  // runtime the image's entrypoint serves (backend RuntimeFamily vocabulary —
+  // "llama-server", "comfyui", …) and which backends its runner binary can
+  // execute ("rocm"/"vulkan"/"cpu"/…, [] = not declared). Optional so rows
+  // from a pre-contract backend still type-check; readers fall back (see
+  // cataloguePinOptions in dash/hw-cascade.js) rather than treating absence
+  // as a veto.
+  runtime_family?: string | null
+  supported_backends?: string[]
   local_path: string | null
   downloaded_at: string | null
   discovered_at: string | null

--- a/ui/src/dash/__tests__/hw-cascade.test.ts
+++ b/ui/src/dash/__tests__/hw-cascade.test.ts
@@ -212,7 +212,7 @@ describe('cataloguePinOptions — downloaded catalogue rows beyond the release c
     expect(out.some((o) => o.ref.includes('toolbox-rocm'))).toBe(false)
   })
 
-  it('offers nothing for slot types llama-server does not serve', () => {
+  it('offers nothing for slot types llama-server does not serve (family-less rows)', () => {
     expect(cataloguePinOptions({ rows, catalogImages, slotType: 'tts' })).toEqual([])
     expect(cataloguePinOptions({ rows, catalogImages, slotType: 'image' })).toEqual([])
   })
@@ -220,6 +220,58 @@ describe('cataloguePinOptions — downloaded catalogue rows beyond the release c
   it('serves every llama-server slot type', () => {
     for (const t of ['llm', 'embedding', 'reranking']) {
       expect(cataloguePinOptions({ rows, catalogImages, slotType: t }).length).toBe(1)
+    }
+  })
+
+  it('gates per row on runtime_family when the backend supplies it', () => {
+    // feat/catalogue-runtime-metadata: a comfyui-family row belongs in the
+    // image-slot drawer and NOT in the llm one — and vice versa for the
+    // llama-server row, all from one rows payload.
+    const mixed = [
+      {
+        id: 'comfyui',
+        image: 'ghcr.io/hal0ai/hal0-comfyui',
+        tag: 'latest',
+        downloaded: true,
+        runtime_family: 'comfyui',
+        supported_backends: ['rocm'],
+      },
+      {
+        id: 'combined-upstream',
+        image: 'ghcr.io/hal0ai/hal0-combined-upstream',
+        tag: '0829',
+        downloaded: true,
+        runtime_family: 'llama-server',
+        supported_backends: ['rocm', 'vulkan'],
+      },
+    ]
+    const forImage = cataloguePinOptions({ rows: mixed, catalogImages, slotType: 'image' })
+    expect(forImage.map((o) => o.id)).toEqual(['comfyui'])
+    const forLlm = cataloguePinOptions({ rows: mixed, catalogImages, slotType: 'llm' })
+    expect(forLlm.map((o) => o.id)).toEqual(['combined-upstream'])
+  })
+
+  it('assumes llama-server when runtime_family is absent (pre-contract backend)', () => {
+    // `rows` above carries no runtime_family — the historical assumption
+    // must keep holding: offered for llm, hidden for tts.
+    expect(cataloguePinOptions({ rows, catalogImages, slotType: 'llm' }).length).toBe(1)
+    expect(cataloguePinOptions({ rows, catalogImages, slotType: 'tts' })).toEqual([])
+  })
+
+  it('never vetoes a family FAMILY_SLOT_TYPES does not know', () => {
+    // Same rule as backendOptions: a new runtime shows up rather than
+    // vanishing; a wrong pick degrades to the out-of-catalog pin path.
+    const novel = [
+      {
+        id: 'novel',
+        image: 'ghcr.io/hal0ai/hal0-novel-runtime',
+        tag: 'v1',
+        downloaded: true,
+        runtime_family: 'novel-runtime',
+      },
+    ]
+    for (const t of ['llm', 'tts', 'image']) {
+      expect(cataloguePinOptions({ rows: novel, catalogImages, slotType: t }).length).toBe(1)
     }
   })
 

--- a/ui/src/dash/hw-cascade.js
+++ b/ui/src/dash/hw-cascade.js
@@ -165,25 +165,28 @@ function repoOfRef(ref) {
  *   lineage the catalog options resolve — offering both would show one image
  *   twice under two spellings).
  *
- * Catalogue rows carry no runtime_family, so they're assumed llama-server
- * (every uncatalogued-family row today is a llama.cpp fork) and offered only
- * for the slot types that family serves. A wrong pick degrades to the
- * existing out-of-catalog pin path (cascade fallback + caution), never a
- * dead end.
+ * Slot-type gating is per row: a row's `runtime_family` (images.json runtime
+ * metadata, feat/catalogue-runtime-metadata) picks its FAMILY_SLOT_TYPES
+ * entry; a row without the field (pre-contract backend, or a manifest entry
+ * that predates it) is assumed llama-server — the historical assumption,
+ * kept as the fallback. A family missing from FAMILY_SLOT_TYPES never
+ * vetoes (same rule as backendOptions: a new runtime shows up rather than
+ * vanishing). A wrong pick degrades to the existing out-of-catalog pin path
+ * (cascade fallback + caution), never a dead end.
  *
  * @param rows          GET /api/runner-images rows (RunnerImage[])
  * @param catalogImages the release-catalog refs already in the dropdown
- * @param slotType      slot.type — gates via FAMILY_SLOT_TYPES["llama-server"]
+ * @param slotType      slot.type — gates each row via FAMILY_SLOT_TYPES
  * @returns [{id, ref, notes}] — ref is the pinnable `repo:tag`
  */
 export function cataloguePinOptions({ rows, catalogImages, slotType }) {
-	if (slotType && !FAMILY_SLOT_TYPES["llama-server"].includes(slotType))
-		return [];
 	const catalogRepos = new Set((catalogImages || []).map(repoOfRef));
 	const out = [];
 	for (const r of rows || []) {
 		if (!r || !r.downloaded || !r.image || !r.tag) continue;
 		if (catalogRepos.has(r.image)) continue;
+		const served = FAMILY_SLOT_TYPES[r.runtime_family || "llama-server"];
+		if (slotType && served && !served.includes(slotType)) continue;
 		out.push({ id: r.id, ref: `${r.image}:${r.tag}`, notes: r.notes || "" });
 	}
 	return out;


### PR DESCRIPTION
**Stacks on #2170** (`fix/runner-image-pin-listings`) — the first two commits here are that branch; review only the top commit (`feat(catalogue): carry runtime_family + supported_backends on catalogue rows`). Merge #2170 first, then rebase or re-target this one.

Companion manifest PR (populates the live `images.json` values): Hal0ai/hal0-runner-images#9.

## Problem

The slot drawer's "catalogued · downloaded" pin lane (#2170) gates the whole option list on `FAMILY_SLOT_TYPES["llama-server"]` because catalogue rows carry no runtime metadata (`cataloguePinOptions`, `ui/src/dash/hw-cascade.js`). A downloaded comfyui row can never surface in an image slot's drawer, and any future non-llama runtime is mis-gated the same way.

## Change

End-to-end runtime metadata for catalogue rows:

- **images.json contract** (`hal0.runner-images.v1`, additive): entries may declare `runtime_family` (vocabulary of `hal0.runners.RuntimeFamily`, `src/hal0/runners/__init__.py`) and `supported_backends` (semantics of `Runner.supported_backends` — metadata, not a selector). Malformed values degrade to "not declared" per the existing fail-soft discipline (`runner_image_sync._apply_manifest_metadata`); they never fail the row or the sync.
- **Model/store/DB**: `RunnerImage.runtime_family: str | None` + `RunnerImage.supported_backends: list[str]`; migration `010_runner_image_runtime_metadata.sql` adds `runtime_family TEXT` + `supported_backends_json TEXT` (same JSON-column pattern as `available_tags_json`).
- **API**: rows inherit both fields via `_image_to_dict`'s `model_dump()` (`src/hal0/api/routes/runner_images.py:51`) — no route change.
- **FE**: `RunnerImage` TS interface gains both fields as optionals (pre-contract backends still type-check); `cataloguePinOptions` now gates **per row** on `row.runtime_family`, falling back to the historical llama-server assumption when the field is absent, and never vetoing a family `FAMILY_SLOT_TYPES` doesn't know (same rule as `backendOptions`).

## Verification

- `ruff check` + `ruff format --check` clean on all touched Python files (ruff 0.15.13)
- `pytest tests/registry/test_runner_image_store.py tests/registry/test_runner_image_sync.py` — 59 passed (new: runtime-metadata round-trip, absent-field defaults, malformed-shape degradation)
- `pytest tests/api/test_runner_images_routes.py` — 91 passed (sync route now asserts both fields on list + detail rows)
- `pytest tests/db/` — 36 passed (migration 010 applies)
- `vitest run src/dash/__tests__/hw-cascade.test.ts` — 24 passed (new: per-row family gating, absent-field fallback, unknown-family no-veto)
- `eslint` clean on touched files; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011o6Hur5YMz4RidLNtsAtN4
