### PR TITLE
feat(hardware): host-truth GTT feasibility signal (warn, never block)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ applying. Add those subsections to a version's section to surface them; see
   the kyuz0 layout by construction, so existing img slots need no
   reconfiguration; `--purge` uninstall still removes the old kyuz0 image on
   upgraded boxes (#2171).
+||||||| parent of 993ea3b6 (feat(hardware): host-truth GTT feasibility signal (warn, never block))
+- **Host-truth GTT feasibility signal.** `GET /api/hardware` now carries live
+  `gtt_used_mb`/`gtt_free_mb` from the amdgpu `mem_info_gtt_*` sysfs counters
+  (host truth even inside an LXC container, where the cgroup-shaped meminfo
+  can show tens of GiB "available" while a GTT weight allocation fails), the
+  slot load path emits an advisory `slot.gtt_feasibility` warning — never a
+  block — when a model's weights exceed the free GTT pool, and the dashboard's
+  Detected-hardware panel shows the live free-GTT figure.
 
 ## [1.1.0] — 2026-08-31
 

--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -142,6 +142,12 @@ def _flatten_for_ui(info: dict[str, Any], gpu: GPUMemorySample | None = None) ->
         "gpu_vendor": vendor,
         "vram_total_mb": 0 if is_uma else vram_mb,
         "gtt_total_mb": (live_gtt_total_mb or vram_mb) if is_uma else 0,
+        # Live HOST-truth GTT occupancy (amdgpu mem_info_gtt_* sysfs — real
+        # even inside an LXC container, where the cgroup-shaped meminfo lies
+        # about what a GTT allocation can actually get). None = counter not
+        # available on this host (non-AMD / no GPU), distinguishable from 0.
+        "gtt_used_mb": gpu.gtt_used_mb if (gpu is not None and is_uma) else None,
+        "gtt_free_mb": gpu.gtt_free_mb if (gpu is not None and is_uma) else None,
         "ram_total_mb": ram_mb,
         "ram_available_mb": info.get("ram_available_mb", 0),
         "unified_memory_mb": unified_mb,

--- a/src/hal0/hardware/gpu_view.py
+++ b/src/hal0/hardware/gpu_view.py
@@ -62,6 +62,33 @@ class GPUMemorySample:
     gpu_busy: float | None  # 0..1, raw
     util_is_forced_high: bool
 
+    @property
+    def gtt_free_mb(self) -> float | None:
+        """Free GTT (MiB): ``gtt_total - gtt_used``, clamped at 0.
+
+        This is HOST truth even inside an LXC container: the amdgpu
+        ``mem_info_gtt_*`` sysfs counters describe the host's shared GART
+        pool, unlike the container's lxcfs-shaped ``/proc/meminfo`` which
+        only reflects the cgroup (field finding: a 47 GiB weight load hit
+        ``cudaMalloc failed: out of memory`` while the container's ``free``
+        showed 65 GiB "available"). ``None`` when either counter is absent
+        (non-AMD, no GPU) — "unknown" stays distinguishable from 0.
+        """
+        if self.gtt_total_mb is None or self.gtt_used_mb is None:
+            return None
+        return max(self.gtt_total_mb - self.gtt_used_mb, 0.0)
+
+    @property
+    def vram_free_mb(self) -> float | None:
+        """Free dedicated VRAM (MiB): ``vram_total - vram_used``, clamped at 0.
+
+        ``None`` when either counter is absent — same contract as
+        :attr:`gtt_free_mb`.
+        """
+        if self.vram_total_mb is None or self.vram_used_mb is None:
+            return None
+        return max(self.vram_total_mb - self.vram_used_mb, 0.0)
+
 
 def _max_pool(*candidates: float | None) -> float | None:
     """max() over the non-None candidates; None when all are missing.

--- a/src/hal0/slots/capacity.py
+++ b/src/hal0/slots/capacity.py
@@ -205,6 +205,51 @@ def estimate_file_size_kv_mb(
     return round(model_mb + companion_mb + kv_mb, 1)
 
 
+def gtt_fit_warning(
+    needed_mb: float,
+    *,
+    gtt_free_mb: float | None,
+    gtt_total_mb: float | None,
+) -> str | None:
+    """WARN-only GTT feasibility check: does ``needed_mb`` fit in free GTT?
+
+    Pure function — no I/O. Returns a human-readable warning string when the
+    incoming model's weights (``needed_mb``, MiB) exceed the free GTT pool
+    (``gtt_total - gtt_used`` from the amdgpu ``mem_info_gtt_*`` sysfs
+    counters, see :attr:`hal0.hardware.gpu_view.GPUMemorySample.gtt_free_mb`),
+    ``None`` otherwise.
+
+    Why this exists (field finding, LXC on a UMA Proxmox host): GTT
+    allocations draw from the HOST's free RAM, so the container's
+    lxcfs-shaped ``/proc/meminfo`` can show tens of GiB "available" while
+    the actual weight allocation fails with ``cudaMalloc failed: out of
+    memory``. The amdgpu sysfs counters are host truth and readable inside
+    the container, so a pre-load comparison against free GTT catches the
+    clearly-infeasible case the cgroup view lies about.
+
+    Deliberately NEVER blocks — the GTT counters can lag (amdgpu grows the
+    GART limit dynamically, evictions land asynchronously), so this is an
+    operator signal, not an admission gate. The blocking admission path
+    stays :mod:`hal0.slots.preload_evict`.
+
+    ``None`` is also returned when either counter is missing (non-AMD /
+    no-GPU host — fail-soft, matching the sample's own contract) or when
+    ``needed_mb`` is not a positive number ("unknown size" never warns).
+    """
+    if gtt_free_mb is None or gtt_total_mb is None:
+        return None
+    if not needed_mb or needed_mb <= 0:
+        return None
+    if needed_mb <= gtt_free_mb:
+        return None
+    return (
+        f"model needs ~{needed_mb / 1024.0:.1f} GiB but only "
+        f"{gtt_free_mb / 1024.0:.1f} GiB of the {gtt_total_mb / 1024.0:.1f} GiB "
+        f"GTT pool is free on the host — the load will likely fail to "
+        f"allocate; free host memory or evict a resident model first"
+    )
+
+
 def _ctx_tokens_for(model_meta: dict[str, Any] | None) -> int:
     """Resolve the effective context window (tokens) for a model.
 
@@ -767,4 +812,5 @@ __all__ = [
     "_host_has_capable_gpu",
     "build_per_slot",
     "estimate_file_size_kv_mb",
+    "gtt_fit_warning",
 ]

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1782,6 +1782,10 @@ class SlotManager:
                 # eviction estimate and _spawn_locked below so a load never
                 # hits the model registry twice for the same model_id.
                 model_info = await self._resolve_model_info(resolved_model)
+                # Advisory GTT feasibility signal (host-truth sysfs vs the
+                # lying container meminfo) — warns, never blocks. See
+                # _warn_gtt_feasibility.
+                await self._warn_gtt_feasibility(slot_name, resolved_model, model_info)
                 # Pre-load eviction (O26): estimate resolved_model's
                 # footprint and, if projected free memory is short, evict
                 # idle, non-pinned resident slots (lowest `priority` first,
@@ -3556,6 +3560,69 @@ class SlotManager:
     async def _sweep_idle_once(self) -> None:
         """See :meth:`hal0.slots.reaper.SlotReaper.sweep_idle_once`."""
         await self._reaper.sweep_idle_once()
+
+    async def _warn_gtt_feasibility(
+        self, slot_name: str, model_id: str, model_info: dict[str, Any] | None
+    ) -> None:
+        """WARN (never block) when a model's weights exceed free HOST GTT.
+
+        Field finding (LXC slot container on a UMA Proxmox host): GTT
+        allocations draw from the HOST's free RAM, so the container's
+        lxcfs-shaped ``/proc/meminfo`` can show tens of GiB "available"
+        while the actual weight allocation dies with ``cudaMalloc failed:
+        out of memory``. The amdgpu ``mem_info_gtt_*`` sysfs counters ARE
+        host truth and readable inside the container, so compare the
+        incoming weights against free GTT
+        (:attr:`hal0.hardware.gpu_view.GPUMemorySample.gtt_free_mb`) and
+        surface a warning the operator can act on BEFORE the slow failure.
+
+        Deliberately advisory: the load proceeds regardless (the counters
+        can lag; :mod:`hal0.slots.preload_evict` stays the blocking gate).
+        Fail-soft everywhere — no GPU / non-AMD / unknown model size all
+        degrade to silence, and no exception ever escapes into ``load()``.
+        """
+        try:
+            size_bytes = float((model_info or {}).get("size_bytes") or 0)
+            if size_bytes <= 0:
+                return
+            from hal0.hardware import gpu_view
+            from hal0.slots.capacity import gtt_fit_warning
+
+            gpu = await asyncio.to_thread(gpu_view.sample)
+            warning = gtt_fit_warning(
+                size_bytes / (1024.0 * 1024.0),
+                gtt_free_mb=gpu.gtt_free_mb,
+                gtt_total_mb=gpu.gtt_total_mb,
+            )
+            if warning is None:
+                return
+            log.warning(
+                "slot.gtt_feasibility: %s: %s",
+                slot_name,
+                warning,
+                extra={
+                    "slot": slot_name,
+                    "model_id": model_id,
+                    "model_mb": round(size_bytes / (1024.0 * 1024.0), 1),
+                    "gtt_free_mb": gpu.gtt_free_mb,
+                    "gtt_total_mb": gpu.gtt_total_mb,
+                },
+            )
+            if self._event_bus is not None:
+                await self._event_bus.emit(
+                    "slot.gtt_feasibility",
+                    "warn",
+                    f"slot:{slot_name}",
+                    f"{slot_name}: {warning}",
+                    data={
+                        "model_id": model_id,
+                        "model_mb": round(size_bytes / (1024.0 * 1024.0), 1),
+                        "gtt_free_mb": gpu.gtt_free_mb,
+                        "gtt_total_mb": gpu.gtt_total_mb,
+                    },
+                )
+        except Exception:  # advisory only — never let the warn path sink a load
+            log.debug("slot.gtt_feasibility_probe_failed", exc_info=True)
 
     def _probe_host_free_mb(self) -> float:
         """Return free host memory in MiB, GTT-aware where possible (§21.10).

--- a/tests/api/test_hardware_routes.py
+++ b/tests/api/test_hardware_routes.py
@@ -648,3 +648,36 @@ class TestLiveUptime:
         resp = client.get("/api/hardware")
         assert resp.status_code == 200, resp.text
         assert resp.json()["uptime_s"] == 4110
+
+
+def test_flatten_uma_carries_live_gtt_used_and_free() -> None:
+    """UMA flatten surfaces the live host-truth GTT occupancy (feat: GTT
+    feasibility). The sysfs counters are host truth even inside an LXC
+    container, where the cgroup-shaped meminfo lies about what a GTT
+    allocation can actually get."""
+    info = HardwareInfo(
+        cpu_model="AMD Ryzen AI Max+ PRO 395",
+        ram_mb=128 * 1024,
+        gpus=[GPUInfo(vendor="amd", name="Radeon 8060S", vram_mb=96 * 1024)],
+        npu=NPUInfo(present=False),
+        platform="strix-halo",
+    ).model_dump(mode="python")
+    sample = _uma_sample(gtt_total_mb=96.0 * 1024, gtt_used_mb=30.0 * 1024)
+    flat = _flatten_for_ui(info, sample)
+    assert flat["gtt_used_mb"] == 30.0 * 1024
+    assert flat["gtt_free_mb"] == 66.0 * 1024
+
+
+def test_flatten_non_uma_gtt_occupancy_is_none() -> None:
+    """Discrete / no-sample shapes report None (unknown), not a fake 0."""
+    info = HardwareInfo(
+        cpu_model="AMD Ryzen 9 7950X",
+        ram_mb=32 * 1024,
+        gpus=[GPUInfo(vendor="amd", name="Radeon RX 7900 XTX", vram_mb=24 * 1024)],
+        npu=NPUInfo(present=False),
+        platform="bare-metal-amd-gpu",
+    ).model_dump(mode="python")
+    assert _flatten_for_ui(info, _discrete_sample())["gtt_used_mb"] is None
+    assert _flatten_for_ui(info, _discrete_sample())["gtt_free_mb"] is None
+    assert _flatten_for_ui(info)["gtt_used_mb"] is None
+    assert _flatten_for_ui(info)["gtt_free_mb"] is None

--- a/tests/hardware/test_gpu_view.py
+++ b/tests/hardware/test_gpu_view.py
@@ -262,3 +262,53 @@ def test_sample_is_frozen(tmp_path: Path) -> None:
     s = sample(vendor="amd", drm=drm)
     with pytest.raises(dataclasses.FrozenInstanceError):
         s.vendor = "nvidia"  # type: ignore[misc]
+
+
+# ── gtt_free_mb / vram_free_mb — host-truth free pool (GTT feasibility) ──────
+
+
+def test_free_pools_derived_from_sysfs(tmp_path: Path) -> None:
+    """free = total - used, straight off the sysfs counters (host truth)."""
+    drm = _mk_drm(
+        tmp_path, vram_used_mb=100, gtt_used_mb=2048, vram_total_mb=512, gtt_total_mb=81920
+    )
+    s = sample(vendor="amd", drm=drm)
+    assert s.gtt_free_mb == pytest.approx(81920.0 - 2048.0)
+    assert s.vram_free_mb == pytest.approx(512.0 - 100.0)
+
+
+def test_free_pools_none_when_counter_absent(tmp_path: Path) -> None:
+    """A missing used/total counter degrades free to None, not 0 (fail-soft)."""
+    drm = _mk_drm(
+        tmp_path, vram_used_mb=None, gtt_used_mb=None, vram_total_mb=512, gtt_total_mb=81920
+    )
+    s = sample(vendor="amd", drm=drm)
+    assert s.gtt_free_mb is None
+    assert s.vram_free_mb is None
+
+
+def test_free_pools_clamped_at_zero() -> None:
+    """used > total (counter races / GART shrink) clamps to 0, never negative."""
+    s = GPUMemorySample(
+        vendor="amd",
+        is_uma=True,
+        vram_total_mb=512.0,
+        gtt_total_mb=81920.0,
+        total_mb=81920.0,
+        vram_used_mb=600.0,
+        gtt_used_mb=90000.0,
+        used_mb=90000.0,
+        gpu_busy=None,
+        util_is_forced_high=False,
+    )
+    assert s.gtt_free_mb == 0.0
+    assert s.vram_free_mb == 0.0
+
+
+def test_free_pools_none_on_no_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No GPU at all (non-AMD, no drm) → both free pools are None."""
+    monkeypatch.setattr(gpu_view, "_amd_drm_device", lambda: None)
+    monkeypatch.setattr(gpu_view, "_run", _no_nvidia)
+    s = sample()
+    assert s.gtt_free_mb is None
+    assert s.vram_free_mb is None

--- a/tests/slots/test_capacity.py
+++ b/tests/slots/test_capacity.py
@@ -29,6 +29,7 @@ from hal0.slots.capacity import (
     _host_has_capable_gpu,
     _systemd_unit_mem_bytes,
     build_per_slot,
+    gtt_fit_warning,
 )
 
 # ── helpers ──────────────────────────────────────────────────────────────
@@ -409,3 +410,46 @@ class TestSystemdUnitMemFallback:
 
         assert result == 999
         mock_fallback.assert_not_called()
+
+
+# ── gtt_fit_warning — WARN-only host-truth GTT feasibility (pure) ───────────
+#
+# Field finding (LXC on a UMA Proxmox host): a 47.3 GiB weight load failed
+# with cudaMalloc OOM while the container's meminfo showed 65 GiB
+# "available" — GTT allocations draw from the HOST's free RAM and the
+# cgroup-shaped meminfo is a lie for GPU purposes. The helper compares the
+# incoming weights against the amdgpu sysfs free-GTT counters instead.
+
+
+class TestGttFitWarning:
+    def test_warns_when_weights_exceed_free_gtt(self) -> None:
+        """The ct105 shape: 47.3 GiB weights vs ~18 GiB actually free."""
+        msg = gtt_fit_warning(47.3 * 1024, gtt_free_mb=18.0 * 1024, gtt_total_mb=96.0 * 1024)
+        assert msg is not None
+        assert "47.3 GiB" in msg
+        assert "18.0 GiB" in msg
+        assert "96.0 GiB" in msg
+
+    def test_silent_when_it_fits(self) -> None:
+        assert gtt_fit_warning(8192.0, gtt_free_mb=20480.0, gtt_total_mb=98304.0) is None
+
+    def test_silent_at_exact_boundary(self) -> None:
+        """needed == free is not "clearly exceeds" — no warning."""
+        assert gtt_fit_warning(20480.0, gtt_free_mb=20480.0, gtt_total_mb=98304.0) is None
+
+    def test_silent_when_counters_absent(self) -> None:
+        """Non-AMD / no-GPU host (None counters) → fail-soft silence."""
+        assert gtt_fit_warning(47.3 * 1024, gtt_free_mb=None, gtt_total_mb=None) is None
+        assert gtt_fit_warning(47.3 * 1024, gtt_free_mb=None, gtt_total_mb=98304.0) is None
+        assert gtt_fit_warning(47.3 * 1024, gtt_free_mb=18432.0, gtt_total_mb=None) is None
+
+    def test_silent_on_unknown_or_zero_size(self) -> None:
+        """Unknown model size never warns (mirrors preload_evict's fail-open)."""
+        assert gtt_fit_warning(0.0, gtt_free_mb=1024.0, gtt_total_mb=98304.0) is None
+        assert gtt_fit_warning(-5.0, gtt_free_mb=1024.0, gtt_total_mb=98304.0) is None
+
+    def test_warns_even_when_free_is_zero(self) -> None:
+        """A fully-consumed pool (free 0) still warns rather than dividing oddly."""
+        msg = gtt_fit_warning(1024.0, gtt_free_mb=0.0, gtt_total_mb=98304.0)
+        assert msg is not None
+        assert "0.0 GiB" in msg

--- a/ui/src/api/hooks/useHardware.ts
+++ b/ui/src/api/hooks/useHardware.ts
@@ -23,6 +23,10 @@ export interface Hardware {
   ram: { total: number; used: number; free: number }
   unifiedMb: number
   gttTotalMb: number
+  // Live host-truth GTT occupancy (amdgpu sysfs). null = counter not
+  // available on this host (non-AMD / no GPU) — distinct from 0.
+  gttUsedMb: number | null
+  gttFreeMb: number | null
   memoryKind: string
   npu: {
     present: boolean
@@ -89,6 +93,8 @@ function normalizeHardware(raw: any): Hardware {
     },
     unifiedMb: Number(raw?.unified_memory_mb ?? 0),
     gttTotalMb: Number(raw?.gtt_total_mb ?? 0),
+    gttUsedMb: raw?.gtt_used_mb == null ? null : Number(raw.gtt_used_mb),
+    gttFreeMb: raw?.gtt_free_mb == null ? null : Number(raw.gtt_free_mb),
     // Authoritative UMA signal is backend memory_kind; fall back to a
     // populated unified_memory_mb (Strix Halo UMA reports it, discrete
     // GPUs don't) so the memory-map pool label is right even on older

--- a/ui/src/dash/settings/pages/system/HardwareRuntimesPage.jsx
+++ b/ui/src/dash/settings/pages/system/HardwareRuntimesPage.jsx
@@ -59,7 +59,7 @@ function DetectedHardwarePanel() {
           <SRow k="GPU" sub="Discrete / integrated graphics adapter" mono v={<span style={{ color: 'var(--fg-2)' }}>{H.gpu || '—'}{H.gpuVendor ? ` · ${H.gpuVendor}` : ''}</span>} />
           <SRow k="ROCm / compute capable" sub="HIP compute stack present (drives the rocm runner)" v={_yn(H.computeCapable)} />
           <SRow k="Vulkan capable" sub="Vulkan runtime present (drives the vulkan runner)" v={_yn(H.vulkanCapable)} />
-          <SRow k="Unified / GTT memory" sub="Shared GPU memory pool (APU) · GTT ceiling" mono v={<span style={{ color: 'var(--fg-3)' }}>{_mb(H.unifiedMb)} unified · {_mb(H.gttTotalMb)} GTT{H.memoryKind ? ` · ${H.memoryKind}` : ''}</span>} />
+          <SRow k="Unified / GTT memory" sub="Shared GPU memory pool (APU) · GTT ceiling · host-truth free" mono v={<span style={{ color: 'var(--fg-3)' }}>{_mb(H.unifiedMb)} unified · {_mb(H.gttTotalMb)} GTT{H.gttFreeMb != null ? ` · ${_mb(H.gttFreeMb)} free` : ''}{H.memoryKind ? ` · ${H.memoryKind}` : ''}</span>} />
           <SRow
             k="NPU"
             sub="AMD XDNA / FastFlowLM accelerator"


### PR DESCRIPTION
## Summary

Live finding on ct105 (LXC container on a Strix Halo Proxmox host): a 47.3 GiB model-weight allocation failed with `cudaMalloc failed: out of memory` on ROCm0 while the container's `free` showed 65 GiB available. GTT allocations draw from the **host's** free RAM (the host had 18 GiB free), and the container's lxcfs-shaped `/proc/meminfo` is a lie for GPU purposes. The amdgpu `mem_info_gtt_*` / `mem_info_vram_*` sysfs counters ARE host truth and are readable inside the container.

This PR surfaces that host truth and adds an advisory (never-blocking) pre-load feasibility signal — extending the existing seams rather than adding new ones:

- **`hardware/gpu_view.GPUMemorySample`** (the existing sysfs reader, `src/hal0/hardware/gpu_view.py`) gains derived `gtt_free_mb` / `vram_free_mb` properties: `total - used`, clamped at 0, `None` when a counter is absent (non-AMD / no GPU — fail-soft).
- **`slots/capacity.gtt_fit_warning`**: pure WARN-only helper — model weights (MiB) vs free GTT. Returns a message only when the weights clearly exceed the free pool; `None` on unknown counters or unknown size. The blocking admission path stays `slots/preload_evict` (already GTT-aware via `reaper.probe_host_free_mb`).
- **`SlotManager.load`**: advisory `_warn_gtt_feasibility` right after model resolution — structured `slot.gtt_feasibility` log + event-bus warn. Fail-soft everywhere; the load always proceeds.
- **`GET /api/hardware`** now carries live `gtt_used_mb` / `gtt_free_mb` (`None` = counter unavailable, distinguishable from 0). `/api/stats/hardware` inherits them via its primary-payload path.
- **FE (minimal, no new panels)**: `useHardware` normalizes the two new fields; the Settings → Hardware "Unified / GTT memory" row appends `· N GB free` when known.

## Testing

- `ruff check` + `ruff format --check` clean on all touched files
- `.venv/bin/pytest tests/hardware/test_gpu_view.py tests/slots/test_capacity.py tests/api/test_hardware_routes.py` — **77 passed** (new: free-pool derivation/clamp/absence via tmp-path sysfs fixtures; `gtt_fit_warning` pure-function matrix incl. the ct105 shape; flatten carries the live occupancy on UMA and honest `None` off it)
- `.venv/bin/pytest tests/slots/test_preload_eviction.py tests/slots/test_manager.py tests/slots/test_loaded_slot.py` — **85 passed** (load-path regression)
- `ui: tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011o6Hur5YMz4RidLNtsAtN4
