### PR TITLE
feat(slots): arch-aware model↔runner fit-check (#2118 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,25 @@ applying. Add those subsections to a version's section to surface them; see
   "catalogued · downloaded" pin lane gates each row on its declared
   runtime family instead of assuming every catalogue row is a
   llama-server fork (#2174).
+- **Host-truth GTT feasibility signal.** `GET /api/hardware` now carries live
+  `gtt_used_mb`/`gtt_free_mb` from the amdgpu `mem_info_gtt_*` sysfs counters
+  (host truth even inside an LXC container, where the cgroup-shaped meminfo
+  can show tens of GiB "available" while a GTT weight allocation fails), the
+  slot load path emits an advisory `slot.gtt_feasibility` warning — never a
+  block — when a model's weights exceed the free GTT pool, and the dashboard's
+  Detected-hardware panel shows the live free-GTT figure.
+- **Arch-aware model↔runner fit-check** (#2118 follow-up). GGUF
+  `general.architecture` is now detected and persisted at model
+  registration (scan commit, add-from-path, pull, curated auto-scan), and
+  runner registry entries can denylist archs their llama.cpp build rejects
+  (`Runner.unsupported_archs` — `qwen4exp` on the default ROCmFPX image).
+  Binding such a model to a slot now WARNS at assignment — API
+  `model_fit_warning` on slot create/config/swap, plus a notice by the slot
+  drawer's Model select — naming the catalogued image that can serve the
+  arch, instead of the operator meeting a silent crash-loop at load. An
+  `image_pin` disarms the check (the pin is the documented escape hatch);
+  nothing is ever blocked and no image is auto-switched.
+
 ### Changed
 
 - The ComfyUI runner family now defaults to hal0's own published image
@@ -48,15 +67,6 @@ applying. Add those subsections to a version's section to surface them; see
   the kyuz0 layout by construction, so existing img slots need no
   reconfiguration; `--purge` uninstall still removes the old kyuz0 image on
   upgraded boxes (#2171).
-||||||| parent of 993ea3b6 (feat(hardware): host-truth GTT feasibility signal (warn, never block))
-- **Host-truth GTT feasibility signal.** `GET /api/hardware` now carries live
-  `gtt_used_mb`/`gtt_free_mb` from the amdgpu `mem_info_gtt_*` sysfs counters
-  (host truth even inside an LXC container, where the cgroup-shaped meminfo
-  can show tens of GiB "available" while a GTT weight allocation fails), the
-  slot load path emits an advisory `slot.gtt_feasibility` warning — never a
-  block — when a model's weights exceed the free GTT pool, and the dashboard's
-  Detected-hardware panel shows the live free-GTT figure.
-
 ## [1.1.0] — 2026-08-31
 
 ### Highlights

--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -936,6 +936,11 @@ async def system_info_endpoint(request: Request) -> dict[str, Any]:
             # read the registry truth instead of assuming a single backend.
             "supported_backends": list(runner.supported_backends),
             "format_arch": runner.format_arch,
+            # format_arch's §4 refinement (hal0#2118): GGUF general.architecture
+            # ids this runner's llama.cpp build is KNOWN to reject at load —
+            # the slot drawer's model↔runner arch fit-check reads this next to
+            # the model row's detected `architecture`.
+            "unsupported_archs": list(runner.unsupported_archs),
             # Per-runner capability metadata (UI-API-1 item 2 / spec §7): expose
             # what the runner registry actually knows so the model drawer can
             # filter its runner-override dropdown to COMPATIBLE runners. Only

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -636,6 +636,126 @@ def _fit_check_warning(device: str | None, binary: str | None) -> str | None:
     return None
 
 
+def _merged_model_default(body: dict[str, Any], before: dict[str, Any]) -> str | None:
+    """The bound-model id a config write resolves to (write wins over disk).
+
+    The ``model`` sub-table may arrive as a dict (``{"default": "id"}``) or —
+    on the create path's pre-normalized flat shape — a bare string; both are
+    folded. A write that omits ``model`` entirely falls back to the persisted
+    section.
+    """
+    for cfg in (body, before):
+        if "model" not in cfg:
+            continue
+        sect = cfg.get("model")
+        if isinstance(sect, str):
+            return sect or None
+        if isinstance(sect, dict):
+            val = sect.get("default")
+            return val if isinstance(val, str) and val else None
+        return None
+    return None
+
+
+def _arch_fit_warning(
+    model_arch: str | None,
+    device: str | None,
+    binary: str | None,
+    image_pin: str | None,
+    *,
+    alternative_ref: str | None = None,
+) -> str | None:
+    """Non-blocking model↔runner GGUF-arch fit-check (hal0#2118).
+
+    WARN — never reject, mirroring :func:`_fit_check_warning` — when the
+    bound model's detected ``general.architecture`` is on the effective
+    runner's ``unsupported_archs`` denylist: the runner's llama.cpp build
+    rejects the arch at model load, so the slot crash-loops with nothing
+    operator-visible but the breaker chip. An ``image_pin`` disarms the
+    check entirely — the pin IS the documented escape hatch (#2118 wires
+    the combined-upstream variant through it), and the catalogue can't
+    know a pinned image's arch table. An unknown/unset arch or BINARY, or
+    a non-GGUF lane, never warns. ``alternative_ref`` (a catalogued image
+    ref that CAN load the arch, resolved by the route glue) turns the
+    warning into an actionable hint.
+    """
+    if not model_arch or image_pin:
+        return None
+    from hal0.runners import (
+        RUNNER_IMAGES,
+        canonical_runner_key,
+        runner_for_backend,
+        runner_supports_arch,
+    )
+
+    backend = _device_backend(device)
+    if binary:
+        runner = RUNNER_IMAGES.get(canonical_runner_key(str(binary)))
+        if runner is None:
+            return None  # unknown BINARY — the launch path reports its own error
+    else:
+        # No BINARY = the HW-gated default the launcher will derive from the
+        # device — check THAT runner, since it's the build that actually loads
+        # the model. Guarded to llama-server lanes below via format_arch.
+        runner = runner_for_backend(backend or None)
+    if runner.format_arch != "gguf":
+        # The arch marker is a GGUF header fact; a non-GGUF runtime family
+        # (flm/kokoro/…) has its own format vocabulary — no opinion here.
+        return None
+    if runner_supports_arch(runner, model_arch):
+        return None
+    msg = (
+        f'model architecture "{model_arch}" is not supported by the '
+        f"{runner.key} runner's llama.cpp build; the model will fail at "
+        "load and the slot will crash-loop"
+    )
+    if alternative_ref:
+        msg += f' — pin "{alternative_ref}" on this slot (image_pin) to serve it'
+    return msg
+
+
+def _model_arch_fit_warning(
+    request: Request,
+    model_id: object,
+    device: str | None,
+    binary: str | None,
+    image_pin: str | None,
+) -> str | None:
+    """Route glue for :func:`_arch_fit_warning`: resolve the bound model's
+    persisted ``architecture`` and, when the arch has a catalogued
+    alternative image (``hal0.runners.ARCH_ALTERNATIVE_IMAGES``), the
+    concrete ``image:tag`` ref for the hint. Best-effort throughout — an
+    unresolvable model / registry / catalogue yields ``None``, never an
+    error, because this only decorates an already-successful write.
+    """
+    if not model_id or not isinstance(model_id, str):
+        return None
+    registry = getattr(request.app.state, "model_registry", None)
+    if registry is None:
+        return None
+    try:
+        model = registry.get(model_id)
+    except Exception:
+        return None
+    arch = getattr(model, "architecture", None)
+    if not arch:
+        return None
+    from hal0.runners import ARCH_ALTERNATIVE_IMAGES
+
+    alternative_ref: str | None = None
+    alt_id = ARCH_ALTERNATIVE_IMAGES.get(arch)
+    if alt_id:
+        store = getattr(request.app.state, "runner_image_registry", None)
+        if store is not None:
+            try:
+                row = store.get(alt_id)
+            except Exception:
+                row = None
+            if row is not None:
+                alternative_ref = f"{row.image}:{row.tag}" if row.tag else row.image
+    return _arch_fit_warning(arch, device, binary, image_pin, alternative_ref=alternative_ref)
+
+
 def _normalize_create_body(
     body: dict[str, Any],
     *,
@@ -769,6 +889,19 @@ async def create_slot(request: Request) -> dict[str, object]:
     fit_warn = _fit_check_warning(body.get("device"), body.get("binary"))
     if fit_warn:
         out["fit_warning"] = fit_warn
+    # Model↔runner arch fit-check (hal0#2118) — same warn-never-reject
+    # contract, keyed separately so the UI can render it by the Model select
+    # rather than the HW grid.
+    model_sect_for_fit = body.get("model")
+    arch_warn = _model_arch_fit_warning(
+        request,
+        model_sect_for_fit.get("default") if isinstance(model_sect_for_fit, dict) else None,
+        body.get("device"),
+        body.get("binary"),
+        body.get("image_pin"),
+    )
+    if arch_warn:
+        out["model_fit_warning"] = arch_warn
 
     # Post-create model-default promotion. The slot is the primary object and is
     # already persisted — a promotion failure (unresolved / unregistered model,
@@ -1294,6 +1427,18 @@ async def update_slot_config(name: str, request: Request) -> dict[str, object]:
     fit_warn = _fit_check_warning(merged_device, merged_binary)
     if fit_warn:
         out["fit_warning"] = fit_warn
+    # Model↔runner arch fit-check (hal0#2118) over the same merged view — a
+    # write that touches only ONE of model/device/binary/image_pin still
+    # checks against the persisted rest.
+    arch_warn = _model_arch_fit_warning(
+        request,
+        _merged_model_default(body, _before),
+        merged_device,
+        merged_binary,
+        body.get("image_pin", _before.get("image_pin")),
+    )
+    if arch_warn:
+        out["model_fit_warning"] = arch_warn
     return out
 
 
@@ -1501,7 +1646,22 @@ async def swap_slot(name: str, request: Request) -> dict[str, object]:
     ) as _rec:
         snap = await sm.swap(name, model_id)
         _rec.after = {"model_id": model_id, "state": _state_value(snap)}
-    return _slot_to_dict(snap, request)
+    out = _slot_to_dict(snap, request)
+    # Model↔runner arch fit-check (hal0#2118): the swap is THE model-assign
+    # verb, so a model whose detected GGUF arch the slot's effective runner
+    # rejects gets the same warn-never-reject notice the config writes carry
+    # — naming why the load it just kicked off is about to crash-loop.
+    cfg_after = await _safe_config(sm, name) or {}
+    arch_warn = _model_arch_fit_warning(
+        request,
+        model_id,
+        cfg_after.get("device"),
+        cfg_after.get("binary"),
+        cfg_after.get("image_pin"),
+    )
+    if arch_warn:
+        out["model_fit_warning"] = arch_warn
+    return out
 
 
 # ── logs ───────────────────────────────────────────────────────────────────

--- a/src/hal0/registry/detect.py
+++ b/src/hal0/registry/detect.py
@@ -264,6 +264,19 @@ class DetectionResult:
 # ── helpers ────────────────────────────────────────────────────────────────
 
 
+def detected_architecture(detection: DetectionResult) -> str | None:
+    """The GGUF ``general.architecture`` id a detection carried, or ``None``.
+
+    ONE accessor over ``raw_hints["architecture"]`` so the registration
+    paths that persist ``Model.architecture`` (scan commit, add-from-path,
+    the pull upsert) read the hint through a single seam instead of each
+    re-spelling the raw dict key. ``None`` for non-GGUF files, unreadable
+    headers, and headers that drop the key.
+    """
+    arch = detection.raw_hints.get("architecture")
+    return arch if isinstance(arch, str) and arch.strip() else None
+
+
 def _filename_capability(name: str) -> str | None:
     """Best-effort capability inferred from filename tokens. ``None`` if no hit.
 
@@ -559,6 +572,7 @@ def detect(path: str | Path, *, filename_hint: str | None = None) -> DetectionRe
 __all__ = [
     "DetectionResult",
     "detect",
+    "detected_architecture",
     "quant_from_file_type",
     "quant_from_filename",
     "quant_from_rocmfpx_filename",

--- a/src/hal0/registry/discover.py
+++ b/src/hal0/registry/discover.py
@@ -376,6 +376,12 @@ def register_candidate(registry: ModelRegistry, candidate: CandidateModel) -> Mo
             hf_filename=curated.hf_file,
             tags=list(curated.tags),
             metadata={"discovered": True, "source": "auto-scan"},
+            # Curated arch id (§7.1d) — feeds the model↔runner arch
+            # fit-check (hal0#2118). The auto-scan path deliberately reads
+            # no GGUF header (it may walk thousands of files), so the
+            # uncurated branch below leaves ``architecture`` unset; those
+            # rows pick it up if re-registered via scan-commit/add-from-path.
+            architecture=curated.architecture,
         )
     else:
         model = Model(

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -1221,16 +1221,23 @@ def _register_pulled(
     # window backfills an unreadable header.
     from hal0.registry.detect import (
         detect,
+        detected_architecture,
         quant_from_filename,
         quant_from_rocmfpx_filename,
     )
 
     ctx_len: int | None = None
     detected_quant: str | None = None
+    detected_arch: str | None = None
     try:
         detection = detect(Path(path))
         ctx_len = detection.context_length
         detected_quant = detection.quant
+        # GGUF general.architecture — persisted so the model↔runner arch
+        # fit-check (hal0#2118) can warn at slot assignment. The header is
+        # authoritative; the curated catalogue backfills an unreadable one
+        # (same tiering as context_length above).
+        detected_arch = detected_architecture(detection)
     except Exception:  # header parse must never fail a completed pull
         ctx_len = None
     # #1890: capability-grouped installs (``_final_path_for_entry``) rename the
@@ -1246,6 +1253,8 @@ def _register_pulled(
         )
     if not ctx_len and curated is not None and curated.context_length:
         ctx_len = int(curated.context_length)
+    if not detected_arch and curated is not None and curated.architecture:
+        detected_arch = str(curated.architecture)
     if ctx_len:
         fresh_meta["context_length"] = int(ctx_len)
         # #1657: mark this value as auto-detected (GGUF header or curated
@@ -1268,6 +1277,13 @@ def _register_pulled(
         "metadata": fresh_meta,
         "quant": detected_quant,
     }
+    # Unlike ``quant`` (written unconditionally, see above), the arch is
+    # written only when this pull actually read/backfilled one — an
+    # unreadable replacement header must not CLEAR an arch a prior read (or
+    # an operator edit) already established, since a missing arch merely
+    # disarms the fit-check rather than mis-arming it.
+    if detected_arch:
+        updates["architecture"] = detected_arch
     if mmproj is not None:
         updates["mmproj"] = mmproj
     try:
@@ -1300,6 +1316,7 @@ def _register_pulled(
                 backends=backends,
                 mmproj=mmproj,
                 metadata=dict(fresh_meta),
+                architecture=detected_arch,
                 defaults=ModelDefaults(**new_defaults_kwargs) if new_defaults_kwargs else None,
                 capability_flags=ModelCapabilities(tool_calling=curated_tool_calling)
                 if curated_tool_calling is not None

--- a/src/hal0/runners/__init__.py
+++ b/src/hal0/runners/__init__.py
@@ -151,6 +151,23 @@ class Runner:
     #: Carries the lxc105 finding — GGUF forks can reject newer GGUF arch
     #: versions — as a coarse first-class marker for the §4 fit-check to refine.
     format_arch: str | None = None
+    #: The §4 refinement of ``format_arch``: GGUF ``general.architecture``
+    #: ids this runner's llama.cpp build is KNOWN to reject at model load
+    #: (``unknown model architecture: '<arch>'`` → instant crash-loop).
+    #:
+    #: A DENYLIST, deliberately not a supported-archs allowlist: a fork
+    #: lineage supports every arch upstream knew at its sync point, so an
+    #: allowlist would duplicate llama.cpp's whole arch table (hundreds of
+    #: entries, stale on every fork sync), while the archs a fork *lacks*
+    #: are exactly the known post-sync-point additions — a small, finite
+    #: set discovered per incident (the lxc105 finding above) and DELETED
+    #: when the fork syncs past the upstream merge (each entry pairs with a
+    #: retirement checklist like hal0#2118's). That maintenance shape also
+    #: matches this module's layout: ``RUNNER_IMAGES`` is a hand-maintained
+    #: code registry, and a one-line deny tuple is reviewable next to the
+    #: image bump that removes it. Empty ``()`` = no known gaps (which is
+    #: NOT a support guarantee — the fit-check stays a WARN, never a block).
+    unsupported_archs: tuple[str, ...] = ()
 
 
 RUNNER_IMAGES: dict[str, Runner] = {
@@ -164,6 +181,14 @@ RUNNER_IMAGES: dict[str, Runner] = {
         None,
         supported_backends=("rocm", "vulkan"),
         format_arch="gguf",
+        # hal0#2118: Qwen3.8-Flash-Next ships arch `qwen4exp`, merged into
+        # upstream llama.cpp 2026-08-27/28 (ggml-org/llama.cpp#27742/#27880);
+        # this image builds from charlie12345/ROCmFPX @ c49ebdbd (2026-08-22),
+        # which predates the merge — the model fails at load with
+        # `unknown model architecture: 'qwen4exp'`. Serving it needs the
+        # pin-only combined-upstream image (see ARCH_ALTERNATIVE_IMAGES).
+        # DELETE this entry when the fork syncs qwen4exp (#2118's checklist).
+        unsupported_archs=("qwen4exp",),
     ),
     "promptforge": Runner(
         "promptforge",
@@ -295,6 +320,32 @@ STALE_RUNNER_IMAGE_REFS = STALE_ROCMFPX_IMAGE_REFS
 #: real binary: the runner is ROCmFPX, whose image happens to ship a
 #: working Vulkan backend (see the collapse spec, 2026-08-30).
 RUNNER_ALIASES: dict[str, str] = {"vulkanfpx": "rocmfpx"}
+
+#: Denylisted arch → the runner-image CATALOGUE id (``RunnerImage.id``, the
+#: GHCR repo path with the host stripped) of an image that IS known to load
+#: it. Consulted by the model↔runner arch fit-check so the WARN can name a
+#: concrete escape hatch (the slot's ``image_pin``) instead of a dead end.
+#: ``qwen4exp`` → the pin-only combined-upstream variant (pristine upstream
+#: llama.cpp @ c841aeeb, no fork patches — packaging/runner/upstream/
+#: manifest.toml, hal0#2118). The hint only renders when the catalogue
+#: actually carries the id, so a box that never synced it degrades to the
+#: bare warning. Entries retire together with the matching
+#: ``unsupported_archs`` entry.
+ARCH_ALTERNATIVE_IMAGES: dict[str, str] = {"qwen4exp": "hal0ai/hal0-combined-upstream"}
+
+
+def runner_supports_arch(runner: Runner, arch: str | None) -> bool:
+    """Is ``arch`` (a GGUF ``general.architecture`` id) loadable by ``runner``?
+
+    ``True`` is "not known-broken", not a guarantee: only archs on the
+    runner's ``unsupported_archs`` denylist return ``False``. An unknown /
+    ``None`` arch (header unreadable, pre-detection registry row, non-GGUF
+    format) never vetoes — the caller WARNS on ``False`` and stays silent
+    otherwise, mirroring the §4 (device, BINARY) fit-check contract.
+    """
+    if not arch:
+        return True
+    return arch not in runner.unsupported_archs
 
 
 def canonical_runner_key(key: str) -> str:
@@ -463,6 +514,7 @@ def runner_matches(runner: Runner, *, device_class: str | None, backend: str | N
 
 
 __all__ = [
+    "ARCH_ALTERNATIVE_IMAGES",
     "CANONICAL_FAMILY",
     "FPX_RUNNER_KEYS",
     "RUNNER_ALIASES",
@@ -478,4 +530,5 @@ __all__ = [
     "resolve_runner_image",
     "runner_for_backend",
     "runner_matches",
+    "runner_supports_arch",
 ]

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from hal0.model_meta import classify
-from hal0.registry.detect import DetectionResult, detect
+from hal0.registry.detect import DetectionResult, detect, detected_architecture
 from hal0.registry.model import _derive_ns
 from hal0.upstreams.filters import apply_filters
 
@@ -406,6 +406,11 @@ async def commit_scan_rows(
                 backends=[str(b) for b in backends],
                 defaults=defaults_obj,
                 metadata=metadata,
+                # GGUF general.architecture from the header read detect()
+                # already performed — persisted so the model↔runner arch
+                # fit-check (hal0#2118) can warn at slot assignment instead
+                # of the operator discovering a crash-loop at load.
+                architecture=detected_architecture(detection),
             )
         except (TypeError, ValueError) as exc:
             skipped.append({"path": str(resolved), "reason": f"invalid_model:{exc}"})
@@ -1118,6 +1123,10 @@ async def add_from_path(body: dict[str, Any], *, registry: Any, event_bus: Any) 
             capabilities=capabilities,
             backends=list(detection.suggested_backends),
             metadata=metadata,
+            # GGUF general.architecture from the header read above — see
+            # commit_scan_rows' matching stamp (model↔runner arch fit-check,
+            # hal0#2118).
+            architecture=detected_architecture(detection),
         )
     except (TypeError, ValueError) as exc:
         raise BadRequest(f"invalid Model payload: {exc}") from exc

--- a/tests/api/test_models_add_from_path.py
+++ b/tests/api/test_models_add_from_path.py
@@ -75,6 +75,30 @@ def test_add_from_path_registers_gguf(
     assert body["id"] in ids
 
 
+def test_add_from_path_persists_detected_architecture(
+    add_path_client: tuple[TestClient, Path],
+) -> None:
+    """A readable GGUF header's ``general.architecture`` lands on the
+    registry row (``Model.architecture``) so the model↔runner arch
+    fit-check (hal0#2118) can warn at slot assignment."""
+    client, drop = add_path_client
+    target = drop / "qwen3.8-flash-next-ud-q2-k-xl.gguf"
+    target.write_bytes(
+        _build_gguf(
+            3,
+            [("general.architecture", _GGUF_TYPE_STRING, _enc_str("qwen4exp"))],
+        )
+    )
+
+    r = client.post("/api/models/add-from-path", json={"path": str(target)})
+    assert r.status_code == 201, r.text
+    assert r.json()["architecture"] == "qwen4exp"
+
+    listing = client.get("/api/models").json()
+    row = next(m for m in listing["models"] if m["id"] == r.json()["id"])
+    assert row["architecture"] == "qwen4exp"
+
+
 def test_add_from_path_surfaces_medium_confidence_for_filename_guess(
     add_path_client: tuple[TestClient, Path],
 ) -> None:

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -2706,3 +2706,136 @@ def test_fit_check_refuses_promptforge_on_a_vulkan_device() -> None:
     # the sibling half: its own backend fits, and cpu is refused too
     assert _fit_check_warning("gpu-rocm", "promptforge") is None
     assert _fit_check_warning("cpu", "promptforge") is not None
+
+
+# ── model↔runner arch fit-check (hal0#2118) ──────────────────────────────────
+
+
+def test_arch_fit_warning_paths() -> None:
+    from hal0.api.routes.slots import _arch_fit_warning
+
+    # The #2118 shape: qwen4exp on the default rocmfpx build → warn.
+    warn = _arch_fit_warning("qwen4exp", "gpu-rocm", "rocmfpx", None)
+    assert warn is not None
+    assert "qwen4exp" in warn
+    assert "rocmfpx" in warn
+    assert "crash-loop" in warn
+    # No BINARY = the HW-gated default derived from the device — a GPU lane
+    # resolves to rocmfpx, so the SAME model still warns (this is exactly how
+    # the #2118 slot was configured: no explicit binary).
+    assert _arch_fit_warning("qwen4exp", "gpu-vulkan", "", None) is not None
+    assert _arch_fit_warning("qwen4exp", "gpu-vulkan", None, None) is not None
+    # An image_pin disarms the check — the pin IS the documented escape hatch.
+    pinned = _arch_fit_warning(
+        "qwen4exp", "gpu-rocm", "rocmfpx", "ghcr.io/hal0ai/hal0-combined-upstream:0829"
+    )
+    assert pinned is None
+    # Arch not on the denylist / unknown arch → silent.
+    assert _arch_fit_warning("llama", "gpu-rocm", "rocmfpx", None) is None
+    assert _arch_fit_warning(None, "gpu-rocm", "rocmfpx", None) is None
+    # Stock-build runners denylist nothing today.
+    assert _arch_fit_warning("qwen4exp", "cpu", "cpu", None) is None
+    # Non-GGUF runtime lane (format_arch != "gguf") has no opinion.
+    assert _arch_fit_warning("qwen4exp", "npu", "flm", None) is None
+    # Unknown BINARY key → the launch path reports its own error.
+    assert _arch_fit_warning("qwen4exp", "gpu-rocm", "does-not-exist", None) is None
+    # The vulkanfpx alias folds to rocmfpx before lookup.
+    assert _arch_fit_warning("qwen4exp", "gpu-vulkan", "vulkanfpx", None) is not None
+
+
+def test_arch_fit_warning_names_the_catalogued_alternative() -> None:
+    from hal0.api.routes.slots import _arch_fit_warning
+
+    ref = "ghcr.io/hal0ai/hal0-combined-upstream:0829"
+    warn = _arch_fit_warning("qwen4exp", "gpu-rocm", "rocmfpx", None, alternative_ref=ref)
+    assert warn is not None
+    assert ref in warn
+    assert "image_pin" in warn
+
+
+def test_merged_model_default_shapes() -> None:
+    from hal0.api.routes.slots import _merged_model_default
+
+    # Write wins over disk, both sub-table and flat-string shapes fold.
+    assert _merged_model_default({"model": {"default": "a"}}, {"model": {"default": "b"}}) == "a"
+    assert _merged_model_default({"model": "a"}, {}) == "a"
+    # A write that omits `model` falls back to the persisted section.
+    assert _merged_model_default({}, {"model": {"default": "b"}}) == "b"
+    # A write that explicitly clears the binding resolves to None.
+    assert _merged_model_default({"model": {"default": ""}}, {"model": {"default": "b"}}) is None
+    assert _merged_model_default({}, {}) is None
+
+
+def test_put_config_warns_on_denylisted_model_arch(
+    tmp_hal0_home: str,
+    isolated_client: TestClient,
+) -> None:
+    """hal0#2118: binding a model whose detected GGUF arch the effective
+    runner denylists WARNS (non-blocking) — the write succeeds (200) and the
+    response carries ``model_fit_warning`` naming the arch."""
+    from hal0.registry.model import Model
+
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "flashnext",
+        [
+            'name = "flashnext"',
+            "port = 8081",
+            'device = "gpu-vulkan"',
+            'provider = "llama-server"',
+            'runtime = "container"',
+            "[model]",
+            'default = "qwen3.8-flash-next-ud-q2-k-xl"',
+        ],
+    )
+    isolated_client.app.state.model_registry.add(
+        Model(
+            id="qwen3.8-flash-next-ud-q2-k-xl",
+            path="/models/qwen3.8-flash-next-ud-q2-k-xl.gguf",
+            architecture="qwen4exp",
+        )
+    )
+    # Touching only the binary still checks against the PERSISTED model.
+    r = isolated_client.put("/api/slots/flashnext/config", json={"binary": "rocmfpx"})
+    assert r.status_code == 200, r.text
+    out = r.json()
+    assert "model_fit_warning" in out
+    assert "qwen4exp" in out["model_fit_warning"]
+    assert "rocmfpx" in out["model_fit_warning"]
+
+    # Pinning an image (THE #2118 escape hatch) disarms the warning.
+    r = isolated_client.put(
+        "/api/slots/flashnext/config",
+        json={"image_pin": "ghcr.io/hal0ai/hal0-combined-upstream:0829"},
+    )
+    assert r.status_code == 200, r.text
+    assert "model_fit_warning" not in r.json()
+
+
+def test_put_config_no_arch_warning_for_supported_arch(
+    tmp_hal0_home: str,
+    isolated_client: TestClient,
+) -> None:
+    """A bound model with a supported (or unknown) arch carries no
+    ``model_fit_warning`` key."""
+    from hal0.registry.model import Model
+
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "plain",
+        [
+            'name = "plain"',
+            "port = 8081",
+            'device = "gpu-vulkan"',
+            'provider = "llama-server"',
+            'runtime = "container"',
+            "[model]",
+            'default = "llama-model"',
+        ],
+    )
+    isolated_client.app.state.model_registry.add(
+        Model(id="llama-model", path="/models/llama.gguf", architecture="llama")
+    )
+    r = isolated_client.put("/api/slots/plain/config", json={"binary": "rocmfpx"})
+    assert r.status_code == 200, r.text
+    assert "model_fit_warning" not in r.json()

--- a/tests/registry/test_detect.py
+++ b/tests/registry/test_detect.py
@@ -381,3 +381,24 @@ class TestRocmfpxQuant:
             _build_gguf(3, kvs),
         )
         assert detect(p).quant == "ROCmFPX"
+
+
+class TestDetectedArchitecture:
+    """detected_architecture() — the one seam registration paths read the
+    GGUF ``general.architecture`` hint through (model↔runner arch
+    fit-check, hal0#2118)."""
+
+    def test_returns_header_arch(self, tmp_path: Path) -> None:
+        from hal0.registry.detect import detected_architecture
+
+        kvs = [
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("qwen4exp")),
+        ]
+        p = _write_fixture(tmp_path, "qwen3.8-flash-next.gguf", _build_gguf(3, kvs))
+        assert detected_architecture(detect(p)) == "qwen4exp"
+
+    def test_none_for_heuristic_only_detection(self, tmp_path: Path) -> None:
+        from hal0.registry.detect import detected_architecture
+
+        p = _write_fixture(tmp_path, "not-gguf.gguf", b"NOPE" + b"\x00" * 64)
+        assert detected_architecture(detect(p)) is None

--- a/tests/runners/test_registry.py
+++ b/tests/runners/test_registry.py
@@ -225,3 +225,42 @@ def test_canonical_family_folds_vulkanfpx() -> None:
 
 def test_canonical_family_map_only_folds_the_fpx_twin() -> None:
     assert CANONICAL_FAMILY == {"vulkanfpx": "rocmfpx"}
+
+
+# --- arch denylist (model↔runner arch fit-check, hal0#2118) ---------------- #
+
+
+def test_rocmfpx_denylists_qwen4exp() -> None:
+    """hal0#2118: the default ROCmFPX fork build (charlie12345/ROCmFPX @
+    c49ebdbd, 2026-08-22) predates upstream's qwen4exp merge (2026-08-27/28),
+    so Qwen3.8-Flash-Next fails at load with `unknown model architecture:
+    'qwen4exp'`. The denylist entry retires with the fork sync (#2118's
+    checklist)."""
+    assert "qwen4exp" in RUNNER_IMAGES["rocmfpx"].unsupported_archs
+
+
+def test_runner_supports_arch_semantics() -> None:
+    from hal0.runners import runner_supports_arch
+
+    rocmfpx = RUNNER_IMAGES["rocmfpx"]
+    assert not runner_supports_arch(rocmfpx, "qwen4exp")
+    # Not on the denylist = not known-broken (never a guarantee).
+    assert runner_supports_arch(rocmfpx, "llama")
+    # Unknown / unset arch never vetoes — the fit-check stays silent.
+    assert runner_supports_arch(rocmfpx, None)
+    assert runner_supports_arch(rocmfpx, "")
+    # Empty denylist (stock builds) refuses nothing.
+    assert runner_supports_arch(RUNNER_IMAGES["cpu"], "qwen4exp")
+
+
+def test_arch_alternative_images_pair_with_a_denylist_entry() -> None:
+    """Every alternative-image hint must correspond to an arch some runner
+    actually denylists — a dangling hint is dead weight that outlived its
+    retirement (the two tables retire together, see ARCH_ALTERNATIVE_IMAGES)."""
+    from hal0.runners import ARCH_ALTERNATIVE_IMAGES
+
+    denylisted = {a for r in RUNNER_IMAGES.values() for a in r.unsupported_archs}
+    for arch in ARCH_ALTERNATIVE_IMAGES:
+        assert arch in denylisted
+    # And the #2118 pairing concretely: qwen4exp → the combined-upstream id.
+    assert ARCH_ALTERNATIVE_IMAGES["qwen4exp"] == "hal0ai/hal0-combined-upstream"

--- a/ui/src/dash/__tests__/hw-cascade.test.ts
+++ b/ui/src/dash/__tests__/hw-cascade.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   applyBackendChoice,
+  archFitWarning,
   backendOptions,
   cataloguePinOptions,
   optionValue,
@@ -277,5 +278,64 @@ describe('cataloguePinOptions — downloaded catalogue rows beyond the release c
 
   it('tolerates missing rows/catalog', () => {
     expect(cataloguePinOptions({ rows: undefined, catalogImages: undefined, slotType: 'llm' })).toEqual([])
+  })
+})
+
+describe('archFitWarning — model↔runner GGUF-arch fit-check (hal0#2118)', () => {
+  // system-info runner rows carrying the denylist the check reads.
+  const archBackends = {
+    rocmfpx: {
+      image: COMBINED,
+      backend: 'rocm',
+      supported_backends: ['rocm', 'vulkan'],
+      device_class: 'gpu',
+      runtime_family: 'llama-server',
+      format_arch: 'gguf',
+      unsupported_archs: ['qwen4exp'],
+    },
+    cpu: {
+      image: 'ghcr.io/hal0ai/hal0-toolbox-cpu:v1',
+      backend: 'cpu',
+      device_class: 'cpu',
+      runtime_family: 'llama-server',
+      format_arch: 'gguf',
+      unsupported_archs: [],
+    },
+    flm: {
+      image: 'ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44',
+      device_class: 'npu',
+      runtime_family: 'flm',
+      format_arch: 'flm',
+      unsupported_archs: [],
+    },
+  }
+  const base = { device: 'gpu-rocm', binary: 'rocmfpx', imagePin: '', backends: archBackends }
+
+  it('warns when the arch is on the effective runner denylist', () => {
+    const msg = archFitWarning({ ...base, arch: 'qwen4exp' })
+    expect(msg).toContain('qwen4exp')
+    expect(msg).toContain('rocmfpx')
+  })
+  it('resolves the HW-gated default runner when no binary is pinned (the #2118 shape)', () => {
+    expect(archFitWarning({ ...base, binary: '', arch: 'qwen4exp' })).toContain('rocmfpx')
+    expect(archFitWarning({ ...base, binary: '', device: 'cpu', arch: 'qwen4exp' })).toBe(null)
+  })
+  it('an image_pin disarms the check — the pin IS the escape hatch', () => {
+    expect(archFitWarning({ ...base, arch: 'qwen4exp', imagePin: COMBINED })).toBe(null)
+  })
+  it('stays silent for supported or unknown archs', () => {
+    expect(archFitWarning({ ...base, arch: 'llama' })).toBe(null)
+    expect(archFitWarning({ ...base, arch: '' })).toBe(null)
+    expect(archFitWarning({ ...base, arch: undefined })).toBe(null)
+  })
+  it('has no opinion on non-GGUF lanes, unknown keys, or an older payload without the denylist', () => {
+    expect(archFitWarning({ ...base, binary: 'flm', arch: 'qwen4exp' })).toBe(null)
+    expect(archFitWarning({ ...base, binary: 'nope', arch: 'qwen4exp' })).toBe(null)
+    const older = { rocmfpx: { ...archBackends.rocmfpx, unsupported_archs: undefined } }
+    expect(archFitWarning({ ...base, backends: older, arch: 'qwen4exp' })).toBe(null)
+  })
+  it('names the alternative image when the caller resolved one', () => {
+    const msg = archFitWarning({ ...base, arch: 'qwen4exp', altRef: COMBINED })
+    expect(msg).toContain(COMBINED)
   })
 })

--- a/ui/src/dash/hw-cascade.js
+++ b/ui/src/dash/hw-cascade.js
@@ -193,6 +193,48 @@ export function cataloguePinOptions({ rows, catalogImages, slotType }) {
 }
 
 /**
+ * Model↔runner GGUF-arch fit-check (hal0#2118) — FE mirror of the backend's
+ * `_arch_fit_warning` in api/routes/slots.py. WARN, never block: returns a
+ * message string when the bound model's detected `general.architecture` is on
+ * the effective runner's `unsupported_archs` denylist (system-info runner
+ * rows), else null. An image_pin disarms the check — the pin IS the #2118
+ * escape hatch, and the catalog can't know a pinned image's arch table.
+ * `altRef` (an image ref known to load the arch) turns the warning into an
+ * actionable hint.
+ *
+ * @param arch     model row's `architecture` (GGUF general.architecture id)
+ * @param device   the slot's (pending) device enum, e.g. "gpu-rocm"
+ * @param binary   the slot's BINARY runner key ('' = HW-gated default)
+ * @param imagePin trimmed image_pin ('' = release-catalog default)
+ * @param backends system-info RUNNER_IMAGES map (key → runner row)
+ * @param altRef   optional catalogued image ref that CAN load the arch
+ */
+export function archFitWarning({ arch, device, binary, imagePin, backends, altRef = "" }) {
+	if (!arch || String(imagePin || "").trim()) return null;
+	const cat = backends || {};
+	let key = String(binary || "");
+	if (!key) {
+		// No BINARY = the HW-gated default the launcher derives from the
+		// device — runner_for_backend's FE mirror (cuda → cuda, cpu → cpu,
+		// any other GPU lane → rocmfpx).
+		const be = deviceBackend(device);
+		key = be === "cuda" ? "cuda" : be === "cpu" ? "cpu" : "rocmfpx";
+	}
+	const runner = cat[key];
+	// Unknown runner key, a non-GGUF runtime lane, or an older system-info
+	// payload without the denylist: no opinion, never a warning.
+	if (!runner || runner.format_arch !== "gguf") return null;
+	const deny = runner.unsupported_archs;
+	if (!Array.isArray(deny) || !deny.includes(arch)) return null;
+	let msg =
+		`⚠ Model architecture "${arch}" is not supported by the ${key} ` +
+		"runner's llama.cpp build — the model will fail at load and the slot " +
+		"will crash-loop.";
+	if (altRef) msg += ` Pin "${altRef}" (Runner Image) to serve it.`;
+	return msg;
+}
+
+/**
  * Resolve a Backend dropdown pick to the state it drives.
  * Unknown values (the out-of-vocab persisted pair rendered as its own option)
  * set the binary and leave the device alone.

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -21,6 +21,7 @@ import { useProfiles } from "@/api/hooks/useProfiles";
 import { useSystemInfo, deviceBackend } from "@/api/hooks/useRuntimes";
 import {
 	applyBackendChoice,
+	archFitWarning,
 	backendOptions,
 	cataloguePinOptions,
 	optionValue,
@@ -1963,6 +1964,40 @@ function EditSlotDrawer({ open, slot, onClose }) {
 												that change (or revert the profile) before swapping.
 											</div>
 										)}
+										{(() => {
+											// Model↔runner GGUF-arch fit-check (hal0#2118) — warn,
+											// never block, same idiom as the HW-grid fit warning
+											// below the Backend select. Reads the bound model's
+											// detected `architecture` against the effective
+											// runner's `unsupported_archs` denylist (system-info);
+											// an image_pin disarms it (the pin IS the escape
+											// hatch). Previews the post-save device/binary/pin so
+											// a live HW edit updates the verdict before Save.
+											const archWarn = archFitWarning({
+												arch: curModelRow?.architecture,
+												device: pendingDevice,
+												binary,
+												imagePin,
+												backends: systemInfoQuery.data?.backends ?? {},
+											});
+											if (!archWarn) return null;
+											return (
+												<div
+													className="hint"
+													data-testid="slot-model-arch-fit-warning"
+													style={{
+														marginTop: 6,
+														padding: "6px 10px",
+														borderRadius: "var(--rad-sm)",
+														color: "var(--warn)",
+														border: "1px solid var(--warn-line)",
+														background: "var(--warn-soft)",
+													}}
+												>
+													{archWarn}
+												</div>
+											);
+										})()}
 									</div>
 								</div>
 							);


### PR DESCRIPTION
## What

Today a GGUF whose architecture the default ROCmFPX fork doesn't know (Qwen3.8-Flash-Next, arch `qwen4exp` — #2118) launches, crashes in-container at arch parse, and the operator sees only a crash-loop breaker chip. This turns that dead end into an assignment-time warning, refining the runner registry's too-coarse `format_arch: "gguf"` marker (the lxc105 finding its docstring cites).

## How

**Model side** — detect + persist GGUF `general.architecture` at registration, through one seam (`registry.detect.detected_architecture`, over the header read `detect()` already performs):
- scan commit (`models_service.commit_scan_rows`) and add-from-path
- the pull upsert (`registry/pull._register_pulled`) — header authoritative, curated catalogue backfills an unreadable one; never clears a previously established arch
- the curated auto-scan branch (`discover.register_candidate`, zero new I/O — the uncurated branch deliberately still reads no header)
- `Model.architecture` already existed (§7.1d, `db/migrations/001_registry.sql:20`) — **no schema migration**

**Runner side** — `Runner.unsupported_archs`, a **denylist** of archs the build rejects at load. Denylist over allowlist because a fork lineage supports every arch upstream knew at its sync point: an allowlist would copy llama.cpp's whole arch table and go stale on every sync, while the gaps are a small per-incident set that *retires with the fork sync* (each entry pairs with a #2118-style checklist). `rocmfpx` denylists `qwen4exp` (fork HEAD `c49ebdbd` 2026-08-22 predates the upstream merge 2026-08-27/28, verified against #2118). `promptforge` is a different ROCmFPX tree (ciru-ai) and stays unstamped until verified.

**Fit-check** — `model_fit_warning` on slot create / config PUT / swap responses: WARN, never block, mirroring the existing `(device, BINARY)` §4 idiom, computed over the merged post-write view so touching only one of model/device/binary/pin still checks the rest. An `image_pin` disarms the check (the pin IS #2118's documented escape hatch), and the hint names the combined-upstream image **when the runner-image catalogue carries it** (`ARCH_ALTERNATIVE_IMAGES` → catalogue `store.get`). No auto-switching of images.

**FE** — pure `archFitWarning` helper (`ui/src/dash/hw-cascade.js`) rendered by the slot drawer next to the Model select, reading the model row's `architecture` against system-info's new per-runner `unsupported_archs`, previewing the post-save device/binary/pin.

## Evidence

- `gh issue view 2118`: default image `hal0-combined:0826` (charlie12345/ROCmFPX @ c49ebdbd) fails `qwen4exp` with `unknown model architecture: 'qwen4exp'`; only `ghcr.io/hal0ai/hal0-combined-upstream:0829` (pin-only) serves it
- `ruff check` + `ruff format --check`: clean (1245 files)
- `pytest tests/runners/test_registry.py tests/registry/test_detect.py`: 66 passed
- `pytest tests/api/test_models_add_from_path.py`: 15 passed
- `pytest tests/api/test_slots_routes.py tests/registry/test_pull.py tests/registry/test_discover.py`: 184 passed
- `pytest tests/api/test_hardware_routes.py tests/api/test_system_info_route.py`: 37 passed
- ui: `vitest run` 29 files / 283 tests passed, `eslint` clean, `tsc --noEmit` clean

## Rollback

Revert the commit — additive surfaces only (`model_fit_warning` response key, `unsupported_archs` system-info field, `Model.architecture` stamping into an existing column). CHANGELOG bullet under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011o6Hur5YMz4RidLNtsAtN4