### PR TITLE
feat(ui): retire the model Capabilities editor; make mmproj pairing first-class (#2193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,13 @@ applying. Add those subsections to a version's section to surface them; see
   restoring that copy (or deleting the two keys) makes the file readable by
   1.1.0 again.
 
+### Changed
+
+- Dashboard: the model Capabilities/Labels editors are retired (#2193). Capabilities
+  display read-only in the model drawer; the Add-from-HF flow now offers a repo's
+  mmproj projector directly and derives the vision label from that choice; the
+  add-by-path flow always auto-detects labels. `/api/models` contracts are unchanged.
+
 ## [1.1.0] — 2026-08-31
 
 ### Highlights

--- a/docs/guides/choose-models.mdx
+++ b/docs/guides/choose-models.mdx
@@ -154,14 +154,18 @@ The drawer is organized top to bottom as:
   divergence" below).
 - **Typed capabilities** — Thinking, MTP, Jinja, and Vision, each an
   Auto/On/Off toggle, plus an editable Chat template picker (saved as
-  `defaults.chat_template`) and a read-only Modality readout derived from
-  capabilities.
+  `defaults.chat_template`), a read-only Modality readout, and a
+  read-only capabilities readout — the model's registry capabilities
+  (pull metadata / auto-detect). As of #2193 capabilities have no
+  chip-editing UI anywhere in the drawer; see "Vision and MTP" below for
+  how a pulled model picks up `vision` in the first place.
 - **Context size** — tokens; empty means the launcher default. Must be a
   whole number ≥ 128 if set; the server enforces the same floor
   (`400 model.context_size_out_of_range`).
-- **Routing** — the Capabilities and Backends chip sets (dispatch/omni
-  eligibility and slot-compat filtering).
-- **Source · re-pull coords** — MMProj sidecar path, HF repo, HF filename.
+- **Runner compatibility** — the Backends chip set (slot-compat
+  filtering); still editable here.
+- **Source · re-pull coords** — MMProj sidecar path (editable; gated by
+  the vision↔mmproj invariant below), HF repo, HF filename.
 
 Saving writes only the fields that changed, plus the full `defaults` block
 (model defaults merge one level deep server-side, so every typed-capability
@@ -192,8 +196,16 @@ current text over your edits.
 Vision is Auto/On/Off, same as the other typed caps: Auto loads the
 `mmproj` sidecar whenever the model carries one; Off force-suppresses it
 even on a vision-capable model (frees roughly 0.9 GB of resident VRAM).
-Setting `capabilities` to include `vision` with no `mmproj` path blocks
-save with an inline error.
+Capabilities — including `vision` — are read-only in this drawer; they
+come from the registry row, not from anything hand-ticked here. A model
+whose capabilities already include `vision` still needs a non-empty
+`mmproj` path to save — clearing the path blocks save with an inline
+error. What changed under #2193 is how a pulled model picks up `vision`
+in the first place: the Add-from-HF modal's projector picker offers any
+mmproj sidecar the repo ships (auto-preselected, with a "None — text
+only" option), and the `vision` label is derived automatically from that
+choice — there's no separate hand-ticked vision toggle in that flow
+anymore.
 
 MTP eligibility is a tri-state on `defaults.mtp`: an explicit `true` or
 `false` wins in either direction over the registry's legacy `mtp` tag;

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -45,6 +45,10 @@ export default defineConfig({
   // abort collection for the ENTIRE suite on its `vitest` import. Every e2e
   // file here is a `.spec.ts`, so pin that explicitly (#1399).
   testMatch: '**/*.spec.ts',
+  // macOS AppleDouble sidecars (`._foo.spec.ts`) appear on NFS/SMB checkouts
+  // and match the glob above; Playwright then aborts collection trying to
+  // parse the resource-fork bytes as TypeScript. Ignore them explicitly.
+  testIgnore: '**/._*',
   timeout: LIVE ? 180_000 : 30_000,
   // 12 minutes was set when the suite was ~8 min and 400-odd specs. At 686 specs
   // it runs 8-12 min on the CI runners, i.e. up to 100% of its own budget, and a

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -336,9 +336,10 @@ const HAL0_DATA = {
 
   // ── v0.4 #544: omnirouter routing table mock removed. The settings
   // rail no longer renders an OmniRouter section — that surface lives
-  // on the MCP view (hal0-mcp#routing) and the live agent view. The
-  // live `/api/omni/route` snapshot drives the MCP view's per-tool
-  // target list when the backend is available.
+  // on the MCP view (hal0-mcp#routing) and the live agent view. There
+  // is no live omni introspection endpoint on the server (no
+  // `/api/omni/route`-shaped route exists under src/hal0/api/routes/);
+  // the routing side of this is tracked by #2192/#2193.
 
   // v0.3 PR-8: HAL0_DATA.approvals removed. The dashboard reads
   // approvals from the live /api/agent/approvals queue (via

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -63,7 +63,8 @@ function sameSet(a, b) {
 // Runner section) were removed; device lives on the slot's HW grid now.
 
 // Modality read-out derived from the model's capabilities/type (typed field —
-// shown read-only in the drawer; the capability toggles below are the control).
+// capabilities themselves are read-only in the drawer since #2193; they come
+// from the registry row, not from a control here).
 function modalityLabel(caps, type) {
 	const c = new Set((caps || []).map((x) => String(x).toLowerCase()));
 	if (c.has("vision")) return "vision";
@@ -395,7 +396,6 @@ function deriveModelChanges(baseline, form) {
 		// name could never be cleared.
 		name: trimmedName !== baseline.name,
 		trimmedName,
-		caps: !sameSet(form.caps, baseline.caps),
 		backends: !sameSet(form.backends, baseline.backends),
 		mmproj: form.mmproj.trim() !== baseline.mmproj,
 		trimmedMmproj: form.mmproj.trim(),
@@ -414,7 +414,6 @@ function deriveModelChanges(baseline, form) {
 	};
 	c.any =
 		c.name ||
-		c.caps ||
 		c.backends ||
 		c.mmproj ||
 		c.hfRepo ||
@@ -440,7 +439,6 @@ function ModelDrawer({ open, onClose, model }) {
 
 	// Identity + typed fields (preserve the full RecipeEditor save surface).
 	const [name, setName] = useStateMD("");
-	const [caps, setCaps] = useStateMD([]);
 	const [backends, setBackends] = useStateMD([]);
 	const [mmproj, setMmproj] = useStateMD("");
 	const [hfRepo, setHfRepo] = useStateMD("");
@@ -487,7 +485,6 @@ function ModelDrawer({ open, onClose, model }) {
 		const b = modelBaseline(model, enums);
 		setBaseline(b);
 		setName(b.name);
-		setCaps(b.caps);
 		setBackends(b.backends);
 		setMmproj(b.mmproj);
 		setHfRepo(b.hfRepo);
@@ -504,8 +501,6 @@ function ModelDrawer({ open, onClose, model }) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [open, model?.id]);
 
-	const toggleCap = (c) =>
-		setCaps((p) => (p.includes(c) ? p.filter((x) => x !== c) : [...p, c]));
 	const toggleBackend = (b) =>
 		setBackends((p) => (p.includes(b) ? p.filter((x) => x !== b) : [...p, b]));
 
@@ -569,10 +564,14 @@ function ModelDrawer({ open, onClose, model }) {
 	// The vision↔mmproj invariant (#1380). A row advertising `vision` with no
 	// projector leaves the launch path no `--mmproj` to load. This used to be a
 	// decorative red div the save ignored, so it now joins flagsError in the one
-	// gate both `onSave` and the Save button consult.
+	// gate both `onSave` and the Save button consult. Capabilities are no longer
+	// editable here (#2193): `vision` comes from the registry row, so the only
+	// way an operator can violate the invariant in this drawer is clearing the
+	// projector path on a model that advertises vision.
+	const visionModel = (baseline?.caps || []).includes("vision");
 	const mmprojError =
-		caps.includes("vision") && !mmproj.trim()
-			? "vision capability requires an mmproj sidecar path"
+		visionModel && !mmproj.trim()
+			? "this model advertises vision — an mmproj sidecar path is required"
 			: null;
 
 	// Context size validation (#1378). A lenient parseInt destroyed data twice
@@ -683,7 +682,6 @@ function ModelDrawer({ open, onClose, model }) {
 	// predicate and nothing touches the live `model` prop.
 	const changes = deriveModelChanges(baseline, {
 		name,
-		caps,
 		backends,
 		mmproj,
 		hfRepo,
@@ -737,7 +735,6 @@ function ModelDrawer({ open, onClose, model }) {
 		// the one derived comparison above (`changes`) — the same values the
 		// dirty aggregate and the Save gate read.
 		if (changes.name) body.name = changes.trimmedName;
-		if (changes.caps) body.capabilities = caps;
 		if (changes.backends) body.backends = backends;
 		if (changes.mmproj) body.mmproj = changes.trimmedMmproj || null;
 		if (changes.hfRepo) body.hf_repo = changes.trimmedRepo;
@@ -754,7 +751,7 @@ function ModelDrawer({ open, onClose, model }) {
 		}
 	};
 
-	const modality = modalityLabel(caps, model.type);
+	const modality = modalityLabel(baseline?.caps || [], model.type);
 
 	return (
 		<>
@@ -1130,9 +1127,12 @@ function ModelDrawer({ open, onClose, model }) {
 				<div className="form-row">
 					<div className="form-lbl">
 						<span>Modality</span>
-						<FieldInfoIcon description="derived from capabilities" />
+						<FieldInfoIcon description="capabilities come from the registry row (pull metadata / auto-detect) — read-only here" />
 					</div>
-					<div className="form-ctl">
+					<div
+						className="form-ctl"
+						style={{ display: "flex", gap: 6, flexWrap: "wrap" }}
+					>
 						<span
 							className="tag"
 							data-testid="model-modality"
@@ -1147,6 +1147,20 @@ function ModelDrawer({ open, onClose, model }) {
 							}}
 						>
 							{modality}
+						</span>
+						<span
+							data-testid="model-caps-readout"
+							style={{ display: "inline-flex", gap: 6, flexWrap: "wrap" }}
+						>
+							{(baseline?.caps || []).map((cap) => (
+								<span
+									key={cap}
+									className="mdl-chip"
+									style={{ pointerEvents: "none", opacity: 0.7 }}
+								>
+									{cap}
+								</span>
+							))}
 						</span>
 					</div>
 				</div>
@@ -1181,36 +1195,9 @@ function ModelDrawer({ open, onClose, model }) {
             slot-owned hardware now (the slot's HW grid), not a model default.
             The one-shot migration folds model.defaults.n_gpu_layers → slot NGL. */}
 
-				{/* ── Routing (capabilities + backends) ── */}
+				{/* ── Runner compatibility (backends) ── */}
 				<div className="form-section" style={{ marginTop: 16 }}>
-					Routing
-				</div>
-				<div className="form-row">
-					<div className="form-lbl">
-						<span>Capabilities</span>
-						<FieldInfoIcon description="dispatch / omni eligibility · canonical vocab" />
-					</div>
-					<div
-						className="form-ctl"
-						style={{ display: "flex", flexWrap: "wrap", gap: 6 }}
-					>
-						{enums.model_capabilities.map((cap) => {
-							const on = caps.includes(cap);
-							return (
-								<button
-									key={cap}
-									type="button"
-									role="switch"
-									aria-checked={on}
-									data-testid={`cap-toggle-${cap}`}
-									className={"mdl-chip" + (on ? " on" : "")}
-									onClick={() => toggleCap(cap)}
-								>
-									{cap}
-								</button>
-							);
-						})}
-					</div>
+					Runner compatibility
 				</div>
 				<div className="form-row">
 					<div className="form-lbl">

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -31,7 +31,9 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
   const [repo, setRepo] = useStateMM("");
   const [variant, setVariant] = useStateMM(null);
   const [name, setName] = useStateMM("");
-  const [labels, setLabels] = useStateMM({ chat: true });
+  // No user-editable capability vocabulary on this modal any more (#2193) —
+  // the pull's `labels` are derived from this one choice: a projector
+  // selected here means `["chat","vision"]`, otherwise `["chat"]`.
   const [mmproj, setMmproj] = useStateMM("");
   // Optional chat-template pin, applied at pull time (WS-6). "auto" = use the
   // GGUF-embedded template — the common case, so it's the default.
@@ -42,17 +44,12 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
   // Chat-template catalogue — gated on `open` like the Recipe editor so the
   // request only fires while the modal is visible.
   const templates = useChatTemplates(open);
-  // One canonical capability vocabulary for every add/edit surface —
-  // meta.model_capabilities (this modal used to carry its own ad-hoc list
-  // with legacy spellings: embeddings/reranking/transcription).
-  const enums = useMetaEnums();
 
   useEffectMM(() => {
     if (open) {
       setRepo(initialRepo || "");
       setVariant(null);
       setName("");
-      setLabels({ chat: true });
       setMmproj("");
       setChatTemplate("auto");
       inspect.reset();
@@ -69,6 +66,14 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
     () => variants.filter(v => /mmproj/i.test(v.id)).map(v => v.id),
     [variants],
   );
+
+  // mmproj-first pairing (#2193): when the repo ships projector files, offer
+  // them immediately and pre-select the first — vision is derived from this
+  // choice, not hand-ticked. One projector per repo is the overwhelming case.
+  useEffectMM(() => {
+    if (inspect.isSuccess) setMmproj(mmprojChoices[0] || "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inspect.isSuccess]);
 
   const onInspect = async () => {
     if (!repo) return;
@@ -90,21 +95,7 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
 
   const inspected = inspect.isSuccess && !!inspect.data;
   const sel = variants.find(v => v.id === variant);
-  // The vision↔mmproj invariant on the CREATE path (#1394) — the exact twin of
-  // the edit drawer's #1380 gate. The message used to render as decoration next
-  // to a live Pull button; it is now folded into the single `canPull` gate so
-  // the modal can't seed a projector-less vision row. Escape hatch: a repo that
-  // ships no mmproj at all can't satisfy "pick one below", so the wording points
-  // at the label instead — the pull itself is fine, only the label is
-  // unsupportable. (The server refuses this shape too, via
-  // `model.vision_requires_mmproj` on POST /pull, so a stale client can't
-  // route around the gate.)
-  const mmprojError = !(labels.vision && !mmproj)
-    ? null
-    : inspected && mmprojChoices.length === 0
-      ? "vision label requires an mmproj file — this repo ships none, so untick vision to pull"
-      : "vision label requires an mmproj file — pick one below";
-  const canPull = inspected && variant && name && !pullJob.inFlight && !mmprojError;
+  const canPull = inspected && variant && name && !pullJob.inFlight;
 
   const onPull = async () => {
     if (!canPull) return;
@@ -115,7 +106,9 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
       // pull job body — the backend resolves them against the registry
       // entry's hf_repo/hf_filename it writes during the curated
       // ``pick-default`` flow.
-      const labelList = Object.entries(labels).filter(([, v]) => v).map(([k]) => k);
+      // vision is derived from the projector choice (#2193) — the registry row's
+      // dispatch classification still keys off these labels server-side.
+      const labelList = mmproj ? ["chat", "vision"] : ["chat"];
       await pullJob.start(name, {
         hf_repo: inspect.data?.repo ?? repo,
         hf_filename: variant,
@@ -222,39 +215,11 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
             </div>
           </div>
 
-          <div className="form-row">
-            <div className="form-lbl">
-              <span>Labels</span>
-              <span className="sub">drives OmniRouter eligibility</span>
-            </div>
-            <div className="form-ctl" style={{display: "flex", flexWrap: "wrap", gap: 8}}>
-              {enums.model_capabilities.map(l => (
-                <label key={l} className="checkbox-row">
-                  <input
-                    type="checkbox"
-                    checked={!!labels[l]}
-                    onChange={e => setLabels({ ...labels, [l]: e.target.checked })}
-                  />
-                  <span className="mono">{l}</span>
-                </label>
-              ))}
-              {mmprojError && (
-                <div
-                  className="err"
-                  data-testid="hf-add-mmproj-error"
-                  style={{flexBasis: "100%"}}
-                >
-                  {mmprojError}
-                </div>
-              )}
-            </div>
-          </div>
-
-          {labels.vision && (
+          {mmprojChoices.length > 0 && (
             <div className="form-row">
               <div className="form-lbl">
-                <span>mmproj file</span>
-                <span className="warn">required for vision-labeled models</span>
+                <span>Vision projector</span>
+                <span className="sub">mmproj sidecar found in this repo — pulled alongside the model and paired automatically</span>
               </div>
               <div className="form-ctl">
                 <select
@@ -263,11 +228,7 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
                   value={mmproj}
                   onChange={e => setMmproj(e.target.value)}
                 >
-                  <option value="">
-                    {mmprojChoices.length === 0
-                      ? "— no mmproj files in repo —"
-                      : "— pick from repo files… —"}
-                  </option>
+                  <option value="">None — text only</option>
                   {mmprojChoices.map(id => <option key={id} value={id}>{id}</option>)}
                 </select>
               </div>

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -18,7 +18,6 @@ import { useModels, useModelInspect, useModelDelete, usePullJob, useScanPreview,
 import { useSlots } from '@/api/hooks/useSlots'
 import { useSettings } from '@/api/hooks/useSettings'
 import { useChatTemplates } from '@/api/hooks/useChatTemplates'
-import { useMetaEnums } from '@/api/hooks/useMeta'
 
 const { useState: useStateMM, useEffect: useEffectMM, useMemo: useMemoMM } = React;
 
@@ -495,33 +494,26 @@ function DownloadRow({ modelId, onRemove }) {
 // PR feat/models-scan-and-add-by-path: minimal modal around
 // /api/models/add-from-path. The operator types (or pastes) an
 // absolute file path; we POST and let the backend's detect() pass
-// derive capabilities/backends/size. The id + name + labels overrides
-// are surfaced for the cases where the auto-derived ones aren't what
-// the operator wants.
+// derive capabilities/backends/size. The id + name overrides are
+// surfaced; labels are always auto-detected from header/filename.
 function AddByPathModal({ open, onClose }) {
   const [path, setPath] = useStateMM("");
   const [id, setId] = useStateMM("");
   const [name, setName] = useStateMM("");
-  const [labelSel, setLabelSel] = useStateMM({ chat: true });
   const add = useAddModelFromPath();
   const settings = useSettings();
-  // Canonical capability vocabulary — same meta-driven list as the HF modal
-  // and the recipe editor (this surface used to hand-roll a third variant).
-  const enums = useMetaEnums();
 
   useEffectMM(() => {
     if (open) {
       setPath("");
       setId("");
       setName("");
-      setLabelSel({ chat: true });
       add.reset();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const scanRoot = settings.data?.models?.roots?.[0] || "";
-  const labels = Object.entries(labelSel).filter(([, v]) => v).map(([k]) => k);
 
   const onSubmit = async () => {
     if (!path.trim()) return;
@@ -529,7 +521,6 @@ function AddByPathModal({ open, onClose }) {
       const body = { path: path.trim() };
       if (id.trim()) body.id = id.trim();
       if (name.trim()) body.name = name.trim();
-      if (labels.length) body.labels = labels;
       const res = await add.mutateAsync(body);
       window.__hal0Toast && window.__hal0Toast(
         `Registered ${res?.name || res?.id || "model"}`, "ok",
@@ -598,25 +589,6 @@ function AddByPathModal({ open, onClose }) {
         </div>
         <div className="form-ctl">
           <input className="input mono" value={name} onChange={e => setName(e.target.value)} />
-        </div>
-      </div>
-
-      <div className="form-row">
-        <div className="form-lbl">
-          <span>Labels</span>
-          <span className="sub">empty → auto-detect from header / filename</span>
-        </div>
-        <div className="form-ctl" style={{display: "flex", flexWrap: "wrap", gap: 8}}>
-          {enums.model_capabilities.map(l => (
-            <label key={l} className="checkbox-row">
-              <input
-                type="checkbox"
-                checked={!!labelSel[l]}
-                onChange={e => setLabelSel({ ...labelSel, [l]: e.target.checked })}
-              />
-              <span className="mono">{l}</span>
-            </label>
-          ))}
         </div>
       </div>
 

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -272,10 +272,13 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
   );
 }
 
-// Model capability + backend vocabularies now come from GET /api/meta/enums
-// (useMetaEnums → meta.model_capabilities / meta.model_backends, with the
-// typed static fallback) — the hardcoded MODEL_CAPABILITIES / MODEL_BACKENDS
-// constants that used to live here are gone.
+// The hardcoded MODEL_CAPABILITIES / MODEL_BACKENDS constants that used to
+// live here are gone, and so is this file's capability/label editing UI
+// (the Capabilities/Labels editors were retired — #2193). GET
+// /api/meta/enums (via useMetaEnums → meta.model_capabilities /
+// meta.model_backends) still backs that vocabulary where it's actually
+// consumed — model-drawer.jsx, models.jsx, stacks.jsx, profiles.jsx,
+// HardwareRuntimesPage.jsx, ModelDefaultsPage.jsx — not in this file.
 
 // ─── Delete model confirm ───────────────────────────────────────
 function DeleteModelDialog({ open, onClose, model }) {

--- a/ui/tests/e2e/specs/hf-add-mmproj-gate.spec.ts
+++ b/ui/tests/e2e/specs/hf-add-mmproj-gate.spec.ts
@@ -1,16 +1,14 @@
 /**
- * hf-add-mmproj-gate — the Add-model-from-HF modal's vision/mmproj error must
- * gate Pull, not decorate it (#1394).
+ * hf-add-mmproj-gate — the Add-model-from-HF modal treats the mmproj
+ * projector as first-class (#2193).
  *
- * Structural twin of #1380 (drawer, PR #1392): the modal rendered
- * "vision label requires an mmproj file" while `canPull` ignored it entirely,
- * so ticking `vision` with no projector selected pulled anyway and
- * `seed_registry_from_body` landed a registry row labelled `vision` with no
- * mmproj — the same broken state, created rather than edited.
- *
- * The no-projector-in-repo case gets its own assertion: "pick one below" is
- * unactionable when the repo ships no mmproj, so the gate points at the label
- * instead (the pull itself is fine — only the label is unsupportable).
+ * Labels checkboxes are gone from this modal entirely — there is no
+ * user-editable capability vocabulary here any more. Instead, when a repo
+ * ships a projector file the modal auto-offers it (pre-selected, since one
+ * projector per repo is the overwhelming case) and the `vision` pull label
+ * is *derived* from that choice rather than hand-ticked. A repo with no
+ * mmproj files renders no projector row at all, and Pull is never gated on
+ * anything projector-related.
  */
 import { test, expect } from '../fixtures/apiMock'
 
@@ -60,65 +58,56 @@ async function openAndInspect(page: import('@playwright/test').Page, repo: strin
 const pullButton = (page: import('@playwright/test').Page) =>
   page.locator('button:has-text("Pull")')
 
-test.describe('Add-by-HF modal — the vision/mmproj error gates Pull (#1394)', () => {
-  test('ticking vision with no mmproj selected disables Pull until one is picked', async ({ page }) => {
+test.describe('Add-by-HF modal — mmproj pairing is first-class (#2193)', () => {
+  test('a repo shipping an mmproj auto-offers it and derives the vision label', async ({ page }) => {
     const pulls = await mockInspectAndPulls(page)
     await openAndInspect(page, VISION_REPO)
 
-    // Pick the main quant — every other gate term (inspected/variant/name) is
-    // satisfied, so Pull is live and only the mmproj term is under test.
+    // No Labels checkboxes anywhere:
+    await expect(page.locator('.checkbox-row')).toHaveCount(0)
+
+    // The projector row is offered without any prior toggle, pre-selected:
+    const sel = page.getByTestId('hf-add-mmproj-select')
+    await expect(sel).toBeVisible()
+    await expect(sel).toHaveValue('mmproj-F16.gguf')
+
+    // Pick the main quant — name is already auto-derived from the repo tail.
     await page.locator('.variant-row:has-text("vision-Q4_K_M.gguf")').click()
-    await expect(page.getByTestId('hf-add-mmproj-error')).toHaveCount(0)
-    await expect(pullButton(page)).toBeEnabled()
-
-    // Tick `vision` with nothing selected in the projector picker.
-    await page.locator('label.checkbox-row:has-text("vision") input').check()
-
-    const err = page.getByTestId('hf-add-mmproj-error')
-    await expect(err).toBeVisible()
-    await expect(err).toContainText('vision label requires an mmproj file')
-    await expect(err).toContainText('pick one below')
-
-    // The gate, not the decoration: the button is dead and a forced click is
-    // a no-op (onPull early-returns on !canPull).
-    await expect(pullButton(page)).toBeDisabled()
-    await pullButton(page).click({ force: true })
-    await page.waitForTimeout(300)
-    expect(pulls).toEqual([])
-
-    // Selecting the repo's projector clears the error and re-arms Pull.
-    await page.getByTestId('hf-add-mmproj-select').selectOption('mmproj-F16.gguf')
-    await expect(page.getByTestId('hf-add-mmproj-error')).toHaveCount(0)
     await expect(pullButton(page)).toBeEnabled()
 
     await pullButton(page).click()
     await expect.poll(() => pulls.length).toBe(1)
     expect(pulls[0].body.mmproj_filename).toBe('mmproj-F16.gguf')
-    expect(pulls[0].body.labels).toContain('vision')
+    expect(pulls[0].body.labels).toEqual(['chat', 'vision'])
   })
 
-  test('a repo with no mmproj files points at the label, not at an empty picker', async ({ page }) => {
+  test('choosing "None" pulls text-only with no vision label', async ({ page }) => {
     const pulls = await mockInspectAndPulls(page)
-    await openAndInspect(page, TEXT_REPO)
-    await page.locator('.variant-row:has-text("text-Q4_K_M.gguf")').click()
+    await openAndInspect(page, VISION_REPO)
 
-    await page.locator('label.checkbox-row:has-text("vision") input').check()
-
-    // "pick one below" would be a lie — the picker's only option is the
-    // "— no mmproj files in repo —" placeholder.
-    const err = page.getByTestId('hf-add-mmproj-error')
-    await expect(err).toBeVisible()
-    await expect(err).toContainText('untick vision to pull')
-    await expect(pullButton(page)).toBeDisabled()
-
-    // Unticking the label is the escape hatch: the pull itself was always fine.
-    await page.locator('label.checkbox-row:has-text("vision") input').uncheck()
-    await expect(page.getByTestId('hf-add-mmproj-error')).toHaveCount(0)
+    await page.locator('.variant-row:has-text("vision-Q4_K_M.gguf")').click()
+    await page.getByTestId('hf-add-mmproj-select').selectOption('')
     await expect(pullButton(page)).toBeEnabled()
 
     await pullButton(page).click()
     await expect.poll(() => pulls.length).toBe(1)
-    expect(pulls[0].body.labels).not.toContain('vision')
     expect(pulls[0].body.mmproj_filename).toBeUndefined()
+    expect(pulls[0].body.labels).toEqual(['chat'])
+  })
+
+  test('a repo with no mmproj files renders no projector row at all', async ({ page }) => {
+    const pulls = await mockInspectAndPulls(page)
+    await openAndInspect(page, TEXT_REPO)
+
+    await expect(page.getByTestId('hf-add-mmproj-select')).toHaveCount(0)
+
+    // Pull is not gated on anything projector-related:
+    await page.locator('.variant-row:has-text("text-Q4_K_M.gguf")').click()
+    await expect(pullButton(page)).toBeEnabled()
+
+    await pullButton(page).click()
+    await expect.poll(() => pulls.length).toBe(1)
+    expect(pulls[0].body.mmproj_filename).toBeUndefined()
+    expect(pulls[0].body.labels).toEqual(['chat'])
   })
 })

--- a/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
@@ -95,7 +95,6 @@ test.describe('Model drawer — complete save and compact field help', () => {
     await openDrawer(page)
 
     await page.getByTestId('model-name-input').fill('Saved model name')
-    await page.getByTestId('cap-toggle-vision').click()
     await page.getByTestId('backend-toggle-vulkan').click()
     await page.getByTestId('model-mmproj-input').fill('/models/mmproj-saved.gguf')
     await page.getByTestId('model-hfrepo-input').fill('org/saved-repo')
@@ -114,7 +113,7 @@ test.describe('Model drawer — complete save and compact field help', () => {
     expect(putBody.name).toBe('Saved model name')
     // Type-tag chips are retired — saves never touch tags.
     expect(putBody).not.toHaveProperty('tags')
-    expect(putBody.capabilities).toEqual(['chat', 'vision'])
+    expect(putBody.capabilities).toBeUndefined()
     expect(putBody.backends).toEqual(['rocm', 'vulkan'])
     expect(putBody.mmproj).toBe('/models/mmproj-saved.gguf')
     expect(putBody.hf_repo).toBe('org/saved-repo')
@@ -148,12 +147,14 @@ test.describe('Model drawer — complete save and compact field help', () => {
 
     const drawer = page.locator('.drawer.open')
     const labels = drawer.locator('.form-lbl')
-    // 14 rows: the Vision tri-state row (+1, spec-hw-slot-ownership §1) and
-    // the retired Types chip row (−1 — type tags are inert, typed fields own
-    // behaviour) net out against the pre-existing 14.
-    await expect(labels).toHaveCount(14)
+    // 13 rows: the pre-existing 14 (Vision tri-state row +1,
+    // spec-hw-slot-ownership §1; retired Types chip row −1 — type tags are
+    // inert, typed fields own behaviour) minus the retired editable
+    // Capabilities chip row (−1, #2193 — capabilities are read-only now, so
+    // there's no control left here to describe).
+    await expect(labels).toHaveCount(13)
     await expect(drawer.locator('.form-lbl .sub')).toHaveCount(0)
-    await expect(drawer.locator('.form-lbl .field-info-btn')).toHaveCount(14)
+    await expect(drawer.locator('.form-lbl .field-info-btn')).toHaveCount(13)
 
     const displayNameLabel = labels.filter({ hasText: 'Display name' })
     const info = displayNameLabel.getByRole('button', { name: 'Info' })

--- a/ui/tests/e2e/specs/model-drawer-validation-gates.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-validation-gates.spec.ts
@@ -2,9 +2,12 @@
  * model-drawer-validation-gates — the drawer's inline errors must actually gate
  * the PUT, and an emptied Display name must clear the stored name.
  *
- * #1380: toggling the `vision` capability with no mmproj sidecar renders a red
- *        inline error but used to let the save through, so the registry row
- *        advertised `vision` with no projector for the launch path to load.
+ * #1380: clearing the mmproj sidecar path on a model that advertises `vision`
+ *        renders a red inline error but used to let the save through, so the
+ *        registry row could advertise `vision` with no projector for the
+ *        launch path to load. Capabilities are read-only in the drawer since
+ *        #2193 — `vision` comes from the registry row, so clearing mmproj is
+ *        the only way left to violate the invariant here.
  * #1381: emptying Display name dropped the `name` key from the PUT entirely —
  *        the old name survived while the drawer closed with a success toast.
  *        `Model.name` is `str` with `default=""`, and normalizeApiModel falls
@@ -17,9 +20,9 @@ const MODEL_ID = 'qwen3.6-27b-mtp'
 const BASE_MODEL = {
   name: 'Original name',
   tags: ['curated'],
-  capabilities: ['chat'],
+  capabilities: ['chat', 'vision'],
   backends: ['rocm'],
-  mmproj: null,
+  mmproj: '/models/mmproj-Q8.gguf',
   hf_repo: 'org/original-repo',
   hf_filename: 'original.gguf',
   defaults: {},
@@ -69,18 +72,18 @@ async function openDrawer(page: import('@playwright/test').Page) {
 }
 
 test.describe('Model drawer — inline errors gate the save (#1380, #1381)', () => {
-  test('vision capability without an mmproj sidecar blocks the PUT until a path is supplied', async ({ page }) => {
+  test('clearing mmproj on a vision model blocks the PUT until a path is restored', async ({ page }) => {
     await seedModel(page)
     const puts = await capturePut(page)
     await openDrawer(page)
 
     await expect(page.getByTestId('model-mmproj-error')).toHaveCount(0)
-    await page.getByTestId('cap-toggle-vision').click()
+    await page.getByTestId('model-mmproj-input').fill('')
 
-    // The invariant is violated: vision is on, mmproj is empty.
+    // The invariant is violated: the row advertises vision, mmproj is empty.
     const err = page.getByTestId('model-mmproj-error')
     await expect(err).toBeVisible()
-    await expect(err).toContainText('vision capability requires an mmproj sidecar path')
+    await expect(err).toContainText('mmproj')
 
     // The error must gate Save the way flagsError does — not decorate it.
     const save = page.getByTestId('model-save')
@@ -90,15 +93,19 @@ test.describe('Model drawer — inline errors gate the save (#1380, #1381)', () 
     expect(puts).toEqual([])
     await expect(page.locator('.drawer.open')).toHaveCount(1)
 
-    // Supplying the projector clears the error and re-arms the save.
+    // Restoring the projector path clears the error. (It also restores the
+    // form to the baseline value, so Save stays disabled on "no changes to
+    // save" — a different gate, not this one.)
     await page.getByTestId('model-mmproj-input').fill('/models/mmproj-Q8.gguf')
     await expect(page.getByTestId('model-mmproj-error')).toHaveCount(0)
-    await expect(save).toBeEnabled()
-    await save.click()
+  })
 
-    await expect.poll(() => puts.length).toBe(1)
-    expect(puts[0].capabilities).toEqual(['chat', 'vision'])
-    expect(puts[0].mmproj).toBe('/models/mmproj-Q8.gguf')
+  test('capability chips are no longer editable in the drawer', async ({ page }) => {
+    await seedModel(page)
+    await openDrawer(page)
+
+    await expect(page.locator('[data-testid^="cap-toggle-"]')).toHaveCount(0)
+    await expect(page.getByTestId('model-caps-readout')).toBeVisible()
   })
 
   test('an emptied Display name sends name:"" so the stored name is cleared', async ({ page }) => {


### PR DESCRIPTION
## Summary

Retires every user-editable model "Capabilities"/"Labels" surface in the dashboard (closes #2193) while keeping the one piece operators actually need — pairing an mmproj vision projector — and making it more discoverable than before.

A live audit on the CT105 box (2026-09-01) confirmed the UI story these editors told was false: `Model.capabilities` is never read by omni tool eligibility (that gate is `capability_flags.tool_calling` + fact-derived modalities), no client sends `omni: true`, and the drawer tooltip claiming "dispatch / omni eligibility" was misleading. Routing-side gaps are tracked separately in #2191 and #2192.

## Changes

- **Model drawer**: the Routing → Capabilities chip row is gone. Capabilities now display as read-only tags next to the Modality readout (`model-caps-readout`); the section heading becomes "Runner compatibility" (Backends only). The MMProj path field stays, and the vision↔mmproj save gate (#1380/#1393) is re-keyed to the registry row — the PUT body never ships `capabilities`.
- **Add from Hugging Face**: the Labels checkboxes are gone. When an inspected repo ships mmproj files, a "Vision projector" picker appears immediately with the first projector pre-selected and a "None — text only" option; the `vision` label is derived from that choice (`["chat","vision"]` vs `["chat"]`). The unreachable `hf-add-mmproj-error` state is removed; the server-side `model.vision_requires_mmproj` gate remains the backstop.
- **Add by path**: the Labels row is gone; the backend `detect()` pass always classifies.
- **Stale references**: `data.jsx`'s comment about a nonexistent `/api/omni/route` endpoint corrected; other "drives OmniRouter eligibility" copy removed.
- **Infra**: Playwright now ignores macOS AppleDouble `._*` sidecar files that abort collection on NFS/SMB checkouts.
- **Docs/CHANGELOG**: `choose-models.mdx` drawer walkthrough updated to match; Unreleased entry added.

Backend contracts are untouched — `Model.capabilities` stays on the wire and continues to drive dispatch-type classification; this is a UI-surface retirement only.

## Testing

- Full UI e2e suite: 682/682 passing (includes rewritten `hf-add-mmproj-gate` and re-keyed `model-drawer-validation-gates` specs, TDD'd red→green)
- UI unit suite: 277/277 passing; lint, typecheck, and vite build clean

## Follow-ups (non-blocking, from final review)

- Scan-directory bulk register still echoes `labels: suggested_capabilities` (backend-derived, not user-edited) — could drop the echo and rely on auto-detect like the single-path modal
- eslint could get the same `._*` ignore the Playwright config now has

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bUrn3nhQKXBBygeerxsnv