### PR TITLE
feat(runners): flip the comfyui family default to ghcr.io/hal0ai/hal0-comfyui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ applying. Add those subsections to a version's section to surface them; see
   "catalogued · downloaded" pin lane gates each row on its declared
   runtime family instead of assuming every catalogue row is a
   llama-server fork (#2174).
+### Changed
+
+- The ComfyUI runner family now defaults to hal0's own published image
+  `ghcr.io/hal0ai/hal0-comfyui` (digest-pinned in `manifest.json`) instead of
+  the third-party `docker.io/kyuz0/amd-strix-halo-comfyui`. The image mirrors
+  the kyuz0 layout by construction, so existing img slots need no
+  reconfiguration; `--purge` uninstall still removes the old kyuz0 image on
+  upgraded boxes (#2171).
 
 ## [1.1.0] — 2026-08-31
 

--- a/manifest.json
+++ b/manifest.json
@@ -36,9 +36,9 @@
       "_upstream_reference": "https://github.com/thewh1teagle/kokoro-onnx"
     },
     "comfyui": {
-      "tag": "docker.io/kyuz0/amd-strix-halo-comfyui@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2",
-      "digest": "sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2",
-      "_notes": "live-validated on CT105 2026-06-11 (Wan2.2/Qwen-Image/Flux/SDXL on gfx1151); repinned from unpublished hal0-toolbox-comfyui (Phase D)",
+      "tag": "ghcr.io/hal0ai/hal0-comfyui:latest",
+      "digest": "sha256:fd8c89309ed69e26d0f7ca1483a5775ab0ef336d12f3d62f9a20c7dd0b5d478b",
+      "_notes": "hal0-owned image (published 2026-07-19, digest-pinned in this change; same digest as Hal0ai/hal0-runner-images images.json). Layout mirrors the previously-pinned kyuz0 Strix Halo build by construction (ComfyUI at /opt/ComfyUI, venv at /opt/venv). Prior kyuz0 validation history (CT105 2026-06-11, Wan2.2/Qwen-Image/Flux/SDXL on gfx1151; Phase D repin) preserved in git.",
       "_upstream_reference": "https://github.com/comfyanonymous/ComfyUI"
     },
     "qwen3tts": {

--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -7,10 +7,11 @@ OpenAI-shaped ``POST /v1/images/generations`` request is translated to a
 parametric workflow (see :mod:`hal0.providers.comfyui_workflows`) and the
 result PNG bytes are unwrapped back into the OpenAI response shape.
 
-Toolbox image:    docker.io/kyuz0/amd-strix-halo-comfyui (manifest digest pin
-                  is the primary path; the :latest tag is the last-resort
-                  fallback). The kyuz0 image ships ComfyUI checked out at
-                  /opt/ComfyUI with its venv at /opt/venv — NOT /app.
+Toolbox image:    ghcr.io/hal0ai/hal0-comfyui (manifest digest pin is the
+                  primary path; the :latest tag is the last-resort fallback).
+                  The image ships ComfyUI checked out at /opt/ComfyUI with
+                  its venv at /opt/venv — NOT /app (layout mirrors the kyuz0
+                  Strix Halo build it replaced, by construction).
 Backend default:  rocm  (Strix Halo iGPU is the v1 first-class target).
 
 Endpoints we touch on the upstream:
@@ -51,11 +52,12 @@ log = logging.getLogger(__name__)
 # Last-resort fallback only — the runner registry's manifest digest pin is
 # the primary path (see image_ref / hal0.runners.resolve_runner_image).
 # Sourced from RUNNER_IMAGES["comfyui"].image (§7.1b / ML-4) so the literal
-# tag lives in exactly one place. Points at the kyuz0 Strix Halo build that
-# the live CT105 deployment validated.
+# tag lives in exactly one place. Points at hal0's own published Strix Halo
+# build (ghcr.io/hal0ai/hal0-comfyui), which mirrors the kyuz0 build the
+# live CT105 deployment validated.
 _HAL0_COMFYUI_IMAGE = RUNNER_IMAGES["comfyui"].image
 
-# In-container app + working-data layout. The kyuz0 image has ComfyUI
+# In-container app + working-data layout. The image has ComfyUI
 # checked out at /opt/ComfyUI (venv at /opt/venv). Host-side working data
 # (models / output / input / user / custom_nodes + extra_model_paths.yaml)
 # lives under "<model-store>/comfyui" and is bind-mounted in so weights and
@@ -121,7 +123,7 @@ class ComfyUIProvider(Provider):
 
     name = "comfyui"
 
-    #: The kyuz0 Strix Halo image is a PyTorch-**ROCm** build (see the module
+    #: The hal0-comfyui Strix Halo image is a PyTorch-**ROCm** build (see the module
     #: docstring's "Backend default: rocm", ``RUNNER_IMAGES["comfyui"]
     #: .supported_backends == ("rocm",)``, and ``container_spec`` forwarding
     #: ``resolve_gpu_device_paths()`` — which includes ``/dev/kfd``). The
@@ -177,7 +179,7 @@ class ComfyUIProvider(Provider):
           2. :func:`hal0.runners.resolve_runner_image` on the ``comfyui``
              runner: ``HAL0_TOOLBOX_IMAGE_COMFYUI`` env var →
              ``manifest.json`` digest pin → the fallback tag
-             ``docker.io/kyuz0/amd-strix-halo-comfyui:latest``.
+             ``ghcr.io/hal0ai/hal0-comfyui:latest``.
 
         ComfyUI was previously the ONE provider that read the manifest at
         all; that behaviour is now unified into the registry resolver
@@ -231,7 +233,7 @@ class ComfyUIProvider(Provider):
         Mirrors `docker inspect comfyui` on CT105 (migration = replicate
         what works):
           * argv: ``bash -lc 'cd /opt/ComfyUI && exec python main.py …'``
-            — the kyuz0 image needs the login shell to activate /opt/venv.
+            — the image needs the login shell to activate /opt/venv.
           * mounts: ``<data_root>/models → /root/comfy-models`` plus
             output/input/user/custom_nodes into /opt/ComfyUI, and
             extra_model_paths.yaml read-only into the app dir.

--- a/src/hal0/runners/__init__.py
+++ b/src/hal0/runners/__init__.py
@@ -102,7 +102,7 @@ _FLM_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44"
 _KOKORO_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
 _MOONSHINE_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-moonshine:v1"
 _QWEN3TTS_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1"
-_COMFYUI_IMAGE = "docker.io/kyuz0/amd-strix-halo-comfyui:latest"
+_COMFYUI_IMAGE = "ghcr.io/hal0ai/hal0-comfyui:latest"
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/config/test_schema_seeds_d1.py
+++ b/tests/config/test_schema_seeds_d1.py
@@ -129,10 +129,10 @@ def test_load_slot_config_string_image_survives_in_extra(tmp_path: Path) -> None
     assert reloaded.extra["image"] == "ghcr.io/foo:v1"
 
 
-def test_manifest_comfyui_pinned_to_kyuz0() -> None:
+def test_manifest_comfyui_pinned_to_hal0_image() -> None:
     manifest = load_manifest(_REPO_ROOT / "manifest.json")
     ref = manifest_image_ref("comfyui", manifest=manifest)
     assert ref == (
-        "docker.io/kyuz0/amd-strix-halo-comfyui"
-        "@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2"
+        "ghcr.io/hal0ai/hal0-comfyui"
+        "@sha256:fd8c89309ed69e26d0f7ca1483a5775ab0ef336d12f3d62f9a20c7dd0b5d478b"
     )

--- a/tests/providers/test_comfyui.py
+++ b/tests/providers/test_comfyui.py
@@ -87,16 +87,17 @@ def test_start_cmd_emits_required_flags(
 
 
 def test_image_ref_follows_manifest_pin_or_fallback(provider: ComfyUIProvider) -> None:
-    # Phase D (#599): manifest.json repins comfyui to the kyuz0 Strix Halo
-    # build. With the repo manifest visible (HAL0_HOME unset), image_ref
-    # returns that digest pin; without a manifest it falls back to
+    # manifest.json pins comfyui to hal0's own published Strix Halo build
+    # (ghcr.io/hal0ai/hal0-comfyui; flipped from the kyuz0 image it mirrors).
+    # With the repo manifest visible (HAL0_HOME unset), image_ref returns
+    # that digest pin; without a manifest it falls back to
     # _HAL0_COMFYUI_IMAGE.
     ref = provider.image_ref({})
     assert (
         ref
         == (
-            "docker.io/kyuz0/amd-strix-halo-comfyui"
-            "@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2"
+            "ghcr.io/hal0ai/hal0-comfyui"
+            "@sha256:fd8c89309ed69e26d0f7ca1483a5775ab0ef336d12f3d62f9a20c7dd0b5d478b"
         )
         or ref == _HAL0_COMFYUI_IMAGE
     )
@@ -148,7 +149,7 @@ def test_container_spec_command_runs_python_main(
     model_info: dict[str, Any],
 ) -> None:
     spec = provider.container_spec(slot_cfg, model_info)
-    # bash -lc so the kyuz0 image's /opt/venv login-shell activation runs.
+    # bash -lc so the image's /opt/venv login-shell activation runs.
     assert spec.command[:2] == ["bash", "-lc"]
     assert "exec python main.py" in spec.command[2]
     # The slot port (not the ComfyUI default) is what we listen on.

--- a/tests/providers/test_comfyui_container_spec.py
+++ b/tests/providers/test_comfyui_container_spec.py
@@ -1,7 +1,8 @@
 """ComfyUI container spec — live-parity with the validated CT105 deployment.
 
 Phase D task D2. The spec must replicate what `docker inspect comfyui`
-showed working on CT105: kyuz0 image (ComfyUI at /opt/ComfyUI, venv at
+showed working on CT105: the kyuz0 image layout that hal0's own
+ghcr.io/hal0ai/hal0-comfyui mirrors (ComfyUI at /opt/ComfyUI, venv at
 /opt/venv), bash -lc cd+exec argv, /mnt/ai-models/comfyui data mounts,
 --ipc=host (host /dev/shm serves Wan/Hunyuan video; podman rejects
 --shm-size with host IPC, unlike docker), host networking,
@@ -139,9 +140,13 @@ def test_comfyui_slot_port_override_flows_into_argv() -> None:
     assert "--port 8189" in spec.command[2]
 
 
-def test_comfyui_fallback_image_is_kyuz0() -> None:
-    """D1 review: the last-resort fallback must not point at an unpublished image."""
-    assert _HAL0_COMFYUI_IMAGE == "docker.io/kyuz0/amd-strix-halo-comfyui:latest"
+def test_comfyui_fallback_image_is_hal0_published() -> None:
+    """D1 review: the last-resort fallback must not point at an unpublished image.
+
+    ghcr.io/hal0ai/hal0-comfyui:latest is live (anonymous registry v2 HEAD
+    200, digest sha256:fd8c8930...) — pull-evidence in the flip commit.
+    """
+    assert _HAL0_COMFYUI_IMAGE == "ghcr.io/hal0ai/hal0-comfyui:latest"
 
 
 # ── renderer integration ──────────────────────────────────────────────────────
@@ -193,7 +198,7 @@ def test_image_section_dict_is_not_an_image_override(monkeypatch) -> None:
     ref = ComfyUIProvider().image_ref(cfg)
     assert isinstance(ref, str)
     assert "idle_restore_minutes" not in ref
-    assert "kyuz0/amd-strix-halo-comfyui" in ref  # manifest pin or fallback tag
+    assert "hal0ai/hal0-comfyui" in ref  # manifest pin or fallback tag
 
 
 def test_comfyui_container_spec_provisions_data_dirs(

--- a/tests/scripts/test_update_toolbox_digests.py
+++ b/tests/scripts/test_update_toolbox_digests.py
@@ -1,13 +1,16 @@
 """scripts/update-toolbox-digests.sh must never null a valid digest pin (#1676).
 
 The script only resolved digests via the ghcr.io registry v2 curl path. The
-comfyui entry pins a docker.io, digest-referenced tag
+comfyui entry used to pin a docker.io, digest-referenced tag
 (``docker.io/kyuz0/amd-strix-halo-comfyui@sha256:...``): the ghcr-only path
 mis-parsed it, reported it "unpublished", and overwrote a valid digest with
 null — which then failed ``release.yml``'s null-digest gate on the very
-manifest this script prepares.
+manifest this script prepares. Comfyui has since flipped to hal0's own
+``ghcr.io/hal0ai/hal0-comfyui`` image, so no live manifest entry exercises
+the non-ghcr paths any more — the #1676 coverage lives entirely in the
+synthetic docker.io fixtures below.
 
-These tests drive the REAL script against a throwaway copy of the manifest,
+These tests drive the REAL script against throwaway fixture manifests,
 under a hermetic PATH where ``curl`` and ``docker`` are stubbed to always
 fail (simulating an offline / token-less run) so the tests are deterministic
 regardless of the sandbox's real network access. A digest-pinned ref must
@@ -20,7 +23,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import stat
 import subprocess
 from pathlib import Path
@@ -29,13 +31,11 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT = _REPO_ROOT / "scripts" / "update-toolbox-digests.sh"
-_MANIFEST = _REPO_ROOT / "manifest.json"
 
-_COMFYUI_TAG = (
-    "docker.io/kyuz0/amd-strix-halo-comfyui"
-    "@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2"
-)
-_COMFYUI_DIGEST = "sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2"
+# Synthetic non-ghcr, digest-pinned ref shaped like the comfyui entry that
+# originally triggered #1676 (docker.io/<owner>/<repo>@sha256:...).
+_PINNED_DIGEST = "sha256:" + "0066678a" * 8
+_PINNED_TAG = f"docker.io/example/imggen@{_PINNED_DIGEST}"
 
 
 def _write_always_failing(path: Path) -> None:
@@ -70,24 +70,6 @@ def _load(manifest: Path) -> dict:
     return json.loads(manifest.read_text(encoding="utf-8"))
 
 
-# ── the regression, against the real manifest ──────────────────────────────
-
-
-def test_comfyui_digest_survives_a_full_offline_run(tmp_path: Path, offline_path: str) -> None:
-    """THE bug: a copy of the real manifest, network fully stubbed off."""
-    manifest = tmp_path / "manifest.json"
-    shutil.copy2(_MANIFEST, manifest)
-    before = _load(manifest)["toolbox_images"]["comfyui"]["digest"]
-    assert before == _COMFYUI_DIGEST  # sanity: fixture assumption still holds
-
-    proc = _run(manifest, offline_path)
-
-    assert proc.returncode == 0, proc.stderr
-    after = _load(manifest)["toolbox_images"]["comfyui"]
-    assert after["digest"] == _COMFYUI_DIGEST
-    assert after["tag"] == _COMFYUI_TAG
-
-
 # ── isolated behaviour, minimal fixture manifests ──────────────────────────
 
 
@@ -104,13 +86,13 @@ def test_digest_pinned_non_ghcr_ref_resolves_without_touching_curl_or_docker(
     tmp_path: Path, offline_path: str
 ) -> None:
     manifest = _fixture_manifest(
-        tmp_path, {"comfyui": {"tag": _COMFYUI_TAG, "digest": "sha256:" + "0" * 64}}
+        tmp_path, {"imggen": {"tag": _PINNED_TAG, "digest": "sha256:" + "0" * 64}}
     )
 
     proc = _run(manifest, offline_path)
 
     assert proc.returncode == 0, proc.stderr
-    assert _load(manifest)["toolbox_images"]["comfyui"]["digest"] == _COMFYUI_DIGEST
+    assert _load(manifest)["toolbox_images"]["imggen"]["digest"] == _PINNED_DIGEST
     assert "unpublished" not in proc.stderr
     assert "1 digest(s) updated, 0 left null" in proc.stdout
 

--- a/ui/src/api/mockFixtures.ts
+++ b/ui/src/api/mockFixtures.ts
@@ -354,7 +354,7 @@ function buildProfiles() {
     },
     {
       name: 'comfyui',
-      image: 'docker.io/kyuz0/amd-strix-halo-comfyui:latest',
+      image: 'ghcr.io/hal0ai/hal0-comfyui:latest',
       flags: '--disable-mmap --bf16-vae --cache-none',
       mtp: false,
       resolved_flags: '--disable-mmap --bf16-vae --cache-none',


### PR DESCRIPTION
Flips the ComfyUI runner family default from the third-party `docker.io/kyuz0/amd-strix-halo-comfyui` to hal0's own published image `ghcr.io/hal0ai/hal0-comfyui`. Closes #2171.

## What changed

- `src/hal0/runners/__init__.py` — `_COMFYUI_IMAGE` fallback tag → `ghcr.io/hal0ai/hal0-comfyui:latest` (runner registry entry itself unchanged).
- `manifest.json` — `toolbox_images.comfyui` tag + digest flipped in the same commit (`manifest_image_ref` composes `tag@digest`, so the pair must move together); `_notes` rewritten for the hal0-owned image, prior kyuz0 validation history preserved in git.
- `src/hal0/providers/comfyui.py` — docstring/comment updates only; **no code change** (the hal0 image mirrors the kyuz0 layout by construction: ComfyUI at `/opt/ComfyUI`, venv at `/opt/venv`).
- Scar-guard tests updated deliberately (Phase D / #599 "never pin an unpublished image" — pull-evidence below):
  - `tests/providers/test_comfyui_container_spec.py` — fallback-image guard renamed + asserts the new ref.
  - `tests/providers/test_comfyui.py` — manifest-pin ref updated to the new digest.
  - `tests/config/test_schema_seeds_d1.py` — `manifest_image_ref("comfyui")` asserts the new composed ref.
  - `tests/scripts/test_update_toolbox_digests.py` — RESTRUCTURED, not just swapped: after the flip no real manifest entry is non-ghcr, so the #1676 digest-pinned non-ghcr coverage moves to a synthetic `docker.io` fixture; the real-manifest offline test (whose premise was the live kyuz0 entry) is removed.
- `ui/src/api/mockFixtures.ts` — cosmetic mock update.
- `installer/uninstall.sh:604` — kyuz0 cleanup pattern deliberately **kept** so `--purge` on upgraded boxes still removes the old image.
- `CHANGELOG.md` — Unreleased bullet (user-visible default change).

## Registry pull-evidence

`ghcr.io/hal0ai/hal0-comfyui:latest` is publicly pullable — anonymous ghcr.io registry v2 token + manifest HEAD (re-verified 2026-08-31 from this session):

```
HTTP/2 200
content-type: application/vnd.oci.image.manifest.v1+json
docker-content-digest: sha256:fd8c89309ed69e26d0f7ca1483a5775ab0ef336d12f3d62f9a20c7dd0b5d478b
```

Same digest as `images.json` in Hal0ai/hal0-runner-images (3.70 GB, pushed 2026-07-19).

## Digest round-trip

`scripts/update-toolbox-digests.sh` resolves the new pin back to the exact digest committed here:

```
  comfyui: resolving ghcr.io/hal0ai/hal0-comfyui:latest
    -> sha256:fd8c89309ed69e26d0f7ca1483a5775ab0ef336d12f3d62f9a20c7dd0b5d478b
...
Done: 9 digest(s) updated, 0 left null.
```

(The run also surfaced a drifted qwen3tts `:v1` digest on ghcr — reverted here as out of scope for this PR.)

`scripts/release-check.sh` step 4 (all toolbox digests non-null) passes against the new manifest.

## Live gate — ct105 PASSED

Live-generation gate ran on ct105 in a parallel operator session (2026-08-31):

- pulled `ghcr.io/hal0ai/hal0-comfyui@sha256:fd8c8930…` into the rootful store; img slot launched on it
- ComfyUI 0.28.0; torch sees Radeon 8060S (gfx1151, 118784 MiB)
- real generation end-to-end: `POST /v1/images/generations` model=sdxl-turbo 512x512 → HTTP 200 in 13.6s, valid PNG
- Qwen-Image/Wan2.2 workflows not exercised (host RAM pressure); sdxl-turbo end-to-end is the gate evidence

Related known bug found during the gate, deliberately NOT fixed here: #2172 (`ComfyUIProvider.image_ref` ignores `image_pin`).

## Tests

```
.venv/bin/pytest tests/providers/test_comfyui_container_spec.py \
  tests/providers/test_comfyui.py tests/config/test_schema_seeds_d1.py \
  tests/scripts/test_update_toolbox_digests.py -q
41 passed in 11.05s
```

`ruff check` + `ruff format --check` clean on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011o6Hur5YMz4RidLNtsAtN4
