### PR TITLE
feat(models): explicit provider/engine field — end of backends-tag authority

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ValidationError
 from hal0.api._audit import record_action
 from hal0.api.middleware.error_codes import BadRequest, NotFound
 from hal0.config.loader import load_hal0_config
+from hal0.model_meta import derive_model_provider
 from hal0.registry import pull_jobs as _pull_jobs
 from hal0.registry.curated import CURATED, CuratedModel, HaloaiModel
 from hal0.registry.pull import PullInvalidSource
@@ -376,6 +377,11 @@ async def create_model(request: Request) -> dict[str, Any]:
     Optional ``source`` (top-level, not part of ``Model``) tags the
     emitted ``model.registered`` event so the footer can colour-code
     catalogue picks vs hand-registered files. Defaults to ``"manual"``.
+
+    A body carrying legacy ``backends`` tags but no ``provider`` gets one
+    derived (``hal0.model_meta.derive_model_provider``) before screening, so
+    create never mints a permanently ``provider=None`` row (Task 3) — an
+    explicit ``provider`` in the body is never overridden.
     """
     from hal0.registry.store import Model
 
@@ -389,6 +395,13 @@ async def create_model(request: Request) -> dict[str, Any]:
     # Pop ``source`` before validation — it's an event-only tag, not a
     # Model field. Default to "manual" for hand-registered single files.
     source = body.pop("source", "manual")
+    # Task 3 fix: a create body can still hand-carry legacy ``backends``
+    # tags (create, unlike PUT, isn't retiring the field as an input) — but
+    # a create with ``backends`` and no ``provider`` must not mint a
+    # permanently provider=None row. Derive only when provider is absent;
+    # an explicit ``provider`` keeps flowing through screen_model_write's
+    # validity check unchanged.
+    body.setdefault("provider", derive_model_provider(body.get("backends")))
     # Screen launch-affecting fields at CREATE time too (UI-API-1 item 1): PUT
     # already screened, but create wrote straight to the registry, so a row
     # born with an extra_args that smuggles --port/--model/… would only fail at

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -600,9 +600,9 @@ async def update_model(model_id: str, request: Request) -> dict[str, Any]:
     """Apply partial updates to a registered model's metadata.
 
     Body accepts any subset of: ``name``, ``capabilities``, ``backends``,
-    ``defaults`` (nested ``ModelDefaults``), plus the legacy fields
-    (``license``, ``tags``, ``metadata`` …). Emits ``model.updated`` with
-    ``changed_fields`` so the footer ticker can render a "you edited X"
+    ``provider``, ``defaults`` (nested ``ModelDefaults``), plus the legacy
+    fields (``license``, ``tags``, ``metadata`` …). Emits ``model.updated``
+    with ``changed_fields`` so the footer ticker can render a "you edited X"
     chip.
 
     ``defaults`` and ``capability_flags`` are the two tables where "any
@@ -620,6 +620,8 @@ async def update_model(model_id: str, request: Request) -> dict[str, Any]:
         outside the launchable range (#1414).
       * ``400 slot.hardware_flag_denied`` / ``400 slot.managed_arg_denied`` —
         ``defaults.extra_args`` reaching for slot- or authority-owned flags.
+      * ``400 model.provider_invalid`` — ``provider`` not a
+        ``hal0.model_meta.RUNTIME_FAMILIES`` member.
       * ``404 model.not_found`` — ``model_id`` not registered.
     """
     registry = request.app.state.model_registry

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -378,7 +378,7 @@ async def create_model(request: Request) -> dict[str, Any]:
     emitted ``model.registered`` event so the footer can colour-code
     catalogue picks vs hand-registered files. Defaults to ``"manual"``.
 
-    A body carrying legacy ``backends`` tags but no ``provider`` gets one
+    A body carrying tag-era ``backends`` tags but no ``provider`` gets one
     derived (``hal0.model_meta.derive_model_provider``) before screening, so
     create never mints a permanently ``provider=None`` row (Task 3) — an
     explicit ``provider`` in the body is never overridden.
@@ -395,7 +395,7 @@ async def create_model(request: Request) -> dict[str, Any]:
     # Pop ``source`` before validation — it's an event-only tag, not a
     # Model field. Default to "manual" for hand-registered single files.
     source = body.pop("source", "manual")
-    # Task 3 fix: a create body can still hand-carry legacy ``backends``
+    # Task 3 fix: a create body can still hand-carry tag-era ``backends``
     # tags (create, unlike PUT, isn't retiring the field as an input) — but
     # a create with ``backends`` and no ``provider`` must not mint a
     # permanently provider=None row. Derive only when provider is absent;

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -599,19 +599,24 @@ async def get_model(model_id: str, request: Request) -> dict[str, Any]:
 async def update_model(model_id: str, request: Request) -> dict[str, Any]:
     """Apply partial updates to a registered model's metadata.
 
-    Body accepts any subset of: ``name``, ``capabilities``, ``backends``,
-    ``provider``, ``defaults`` (nested ``ModelDefaults``), plus the legacy
-    fields (``license``, ``tags``, ``metadata`` …). Emits ``model.updated``
-    with ``changed_fields`` so the footer ticker can render a "you edited X"
-    chip.
+    Body accepts any subset of: ``name``, ``capabilities``, ``provider``,
+    ``defaults`` (nested ``ModelDefaults``), plus the legacy fields
+    (``license``, ``tags``, ``metadata`` …). Emits ``model.updated`` with
+    ``changed_fields`` so the footer ticker can render a "you edited X" chip.
+
+    ``backends`` is retired as an editable/authoritative surface (Task 3 of
+    the slot/model drawer overhaul): a client-sent ``backends`` key is
+    dropped silently before screening/update, logged as
+    ``model.backends_write_ignored``. ``provider`` is the write path now —
+    the stored tags keep existing as vestigial lane hints (a future column
+    removal), but never change via this endpoint again.
 
     ``defaults`` and ``capability_flags`` are the two tables where "any
     subset" reaches INSIDE the object (#1413): an absent sub-key keeps the
     stored value, an explicit ``null`` clears that one value, and
     ``{"defaults": null}`` drops the whole table. Every other field —
-    including ``metadata`` and the list-valued ``capabilities``/``tags``/
-    ``backends`` — is a flat replace. See
-    :func:`hal0.registry.store.merge_update`.
+    including ``metadata`` and the list-valued ``capabilities``/``tags`` —
+    is a flat replace. See :func:`hal0.registry.store.merge_update`.
 
     Errors:
       * ``400 model.defaults_invalid`` — a ``defaults`` value that isn't
@@ -631,6 +636,17 @@ async def update_model(model_id: str, request: Request) -> dict[str, Any]:
         raise BadRequest("body must be valid JSON", details={"error": str(exc)}) from exc
     if not isinstance(body, dict):
         raise BadRequest("body must be a JSON object")
+
+    # Task 3: ``backends`` is retired as an editable/authoritative surface —
+    # ``provider`` (screened below) is the write path now. A client-sent
+    # ``backends`` is dropped silently (not rejected) rather than erroring,
+    # since older dashboards/scripts may still send the field out of habit.
+    if "backends" in body:
+        log.info(
+            "model.backends_write_ignored",
+            extra={"model_id": model_id, "backends": body.get("backends")},
+        )
+        body.pop("backends", None)
 
     # Snapshot the pre-update model FIRST — it feeds two consumers: the
     # changed-fields diff below, and the write screen, which needs the stored row

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -77,6 +77,7 @@ _RUNTIME_TO_HOST_BACKENDS: dict[str, tuple[str, ...]] = {
     "kokoro": ("gpu-vulkan", "cpu"),
     "vibevoice": ("gpu-vulkan", "cpu"),
     "comfyui": ("gpu-vulkan",),
+    "qwen3tts": ("gpu-rocm",),  # Qwen3-TTS runner is ROCm-only (needs /dev/kfd)
 }
 
 _CAPABILITY_TO_SLOT_TYPE: dict[str, str] = {
@@ -427,6 +428,20 @@ def _backend_variants(entry: Any) -> list[str]:
         cap_str = getattr(entry, "capability", "") or ""
         if comfy_subdir or cap_str == "image":
             raw.append("comfyui")
+
+    # An untagged row (backends=[], no .backend, no comfy signal) whose
+    # resolved engine is llama-server — explicit provider="llama-server",
+    # OR provider absent/None (derive_model_provider's total default) — has
+    # nothing in ``raw`` to fan out on, so ``out`` would stay empty and
+    # runs_on_for_model() would silently report zero lanes for a model that
+    # actually runs everywhere llama.cpp does. Reaching this point already
+    # proves ``explicit`` is not any OTHER provider (those paths returned
+    # above, including "flm" → ["npu"]) — so a remaining untagged case is
+    # llama-server by construction. Treat it as a bare
+    # ``backends=["llama-server"]`` row and let the fan-out below run its
+    # normal host-present AMD/CPU logic.
+    if not raw:
+        raw.append("llama-server")
 
     out: list[str] = []
     for b in raw:

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -385,6 +385,14 @@ def _backend_variants(entry: Any) -> list[str]:
     will surface a clear error if the specific model doesn't have an
     FLM-packaged variant.
     """
+    explicit = getattr(entry, "provider", None)
+    if explicit and explicit != "llama-server":
+        if explicit == "flm":
+            return ["npu"]
+        return list(_RUNTIME_TO_HOST_BACKENDS.get(explicit, ()))
+    # explicit llama-server (or unset) falls through to the existing
+    # lane fan-out, which already encodes host-present AMD/CPU logic.
+
     raw: list[str] = []
     backend = getattr(entry, "backend", None)
     if isinstance(backend, str) and backend:
@@ -485,6 +493,9 @@ def _provider_for_backend(entry_backend: str, backend_id: str, *, entry: Any = N
     """Pick the provider that pairs with this backend / entry combo.
 
     Resolution order:
+      0. The explicit ``entry.provider`` field (Task 1 — a registry Model
+         may carry it, set by the operator or a prior pull). Wins over
+         every tag-derived guess below: it's the source of truth once set.
       1. NPU backend → always FLM.
       2. The singular ``entry.backend`` tag (CuratedModel uses this).
       3. The ``entry.backends`` list (registry Model uses this; .backend
@@ -500,6 +511,9 @@ def _provider_for_backend(entry_backend: str, backend_id: str, *, entry: Any = N
     moonshine selection in capabilities.toml and the underlying slot
     TOML the next time they touched the card.
     """
+    explicit = getattr(entry, "provider", None)
+    if explicit:
+        return str(explicit)
     if backend_id == "npu":
         return "flm"
     if entry_backend in _BACKEND_TO_PROVIDER:
@@ -1062,9 +1076,21 @@ def catalogs_by_slot(
     }
 
 
+def runs_on_for_model(model: Any) -> list[str]:
+    """Host-backend lanes a registry model can run on (derived; UI 'Runs on').
+
+    Thin public wrapper over :func:`_backend_variants` so callers outside
+    this module (the models-service row serialiser) don't reach for a
+    private symbol. Honors the explicit ``model.provider`` field first,
+    same as every other catalog resolution (see :func:`_backend_variants`).
+    """
+    return _backend_variants(model)
+
+
 __all__ = [
     "available_backends",
     "catalogs_by_slot",
     "get_backend",
     "models_for_capability",
+    "runs_on_for_model",
 ]

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -61,6 +61,7 @@ _BACKEND_TO_PROVIDER: dict[str, str] = {
     "whispercpp": "whispercpp",  # the whisper.cpp STT recipe
     "vibevoice": "kokoro",  # closest existing provider; the UI lets the user override
     "comfyui": "comfyui",
+    "qwen3tts": "qwen3tts",
 }
 
 # Per-runtime allow-list of host backends the toolbox image can actually
@@ -388,8 +389,20 @@ def _backend_variants(entry: Any) -> list[str]:
     explicit = getattr(entry, "provider", None)
     if explicit and explicit != "llama-server":
         if explicit == "flm":
+            # Mirrors the untouched legacy ``{"flm", "npu"}`` tag branch
+            # below: NPU is offered unconditionally, with no
+            # ``available_backends()`` intersection — host-truth NPU
+            # gating lives downstream, in the load-time FLM probe
+            # (:func:`_flm_rows_for_capability` / :func:`available_backends`
+            # itself), not here.
             return ["npu"]
-        return list(_RUNTIME_TO_HOST_BACKENDS.get(explicit, ()))
+        # Same host-presence intersection as the tag-driven
+        # ``_RUNTIME_TO_HOST_BACKENDS`` branch further down (moonshine's
+        # CPU-only ONNX wheel, ComfyUI's Vulkan-only image, …) — an
+        # explicit provider still can't advertise a lane the host can't
+        # actually serve.
+        host_backends = {b["id"] for b in available_backends()}
+        return [c for c in _RUNTIME_TO_HOST_BACKENDS.get(explicit, ()) if c in host_backends]
     # explicit llama-server (or unset) falls through to the existing
     # lane fan-out, which already encodes host-present AMD/CPU logic.
 

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -390,7 +390,7 @@ def _backend_variants(entry: Any) -> list[str]:
     explicit = getattr(entry, "provider", None)
     if explicit and explicit != "llama-server":
         if explicit == "flm":
-            # Mirrors the untouched legacy ``{"flm", "npu"}`` tag branch
+            # Mirrors the untouched original ``{"flm", "npu"}`` tag branch
             # below: NPU is offered unconditionally, with no
             # ``available_backends()`` intersection — host-truth NPU
             # gating lives downstream, in the load-time FLM probe

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1595,7 +1595,20 @@ class StackModelMeta(BaseModel):
         default_factory=list, description="Capability strings, e.g. ['chat','vision']."
     )
     backends: list[str] = Field(
-        default_factory=list, description="Runnable backends, e.g. ['rocm','vulkan']."
+        default_factory=list,
+        description=(
+            "Runnable backends, e.g. ['rocm','vulkan'] — vestigial lane hints kept for "
+            "transport; ``provider`` is the engine-identity source of truth (Task 3)."
+        ),
+    )
+    provider: str | None = Field(
+        default=None,
+        description=(
+            "Engine identity (a hal0.model_meta.RUNTIME_FAMILIES member), embedded "
+            "verbatim from the source row's explicit provider, or derived from "
+            "``backends`` via hal0.model_meta.derive_model_provider when the row had "
+            "none set. None only for a bare-id unresolvable ref."
+        ),
     )
     mmproj: str | None = Field(
         default=None,

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1562,7 +1562,7 @@ class ProfilesConfig(BaseModel):
 
 # Stacks carry their own schema version (independent of hal0.toml meta.schema_version),
 # stamped on every StackConfig and on the export envelope (PR-3).
-STACK_SCHEMA_VERSION_CURRENT = 1
+STACK_SCHEMA_VERSION_CURRENT = 2
 
 #: Profile export envelopes carry their own schema version (independent of
 #: hal0.toml meta.schema_version), stamped on every ``.hal0profile.json`` export.

--- a/src/hal0/db/repository.py
+++ b/src/hal0/db/repository.py
@@ -47,6 +47,11 @@ _CONTEXT_LENGTH_KEY = "context_length"
 _CAPABILITY_FLAGS_EXTRA_KEY = "_capability_flags"
 _MODALITIES_OVERRIDE_EXTRA_KEY = "_modalities_override"
 
+#: Explicit engine identity (:attr:`hal0.registry.model.Model.provider`) —
+#: same "no dedicated column" treatment as the two keys above. Only written
+#: when set (None means "derive"), mirroring _DEFAULT_EXTRA_KEY's rule.
+_PROVIDER_EXTRA_KEY = "_provider"
+
 #: spec-hw-slot-ownership §1: ``ModelDefaults.enable_thinking`` / ``.vision``
 #: are tri-state (None/False/True) reasoning + vision-projector owners, moved
 #: onto the model from the slot. Like ``capability_flags`` /
@@ -164,6 +169,9 @@ def model_to_row(
         metadata[_CAPABILITY_FLAGS_EXTRA_KEY] = capability_flags
     if model.modalities_override is not None:
         metadata[_MODALITIES_OVERRIDE_EXTRA_KEY] = [m.value for m in model.modalities_override]
+    # Explicit engine identity — only stamped when set (None means "derive").
+    if model.provider is not None:
+        metadata[_PROVIDER_EXTRA_KEY] = model.provider
     # Per-type default marker — only stamped when set (see _DEFAULT_EXTRA_KEY).
     if model.default:
         metadata[_DEFAULT_EXTRA_KEY] = True
@@ -410,6 +418,8 @@ def row_to_model(row: sqlite3.Row, *, backends: list[str] | None = None) -> Mode
     modalities_override = (
         list(raw_modalities_override) if isinstance(raw_modalities_override, list) else None
     )
+    raw_provider = metadata.pop(_PROVIDER_EXTRA_KEY, None)
+    provider = raw_provider if isinstance(raw_provider, str) else None
     default = bool(metadata.pop(_DEFAULT_EXTRA_KEY, False))
     raw_enable_thinking = metadata.pop(_ENABLE_THINKING_EXTRA_KEY, None)
     enable_thinking = raw_enable_thinking if isinstance(raw_enable_thinking, bool) else None
@@ -444,6 +454,7 @@ def row_to_model(row: sqlite3.Row, *, backends: list[str] | None = None) -> Mode
         # drop deferred post-1.0); the deploy-window fold reads them directly.
         capability_flags=capability_flags,
         modalities_override=modalities_override,
+        provider=provider,
         defaults=defaults,
         default=default,
         metadata=metadata,

--- a/src/hal0/model_meta/__init__.py
+++ b/src/hal0/model_meta/__init__.py
@@ -206,7 +206,7 @@ _PROVIDER_TAGS: dict[str, str] = {
 
 
 def derive_model_provider(backends: Sequence[str] | None) -> str:
-    """Engine identity for a registry model from its legacy backend tags.
+    """Engine identity for a registry model from its tag-era backend tags.
 
     Lane tags (rocm/vulkan/cuda/cpu) are hardware lanes, not engines — they
     resolve to the llama-server default. Mirrors capabilities.catalog's

--- a/src/hal0/model_meta/__init__.py
+++ b/src/hal0/model_meta/__init__.py
@@ -79,7 +79,7 @@ Unknown-value policy — ONE documented rule per translation direction
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -191,6 +191,37 @@ RUNTIME_FAMILIES: tuple[str, ...] = (
     "moonshine",
     "comfyui",
 )
+
+#: Legacy backend/tag → runtime family, for :func:`derive_model_provider`.
+#: Lane tags (rocm/vulkan/cuda/cpu) are deliberately absent — they are
+#: hardware lanes, not engines, and fall through to the llama-server default.
+_PROVIDER_TAGS: dict[str, str] = {
+    "flm": "flm",
+    "npu": "flm",
+    "moonshine": "moonshine",
+    "kokoro": "kokoro",
+    "comfyui": "comfyui",
+    "qwen3tts": "qwen3tts",
+}
+
+
+def derive_model_provider(backends: Sequence[str] | None) -> str:
+    """Engine identity for a registry model from its legacy backend tags.
+
+    Lane tags (rocm/vulkan/cuda/cpu) are hardware lanes, not engines — they
+    resolve to the llama-server default. Mirrors capabilities.catalog's
+    step-3 resolution for registry rows; curated-only tokens (whispercpp,
+    vibevoice) never appear on registry models.
+
+    Total: always returns a :data:`RUNTIME_FAMILIES` member, even for an
+    empty/``None`` input or an unrecognised tag set.
+    """
+    for tag in backends or ():
+        fam = _PROVIDER_TAGS.get(str(tag).strip().lower())
+        if fam:
+            return fam
+    return "llama-server"
+
 
 #: Legacy ``backend`` token → canonical ``device``. Used by the SlotConfig
 #: and CapabilitySelection promote-then-drop shims (auto-promote a legacy
@@ -667,6 +698,7 @@ __all__ = [
     "canonical_device",
     "capability_from_filename",
     "classify",
+    "derive_model_provider",
     "device_to_backend",
     "is_resolvable",
     "labels_of",

--- a/src/hal0/registry/discover.py
+++ b/src/hal0/registry/discover.py
@@ -372,7 +372,7 @@ def register_candidate(registry: ModelRegistry, candidate: CandidateModel) -> Mo
             if curated.capability
             else (["image"] if is_comfyui else ["chat"]),
             backends=comfyui_backends,
-            # Task 3: stamp provider alongside the legacy backends tag on a
+            # Task 3: stamp provider alongside the tag-era backends tag on a
             # NEW row — backends stays a vestigial lane hint (non-comfyui
             # rows carry none), provider is the write-path source of truth.
             provider=derive_model_provider(comfyui_backends),

--- a/src/hal0/registry/discover.py
+++ b/src/hal0/registry/discover.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from hal0.config.schema import ModelsConfig
-from hal0.model_meta import capability_from_filename
+from hal0.model_meta import capability_from_filename, derive_model_provider
 from hal0.registry.curated import CURATED_MODELS, CuratedModel
 from hal0.registry.fileset import SHARD_RE
 from hal0.registry.model import Model
@@ -372,6 +372,10 @@ def register_candidate(registry: ModelRegistry, candidate: CandidateModel) -> Mo
             if curated.capability
             else (["image"] if is_comfyui else ["chat"]),
             backends=comfyui_backends,
+            # Task 3: stamp provider alongside the legacy backends tag on a
+            # NEW row — backends stays a vestigial lane hint (non-comfyui
+            # rows carry none), provider is the write-path source of truth.
+            provider=derive_model_provider(comfyui_backends),
             hf_repo=curated.hf_repo,
             hf_filename=curated.hf_file,
             tags=list(curated.tags),
@@ -391,6 +395,7 @@ def register_candidate(registry: ModelRegistry, candidate: CandidateModel) -> Mo
             size_bytes=candidate.size_bytes,
             capabilities=["image"] if is_comfyui else [candidate.capability_guess],
             backends=comfyui_backends,
+            provider=derive_model_provider(comfyui_backends),
             metadata={"discovered": True, "source": "auto-scan"},
         )
     # Carry a discovered mmproj sidecar onto the model so the llama-server

--- a/src/hal0/registry/import_toml.py
+++ b/src/hal0/registry/import_toml.py
@@ -27,6 +27,7 @@ from hal0.config import paths
 from hal0.db import repository
 from hal0.db.connection import connect, tx
 from hal0.db.migrate import migrate
+from hal0.model_meta import derive_model_provider
 from hal0.registry.model import Model
 
 log = logging.getLogger(__name__)
@@ -69,7 +70,16 @@ def _load_toml_models(registry_file: Path) -> tuple[dict[str, Model], int]:
                 skipped_invalid += 1
                 continue
             try:
-                out[mid] = Model.model_validate({**entry, "id": mid})
+                # Task 3: a legacy entry may only ever have carried
+                # ``backends`` tags — ``provider`` is the write-path source
+                # of truth now, so backfill it here rather than leaving a
+                # freshly-imported row to fall back on lazy derivation.
+                # ``setdefault`` never overrides an entry's own explicit
+                # ``provider`` (post-Task-1 registry.toml writes may already
+                # carry one).
+                payload = {**entry, "id": mid}
+                payload.setdefault("provider", derive_model_provider(payload.get("backends")))
+                out[mid] = Model.model_validate(payload)
             except Exception as exc:
                 log.warning("import_toml: entry %r failed validation: %s", mid, exc)
                 skipped_invalid += 1

--- a/src/hal0/registry/import_toml.py
+++ b/src/hal0/registry/import_toml.py
@@ -70,7 +70,7 @@ def _load_toml_models(registry_file: Path) -> tuple[dict[str, Model], int]:
                 skipped_invalid += 1
                 continue
             try:
-                # Task 3: a legacy entry may only ever have carried
+                # Task 3: a tag-era entry may only ever have carried
                 # ``backends`` tags — ``provider`` is the write-path source
                 # of truth now, so backfill it here rather than leaving a
                 # freshly-imported row to fall back on lazy derivation.

--- a/src/hal0/registry/model.py
+++ b/src/hal0/registry/model.py
@@ -321,7 +321,7 @@ class Model(BaseModel):
         default=None,
         description=(
             "Engine identity (a hal0.model_meta.RUNTIME_FAMILIES member). "
-            "None means 'derive' — resolve from the legacy backend tags via "
+            "None means 'derive' — resolve from the stored backend tags via "
             "hal0.model_meta.derive_model_provider. Persists in the registry "
             "row's ``extra`` JSON blob (repository.py) — no schema migration, "
             "same fold as capability_flags/modalities_override."

--- a/src/hal0/registry/model.py
+++ b/src/hal0/registry/model.py
@@ -317,6 +317,17 @@ class Model(BaseModel):
         ),
     )
 
+    provider: str | None = Field(
+        default=None,
+        description=(
+            "Engine identity (a hal0.model_meta.RUNTIME_FAMILIES member). "
+            "None means 'derive' — resolve from the legacy backend tags via "
+            "hal0.model_meta.derive_model_provider. Persists in the registry "
+            "row's ``extra`` JSON blob (repository.py) — no schema migration, "
+            "same fold as capability_flags/modalities_override."
+        ),
+    )
+
     capability_flags: ModelCapabilities = Field(
         default_factory=ModelCapabilities,
         description=(

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -1315,7 +1315,7 @@ def _register_pulled(
                 quant=detected_quant,
                 capabilities=caps,
                 backends=backends,
-                # Task 3: stamp provider alongside the legacy backends tag on
+                # Task 3: stamp provider alongside the tag-era backends tag on
                 # a NEW row — backends stays a vestigial lane hint, provider
                 # is the write-path source of truth.
                 provider=derive_model_provider(backends),
@@ -2134,7 +2134,7 @@ def _register_flm_pulled(
                 size_bytes=size_bytes,
                 capabilities=caps,
                 backends=["npu"],
-                # Task 3: stamp provider alongside the legacy backends tag on
+                # Task 3: stamp provider alongside the tag-era backends tag on
                 # a NEW row — see the matching comment in ``_register_pulled``.
                 provider=derive_model_provider(["npu"]),
                 metadata={"runtime": "flm"},

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -40,6 +40,7 @@ from hal0.db import repository
 from hal0.db.connection import connect, tx
 from hal0.errors import Hal0Error
 from hal0.install.perms import ensure_shared_dir
+from hal0.model_meta import derive_model_provider
 from hal0.registry.fileset import FileSetEntry, FileSetPlan
 from hal0.registry.model import Model, ModelCapabilities, ModelDefaults
 from hal0.registry.store import ModelNotFound, ModelRegistry, _fsync_dir
@@ -1314,6 +1315,10 @@ def _register_pulled(
                 quant=detected_quant,
                 capabilities=caps,
                 backends=backends,
+                # Task 3: stamp provider alongside the legacy backends tag on
+                # a NEW row — backends stays a vestigial lane hint, provider
+                # is the write-path source of truth.
+                provider=derive_model_provider(backends),
                 mmproj=mmproj,
                 metadata=dict(fresh_meta),
                 architecture=detected_arch,
@@ -2129,6 +2134,9 @@ def _register_flm_pulled(
                 size_bytes=size_bytes,
                 capabilities=caps,
                 backends=["npu"],
+                # Task 3: stamp provider alongside the legacy backends tag on
+                # a NEW row — see the matching comment in ``_register_pulled``.
+                provider=derive_model_provider(["npu"]),
                 metadata={"runtime": "flm"},
             )
         )

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -399,9 +399,7 @@ async def commit_scan_rows(
             # spec forbids on registry rows). Screen it against the same
             # vocab the create path enforces (see the ``model.provider_invalid``
             # check further down this module) and reject the row instead.
-            skipped.append(
-                {"path": str(resolved), "reason": f"invalid_provider:{provider!r}"}
-            )
+            skipped.append({"path": str(resolved), "reason": f"invalid_provider:{provider!r}"})
             continue
 
         suggested_id = row.get("id") or suggest_id_from_path(resolved)

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -23,7 +23,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from hal0.model_meta import classify
+from hal0.model_meta import classify, derive_model_provider
 from hal0.registry.detect import DetectionResult, detect, detected_architecture
 from hal0.registry.model import _derive_ns
 from hal0.upstreams.filters import apply_filters
@@ -348,11 +348,13 @@ async def commit_scan_rows(
     """Persist user-edited preview rows into the registry.
 
     Each row is a dict with at least ``path``. Optional fields override
-    detection: ``id``, ``name``, ``backends``, ``capabilities``,
+    detection: ``id``, ``name``, ``backends``, ``capabilities``, ``provider``,
     ``defaults`` (nested ``ModelDefaults`` shape). Missing fields are
     backfilled by re-running ``detect()`` on the path so the operator can
     edit only what matters and still get high-confidence defaults for the
-    rest.
+    rest. ``provider`` defaults to ``derive_model_provider(backends)`` when
+    not given, so a freshly-committed row always carries an explicit
+    provider (Task 3) instead of leaving it for lazy derivation.
     """
     from hal0.registry.model import Model, ModelDefaults
     from hal0.registry.store import ModelAlreadyExists
@@ -383,6 +385,13 @@ async def commit_scan_rows(
             backends = list(detection.suggested_backends)
         if not isinstance(capabilities, list):
             capabilities = list(detection.suggested_capabilities)
+        # Task 3: an operator-edited ``provider`` override always wins (same
+        # "explicit input wins" rule as backends/capabilities above);
+        # otherwise derive it from whichever backends this row actually
+        # landed on, so a NEW row never persists with provider=None.
+        provider = row.get("provider")
+        if not isinstance(provider, str) or not provider.strip():
+            provider = derive_model_provider(backends)
 
         suggested_id = row.get("id") or suggest_id_from_path(resolved)
         name = row.get("name") or resolved.stem
@@ -413,6 +422,7 @@ async def commit_scan_rows(
                 quant=detection.quant,
                 capabilities=[str(c) for c in capabilities],
                 backends=[str(b) for b in backends],
+                provider=provider,
                 defaults=defaults_obj,
                 metadata=metadata,
                 # GGUF general.architecture from the header read detect()
@@ -824,6 +834,13 @@ async def list_all(
                 dumped["backends"] = _bes
             if _cat is not None:
                 dumped["comfyui_category"] = _cat
+            # Task 3: seed ``provider`` alongside the self-healed tag — a row
+            # with no explicit provider (the pre-Task-1 pull shape this
+            # heuristic exists for) must not keep reading as
+            # provider=None/llama-server just because this repair patches
+            # the response dict rather than the persisted row.
+            if not dumped.get("provider"):
+                dumped["provider"] = derive_model_provider(_bes)
         data.append(dumped)
         seen.add(entry.id)
         by_id[entry.id] = dumped
@@ -1131,6 +1148,9 @@ async def add_from_path(body: dict[str, Any], *, registry: Any, event_bus: Any) 
             quant=detection.quant,
             capabilities=capabilities,
             backends=list(detection.suggested_backends),
+            # Task 3: stamp provider alongside the detected backends on this
+            # NEW row — see commit_scan_rows' matching stamp.
+            provider=derive_model_provider(detection.suggested_backends),
             metadata=metadata,
             # GGUF general.architecture from the header read above — see
             # commit_scan_rows' matching stamp (model↔runner arch fit-check,

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -23,7 +23,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from hal0.model_meta import classify, derive_model_provider
+from hal0.model_meta import RUNTIME_FAMILIES, classify, derive_model_provider
 from hal0.registry.detect import DetectionResult, detect, detected_architecture
 from hal0.registry.model import _derive_ns
 from hal0.upstreams.filters import apply_filters
@@ -392,6 +392,17 @@ async def commit_scan_rows(
         provider = row.get("provider")
         if not isinstance(provider, str) or not provider.strip():
             provider = derive_model_provider(backends)
+        elif provider not in RUNTIME_FAMILIES:
+            # Final-review fix: an operator-supplied provider string was
+            # persisted unscreened, letting POST /api/models/scan mint an
+            # out-of-vocab row (e.g. "whispercpp", a curated-only tag the
+            # spec forbids on registry rows). Screen it against the same
+            # vocab the create path enforces (see the ``model.provider_invalid``
+            # check further down this module) and reject the row instead.
+            skipped.append(
+                {"path": str(resolved), "reason": f"invalid_provider:{provider!r}"}
+            )
+            continue
 
         suggested_id = row.get("id") or suggest_id_from_path(resolved)
         name = row.get("name") or resolved.stem

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -213,6 +213,12 @@ def model_to_dict(model: Any) -> dict[str, Any]:
       derived from the filename (path basename, then ``hf_filename``) so
       registries written before the field existed surface quant without
       re-registration. Filename-only on this hot path — no header read.
+    * ``runs_on`` — derived host-backend lanes (``gpu-rocm`` / ``gpu-vulkan``
+      / ``cpu`` / ``npu``) this model can run under, via
+      :func:`hal0.capabilities.catalog.runs_on_for_model`. Imported lazily
+      below: ``hal0.capabilities.catalog`` imports from ``hal0.registry``,
+      which this module is itself imported by, so a module-level import
+      here would cycle.
     """
     if hasattr(model, "model_dump"):
         dumped = model.model_dump(mode="json")
@@ -230,6 +236,9 @@ def model_to_dict(model: Any) -> dict[str, Any]:
         quant = lazy_quant(dumped)
         if quant:
             dumped["quant"] = quant
+    from hal0.capabilities.catalog import runs_on_for_model
+
+    dumped["runs_on"] = runs_on_for_model(model)
     return dumped
 
 

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -1457,6 +1457,9 @@ def screen_model_write(
       worker — stay editable, so an unrelated rename does not have to fix an
       invariant it never violated. Every write that could CREATE or PRESERVE the
       broken pairing is still screened.
+    * ``provider`` — must be a ``hal0.model_meta.RUNTIME_FAMILIES`` member when
+      present, else ``400 model.provider_invalid``. ``None``/absent means
+      "derive" and is never screened here.
 
     spec-hw-slot-ownership: ``preferred_runner`` is no longer a model field (the
     runner is slot-owned via ``SlotConfig.binary``) — it is neither validated nor
@@ -1503,6 +1506,16 @@ def screen_model_write(
         # managed-arg one — ``-ngl`` is in both sets.
         _deny_slot_hardware_flags(tokens, segment=seg)
         _deny_managed_flags(tokens, segment=seg)
+
+    provider = body.get("provider")
+    if provider is not None:
+        from hal0.model_meta import RUNTIME_FAMILIES
+
+        if provider not in RUNTIME_FAMILIES:
+            raise BadRequest(
+                f"provider must be one of {', '.join(RUNTIME_FAMILIES)} (got {provider!r})",
+                code="model.provider_invalid",
+            )
 
 
 # (The duplicate-model service — ``POST /api/models/{id}/duplicate`` — was

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -834,13 +834,18 @@ async def list_all(
                 dumped["backends"] = _bes
             if _cat is not None:
                 dumped["comfyui_category"] = _cat
-            # Task 3: seed ``provider`` alongside the self-healed tag — a row
-            # with no explicit provider (the pre-Task-1 pull shape this
-            # heuristic exists for) must not keep reading as
-            # provider=None/llama-server just because this repair patches
-            # the response dict rather than the persisted row.
-            if not dumped.get("provider"):
-                dumped["provider"] = derive_model_provider(_bes)
+            # Task 3: force ``provider`` alongside the self-healed tag — this
+            # whole branch already treats the ON-DISK PATH as more
+            # authoritative than whatever the row's own ``backends`` says
+            # (it force-appends "comfyui" unconditionally, above), so
+            # ``provider`` gets the same treatment rather than only filling
+            # a falsy value. Otherwise a row created with a comfyui path but
+            # ``backends=[]`` and no explicit provider — via the create-model
+            # write path, which now stamps ``derive_model_provider([]) ==
+            # "llama-server"`` at write time (see create_model) — would read
+            # back "llama-server" forever, since a truthy stored value would
+            # never again look like "needs healing".
+            dumped["provider"] = derive_model_provider(_bes)
         data.append(dumped)
         seen.add(entry.id)
         by_id[entry.id] = dumped

--- a/src/hal0/stacks/portable.py
+++ b/src/hal0/stacks/portable.py
@@ -97,7 +97,7 @@ def embed_references(
                 size_bytes=m.size_bytes,
                 capabilities=list(m.capabilities),
                 backends=list(m.backends),
-                # Task 3: legacy backends is a vestigial lane hint now —
+                # Task 3: tag-era backends is a vestigial lane hint now —
                 # embed the row's explicit provider verbatim, or derive it
                 # from those same backends when the row never got one.
                 provider=m.provider or derive_model_provider(m.backends),

--- a/src/hal0/stacks/portable.py
+++ b/src/hal0/stacks/portable.py
@@ -36,6 +36,7 @@ from hal0.config.schema import (
     StackSlotEntry,
 )
 from hal0.errors import BadRequest
+from hal0.model_meta import derive_model_provider
 from hal0.registry.curated import get_curated
 from hal0.registry.store import ModelRegistry
 
@@ -96,6 +97,10 @@ def embed_references(
                 size_bytes=m.size_bytes,
                 capabilities=list(m.capabilities),
                 backends=list(m.backends),
+                # Task 3: legacy backends is a vestigial lane hint now —
+                # embed the row's explicit provider verbatim, or derive it
+                # from those same backends when the row never got one.
+                provider=m.provider or derive_model_provider(m.backends),
                 mmproj="present" if m.mmproj else None,
             )
         else:

--- a/src/hal0/stacks/portable.py
+++ b/src/hal0/stacks/portable.py
@@ -277,7 +277,9 @@ def import_stack(
             code="stacks.envelope_too_new",
             details={"got": env.stack.schema_version, "supported": STACK_SCHEMA_VERSION_CURRENT},
         )
-    # (forward-compat seam: older schema_version would migrate here; only v1 exists.)
+    # (forward-compat seam: older schema_version would migrate here; v1 and v2
+    # both import cleanly today — v2 only added StackModelMeta.provider, which
+    # v1 importers never wrote and v2 readers treat as optional.)
     _reconcile_profiles(env.stack, profiles_path)
     resolved = catalog.create(slug, env.stack)
     report = resolve_models(env.stack, registry)

--- a/tests/api/test_models_add_from_path.py
+++ b/tests/api/test_models_add_from_path.py
@@ -75,6 +75,26 @@ def test_add_from_path_registers_gguf(
     assert body["id"] in ids
 
 
+def test_add_from_path_stamps_provider_alongside_detected_backends(
+    add_path_client: tuple[TestClient, Path],
+) -> None:
+    """Task 3: a fresh add-from-path row gets ``provider`` derived from
+    detect()'s ``suggested_backends`` stamped on the row, not left ``None``
+    for lazy derivation. A "kokoro" filename hint detects a kokoro backend."""
+    client, drop = add_path_client
+    target = drop / "kokoro-en-v1.gguf"
+    target.write_bytes(b"\x00" * 32)
+
+    r = client.post("/api/models/add-from-path", json={"path": str(target)})
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["backends"] == ["kokoro"]
+    assert body["provider"] == "kokoro"
+
+    row = client.get(f"/api/models/{body['id']}").json()
+    assert row["provider"] == "kokoro"
+
+
 def test_add_from_path_persists_detected_architecture(
     add_path_client: tuple[TestClient, Path],
 ) -> None:

--- a/tests/api/test_models_crud.py
+++ b/tests/api/test_models_crud.py
@@ -249,6 +249,47 @@ def test_create_defaults_source_to_manual(
     ), events
 
 
+def test_create_derives_provider_from_backends_when_absent(
+    crud_client: TestClient,
+    crud_models_root: Path,
+) -> None:
+    """Task 3 fix: POST /api/models with ``backends`` but no ``provider``
+    must not mint a permanently ``provider=None`` row — the create path
+    derives it the same way the PUT/import/seed paths do."""
+    fpath = crud_models_root / "kokoro-voice.gguf"
+    fpath.write_bytes(b"\x00" * 16)
+    r = crud_client.post(
+        "/api/models",
+        json={"id": "kokoro-voice", "path": str(fpath), "backends": ["kokoro"]},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["provider"] == "kokoro"
+
+    row = crud_client.get("/api/models/kokoro-voice").json()
+    assert row["provider"] == "kokoro"
+
+
+def test_create_explicit_provider_wins_over_backends(
+    crud_client: TestClient,
+    crud_models_root: Path,
+) -> None:
+    """An explicit ``provider`` in the create body is never overridden by
+    the tag-derived guess, even when the tags disagree."""
+    fpath = crud_models_root / "explicit-provider.gguf"
+    fpath.write_bytes(b"\x00" * 16)
+    r = crud_client.post(
+        "/api/models",
+        json={
+            "id": "explicit-provider",
+            "path": str(fpath),
+            "backends": ["kokoro"],
+            "provider": "llama-server",
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["provider"] == "llama-server"
+
+
 # ── PUT /api/models/{id} ───────────────────────────────────────────────────
 
 

--- a/tests/api/test_models_crud.py
+++ b/tests/api/test_models_crud.py
@@ -1070,3 +1070,29 @@ def test_put_clearing_mmproj_and_vision_together_accepted(
     )
     assert r.status_code == 200, r.text
     assert r.json()["mmproj"] is None
+
+
+# ── Task 1: Model.provider explicit engine identity ─────────────────────────
+
+
+def test_update_model_provider_valid_and_invalid(
+    crud_client: TestClient,
+    crud_models_root: Path,
+) -> None:
+    """PUT accepts a RUNTIME_FAMILIES member into ``provider``, it survives
+    the extra-JSON round trip, and a non-member is rejected with
+    ``model.provider_invalid`` (screened before the row is touched)."""
+    fpath = crud_models_root / "prov1.gguf"
+    fpath.write_bytes(b"\x00" * 16)
+    crud_client.post("/api/models", json={"id": "prov1", "path": str(fpath)})
+
+    r = crud_client.put("/api/models/prov1", json={"provider": "kokoro"})
+    assert r.status_code == 200, r.text
+    assert r.json()["provider"] == "kokoro"
+
+    r2 = crud_client.get("/api/models/prov1")
+    assert r2.json()["provider"] == "kokoro"  # survives the extra-JSON round trip
+
+    bad = crud_client.put("/api/models/prov1", json={"provider": "whispercpp"})
+    assert bad.status_code == 400, bad.text
+    assert bad.json()["error"]["code"] == "model.provider_invalid"

--- a/tests/api/test_models_crud.py
+++ b/tests/api/test_models_crud.py
@@ -256,6 +256,10 @@ def test_update_accepts_new_editable_fields_and_emits(
     crud_client: TestClient,
     crud_models_root: Path,
 ) -> None:
+    """Task 3: ``backends`` is retired from the PUT write path — sent
+    alongside real editable fields, it is silently ignored (not rejected,
+    not applied) while ``name``/``capabilities``/``defaults`` still save and
+    still surface in ``changed_fields``."""
     fpath = crud_models_root / "upd.gguf"
     fpath.write_bytes(b"\x00" * 16)
     crud_client.post("/api/models", json={"id": "upd", "path": str(fpath)})
@@ -274,14 +278,15 @@ def test_update_accepts_new_editable_fields_and_emits(
     body = r.json()
     assert body["name"] == "Updated Name"
     assert set(body["capabilities"]) == {"chat", "embed"}
-    assert set(body["backends"]) == {"vulkan", "rocm"}
+    assert body["backends"] == []  # never had any; the PUT's backends is dead
     assert body["defaults"]["context_size"] == 4096
 
     events = _events_since(crud_client, pre, "model.updated")
     assert events, "expected model.updated event"
     payload = next(ev for ev in events if ev["data"].get("id") == "upd")
     changed = set(payload["data"]["changed_fields"])
-    assert {"name", "capabilities", "backends", "defaults"} <= changed
+    assert {"name", "capabilities", "defaults"} <= changed
+    assert "backends" not in changed
 
 
 def test_update_changed_fields_only_lists_actual_changes(

--- a/tests/api/test_models_routes.py
+++ b/tests/api/test_models_routes.py
@@ -860,6 +860,48 @@ def test_update_model_rejects_managed_args_in_extra_args(
     assert ok.status_code == 200, ok.text
 
 
+def test_update_model_ignores_backends_writes(
+    inspect_client: TestClient, tmp_hal0_home: str
+) -> None:
+    """Task 3: ``backends`` is retired as an editable/authoritative surface —
+    a PUT that sends ``backends`` is silently ignored (not rejected), leaving
+    the stored tags untouched. ``provider`` is the write surface now."""
+    fp = Path(tmp_hal0_home) / "tagged.gguf"
+    fp.write_bytes(b"\x00" * 8)
+    inspect_client.post(
+        "/api/models", json={"id": "tagged", "path": str(fp), "backends": ["vulkan"]}
+    )
+    before = inspect_client.get("/api/models/tagged").json()["backends"]
+
+    r = inspect_client.put("/api/models/tagged", json={"backends": ["comfyui"]})
+    assert r.status_code == 200, r.text
+
+    after = inspect_client.get("/api/models/tagged").json()["backends"]
+    assert after == before  # tag writes are dead
+
+
+def test_list_models_self_heals_provider_for_mistagged_comfyui_row(
+    inspect_client: TestClient,
+) -> None:
+    """The ComfyUI path-derived repair heuristic (models_service.list_all)
+    self-heals ``backends`` for a row an older pull mis-tagged — Task 3 also
+    stamps ``provider`` alongside that self-heal, not just the tag."""
+    inspect_client.post(
+        "/api/models",
+        json={
+            "id": "old-sdxl",
+            "path": "/var/lib/hal0/comfyui/models/checkpoints/sdxl.safetensors",
+            "capabilities": ["chat"],
+            "backends": [],
+        },
+    )
+    rows = {m["id"]: m for m in inspect_client.get("/api/models").json()["models"]}
+    row = rows["old-sdxl"]
+    assert row["owned_by"] == "comfyui"
+    assert "comfyui" in row["backends"]
+    assert row["provider"] == "comfyui"
+
+
 # ── O10 guard: screen_extra_args_json (pure) ──────────────────────────────────
 
 

--- a/tests/api/test_models_scan.py
+++ b/tests/api/test_models_scan.py
@@ -72,3 +72,24 @@ def test_scan_idempotent(
     assert "qwen3-4b" in first["added"]
     second = client.post("/api/models/scan").json()
     assert second["added"] == []
+
+
+def test_commit_rows_stamps_provider_alongside_backends(tmp_hal0_home: str) -> None:
+    """Task 3: committing a preview row (POST /api/models/scan {"rows": [...]})
+    stamps ``provider`` on the new registry row alongside the operator-edited
+    (or detection-derived) ``backends`` tag — not left ``None``."""
+    fp = Path(tmp_hal0_home) / "kokoro-voice.gguf"
+    fp.write_bytes(b"\x00" * 8)
+
+    app: FastAPI = create_app()
+    with TestClient(app) as client:
+        r = client.post(
+            "/api/models/scan",
+            json={"rows": [{"path": str(fp), "id": "kokoro-voice", "backends": ["kokoro"]}]},
+        )
+        assert r.status_code == 200, r.text
+        assert "kokoro-voice" in r.json()["added"]
+
+        row = client.get("/api/models/kokoro-voice").json()
+        assert row["provider"] == "kokoro"
+        assert row["backends"] == ["kokoro"]

--- a/tests/api/test_models_scan.py
+++ b/tests/api/test_models_scan.py
@@ -93,3 +93,52 @@ def test_commit_rows_stamps_provider_alongside_backends(tmp_hal0_home: str) -> N
         row = client.get("/api/models/kokoro-voice").json()
         assert row["provider"] == "kokoro"
         assert row["backends"] == ["kokoro"]
+
+
+def test_scan_commit_rejects_out_of_vocab_provider(tmp_hal0_home: str) -> None:
+    """An operator-supplied ``provider`` on a scan-commit row must be screened
+    against RUNTIME_FAMILIES same as the POST /api/models create path — an
+    out-of-vocab token like "whispercpp" (a curated-only tag, never valid on
+    a registry row) must be skipped, not persisted unscreened."""
+    fp = Path(tmp_hal0_home) / "mystery-voice.gguf"
+    fp.write_bytes(b"\x00" * 8)
+
+    app: FastAPI = create_app()
+    with TestClient(app) as client:
+        r = client.post(
+            "/api/models/scan",
+            json={
+                "rows": [
+                    {"path": str(fp), "id": "mystery-voice", "provider": "whispercpp"},
+                ]
+            },
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "mystery-voice" not in body["added"]
+        assert any(s.get("path") == str(fp) for s in body["skipped"]), body["skipped"]
+
+        listing = client.get("/api/models").json()
+        ids = {m["id"] for m in listing.get("models", [])}
+        assert "mystery-voice" not in ids
+
+
+def test_scan_commit_persists_valid_explicit_provider(tmp_hal0_home: str) -> None:
+    fp = Path(tmp_hal0_home) / "explicit-qwen.gguf"
+    fp.write_bytes(b"\x00" * 8)
+
+    app: FastAPI = create_app()
+    with TestClient(app) as client:
+        r = client.post(
+            "/api/models/scan",
+            json={
+                "rows": [
+                    {"path": str(fp), "id": "explicit-qwen", "provider": "qwen3tts"},
+                ]
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert "explicit-qwen" in r.json()["added"]
+
+        row = client.get("/api/models/explicit-qwen").json()
+        assert row["provider"] == "qwen3tts"

--- a/tests/capabilities/test_provider_field.py
+++ b/tests/capabilities/test_provider_field.py
@@ -24,9 +24,14 @@ from typing import Any
 import pytest
 
 from hal0.capabilities import catalog
-from hal0.model_meta import derive_model_provider
+from hal0.model_meta import RUNTIME_FAMILIES, derive_model_provider
 from hal0.registry.model import Model
 from hal0.registry.store import ModelRegistry
+
+
+def _hosts(*ids: str) -> list[dict[str, Any]]:
+    """A minimal ``available_backends()``-shaped stand-in, host ids only."""
+    return [{"id": i} for i in ids]
 
 
 class _Entry:
@@ -48,13 +53,39 @@ def test_provider_for_backend_legacy_paths_unchanged() -> None:
     assert catalog._provider_for_backend("", "npu", entry=_Entry()) == "flm"
 
 
-def test_backend_variants_provider_specialty() -> None:
-    # Provider set → lanes come from the runtime map, tags ignored. No host
-    # facts are consulted for this branch (no monkeypatching needed here) —
-    # if this hangs or errors reaching for host facts, the specialty branch
-    # isn't returning early.
+def test_backend_variants_provider_specialty(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Provider set → lanes come from the runtime map, tags ignored.
+    monkeypatch.setattr(catalog, "available_backends", lambda: _hosts("cpu"))
     e = _Entry(provider="moonshine", backends=["vulkan", "rocm"])
     assert catalog._backend_variants(e) == ["cpu"]
+
+
+def test_backend_variants_provider_specialty_filters_by_host_presence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An explicit provider's lanes are still intersected with what the host
+    # actually advertises — same rule the legacy ``_RUNTIME_TO_HOST_BACKENDS``
+    # tag branch applies (moonshine's CPU-only wheel, ComfyUI's Vulkan-only
+    # image, …). Kokoro's runtime map offers ("gpu-vulkan", "cpu").
+    e = _Entry(provider="kokoro", backends=["vulkan"])
+
+    monkeypatch.setattr(catalog, "available_backends", lambda: _hosts("cpu"))
+    assert catalog._backend_variants(e) == ["cpu"], "gpu-vulkan absent from host, must be dropped"
+
+    monkeypatch.setattr(catalog, "available_backends", lambda: _hosts("gpu-vulkan", "cpu"))
+    assert catalog._backend_variants(e) == ["gpu-vulkan", "cpu"]
+
+
+def test_backend_variants_provider_specialty_npu_unfiltered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Mirrors the untouched legacy ``{"flm", "npu"}`` tag branch: NPU is
+    # offered unconditionally, with no ``available_backends()`` intersection.
+    # A host with NO backends at all (not even the NPU) still gets the lane —
+    # if this ever regresses to consulting host facts, this test must fail.
+    monkeypatch.setattr(catalog, "available_backends", lambda: _hosts())
+    e = _Entry(provider="flm")
+    assert catalog._backend_variants(e) == ["npu"]
 
 
 class _StripProvider:
@@ -85,6 +116,7 @@ def seeded_registry(tmp_path: Path) -> ModelRegistry:
         Model(id="npu-a", path=str(tmp_path / "npu-a"), backends=["flm"]),
         Model(id="stt-a", path=str(tmp_path / "stt-a"), backends=["moonshine"]),
         Model(id="tts-a", path=str(tmp_path / "tts-a"), backends=["kokoro"]),
+        Model(id="tts-b", path=str(tmp_path / "tts-b"), backends=["qwen3tts"]),
         Model(id="img-a", path=str(tmp_path / "img-a"), backends=["comfyui"]),
         Model(id="unknown-a", path=str(tmp_path / "unknown-a"), backends=[]),
     ]
@@ -94,8 +126,15 @@ def seeded_registry(tmp_path: Path) -> ModelRegistry:
 
 
 def test_provider_split_matches_legacy_resolution(seeded_registry: ModelRegistry) -> None:
+    resolved: set[str] = set()
     for model in seeded_registry.list():
         legacy = catalog._provider_for_backend(
             "", "cpu", entry=_StripProvider(model)
         )
         assert derive_model_provider(model.backends) == legacy, model.id
+        resolved.add(legacy)
+    # Total over RUNTIME_FAMILIES — no family is excluded from the parity
+    # check. If a future runtime family is added to either map without a
+    # matching seed row (or without keeping both maps in sync), this fails
+    # instead of silently passing on a narrower fixture.
+    assert resolved == set(RUNTIME_FAMILIES)

--- a/tests/capabilities/test_provider_field.py
+++ b/tests/capabilities/test_provider_field.py
@@ -138,3 +138,52 @@ def test_provider_split_matches_legacy_resolution(seeded_registry: ModelRegistry
     # matching seed row (or without keeping both maps in sync), this fails
     # instead of silently passing on a narrower fixture.
     assert resolved == set(RUNTIME_FAMILIES)
+
+
+# ── empty-``backends`` llama fall-through (final-review fix) ──────────────────
+#
+# runs_on_for_model(Model(backends=[], provider="llama-server")) used to
+# return [] — the tag fan-out in ``_backend_variants`` only ran off
+# ``entry.backend``/``entry.backends`` tags, and an explicit llama-server row
+# (or a legacy provider=None row, which derives to llama-server too) with no
+# tags supplied neither of those. Both must now fall through to the same
+# host-present AMD/CPU fan-out as a ``backends=["llama-server"]`` row.
+
+
+def test_backend_variants_llama_provider_empty_backends_falls_through(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(catalog, "available_backends", lambda: _hosts("gpu-vulkan", "cpu"))
+    m = Model(id="llama-a", path=str(tmp_path / "llama-a.gguf"), backends=[], provider="llama-server")
+    assert catalog._backend_variants(m) == ["gpu-vulkan", "cpu"]
+
+
+def test_backend_variants_legacy_none_provider_empty_backends_falls_through(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # provider=None (pre-Task-1 row) derives to llama-server; must get the
+    # same fall-through as an explicit provider="llama-server" row.
+    monkeypatch.setattr(catalog, "available_backends", lambda: _hosts("gpu-vulkan", "cpu"))
+    m = Model(id="legacy-a", path=str(tmp_path / "legacy-a.gguf"), backends=[], provider=None)
+    assert derive_model_provider(m.backends) == "llama-server"
+    assert catalog._backend_variants(m) == ["gpu-vulkan", "cpu"]
+
+
+def test_runs_on_for_model_non_empty_for_empty_backends_llama_row(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """model_to_dict(model)["runs_on"] must not be silently empty — the
+    coverage gap this branch's final review flagged."""
+    from hal0.services.models_service import model_to_dict
+
+    monkeypatch.setattr(catalog, "available_backends", lambda: _hosts("gpu-vulkan", "cpu"))
+    m = Model(id="llama-b", path=str(tmp_path / "llama-b.gguf"), backends=[], provider="llama-server")
+    assert model_to_dict(m)["runs_on"] == ["gpu-vulkan", "cpu"]
+
+
+def test_backend_variants_qwen3tts_yields_gpu_rocm(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(catalog, "available_backends", lambda: _hosts("gpu-rocm", "cpu"))
+    m = Model(id="tts-c", path=str(tmp_path / "tts-c"), backends=[], provider="qwen3tts")
+    assert catalog._backend_variants(m) == ["gpu-rocm"]

--- a/tests/capabilities/test_provider_field.py
+++ b/tests/capabilities/test_provider_field.py
@@ -1,0 +1,101 @@
+"""Provider-first resolution (Task 2 of the slot/model drawer overhaul).
+
+The explicit ``Model.provider`` field (Task 1,
+:func:`hal0.model_meta.derive_model_provider`) must now win over the legacy
+backend-tag resolution in both catalog surfaces:
+
+* :func:`hal0.capabilities.catalog._provider_for_backend` — the picker row's
+  ``provider`` column.
+* :func:`hal0.capabilities.catalog._backend_variants` — the picker row's
+  fan-out of runnable host-backend lanes.
+
+Plus the migration-safety gate: for every model already in a populated
+registry, deriving the provider from ``backends`` (Task 1's pure function)
+must agree with what the legacy tag-based catalog resolution already
+produces — the split must be a pure refactor, not a behaviour change, for
+pre-existing rows that have no explicit ``provider`` set yet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.capabilities import catalog
+from hal0.model_meta import derive_model_provider
+from hal0.registry.model import Model
+from hal0.registry.store import ModelRegistry
+
+
+class _Entry:
+    def __init__(self, provider: str | None = None, backend: str = "", backends: Any = ()):
+        self.provider = provider
+        self.backend = backend
+        self.backends = list(backends)
+
+
+def test_provider_for_backend_prefers_explicit_field() -> None:
+    e = _Entry(provider="kokoro", backends=["vulkan"])  # tags would say llama-server
+    assert catalog._provider_for_backend("", "gpu-vulkan", entry=e) == "kokoro"
+
+
+def test_provider_for_backend_legacy_paths_unchanged() -> None:
+    # No provider attr / None → exact pre-split behavior.
+    e = _Entry(provider=None, backends=["moonshine"])
+    assert catalog._provider_for_backend("", "cpu", entry=e) == "moonshine"
+    assert catalog._provider_for_backend("", "npu", entry=_Entry()) == "flm"
+
+
+def test_backend_variants_provider_specialty() -> None:
+    # Provider set → lanes come from the runtime map, tags ignored. No host
+    # facts are consulted for this branch (no monkeypatching needed here) —
+    # if this hangs or errors reaching for host facts, the specialty branch
+    # isn't returning early.
+    e = _Entry(provider="moonshine", backends=["vulkan", "rocm"])
+    assert catalog._backend_variants(e) == ["cpu"]
+
+
+class _StripProvider:
+    """Proxy that exposes everything about a Model EXCEPT ``.provider``.
+
+    Used to force ``_provider_for_backend``/``_backend_variants`` down the
+    legacy tag-resolution path even though the underlying ``Model`` may
+    carry an explicit ``provider`` value.
+    """
+
+    def __init__(self, model: Model) -> None:
+        self._model = model
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "provider":
+            raise AttributeError(name)
+        return getattr(self._model, name)
+
+
+@pytest.fixture
+def seeded_registry(tmp_path: Path) -> ModelRegistry:
+    """A populated registry spanning every legacy backend-tag family."""
+    registry = ModelRegistry(registry_dir=tmp_path / "registry")
+    seed = [
+        Model(id="chat-a", path=str(tmp_path / "chat-a.gguf"), backends=["llama-server"]),
+        Model(id="chat-b", path=str(tmp_path / "chat-b.gguf"), backends=["vulkan"]),
+        Model(id="chat-c", path=str(tmp_path / "chat-c.gguf"), backends=["rocm"]),
+        Model(id="npu-a", path=str(tmp_path / "npu-a"), backends=["flm"]),
+        Model(id="stt-a", path=str(tmp_path / "stt-a"), backends=["moonshine"]),
+        Model(id="tts-a", path=str(tmp_path / "tts-a"), backends=["kokoro"]),
+        Model(id="img-a", path=str(tmp_path / "img-a"), backends=["comfyui"]),
+        Model(id="unknown-a", path=str(tmp_path / "unknown-a"), backends=[]),
+    ]
+    for model in seed:
+        registry.add(model)
+    return registry
+
+
+def test_provider_split_matches_legacy_resolution(seeded_registry: ModelRegistry) -> None:
+    for model in seeded_registry.list():
+        legacy = catalog._provider_for_backend(
+            "", "cpu", entry=_StripProvider(model)
+        )
+        assert derive_model_provider(model.backends) == legacy, model.id

--- a/tests/capabilities/test_provider_field.py
+++ b/tests/capabilities/test_provider_field.py
@@ -128,9 +128,7 @@ def seeded_registry(tmp_path: Path) -> ModelRegistry:
 def test_provider_split_matches_legacy_resolution(seeded_registry: ModelRegistry) -> None:
     resolved: set[str] = set()
     for model in seeded_registry.list():
-        legacy = catalog._provider_for_backend(
-            "", "cpu", entry=_StripProvider(model)
-        )
+        legacy = catalog._provider_for_backend("", "cpu", entry=_StripProvider(model))
         assert derive_model_provider(model.backends) == legacy, model.id
         resolved.add(legacy)
     # Total over RUNTIME_FAMILIES — no family is excluded from the parity
@@ -154,7 +152,9 @@ def test_backend_variants_llama_provider_empty_backends_falls_through(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(catalog, "available_backends", lambda: _hosts("gpu-vulkan", "cpu"))
-    m = Model(id="llama-a", path=str(tmp_path / "llama-a.gguf"), backends=[], provider="llama-server")
+    m = Model(
+        id="llama-a", path=str(tmp_path / "llama-a.gguf"), backends=[], provider="llama-server"
+    )
     assert catalog._backend_variants(m) == ["gpu-vulkan", "cpu"]
 
 
@@ -177,7 +177,9 @@ def test_runs_on_for_model_non_empty_for_empty_backends_llama_row(
     from hal0.services.models_service import model_to_dict
 
     monkeypatch.setattr(catalog, "available_backends", lambda: _hosts("gpu-vulkan", "cpu"))
-    m = Model(id="llama-b", path=str(tmp_path / "llama-b.gguf"), backends=[], provider="llama-server")
+    m = Model(
+        id="llama-b", path=str(tmp_path / "llama-b.gguf"), backends=[], provider="llama-server"
+    )
     assert model_to_dict(m)["runs_on"] == ["gpu-vulkan", "cpu"]
 
 

--- a/tests/model_meta/test_model_meta.py
+++ b/tests/model_meta/test_model_meta.py
@@ -22,9 +22,11 @@ from typing import Any
 import pytest
 
 from hal0.model_meta import (
+    RUNTIME_FAMILIES,
     canonical_device,
     capability_from_filename,
     classify,
+    derive_model_provider,
     device_to_backend,
     is_resolvable,
     labels_of,
@@ -441,3 +443,30 @@ def test_model_is_mtp_eligible(model_info: dict[str, Any], expected: bool) -> No
     from hal0.model_meta import model_is_mtp_eligible
 
     assert model_is_mtp_eligible(model_info) is expected
+
+
+# ── derive_model_provider ────────────────────────────────────────────────────
+
+
+def test_derive_model_provider_specialty_tags() -> None:
+    assert derive_model_provider(["moonshine"]) == "moonshine"
+    assert derive_model_provider(["kokoro"]) == "kokoro"
+    assert derive_model_provider(["comfyui"]) == "comfyui"
+    assert derive_model_provider(["qwen3tts"]) == "qwen3tts"
+    assert derive_model_provider(["npu"]) == "flm"
+    assert derive_model_provider(["flm"]) == "flm"
+
+
+def test_derive_model_provider_llama_lanes_and_defaults() -> None:
+    # GPU lane tags are lanes, not engines — they derive llama-server.
+    assert derive_model_provider(["rocm", "vulkan"]) == "llama-server"
+    assert derive_model_provider(["cpu"]) == "llama-server"
+    assert derive_model_provider([]) == "llama-server"
+    assert derive_model_provider(None) == "llama-server"
+    # First specialty tag wins even mixed with lanes.
+    assert derive_model_provider(["vulkan", "moonshine"]) == "moonshine"
+
+
+def test_derive_model_provider_total_over_families() -> None:
+    for fam in RUNTIME_FAMILIES:
+        assert derive_model_provider([fam]) in RUNTIME_FAMILIES

--- a/tests/registry/test_discover.py
+++ b/tests/registry/test_discover.py
@@ -199,6 +199,10 @@ def test_register_candidate_curated_uses_curated_id(
     assert model.id == "qwen3-4b"
     assert "Qwen3" in model.name
     assert model.hf_repo  # populated from the curated entry
+    # Task 3: a NEW row's provider is stamped alongside backends — a
+    # non-comfyui curated match carries no backend tags, so this derives to
+    # the llama-server default rather than being left None.
+    assert model.provider == "llama-server"
 
 
 def test_register_candidate_non_curated_uses_suggested_id(
@@ -213,6 +217,7 @@ def test_register_candidate_non_curated_uses_suggested_id(
     model = register_candidate(registry, embed)
     assert model.id == "nomic-embed-text-v1"
     assert "embed" in model.capabilities
+    assert model.provider == "llama-server"
 
 
 def test_register_candidate_comfyui_checkpoint_tagged_image(
@@ -229,6 +234,8 @@ def test_register_candidate_comfyui_checkpoint_tagged_image(
     model = register_candidate(registry, cand)
     assert model.capabilities == ["image"]
     assert model.backends == ["comfyui"]
+    # Task 3: provider stamped alongside the comfyui backend tag.
+    assert model.provider == "comfyui"
 
 
 def test_scan_and_register_idempotent(model_root: Path, registry: ModelRegistry) -> None:

--- a/tests/registry/test_import_toml_provider.py
+++ b/tests/registry/test_import_toml_provider.py
@@ -1,0 +1,74 @@
+"""Task 3: the TOML→SQLite import shim derives ``provider`` for legacy
+entries that only ever carried ``backends`` tags.
+
+Mirrors the fixture idiom from ``tests/registry/test_import_export_roundtrip.py``
+(``_write_registry_toml`` + ``import_toml_to_sqlite`` + ``SqliteModelRegistry``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomli_w
+
+from hal0.registry.import_toml import import_toml_to_sqlite
+from hal0.registry.sqlite_store import SqliteModelRegistry
+
+
+def _write_registry_toml(path: Path, models: dict[str, dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        tomli_w.dump({"models": models}, f)
+
+
+def test_import_toml_derives_provider_from_tags(tmp_path: Path) -> None:
+    """A legacy entry with ``backends=["kokoro"]`` and no ``provider`` key
+    imports with ``provider`` derived from the tag, not left ``None``."""
+    registry_dir = tmp_path / "registry"
+    rfile = registry_dir / "registry.toml"
+    _write_registry_toml(
+        rfile,
+        {
+            "kokoro-tts": {
+                "name": "Kokoro TTS",
+                "path": "/models/kokoro.onnx",
+                "size_bytes": 100,
+                "backends": ["kokoro"],
+            }
+        },
+    )
+
+    report = import_toml_to_sqlite(registry_file=rfile, db_path=tmp_path / "hal0.db")
+    assert report.imported == 1
+
+    registry = SqliteModelRegistry(db_path=tmp_path / "hal0.db")
+    model = registry.get("kokoro-tts")
+    assert model.provider == "kokoro"
+    # Tags themselves are still stored (vestigial lane hints — intentional).
+    assert model.backends == ["kokoro"]
+
+
+def test_import_toml_respects_explicit_provider(tmp_path: Path) -> None:
+    """An entry that already carries an explicit ``provider`` is never
+    overridden by the tag-derived guess."""
+    registry_dir = tmp_path / "registry"
+    rfile = registry_dir / "registry.toml"
+    _write_registry_toml(
+        rfile,
+        {
+            "explicit-model": {
+                "name": "Explicit",
+                "path": "/models/explicit.gguf",
+                "size_bytes": 100,
+                "backends": ["kokoro"],
+                "provider": "llama-server",
+            }
+        },
+    )
+
+    report = import_toml_to_sqlite(registry_file=rfile, db_path=tmp_path / "hal0.db")
+    assert report.imported == 1
+
+    registry = SqliteModelRegistry(db_path=tmp_path / "hal0.db")
+    model = registry.get("explicit-model")
+    assert model.provider == "llama-server"

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -1854,3 +1854,77 @@ def test_register_flm_pulled_re_pull_corrects_stale_capabilities(
         capabilities=["embed"],
     )
     assert registry.get("embed-gemma:300m").capabilities == ["embed"]
+
+
+# ── Task 3: provider seeded alongside backends on fresh registration ────────
+
+
+def test_register_flm_pulled_stamps_provider_on_new_row(tmp_hal0_home: str) -> None:
+    """A brand-new FLM-pulled row gets ``provider="flm"`` stamped alongside
+    the legacy ``backends=["npu"]`` tag — not left for lazy derivation."""
+    registry = ModelRegistry()
+    _register_flm_pulled(
+        registry,
+        tag="qwen3-embed:4b",
+        path="/models/qwen3-embed",
+        size_bytes=100,
+        capabilities=["embed"],
+    )
+    entry = registry.get("qwen3-embed:4b")
+    assert entry.provider == "flm"
+    assert entry.backends == ["npu"]  # tag still written — vestigial lane hint
+
+
+@pytest.mark.asyncio
+async def test_run_pull_stamps_llama_server_provider_on_fresh_registration(
+    tmp_hal0_home: str,
+) -> None:
+    """A plain GGUF chat pull (no comfyui/npu routing) gets the
+    ``derive_model_provider`` default, ``"llama-server"``, stamped on the
+    fresh row rather than left ``None``."""
+    body = _payload(4096)
+    job = make_job("some-plain-chat-gguf")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_ok_handler(body))
+    try:
+        await run_pull(
+            job,
+            hf_repo="org/plain-chat-GGUF",
+            hf_file="plain-chat-Q4_K_M.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    entry = registry.get("some-plain-chat-gguf")
+    assert entry.provider == "llama-server"
+
+
+@pytest.mark.asyncio
+async def test_run_pull_stamps_comfyui_provider_on_fresh_registration(
+    tmp_hal0_home: str,
+) -> None:
+    """A pull routed into the ComfyUI tree gets ``provider="comfyui"``
+    stamped alongside the ``backends=["comfyui"]`` tag on the new row."""
+    body = _payload(4096)
+    job = make_job("some-comfyui-checkpoint")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_ok_handler(body))
+    try:
+        await run_pull(
+            job,
+            hf_repo="org/comfyui-checkpoint",
+            hf_file="checkpoint.safetensors",
+            registry=registry,
+            client=client,
+            comfyui_subdir="checkpoints",
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    entry = registry.get("some-comfyui-checkpoint")
+    assert entry.provider == "comfyui"
+    assert entry.backends == ["comfyui"]

--- a/tests/stacks/test_export.py
+++ b/tests/stacks/test_export.py
@@ -116,9 +116,7 @@ class TestEmbedReferences:
                 provider="kokoro",
             )
         )
-        stack = StackConfig(
-            name="Voice", slots=[StackSlotEntry(slot="tts", model="kokoro-voice")]
-        )
+        stack = StackConfig(name="Voice", slots=[StackSlotEntry(slot="tts", model="kokoro-voice")])
         out = embed_references(stack, registry=r)
         assert out.models["kokoro-voice"].provider == "kokoro"
 

--- a/tests/stacks/test_export.py
+++ b/tests/stacks/test_export.py
@@ -94,6 +94,33 @@ class TestEmbedReferences:
         assert "custom-moe" in out.profiles
         assert out.profiles["custom-moe"].quant == "FP4"
 
+    def test_embeds_derived_provider_from_backends(
+        self, reg: ModelRegistry, tmp_hal0_home: str
+    ) -> None:
+        """Task 3: an exported model with no explicit ``provider`` carries
+        one derived from its legacy backends tag — ``rocm`` is a hardware
+        lane, not an engine, so it derives to the ``llama-server`` default."""
+        out = embed_references(_stack(), registry=reg)
+        assert out.models["ace-saber"].provider == "llama-server"
+
+    def test_embeds_respects_explicit_provider(self, tmp_path: Path) -> None:
+        """A registry row that already carries an explicit ``provider``
+        embeds that value verbatim — never re-derived from backends."""
+        r = ModelRegistry(registry_dir=tmp_path / "registry-explicit")
+        r.add(
+            Model(
+                id="kokoro-voice",
+                path="/models/kokoro.gguf",
+                backends=["kokoro"],
+                provider="kokoro",
+            )
+        )
+        stack = StackConfig(
+            name="Voice", slots=[StackSlotEntry(slot="tts", model="kokoro-voice")]
+        )
+        out = embed_references(stack, registry=r)
+        assert out.models["kokoro-voice"].provider == "kokoro"
+
     def test_stamps_hal0_version(self, reg: ModelRegistry, tmp_hal0_home: str) -> None:
         from hal0 import __version__
 

--- a/tests/stacks/test_export.py
+++ b/tests/stacks/test_export.py
@@ -12,6 +12,7 @@ import pytest
 
 from hal0.config.loader import save_profiles_config
 from hal0.config.schema import (
+    STACK_SCHEMA_VERSION_CURRENT,
     ProfileConfig,
     ProfilesConfig,
     StackCapabilityRow,
@@ -184,6 +185,18 @@ class TestExportEnvelope:
         assert env["exported_at"] == "2026-06-20T00:00:00Z"
         assert env["checksum"].startswith("sha256:")
         assert env["stack"]["models"]["ace-saber"]["hf_repo"] == "jcbtc/ace"
+
+    def test_export_stamps_current_schema_version_2(
+        self, reg: ModelRegistry, tmp_hal0_home: str
+    ) -> None:
+        """Model.provider landed on StackModelMeta this branch (extra="forbid"),
+        so a stack exported by this build must stamp schema_version 2 — a
+        pre-PR-1 importer must hit the designed envelope_too_new gate rather
+        than fail raw pydantic validation on the unknown ``provider`` field."""
+        env = export_envelope(_stack(), exported_at="2026-06-20T00:00:00Z", registry=reg)
+        assert STACK_SCHEMA_VERSION_CURRENT == 2
+        assert env["schema_version"] == 2
+        assert env["stack"]["schema_version"] == 2
 
     def test_checksum_is_deterministic_and_ignores_exported_at(
         self, reg: ModelRegistry, tmp_hal0_home: str


### PR DESCRIPTION
PR-1 of the slot+model drawer overhaul (spec: local .devdocs; operator-approved 2026-09-01).

## What

- `Model.provider` — explicit engine identity on registry models, vocabulary derived from `RUNTIME_FAMILIES` (six tokens incl. qwen3tts; never hand-listed). Persists via the `extra` JSON fold — no schema migration.
- Capabilities catalog resolves provider-first (`_provider_for_backend` step 0); explicit-provider specialty lanes host-filtered exactly like the tag path; `_BACKEND_TO_PROVIDER` gained `qwen3tts`; `_RUNTIME_TO_HOST_BACKENDS` gained `qwen3tts: (gpu-rocm,)`.
- `runs_on` derived host-lane list on every `GET /api/models` row (llama fall-through when tags are empty).
- Backends tags retired from the write path: PUT drops the key (`model.backends_write_ignored`), POST create derives provider, every internal seed path (discover/pull/add-from-path/scan-commit/TOML import/stack export-import) stamps provider, scan-commit screens provider against the vocabulary.
- Stack envelope `schema_version` bumped to 2 (`StackModelMeta` gained an optional field under `extra="forbid"` — old importers now reject new envelopes via the designed `stacks.envelope_too_new` gate instead of a raw validation error).
- Migration-parity gate: `test_provider_split_matches_legacy_resolution` is total over `RUNTIME_FAMILIES`.

## Transition note

The shipped model drawer still sends `backends` on save — now a silent no-op (200, edit reverts). The drawer UI PR (PR-3 of this wave) closes that hole; until it lands, backends chips in the model drawer are display-only in effect.

## Tests

3709 passed post-rebase on 5b3d1362 (capabilities/api/config/registry/model_meta/stacks/profiles); 5 failures are pre-existing updater/slot-logs cases confirmed unrelated via stash re-run. TDD per task; adversarial task reviews + whole-branch final review applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hXYtiC9A1iyLeFnQxs68v