### PR TITLE
feat(runners): strix runner — Vulkan-only qwen4exp optional runtime

### DIFF
--- a/exports/runner-image-pins.json
+++ b/exports/runner-image-pins.json
@@ -1,7 +1,8 @@
 {
   "pins": [
     "ghcr.io/hal0ai/hal0-combined:0826",
-    "ghcr.io/hal0ai/hal0-promptforge:v2.3-qwen38"
+    "ghcr.io/hal0ai/hal0-promptforge:v2.3-qwen38",
+    "ghcr.io/hal0ai/hal0-strix-vulkan:0831"
   ],
   "source": "src/hal0/config/schema.py"
 }

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1177,11 +1177,17 @@ preflight_gpu() {
 # layer in the system is the wrong place to re-derive logic that already has a
 # tested implementation twenty seconds later in the install.
 #
-# It recognises only the single-member shape of VULKAN_CAPABLE_IMAGE_REFS (a
-# default equal to VULKAN_FIXED_IMAGE) and answers "no" to everything else,
-# including anything it cannot parse. tests/installer/test_preflight_gpu_gate.py
-# pins agreement with the Python predicate, and trips if the capable set ever
-# grows past one member without this mirror being taught about it.
+# GENERAL CASE (VULKAN_CAPABLE_IMAGE_REFS may hold any number of members):
+# read the ``VULKAN_CAPABLE_IMAGE_REFS = frozenset({A, B, ...})`` literal,
+# resolve each element NAME to its own ``NAME = "ref"`` assignment earlier in
+# the file, and test whether DEFAULT_ROCMFPX_IMAGE's literal matches ANY of
+# them -- not just VULKAN_FIXED_IMAGE. A frozenset element that is itself a
+# quoted string literal (rather than a NAME) is also accepted, unresolved.
+# Answers "no" on anything it cannot parse, same as before. #2118 (the strix
+# runner) is what grew the set past one member and is the reason this mirror
+# had to stop assuming a single fixed pin.
+# tests/installer/test_preflight_gpu_gate.py pins agreement with the Python
+# predicate for whatever this checkout's set currently contains.
 #
 # Test seams: HAL0_GPU_VULKAN_LANE_OVERRIDE (1/0, decides outright),
 # HAL0_SCHEMA_PY_OVERRIDE (path to the schema.py to read).
@@ -1200,10 +1206,34 @@ _hal0_vulkan_lane_serves_default_image() {
     fi
     [[ -r "${schema}" ]] || return 1
 
-    local default_ref fixed_ref
+    local default_ref
     default_ref="$(sed -n 's/^DEFAULT_ROCMFPX_IMAGE = "\(.*\)"$/\1/p' "${schema}" | head -n1)"
-    fixed_ref="$(sed -n 's/^VULKAN_FIXED_IMAGE = "\(.*\)"$/\1/p' "${schema}" | head -n1)"
-    [[ -n "${default_ref}" && -n "${fixed_ref}" && "${default_ref}" == "${fixed_ref}" ]]
+    [[ -n "${default_ref}" ]] || return 1
+
+    # Pull the frozenset's element list, e.g. "VULKAN_FIXED_IMAGE,
+    # DEFAULT_STRIX_IMAGE" out of "VULKAN_CAPABLE_IMAGE_REFS = frozenset({...})".
+    local refs_line
+    refs_line="$(sed -n 's/^VULKAN_CAPABLE_IMAGE_REFS = frozenset(\(.*\))$/\1/p' "${schema}" | head -n1)"
+    [[ -n "${refs_line}" ]] || return 1
+    refs_line="${refs_line#\{}"
+    refs_line="${refs_line%\}}"
+    [[ -n "${refs_line}" ]] || return 1
+
+    local member member_ref
+    local IFS=','
+    for member in ${refs_line}; do
+        member="${member//[[:space:]]/}"
+        [[ -z "${member}" ]] && continue
+        if [[ "${member}" == \"*\" ]]; then
+            # A quoted literal in the set, not a NAME -- use it as-is.
+            member_ref="${member#\"}"
+            member_ref="${member_ref%\"}"
+        else
+            member_ref="$(sed -n "s/^${member} = \"\\(.*\\)\"\$/\\1/p" "${schema}" | head -n1)"
+        fi
+        [[ -n "${member_ref}" && "${member_ref}" == "${default_ref}" ]] && return 0
+    done
+    return 1
 }
 
 # -- CPU-lane runner-image gate (shell mirror of hal0.runners, #2126) --------

--- a/manifest.json
+++ b/manifest.json
@@ -50,6 +50,11 @@
       "tag": "ghcr.io/hal0ai/hal0-promptforge:v2.3-qwen38",
       "digest": "sha256:370af6e9717e8c96742198a4b920888e6a248d447e21e3432de4d2c913703aea",
       "_notes": "PromptForge/ActiveFPX runner (HIP-only, GGML_VULKAN=OFF) for jcbtc Qwen3.8 CIRU distributions — OPTIONAL runner, never the AMD default. Digest is the exact image the #1891 ct150 gate validated 2026-08-30 (Paris + HumanEval+ 0.939/0.909 + MTP depth-4 ~86% acceptance; report in /mnt/mintdev/artifacts/). Tracked recipe: packaging/runner/promptforge/. Same digest pinned in Hal0ai/hal0-runner-images images.json."
+    },
+    "strix": {
+      "tag": "ghcr.io/hal0ai/hal0-strix-vulkan:0831",
+      "digest": "sha256:b50a73487d05bcae146aa54170cec981c7c6a158cc5cd1fa45a6096dfc5fe107",
+      "_notes": "Strix runner (Vulkan-only, GGML_HIP=OFF): Qwen3.8-Flash-Next qwen4exp + NextN/MTP (--spec-type draft-mtp, adaptive) + --tensor-read-lazy, built from the published r/StrixHalo production snapshot (myhacsint/llama.cpp @ 5d43efe26) — OPTIONAL runner, never the AMD default; successor to the hal0-combined-upstream:0829 pin (#2118). Digest is the exact image the 2026-08-31 §3-C gate validated on ct150 (kfd-present) AND ct151 (kfd-absent): Vulkan0 offload confirmed, temp-0 Paris, 256-token clean tail byte-identical across both boxes, json_schema constrained output, #1936 device-less diagnostic exit 78; report in /mnt/mintdev/artifacts/. Tracked recipe: packaging/runner/strix/."
     }
   },
   "_legacy_toolboxes": {

--- a/packaging/runner/strix/build.sh
+++ b/packaging/runner/strix/build.sh
@@ -1,0 +1,1 @@
+../rocmfpx/build.sh

--- a/packaging/runner/strix/entrypoint.sh
+++ b/packaging/runner/strix/entrypoint.sh
@@ -1,0 +1,1 @@
+../rocmfpx/entrypoint.sh

--- a/packaging/runner/strix/manifest.toml
+++ b/packaging/runner/strix/manifest.toml
@@ -1,0 +1,160 @@
+# Provenance for the STRIX runner image (Qwen3.8-Flash-Next + MTP,
+# strix-halo-tuned llama.cpp, Vulkan-only).
+#
+# WHY THIS EXISTS: ../upstream (hal0-combined-upstream:0829, #2118) unblocked
+# the qwen4exp architecture, but it is pristine ggml-org master: no NextN/MTP
+# speculative decode, no --tensor-read-lazy PLE gather, and none of the
+# strix-halo FA/MoE-prefill kernels. The pinned [source] below is the
+# published production tree behind the r/StrixHalo field report (2026-08-31,
+# "definitive highest throughput" post) — a curated snapshot combining
+# upstream, the Nathanw1014 strix-halo Vulkan line, and the apepojken
+# qwen4exp optimizations, tuned for exactly the gfx1151 UMA hardware the
+# fleet's GPU box runs. The report's deployment of that tree serves
+# Qwen3.8-Flash-Next Q4_K_M with a grafted Q8_0 MTP head at pp512 485 t/s /
+# MTP decode 52 t/s at ~91% draft acceptance on this silicon.
+#
+# WHAT THIS IS: a first-class OPTIONAL runner — RUNNER_IMAGES["strix"], the
+# promptforge shape, not the ../upstream pin-only shape. It appears in the
+# slot-drawer dropdown and a slot gets it only by selecting it; nothing
+# resolves to it by default and DEFAULT_ROCMFPX_IMAGE is untouched. It is
+# the intended SUCCESSOR to the hal0-combined-upstream:0829 pin for qwen4exp
+# slots (the #2118 retirement path).
+#
+# VULKAN-ONLY, deliberately — the first per-recipe cmake_flags divergence
+# from ../rocmfpx, and the mirror of promptforge's HIP-only rule on the
+# opposite lane: the snapshot's own scope statement is "Vulkan-first for
+# the documented production deployment" (Vulkan + system RADV, no ROCm
+# runtime required), its ROCm paths ride along inherited and unvalidated,
+# and every lineage feeding it (the Nathanw1014 fork's published artifact
+# line included) validates Vulkan only. GGML_HIP=ON here would ship an
+# untested backend under a tag whose name promises tuning. The registry
+# entry declares supported_backends=("vulkan",), so the existing
+# (device, BINARY) fit-check refuses a gpu-rocm pairing with no new code.
+# Launch-time admission to the gpu-vulkan lane is separately gated by
+# VULKAN_CAPABLE_IMAGE_REFS (#1888 / §3-C: evidence on a kfd-present AND a
+# kfd-absent box) — and since Vulkan is this runner's ONLY lane, earning
+# that membership IS the acceptance gate for the image, not an extra.
+# GATE PASSED 2026-08-31 for the :0831 build (digest sha256:b50a7348…, the
+# manifest.json toolbox_images.strix pin): ct150 (kfd-present) + ct151
+# (kfd-absent, renderD128-only) — Vulkan0 offload, temp-0 Paris, 256-token
+# clean tail byte-identical across boxes, json_schema constrained, #1936
+# device-less exit 78. Report: /mnt/mintdev/artifacts/
+# hal0-strix-gate-2026-08-31.md. A REBUILD does not inherit this: new
+# digest, new gate.
+# Driver note: the reference deployment ran system RADV (Fedora Mesa
+# 26.1.7); this image likewise uses the base toolbox's dnf
+# mesa-vulkan-drivers — NOT the Nathanw1014 toolbox's bundled dev Mesa
+# snapshot, whose known repeatability defect (their v0.7.3 notes) this
+# lineage sidesteps entirely.
+#
+# FEATURE DELTA vs ../upstream (:0829), per the pinned tree's own
+# PATCHSET.md (a provenance doc the snapshot ships in-tree) and the field
+# report:
+#   GAINED:
+#     * NextN/MTP speculative decode for qwen4exp (PR 27836 derivation:
+#       `--spec-type draft-mtp`, sidecar or in-file draft tensors) PLUS
+#       adaptive draft sizing (`--spec-draft-adaptive`) and the checkpoint/
+#       rollback/cache/server fixes the report calls out for reliable MTP
+#     * --tensor-read-lazy (PR 27794 lineage): random-access mmap advice +
+#       batched PLE row prefetch for the ~95 GiB gather table
+#     * the strix-halo Vulkan kernel line (Nathanw1014 fork work): FA +
+#       MoE-prefill fixes, mmid row-lists, lazy PLE handling
+#     * selected qwen4exp Vulkan execution-path work (apepojken line):
+#       skinny prefill, gathered QSA decode, radix top-k, GDN contiguity,
+#       static RDNA3 mat-vec paths, quantized-KV QSA support
+#     * qwen4exp correctness follow-ups (PR 27941 lineage), recurrent-state
+#       rollback, disconnect cancellation
+#   LOST vs ../upstream: the HIP lane (see VULKAN-ONLY above — ../upstream
+#   keeps combined flags; a qwen4exp slot that must run gpu-rocm stays on
+#   the 0829 pin).
+#   INHERITED-UNVALIDATED (the snapshot's own words): DeepSeek V4 sparse
+#   attention, DFlash2, Muse Glimmer, BailingMoE3, Motif-3, ROCm paths ride
+#   along untested — do not read their presence as support.
+#   ABSENT vs ../rocmfpx, same rule as ../upstream: no ROCmFPX/ROCmI4/IU4
+#   quant formats, no minicpm5/lfm2.5 patches. FPX-family GGUFs must never
+#   be launched on this image (hal0#1790 SIGSEGV class); "strix" staying out
+#   of FPX_RUNNER_KEYS is the guard.
+#
+# MTP SERVING NOTE: the draft head needs GTT headroom BESIDE the target — on
+# the fork's 64 GB reference box that means -ncmoe 4+; the 124 GiB fleet box
+# has more runway. Flags ride the slot profile / model defaults
+# (`--spec-type draft-mtp` + --spec-draft-*), gated by supports.mtp.
+
+[image]
+#: NOT DEFAULT_ROCMFPX_IMAGE and must never become it — see header. Kept in
+#: lockstep with hal0.config.schema.DEFAULT_STRIX_IMAGE by
+#: tests/packaging/test_strix_recipe.py.
+tag = "ghcr.io/hal0ai/hal0-strix-vulkan:0831"
+
+[base]
+#: Same base, same digest, same rationale as ../rocmfpx/manifest.toml and
+#: ../upstream/manifest.toml — byte-identical lineage so the variables
+#: between the three images are [source] and this recipe's declared
+#: Vulkan-only flag set. Yes, that keeps the ROCm 7.2.4 toolchain in a
+#: HIP-less image: the builder stage needs the base's cmake/glslc/vulkan
+#: toolchain either way, and a shared pinned base is what keeps the
+#: three-recipe lineage comparable (and the runtime dnf layer identical).
+image = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"
+digest = "sha256:4f5418c1b1e39e5ad9bbadfd2e8381c6b8a70e9b03f667179a7233c6f681462a"
+rocm_version = "7.2.4"
+upstream_family = "https://github.com/kyuz0/amd-strix-halo-toolboxes"
+upstream_ref = "unknown — inherited finding, see ../rocmfpx/manifest.toml"
+dnf_packages_pinned = false
+
+[source]
+#: The field report's OWN production tree, published for reproducibility:
+#: myhacsint/llama.cpp branch `production/strix-halo-qwen4exp-b10669` —
+#: upstream master 9f0d017ef (2026-08-17) + ONE squashed snapshot commit
+#: (77ee2ed74) whose git TREE (fff0302a9f70ae9073588dd914db08cc578f256c) is
+#: byte-identical to the production commit the deployed binary reports
+#: (3287a6e9d / build 10669; llama-server sha256 c3adcbee09…, all recorded
+#: in the tree's PRODUCTION-SNAPSHOT.md). Chosen over the Nathanw1014
+#: branch tip this recipe first pinned because the snapshot ADDs the pieces
+#: the fork lacks (adaptive MTP draft sizing, skinny prefill, the MTP
+#: reliability fixes) and IS the tested deployment the numbers came from.
+#: The pin is the branch tip: snapshot + a docs/provenance commit that
+#: changes no compiled source (its own stated property).
+#: Squashed-history caveat, stated: the 205-commit working lineage is not
+#: public, so review means reading the snapshot diff, not cherry-picks —
+#: and hal0's §3-C acceptance pass (see VULKAN-ONLY above) is the
+#: validation gate before this runner serves anything real.
+repo = "https://github.com/myhacsint/llama.cpp.git"
+ref = "5d43efe26f68249eb74e93ee1abd05f984dcb133"
+ref_description = "docs: publish Strix Halo build and MTP provenance (production/strix-halo-qwen4exp-b10669 tip)"
+submodules = false
+
+[build]
+#: NOT the ../rocmfpx flag set — see the VULKAN-ONLY header block for why
+#: GGML_HIP is OFF here and what that forbids at slot level. The rest
+#: follows the snapshot's documented reference build (its
+#: PRODUCTION-SNAPSHOT.md "Rebuild" section): Release, static libs,
+#: Vulkan-only. Two deliberate deviations from that reference, named so
+#: nobody "restores" them silently:
+#:   * LLAMA_OPENSSL is not enabled — slots serve loopback HTTP behind the
+#:     hal0 entrypoint's /health supervision; enabling it would also mean
+#:     adding openssl-devel to the SHARED builder stage in
+#:     ../rocmfpx/build.sh, a cross-recipe edit this image does not need.
+#:   * LLAMA_BUILD_TESTS stays off (build.sh builds the four runtime
+#:     targets only; the flag would configure test targets nothing builds).
+#: GGML_NATIVE=ON matches the reference and specializes for the BUILD
+#: host's CPU: the build must run on lxc130 (strix-halo-class host). If the
+#: build host ever stops matching the fleet's CPU family, flip this OFF —
+#: a mismatched -march is the #2126 SIGILL class at model load.
+#: gpu_arch kept for provenance symmetry (the Vulkan backend compiles
+#: SPIR-V, not per-arch code objects; nothing consumes it at configure).
+gpu_arch = "gfx1151"
+cmake_flags = [
+    "-DCMAKE_BUILD_TYPE=Release",
+    "-DGGML_HIP=OFF",
+    "-DGGML_VULKAN=ON",
+    "-DGGML_CUDA=OFF",
+    "-DGGML_NATIVE=ON",
+    "-DBUILD_SHARED_LIBS=OFF",
+    "-DLLAMA_BUILD_SERVER=ON",
+    "-DLLAMA_BUILD_WEBUI=OFF",
+    "-DLLAMA_USE_PREBUILT_WEBUI=OFF",
+]
+
+#: No patches. Candidates live in the FEATURE DELTA header block (adaptive
+#: MTP draft sizing, skinny prefill) — add them here with a public PR
+#: reference when one exists, never as blind diffs from the field report.

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1099,6 +1099,32 @@ DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-combined:0826"
 #: is untouched by any of this.
 DEFAULT_PROMPTFORGE_IMAGE = "ghcr.io/hal0ai/hal0-promptforge:v2.3-qwen38"
 
+#: ``DEFAULT_STRIX_IMAGE`` — the strix-flavor runner: Vulkan-only build of
+#: the published production tree behind the 2026-08-31 r/StrixHalo field
+#: report (myhacsint/llama.cpp ``production/strix-halo-qwen4exp-b10669`` —
+#: upstream + the Nathanw1014 strix-halo Vulkan line + the apepojken
+#: qwen4exp optimizations + adaptive MTP; recipe at
+#: ``packaging/runner/strix/``; GGML_HIP=OFF because that tree's own scope
+#: statement and every lineage feeding it validate Vulkan only — mirror of
+#: the promptforge single-backend rule, opposite lane). What it adds over
+#: the upstream
+#: variant it supersedes for qwen4exp work (#2118): NextN/MTP speculative
+#: decode (``--spec-type draft-mtp``), ``--tensor-read-lazy`` PLE gathers,
+#: and the gfx1151 Vulkan FA/MoE kernels. Like promptforge, an OPTIONAL
+#: runner — never the AMD default; DEFAULT_ROCMFPX_IMAGE above is untouched.
+#: No FPX-family quant support: FPX GGUFs on this image are the #1790
+#: SIGSEGV class, and the launch-time guard keys off FPX_RUNNER_KEYS
+#: excluding it. GATE PASSED 2026-08-31: §3-C on ct150 (kfd-present) and
+#: ct151 (kfd-absent) — see the membership note on
+#: :data:`VULKAN_CAPABLE_IMAGE_REFS` below, which this ref joined on that
+#: evidence (Vulkan is its ONLY lane, so membership is what makes the
+#: runner launchable at all). manifest.json's ``toolbox_images.strix``
+#: carries the gate-validated digest and the strix Runner's ``manifest_key``
+#: points at it; this tag constant is the bundled fallback and stays in
+#: lockstep with the manifest entry (pinned by
+#: tests/packaging/test_strix_recipe.py).
+DEFAULT_STRIX_IMAGE = "ghcr.io/hal0ai/hal0-strix-vulkan:0831"
+
 #: Historical DEFAULT_ROCMFPX_IMAGE values (and their pre-consolidation
 #: equivalents). A slot-level ``image`` pin equal to one of these is a STALE
 #: FORMER DEFAULT — debris from slot creation under an older release — not a
@@ -1204,7 +1230,18 @@ VULKAN_FIXED_IMAGE = "ghcr.io/hal0ai/hal0-combined:0826"
 #: :data:`DEFAULT_ROCMFPX_IMAGE` is NOT a member while the default pin is still
 #: the ade07ba lineage — which is the whole reason the gate cannot key off the
 #: default.
-VULKAN_CAPABLE_IMAGE_REFS = frozenset({VULKAN_FIXED_IMAGE})
+#:
+#: ``DEFAULT_STRIX_IMAGE`` earned membership 2026-08-31 (§3-C run on ct150,
+#: kfd PRESENT, and ct151, kfd ABSENT — the renderD128-only #1888 box shape;
+#: report in /mnt/mintdev/artifacts/hal0-strix-gate-2026-08-31.md): Vulkan0
+#: (RADV GFX1151) offload confirmed on both boxes, temp-0 Paris probe,
+#: 256-token clean tail BYTE-IDENTICAL across the two boxes, json_schema
+#: returning grammar-constrained output with 200s across the thinking-kwarg
+#: matrix, and the #1936 device-less diagnostic (exit 78). The image is
+#: Vulkan-ONLY (GGML_HIP=OFF), so this lane is its only lane — membership
+#: here is what makes the runner launchable at all. The gate digest is
+#: pinned in manifest.json's ``toolbox_images.strix``.
+VULKAN_CAPABLE_IMAGE_REFS = frozenset({VULKAN_FIXED_IMAGE, DEFAULT_STRIX_IMAGE})
 
 #: Lean fallback toolbox images for the two non-rocmfpx lanes. The rocmfpx
 #: runner is Vulkan-portable — its Mesa/RADV Vulkan backend runs on any AMD GPU

--- a/src/hal0/runners/__init__.py
+++ b/src/hal0/runners/__init__.py
@@ -57,6 +57,7 @@ from typing import Literal
 from hal0.config.schema import (
     DEFAULT_PROMPTFORGE_IMAGE,
     DEFAULT_ROCMFPX_IMAGE,
+    DEFAULT_STRIX_IMAGE,
     FALLBACK_CUDA_IMAGE,
     FALLBACK_VULKAN_IMAGE,
     STALE_ROCMFPX_IMAGE_REFS,
@@ -210,6 +211,37 @@ RUNNER_IMAGES: dict[str, Runner] = {
         supported_backends=("rocm",),  # HIP-only build: deliberately NOT
         # vulkan — the existing (device, BINARY) fit-check refuses a
         # gpu-vulkan pairing with no new code.
+        format_arch="gguf",
+    ),
+    "strix": Runner(
+        "strix",
+        DEFAULT_STRIX_IMAGE,
+        "llama-server",
+        # mtp=True: the pinned tree carries the NextN/MTP draft graph
+        # (--spec-type draft-mtp, sidecar or in-file draft tensors, adaptive
+        # sizing), so AUTO MTP resolution may speculate here exactly as on
+        # rocmfpx. mmproj: stock upstream multimodal (the source lineage
+        # documents the qwen4exp vision path). NO FPX-family quants —
+        # deliberately not in FPX_RUNNER_KEYS, so the #1790 quant/runner
+        # guard refuses FPX GGUFs here instead of letting them SIGSEGV.
+        RunnerSupports(mtp=True, jinja=True, mmproj=True),
+        "gpu",
+        "vulkan",
+        # Real key as of the 2026-08-31 §3-C gate PASS (ct150 kfd-present +
+        # ct151 kfd-absent; report in /mnt/mintdev/artifacts/): manifest.json's
+        # toolbox_images.strix was created FRESH for this image lineage (the
+        # promptforge pattern, never the rocmfpx wrong-lineage trap — module
+        # docstring) and carries the exact digest the gate validated.
+        "strix",
+        # Vulkan ONLY — the promptforge single-backend rule, opposite lane:
+        # the source tree's validated deployment is Vulkan + system RADV
+        # (recipe packaging/runner/strix/ builds GGML_HIP=OFF), so the existing
+        # (device, BINARY) fit-check refuses a gpu-rocm pairing with no new
+        # code. Launch-time admission to the gpu-vulkan lane is separately
+        # gated by VULKAN_CAPABLE_IMAGE_REFS (§3-C evidence), which this
+        # image must earn — this tuple is fit-check metadata, not a
+        # correctness claim.
+        supported_backends=("vulkan",),
         format_arch="gguf",
     ),
     "cuda": Runner(

--- a/tests/config/test_runner_image_pins_export.py
+++ b/tests/config/test_runner_image_pins_export.py
@@ -19,6 +19,9 @@ Membership rule (why these constants and not the others):
   retention sweep's blast radius, and its tag shape is not release-shaped, so
   the allowlist is its only durable protection once the runner-images
   ``images.json`` entry moves on.
+* ``DEFAULT_STRIX_IMAGE`` — same argument as promptforge: bundled fallback
+  for the optional strix runner, ``hal0-``-prefixed package inside the sweep,
+  date-stamped tag with no manifest pin yet.
 
 Deliberately excluded: ``STALE_ROCMFPX_IMAGE_REFS`` and
 ``NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS`` (string-comparison retag/deny lists —
@@ -35,6 +38,7 @@ from pathlib import Path
 from hal0.config.schema import (
     DEFAULT_PROMPTFORGE_IMAGE,
     DEFAULT_ROCMFPX_IMAGE,
+    DEFAULT_STRIX_IMAGE,
     VULKAN_CAPABLE_IMAGE_REFS,
 )
 
@@ -44,7 +48,8 @@ _EXPORT_PATH = _REPO_ROOT / "exports" / "runner-image-pins.json"
 
 def _expected_export_text() -> str:
     pins = sorted(
-        {DEFAULT_ROCMFPX_IMAGE, DEFAULT_PROMPTFORGE_IMAGE} | set(VULKAN_CAPABLE_IMAGE_REFS)
+        {DEFAULT_ROCMFPX_IMAGE, DEFAULT_PROMPTFORGE_IMAGE, DEFAULT_STRIX_IMAGE}
+        | set(VULKAN_CAPABLE_IMAGE_REFS)
     )
     doc = {"source": "src/hal0/config/schema.py", "pins": pins}
     return json.dumps(doc, indent=2, sort_keys=True) + "\n"

--- a/tests/installer/test_preflight_gpu_gate.py
+++ b/tests/installer/test_preflight_gpu_gate.py
@@ -341,16 +341,19 @@ def test_the_shell_mirror_agrees_with_the_python_predicate(tmp_path: Path) -> No
     of ``providers._gpu.default_image_serves_vulkan_lane`` (preflight runs
     before hal0 is installed, so it cannot just call it). Two implementations
     of one predicate drift; this is the tripwire.
-    """
-    from hal0.config.schema import VULKAN_CAPABLE_IMAGE_REFS
-    from hal0.providers._gpu import default_image_serves_vulkan_lane
 
-    assert len(VULKAN_CAPABLE_IMAGE_REFS) == 1, (
-        "VULKAN_CAPABLE_IMAGE_REFS has grown past one member — the shell mirror in "
-        "installer/lib/preflight.sh only recognises the single-member shape "
-        "(default == VULKAN_FIXED_IMAGE) and must be taught the general case, or "
-        "fresh installs will be refused on a validated image"
-    )
+    Historically this test also asserted ``len(VULKAN_CAPABLE_IMAGE_REFS) ==
+    1`` as a static guard: the shell mirror used to recognise only the
+    single-member shape (default == VULKAN_FIXED_IMAGE) and would silently
+    refuse a validated image once the set grew. #2118 (the strix runner)
+    grew VULKAN_CAPABLE_IMAGE_REFS to two members, which tripped that guard;
+    the shell mirror in installer/lib/preflight.sh was taught the general
+    case (it now resolves every frozenset member to its own literal and
+    checks membership), so the static member-count guard no longer applies
+    and this test goes back to what it always was underneath: a runtime
+    agreement check against whatever this checkout's set actually contains.
+    """
+    from hal0.providers._gpu import default_image_serves_vulkan_lane
 
     script = (
         "set -euo pipefail\n"
@@ -365,6 +368,55 @@ def test_the_shell_mirror_agrees_with_the_python_predicate(tmp_path: Path) -> No
         "the shell mirror and the Python predicate disagree about whether this "
         f"checkout's default runner image serves the Vulkan lane (shell={shell_says})"
     )
+
+
+def _run_shell_mirror(schema_path: Path) -> str:
+    script = (
+        "set -euo pipefail\n"
+        f"source {PREFLIGHT!s}\n"
+        "if _hal0_vulkan_lane_serves_default_image; then echo yes; else echo no; fi\n"
+    )
+    env = {
+        **{k: v for k, v in os.environ.items() if k != "HAL0_GPU_VULKAN_LANE_OVERRIDE"},
+        "HAL0_SCHEMA_PY_OVERRIDE": str(schema_path),
+    }
+    proc = subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+    return proc.stdout.strip()
+
+
+def test_the_shell_mirror_matches_a_non_first_member_of_a_multi_member_set(
+    tmp_path: Path,
+) -> None:
+    """The actual regression this task fixes: before the shell mirror was
+    taught the general case, it only ever compared the default against
+    VULKAN_FIXED_IMAGE — the FIRST historical member. A default that matches
+    some OTHER member of a (now multi-member) VULKAN_CAPABLE_IMAGE_REFS, e.g.
+    DEFAULT_STRIX_IMAGE joining alongside VULKAN_FIXED_IMAGE (#2118), must
+    still be recognised."""
+    schema = tmp_path / "schema.py"
+    schema.write_text(
+        'DEFAULT_ROCMFPX_IMAGE = "ghcr.io/example/combined:default"\n'
+        'VULKAN_FIXED_IMAGE = "ghcr.io/example/combined:fixed"\n'
+        'DEFAULT_STRIX_IMAGE = "ghcr.io/example/combined:default"\n'
+        "VULKAN_CAPABLE_IMAGE_REFS = frozenset({VULKAN_FIXED_IMAGE, DEFAULT_STRIX_IMAGE})\n"
+    )
+    assert _run_shell_mirror(schema) == "yes"
+
+
+def test_the_shell_mirror_still_says_no_when_default_matches_no_member(
+    tmp_path: Path,
+) -> None:
+    """A multi-member set that still doesn't include the default must answer
+    'no' — growing the set past one member must not accidentally widen this
+    into an always-yes check."""
+    schema = tmp_path / "schema.py"
+    schema.write_text(
+        'DEFAULT_ROCMFPX_IMAGE = "ghcr.io/example/combined:unvalidated"\n'
+        'VULKAN_FIXED_IMAGE = "ghcr.io/example/combined:fixed"\n'
+        'DEFAULT_STRIX_IMAGE = "ghcr.io/example/strix:default"\n'
+        "VULKAN_CAPABLE_IMAGE_REFS = frozenset({VULKAN_FIXED_IMAGE, DEFAULT_STRIX_IMAGE})\n"
+    )
+    assert _run_shell_mirror(schema) == "no"
 
 
 def test_the_shell_mirror_fails_closed_on_an_unreadable_schema(tmp_path: Path) -> None:

--- a/tests/packaging/test_strix_recipe.py
+++ b/tests/packaging/test_strix_recipe.py
@@ -1,0 +1,147 @@
+"""The strix runner: qwen4exp + MTP + strix-halo tuning as a FIRST-CLASS entry.
+
+The variant exists because ../upstream (hal0-combined-upstream:0829) unblocked
+the qwen4exp ARCH but carries none of the NextN/MTP speculative-decode wiring,
+the --tensor-read-lazy PLE gather, or the gfx1151 Vulkan kernels that
+Nathanw1014/llama.cpp's `strix-halo-vulkan` branch ships. Unlike the upstream
+variant (pin-only) it is a registry entry — the promptforge shape: optional,
+dropdown-selectable, never the AMD default.
+
+Every claim its manifest makes is held here as an executable assertion:
+same base digest as the rocmfpx recipe, the DECLARED Vulkan-only cmake flag
+divergence (the fork's artifact line is Vulkan-only; GGML_HIP=ON would ship
+an untested backend), shared build script and entrypoint — and the registry
+entry is held to the manifest (tag lockstep, vulkan lane only, no FPX claim).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from hal0.config.schema import DEFAULT_ROCMFPX_IMAGE, DEFAULT_STRIX_IMAGE
+from hal0.runners import FPX_RUNNER_KEYS, RUNNER_IMAGES
+
+RUNNER = Path(__file__).resolve().parents[2] / "packaging" / "runner"
+STRIX = RUNNER / "strix"
+ROCMFPX = RUNNER / "rocmfpx"
+UPSTREAM = RUNNER / "upstream"
+
+MANIFEST = tomllib.loads((STRIX / "manifest.toml").read_text(encoding="utf-8"))
+ROCMFPX_MANIFEST = tomllib.loads((ROCMFPX / "manifest.toml").read_text(encoding="utf-8"))
+UPSTREAM_MANIFEST = tomllib.loads((UPSTREAM / "manifest.toml").read_text(encoding="utf-8"))
+
+
+def test_the_runner_is_not_the_shipped_default() -> None:
+    """Same rule as the upstream variant: if this tag ever equals
+    DEFAULT_ROCMFPX_IMAGE, the strix runner silently replaced the default and
+    every FPX-family model loses its runtime (hal0#1790 SIGSEGV class)."""
+    assert MANIFEST["image"]["tag"] != DEFAULT_ROCMFPX_IMAGE
+    assert MANIFEST["image"]["tag"] != ROCMFPX_MANIFEST["image"]["tag"]
+    assert MANIFEST["image"]["tag"] != UPSTREAM_MANIFEST["image"]["tag"]
+
+
+def test_the_registry_entry_is_in_lockstep_with_the_recipe() -> None:
+    """The manifest names the image the recipe builds; the registry names the
+    image the slot pulls. One string, two authorities — this is the pin."""
+    assert MANIFEST["image"]["tag"] == DEFAULT_STRIX_IMAGE
+    assert RUNNER_IMAGES["strix"].image == DEFAULT_STRIX_IMAGE
+
+
+def test_the_shipped_pin_matches_the_gate_digest() -> None:
+    """The manifest.json entry IS the 2026-08-31 §3-C gate evidence made
+    durable (promptforge precedent): tag in lockstep with DEFAULT_STRIX_IMAGE,
+    digest exactly the image the ct150+ct151 gate validated."""
+    import json
+
+    manifest = json.loads(
+        (Path(__file__).resolve().parents[2] / "manifest.json").read_text(encoding="utf-8")
+    )
+    entry = manifest["toolbox_images"]["strix"]
+    assert entry["tag"] == DEFAULT_STRIX_IMAGE
+    assert entry["digest"] == (
+        "sha256:b50a73487d05bcae146aa54170cec981c7c6a158cc5cd1fa45a6096dfc5fe107"
+    )
+
+
+def test_the_image_is_admitted_to_its_only_lane() -> None:
+    """Vulkan is this runner's ONLY lane; without VULKAN_CAPABLE membership
+    the launch preflight refuses every launch and the registry entry is a
+    dropdown item that can never serve. Membership was earned by the
+    2026-08-31 §3-C gate — removing it must be a deliberate revocation."""
+    from hal0.config.schema import VULKAN_CAPABLE_IMAGE_REFS
+
+    assert DEFAULT_STRIX_IMAGE in VULKAN_CAPABLE_IMAGE_REFS
+
+
+def test_the_registry_entry_declares_what_the_manifest_promises() -> None:
+    """Vulkan-only build => exactly one GPU lane as fit-check metadata (the
+    promptforge single-backend rule, opposite lane); MTP is the headline
+    capability; and strix must stay OUT of FPX_RUNNER_KEYS — that exclusion
+    is the launch-time guard that refuses FPX-family GGUFs here."""
+    runner = RUNNER_IMAGES["strix"]
+    assert set(runner.supported_backends) == {"vulkan"}
+    assert runner.supports.mtp
+    assert runner.format_arch == "gguf"
+    assert runner.device_class == "gpu"
+    assert "strix" not in FPX_RUNNER_KEYS
+
+
+def test_the_source_is_the_published_production_snapshot() -> None:
+    assert MANIFEST["source"]["repo"] == "https://github.com/myhacsint/llama.cpp.git"
+
+
+def test_the_source_ref_is_pinned_not_a_branch() -> None:
+    ref = MANIFEST["source"]["ref"]
+    assert ref not in ("main", "master", "HEAD", "production/strix-halo-qwen4exp-b10669"), ref
+    assert len(ref) == 40, f"pin the full 40-char sha, got {ref!r}"
+    assert all(c in "0123456789abcdef" for c in ref.lower()), ref
+
+
+def test_the_base_digest_is_byte_identical_to_the_default_recipe() -> None:
+    """Same base digest => same ROCm toolchain lineage across the three GPU
+    recipe images; the only intended variable is [source]."""
+    assert MANIFEST["base"]["digest"] == ROCMFPX_MANIFEST["base"]["digest"]
+    assert MANIFEST["base"]["image"] == ROCMFPX_MANIFEST["base"]["image"]
+    assert MANIFEST["base"]["rocm_version"] == ROCMFPX_MANIFEST["base"]["rocm_version"]
+
+
+def test_the_cmake_flags_are_vulkan_only_by_declaration() -> None:
+    """The divergence from rocmfpx is deliberate and exactly this: HIP off,
+    Vulkan on, CUDA off, server preserved. A well-meant "restore parity with
+    rocmfpx" edit (GGML_HIP=ON) would ship the fork's untested HIP lane —
+    see the VULKAN-ONLY manifest block."""
+    flags = set(MANIFEST["build"]["cmake_flags"])
+    assert "-DGGML_HIP=OFF" in flags
+    assert "-DGGML_VULKAN=ON" in flags
+    assert "-DGGML_CUDA=OFF" in flags
+    assert "-DGGML_HIP=ON" not in flags
+    # The entrypoint supervises llama-server; a flag edit that drops the
+    # server target would build an image the slot manager cannot launch.
+    assert "-DLLAMA_BUILD_SERVER=ON" in flags
+    # Reference-build parity (the snapshot's PRODUCTION-SNAPSHOT.md rebuild
+    # recipe): Release + static. GGML_NATIVE=ON is the manifest's declared
+    # build-host constraint (lxc130, strix-halo-class CPU) — if this
+    # assertion is being edited to OFF, edit the manifest note with it.
+    assert "-DCMAKE_BUILD_TYPE=Release" in flags
+    assert "-DBUILD_SHARED_LIBS=OFF" in flags
+    assert "-DGGML_NATIVE=ON" in flags
+    assert MANIFEST["build"]["gpu_arch"] == ROCMFPX_MANIFEST["build"]["gpu_arch"]
+
+
+def test_build_script_and_entrypoint_are_shared_not_copied() -> None:
+    """A copy drifts; a symlink cannot. The entrypoint carries the #1936 GPU
+    preflight and the #2037/#2126 exit-64 load-death translation the slot
+    manager depends on regardless of which llama.cpp is inside."""
+    for name in ("build.sh", "entrypoint.sh"):
+        link = STRIX / name
+        assert link.is_symlink(), f"{name} must be a symlink into ../rocmfpx"
+        assert link.resolve() == (ROCMFPX / name).resolve()
+
+
+def test_the_patch_series_is_deliberately_empty() -> None:
+    """Candidates (adaptive MTP draft sizing, skinny prefill) are named in the
+    manifest header; an entry appearing here deserves a review with a public
+    PR reference, never a blind diff from a field report."""
+    assert not MANIFEST.get("patches"), "recipe declares patches — see manifest header"
+    assert not list((STRIX / "patches").glob("*.patch"))

--- a/tests/runners/test_registry.py
+++ b/tests/runners/test_registry.py
@@ -38,6 +38,7 @@ def test_registry_has_every_expected_key() -> None:
     assert set(RUNNER_IMAGES) == {
         "rocmfpx",
         "promptforge",
+        "strix",
         "cuda",
         "cpu",
         "flm",


### PR DESCRIPTION
Registry entry + manifest digest pin for ghcr.io/hal0ai/hal0-strix-vulkan:0831 (gate-validated 2026-08-31 §3-C on kfd-present and kfd-absent boxes). Optional runner, never the AMD default; successor to the pin-only hal0-combined-upstream:0829 variant (#2118), following the promptforge single-backend pattern on the Vulkan lane. Not in FPX_RUNNER_KEYS so the #1790 quant guard refuses FPX GGUFs cleanly. Tracked recipe: packaging/runner/strix/. Tests: 69 passed (tests/packaging/test_strix_recipe.py, tests/config/test_runner_image_pins_export.py, tests/runners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182BPiqrg3aP6YGFY1NZ7Te