### PR TITLE
fix(hardware): kfd-aware ROCm feasibility — FE gate matches the backend reconcile

### DIFF
--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2110,6 +2110,21 @@ class HardwareInfo(BaseModel):
     npu: NPUInfo = Field(
         default_factory=NPUInfo, description="Detected NPU (present=False if none)."
     )
+    kfd_present: bool = Field(
+        default=False,
+        description=(
+            "Whether /dev/kfd is present AND usable by the slot-runner "
+            "identity, per hal0.providers._gpu.kfd_present. This is the "
+            "same host-truth signal the backend's device/profile "
+            "reconciliation gate (_reconcile_device_profile) uses to decide "
+            "ROCm feasibility. Distinct from gpus[].compute_capable, which "
+            "requires a HOST rocminfo probe to succeed — many boxes run "
+            "ROCm slots fine via a containerized userland with no host "
+            "rocminfo, so compute_capable alone under-reports ROCm "
+            "feasibility. Consumers should treat ROCm as feasible when "
+            "EITHER signal is true."
+        ),
+    )
     disk_free_mb: int = Field(
         default=0,
         ge=0,

--- a/src/hal0/hardware/probe.py
+++ b/src/hal0/hardware/probe.py
@@ -31,6 +31,7 @@ import structlog
 from hal0.config import paths as _paths
 from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
 from hal0.errors import Hal0Error
+from hal0.providers._gpu import kfd_present as _kfd_present
 
 log = structlog.get_logger(__name__)
 
@@ -972,6 +973,12 @@ class HardwareProbe:
                 gpus=visible_gpus,
                 gpu_group_gids=_gpu_group_gids(),
                 npu=npu,
+                # Same host-truth signal the backend's device/profile
+                # reconcile gate uses (config_write._reconcile_device_profile)
+                # — cheap (file stat + mode check, no subprocess), so safe on
+                # the hot probe path. See HardwareInfo.kfd_present docstring
+                # for why this is a distinct signal from gpu.compute_capable.
+                kfd_present=_kfd_present(),
                 disk_free_mb=disk_mb,
                 cgroup_max_mb=_read_cgroup_memory_max_mb(),
                 platform=platform,

--- a/tests/api/test_hardware_routes.py
+++ b/tests/api/test_hardware_routes.py
@@ -82,6 +82,26 @@ def test_flatten_pass_through_kvm_with_virtio_gpu() -> None:
     assert flat["npu_present"] is False
 
 
+def test_flatten_passes_through_kfd_present() -> None:
+    """``kfd_present`` is a top-level HardwareInfo field (host-truth ROCm
+    feasibility signal, matching the backend's own
+    ``_reconcile_device_profile`` gate) — the flatten step spreads ``**info``
+    first and never overwrites it, so it must survive to the UI payload even
+    when the GPU's own ``compute_capable`` is False (the FE/BE mismatch this
+    field exists to fix: a kfd-present, host-rocminfo-less box actively runs
+    ROCm slots but ``compute_capable`` alone reports it as infeasible)."""
+    info = HardwareInfo(
+        cpu_model="AMD Ryzen AI Max+ PRO 395",
+        gpus=[GPUInfo(vendor="amd", name="Radeon 8060S", compute_capable=False)],
+        npu=NPUInfo(present=False),
+        platform="strix-halo",
+        kfd_present=True,
+    ).model_dump(mode="python")
+    flat = _flatten_for_ui(info)
+    assert flat["kfd_present"] is True
+    assert flat["gpus"][0]["compute_capable"] is False
+
+
 def test_flatten_strix_halo_is_unified() -> None:
     """is_uma comes from the live gpu_view sample (#703) — the old
     ``vram > ram*0.5`` route heuristic is deleted. For this fixture both

--- a/tests/hardware/test_probe.py
+++ b/tests/hardware/test_probe.py
@@ -427,6 +427,7 @@ def test_probe_assembles_hardware_info(monkeypatch: pytest.MonkeyPatch, tmp_path
     )
     monkeypatch.setattr(probe_mod, "_gpu_group_gids", lambda: {"render": 993, "video": 44})
     monkeypatch.setattr(probe_mod, "_disk_free_mb", lambda _: 512000)
+    monkeypatch.setattr(probe_mod, "_kfd_present", lambda: False)
 
     def fake_read_text(path: Path) -> str | None:
         s = str(path)
@@ -475,6 +476,47 @@ def test_probe_assembles_hardware_info(monkeypatch: pytest.MonkeyPatch, tmp_path
     assert info.uptime_s == 4242
     assert info.kernel == "Linux version 7.0.6-2-pve"
     assert info.distro == "Debian GNU/Linux 13 (trixie)"
+    assert info.kfd_present is False
+
+
+def test_probe_kfd_present_true_surfaces_on_hardware_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A kfd-usable box (containerized ROCm userland, no host rocminfo)
+    reports ``kfd_present=True`` on the payload even when the GPU's own
+    ``compute_capable`` is False (issue: FE/BE ROCm gate mismatch) — this
+    is the same signal ``_reconcile_device_profile`` gates ROCm feasibility
+    on, via ``hal0.providers._gpu.kfd_present``."""
+    monkeypatch.setattr(probe_mod, "_parse_cpuinfo", lambda: ("Test CPU", 8, 16))
+    monkeypatch.setattr(probe_mod, "_parse_meminfo", lambda: (32768, 24576))
+    monkeypatch.setattr(
+        probe_mod,
+        "_detect_gpus",
+        lambda: [GPUInfo(vendor="amd", index=0, name="Radeon", compute_capable=False)],
+    )
+    monkeypatch.setattr(probe_mod, "_detect_npu", lambda: probe_mod.NPUInfo(present=False))
+    monkeypatch.setattr(probe_mod, "_gpu_group_gids", lambda: {})
+    monkeypatch.setattr(probe_mod, "_disk_free_mb", lambda _: 0)
+    monkeypatch.setattr(probe_mod, "_kfd_present", lambda: True)
+    monkeypatch.setattr(probe_mod, "_read_text", lambda _path: None)
+
+    info = HardwareProbe().probe()
+    assert info.gpus[0].compute_capable is False
+    assert info.kfd_present is True
+
+
+def test_probe_kfd_present_defaults_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(probe_mod, "_parse_cpuinfo", lambda: ("Test CPU", 8, 16))
+    monkeypatch.setattr(probe_mod, "_parse_meminfo", lambda: (32768, 24576))
+    monkeypatch.setattr(probe_mod, "_detect_gpus", lambda: [])
+    monkeypatch.setattr(probe_mod, "_detect_npu", lambda: probe_mod.NPUInfo(present=False))
+    monkeypatch.setattr(probe_mod, "_gpu_group_gids", lambda: {})
+    monkeypatch.setattr(probe_mod, "_disk_free_mb", lambda _: 0)
+    monkeypatch.setattr(probe_mod, "_kfd_present", lambda: False)
+    monkeypatch.setattr(probe_mod, "_read_text", lambda _path: None)
+
+    info = HardwareProbe().probe()
+    assert info.kfd_present is False
 
 
 _DMIDECODE_SAMPLE = """\

--- a/ui/src/api/hooks/useHardware.ts
+++ b/ui/src/api/hooks/useHardware.ts
@@ -84,7 +84,15 @@ function normalizeHardware(raw: any): Hardware {
     cores: cores ? `${cores}c · ${threads}t` : (raw?.cores ?? ''),
     gpu: raw?.gpu_name ?? gpu0?.name ?? raw?.gpu ?? '',
     gpuVendor: raw?.gpu_vendor ?? gpu0?.vendor ?? '',
-    computeCapable: !!gpu0?.compute_capable,
+    // `compute_capable` alone is a HOST rocminfo probe — false on a box
+    // where /dev/kfd is passed through but rocminfo isn't installed on the
+    // host (containers bring their own ROCm userland). Such a box actively
+    // runs ROCm slots, so fold in the same `kfd_present` host-truth signal
+    // the backend's own feasibility gate uses (kfd_present is AMD-only —
+    // never set on an NVIDIA box — so this can't leak a false CUDA signal).
+    // Otherwise the Hardware & Runtimes page shows "ROCm / compute capable:
+    // no" on a box that is, in fact, running ROCm.
+    computeCapable: !!(gpu0?.compute_capable || raw?.kfd_present),
     vulkanCapable: !!gpu0?.vulkan_capable,
     ram: {
       total: ramTotalMb ? mbToGb(ramTotalMb) : Number(ram?.total ?? 0),

--- a/ui/src/dash/__tests__/host-hw-flags.test.ts
+++ b/ui/src/dash/__tests__/host-hw-flags.test.ts
@@ -43,4 +43,34 @@ describe('hostHwFlags', () => {
       hostHwFlags({ gpus: [{ compute_capable: false, vulkan_capable: true }] }),
     ).toEqual({ rocm: false, vulkan: true, cuda: false })
   })
+
+  // kfd_present: FE/BE ROCm gate mismatch (host-truth fix). A box with
+  // /dev/kfd but no host rocminfo (containers bring their own ROCm
+  // userland) actively runs ROCm slots — the backend's own feasibility
+  // gate (config_write._reconcile_device_profile via
+  // hal0.providers._gpu.kfd_present) allows it, so the drawer must not
+  // veto it just because the host-rocminfo-backed compute_capable is false.
+
+  it('gpu0 present, compute_capable false but top-level kfd_present true → rocm true, cuda still false', () => {
+    expect(
+      hostHwFlags({
+        kfd_present: true,
+        gpus: [{ compute_capable: false, vulkan_capable: false }],
+      }),
+    ).toEqual({ rocm: true, vulkan: false, cuda: false })
+  })
+
+  it('gpu0 present, compute_capable true and kfd_present false → rocm true (compute_capable alone still sufficient)', () => {
+    expect(
+      hostHwFlags({
+        kfd_present: false,
+        gpus: [{ compute_capable: true, vulkan_capable: false }],
+      }),
+    ).toEqual({ rocm: true, vulkan: false, cuda: true })
+  })
+
+  it('no gpus[0] but top-level kfd_present true → still {} (unknown shape preserved, no veto)', () => {
+    expect(hostHwFlags({ kfd_present: true, gpus: [] })).toEqual({})
+    expect(hostHwFlags({ kfd_present: true })).toEqual({})
+  })
 })

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -181,7 +181,13 @@ export function hostHwFlags(rawHardware) {
 	const gpu0 = rawHardware?.gpus?.[0];
 	if (!gpu0) return {};
 	return {
-		rocm: !!gpu0.compute_capable,
+		// ROCm feasibility also passes when the top-level `kfd_present` probe
+		// fact is true, even if `compute_capable` (a HOST rocminfo probe) is
+		// false — a box with /dev/kfd but no host rocminfo (containers bring
+		// their own ROCm userland) actively runs ROCm slots, so this must
+		// match the backend's own gate (config_write._reconcile_device_profile
+		// via hal0.providers._gpu.kfd_present), not just the host probe.
+		rocm: !!(gpu0.compute_capable || rawHardware?.kfd_present),
 		vulkan: !!gpu0.vulkan_capable,
 		cuda: !!gpu0.compute_capable,
 	};


### PR DESCRIPTION
Live-box finding after #2187: on a box with /dev/kfd passed through but no host rocminfo, `gpus[0].compute_capable` probes false while the box actively serves ROCm slots — the slot drawer's hardware filter then hides ROCm-only runtimes (PromptForge) and renders the persisted binary as out-of-catalog, disagreeing with the backend reconcile's own kfd_present gate.

Fix: the hardware payload gains a top-level `kfd_present` (same hal0.providers._gpu.kfd_present signal the reconcile uses; cheap stat, no subprocess), and both FE consumers (`hostHwFlags` rocm lane, `normalizeHardware.computeCapable` for the Hardware & Runtimes page) treat ROCm as feasible when either signal is true. CUDA stays keyed to compute_capable alone (kfd is AMD-only). Tests: probe, hardware route payload, host-hw-flags kfd cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182BPiqrg3aP6YGFY1NZ7Te