### PR TITLE
fix(updater): read installed version from current/VERSION, not wheel metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Fixed
+
+- `hal0 update` now reads the installed version from the active release's
+  `current/VERSION` file instead of the wheel metadata. A nightly wheel
+  deliberately carries only the BASE version in pip metadata (PEP 440 has no
+  shape for `v<base>-nightly.<stamp>`), so a box already on the newest
+  nightly compared `1.1.0 < 1.1.0-nightly.<stamp>` and looped "update
+  available" forever, re-staging the same release on every run.
+
 ### Added
 
 - The dashboard now surfaces the decisive crash line when a slot container

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -674,7 +674,7 @@ def _enforce_upgrade_floor(
     spec = (manifest.upgrade_from or "").strip()
     if not spec:
         return
-    installed = current or hal0.__version__
+    installed = current or installed_version()
     try:
         from packaging.specifiers import InvalidSpecifier, SpecifierSet
         from packaging.version import InvalidVersion, Version
@@ -2116,6 +2116,32 @@ def _versioned_install_dir(version: str) -> Path:
 def _current_symlink() -> Path:
     """Return ``<usr_lib>/current`` — the atomic-swap target."""
     return _usr_lib_root() / "current"
+
+
+def installed_version() -> str:
+    """The release version actually running — ``current/VERSION`` when present,
+    else ``hal0.__version__``.
+
+    A nightly wheel deliberately carries the BASE version in its package
+    metadata: PEP 440 has no vocabulary for the ``v<base>-nightly.<stamp>``
+    tag shape, so pip metadata can't hold it (that is why release.yml's
+    version gate only base-matches nightly tags). ``hal0.__version__`` is
+    therefore blind to WHICH nightly is installed — a box already on the
+    newest nightly compared ``1.1.0 < 1.1.0-nightly.<stamp>`` and reported
+    "update available" forever, re-staging the same release on every
+    ``hal0 update`` (live on ct105 + ct150, 2026-09-01).
+
+    The release tarball ships its exact version in the top-level ``VERSION``
+    file and activation swaps ``current`` onto that tree, so
+    ``current/VERSION`` IS the installed identity. The wheel version remains
+    the fallback for source/dev installs with no release dir. Fail-soft: any
+    unreadable/empty VERSION degrades to the old behavior, never an error.
+    """
+    try:
+        v = (_current_symlink() / "VERSION").read_text(encoding="utf-8").strip()
+    except OSError:
+        return hal0.__version__
+    return v or hal0.__version__
 
 
 # ── Release-directory tokens (the only thing that crosses the privileged seam) ──
@@ -4433,7 +4459,9 @@ class Updater:
         """Check for a newer version on the configured release channel.
 
         Fetches the release manifest, validates it against the
-        ``ReleaseManifest`` schema, and compares against ``hal0.__version__``.
+        ``ReleaseManifest`` schema, and compares against
+        :func:`installed_version` (``current/VERSION``-first — see its
+        docstring for the nightly wheel-metadata story).
 
         Returns a ``ReleaseInfo`` dataclass; the route layer constructs the
         wire JSON from this so the CLI + API surface stay in lock-step.
@@ -4452,7 +4480,8 @@ class Updater:
         # operator should not be nudged toward a release we've pulled. The
         # version is still surfaced (revoked + reason) so the dashboard can
         # explain why no update is offered. See docs/internal/release-manifest.md.
-        update_available = bool(latest) and not revoked and _is_newer(latest, hal0.__version__)
+        current_version = installed_version()
+        update_available = bool(latest) and not revoked and _is_newer(latest, current_version)
         if revoked and bool(latest):
             log.warning(
                 "updater.latest_revoked",
@@ -4461,7 +4490,7 @@ class Updater:
                 reason=revoked_reason,
             )
         return ReleaseInfo(
-            current=hal0.__version__,
+            current=current_version,
             latest=latest or None,
             channel=ch,
             update_available=update_available,

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -2377,3 +2377,54 @@ class TestVenvRefreshIsCommitAgnostic:
         assert "--force-reinstall" in cmd
         # Never conditions the pip call on a version comparison.
         assert str(tmp_path / "hal0-0.9.8") in cmd
+
+
+# ── installed_version — current/VERSION beats wheel metadata (nightly loop) ──
+#
+# A nightly wheel carries the BASE version in its pip metadata (PEP 440 has
+# no shape for v<base>-nightly.<stamp>), so hal0.__version__ can't say which
+# nightly is installed. Boxes on the newest nightly compared
+# 1.1.0 < 1.1.0-nightly.<stamp> and saw "update available" forever, re-staging
+# the same release on every `hal0 update` (ct105 + ct150, 2026-09-01).
+
+
+def test_installed_version_prefers_current_version_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hal0.updater.updater import installed_version
+
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    release = tmp_path / "usr-lib" / "hal0" / "hal0-1.1.0-nightly.20260901025155"
+    release.mkdir(parents=True)
+    (release / "VERSION").write_text("1.1.0-nightly.20260901025155\n", encoding="utf-8")
+    current = tmp_path / "usr-lib" / "hal0" / "current"
+    current.symlink_to(release)
+
+    assert installed_version() == "1.1.0-nightly.20260901025155"
+
+
+def test_installed_version_falls_back_to_wheel_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hal0
+    from hal0.updater.updater import installed_version
+
+    # No current symlink at all (source/dev install) → wheel metadata.
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    assert installed_version() == hal0.__version__
+
+    # An EMPTY VERSION file degrades the same way, never answers "".
+    release = tmp_path / "usr-lib" / "hal0" / "hal0-x"
+    release.mkdir(parents=True)
+    (release / "VERSION").write_text("", encoding="utf-8")
+    (tmp_path / "usr-lib" / "hal0" / "current").symlink_to(release)
+    assert installed_version() == hal0.__version__
+
+
+def test_nightly_box_on_latest_nightly_sees_no_update() -> None:
+    # The loop itself: same nightly on both sides must not read as newer.
+    assert _is_newer("1.1.0-nightly.20260901025155", "1.1.0-nightly.20260901025155") is False
+    # And the pre-fix comparison that caused the loop stays true (the manifest
+    # IS newer than the bare wheel base) — proving the fix must come from the
+    # installed side, not from _is_newer.
+    assert _is_newer("1.1.0-nightly.20260901025155", "1.1.0") is True


### PR DESCRIPTION
## What

`hal0 update` compared the channel manifest against `hal0.__version__` (wheel pip metadata). A nightly wheel deliberately carries only the BASE version there — PEP 440 has no shape for `v<base>-nightly.<stamp>`, which is exactly why release.yml's version gate only base-matches nightly tags — so a box already on the newest nightly compared `1.1.0 < 1.1.0-nightly.20260901025155` and looped **"update available" forever**, re-staging and re-activating the same release on every run. Observed live on ct105 and ct150 immediately after the first nightly deploy (journal shows three consecutive `updater.swap_ok` onto the same version).

## Fix

New `installed_version()` in `src/hal0/updater/updater.py`: prefer the active release tree's own identity — `current/VERSION`, shipped by every release tarball and atomically swapped at activation — falling back to `hal0.__version__` for source/dev installs. `check()` (both the comparison and the reported `current`) and `_enforce_upgrade_floor` use it. Fail-soft: unreadable or empty VERSION degrades to the old behavior.

## Evidence

- `tests/updater/test_updater.py` + `test_upgrade_floor.py`: **148 passed** — 3 new tests: VERSION-file preference (HAL0_HOME layout), wheel-metadata fallback (no symlink + empty file), and the loop invariant (`_is_newer(same-nightly, same-nightly) is False` while `_is_newer(nightly, base) is True`, proving the fix must come from the installed side).
- ruff check + format clean.
- Live repro on ct105: `hal0 --version` → 1.1.0, `current/VERSION` → 1.1.0-nightly.20260901025155, `hal0 update --check` → "update available" for the version already running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011o6Hur5YMz4RidLNtsAtN4