### PR TITLE
feat(models): seed-profile stamp route + GTT feasibility preflight

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -620,6 +620,7 @@ async def models_feasibility(request: Request) -> dict[str, Any]:
             gpu = await asyncio.to_thread(stats.gpu_sample)
         except Exception:
             gpu = None
+            log.warning("models.feasibility_gpu_sample_failed", exc_info=True)
     free = getattr(gpu, "gtt_free_mb", None)
     total = getattr(gpu, "gtt_total_mb", None)
 
@@ -628,9 +629,27 @@ async def models_feasibility(request: Request) -> dict[str, Any]:
         if not isinstance(item, dict):
             continue
         mid = str(item.get("model_id") or "")
+        # The WHOLE per-row computation is guarded, not just the registry
+        # lookup: a malformed stored row (bad size_bytes, unparseable
+        # defaults, …) must degrade that one row to "unknown" rather than
+        # 500 the entire batch — this endpoint never blocks, not even on
+        # its own bugs.
         try:
             model = registry.get(mid)
+            model_mb = float(model.size_bytes or 0) / (1024 * 1024)
+            ctx_meta = model.model_dump(mode="json")
+            ctx = item.get("ctx")
+            if isinstance(ctx, int) and ctx > 0:
+                ctx_meta["defaults"] = {
+                    **(ctx_meta.get("defaults") or {}),
+                    "context_size": ctx,
+                }
+            needed = estimate_file_size_kv_mb(model_mb, ctx_meta)
+            verdict = gtt_feasibility_verdict(needed, gtt_free_mb=free, gtt_total_mb=total)
         except Exception:
+            log.warning(
+                "models.feasibility_row_failed model_id=%s", mid, exc_info=True
+            )
             results.append(
                 {
                     "model_id": mid,
@@ -641,13 +660,6 @@ async def models_feasibility(request: Request) -> dict[str, Any]:
                 }
             )
             continue
-        model_mb = float(model.size_bytes or 0) / (1024 * 1024)
-        ctx_meta = model.model_dump(mode="json")
-        ctx = item.get("ctx")
-        if isinstance(ctx, int) and ctx > 0:
-            ctx_meta["defaults"] = {**(ctx_meta.get("defaults") or {}), "context_size": ctx}
-        needed = estimate_file_size_kv_mb(model_mb, ctx_meta)
-        verdict = gtt_feasibility_verdict(needed, gtt_free_mb=free, gtt_total_mb=total)
         results.append({"model_id": mid, **verdict})
     return {"results": results}
 

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -16,7 +16,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Request, Response
+from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ValidationError
 
@@ -30,6 +30,7 @@ from hal0.registry.pull import PullInvalidSource
 from hal0.registry.update_check import evaluate_model_update, fetch_remote_lfs_shas
 from hal0.runners import RUNNER_IMAGES as _runner_images_registry
 from hal0.services import models_service as _svc
+from hal0.slots.capacity import estimate_file_size_kv_mb, gtt_feasibility_verdict
 
 # See slots.py for the writer-gate rationale.
 
@@ -588,6 +589,81 @@ async def update_model_from_hf(
         dest=dest,
         run_wrapper=_run_pull_with_events,
     )
+
+
+@router.post("/feasibility")
+async def models_feasibility(request: Request) -> dict[str, Any]:
+    """Advisory GTT preflight for a batch of (model, ctx) picks.
+
+    Registered ABOVE the ``/{model_id}`` catch-all below so the literal
+    ``feasibility`` path never resolves as a model id (same reason
+    ``/pulls`` and ``/updates/check`` sit above it).
+
+    Never 404s, never blocks — an unknown model id or missing host GPU
+    truth (no ``hardware_stats`` wired, or the sample failed) yields a
+    ``verdict: "unknown"`` row rather than an error. This is a batch
+    advisory endpoint for the drawer's model picker, not a gate.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest("body must be valid JSON", details={"error": str(exc)}) from exc
+    if not isinstance(body, dict):
+        raise BadRequest("body must be a JSON object")
+    items = body.get("models") or []
+
+    registry = request.app.state.model_registry
+    stats = getattr(request.app.state, "hardware_stats", None)
+    gpu = None
+    if stats is not None:
+        try:
+            gpu = await asyncio.to_thread(stats.gpu_sample)
+        except Exception:
+            gpu = None
+    free = getattr(gpu, "gtt_free_mb", None)
+    total = getattr(gpu, "gtt_total_mb", None)
+
+    results: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        mid = str(item.get("model_id") or "")
+        try:
+            model = registry.get(mid)
+        except Exception:
+            results.append(
+                {
+                    "model_id": mid,
+                    "verdict": "unknown",
+                    "needed_mb": 0.0,
+                    "gtt_free_mb": free,
+                    "gtt_total_mb": total,
+                }
+            )
+            continue
+        model_mb = float(model.size_bytes or 0) / (1024 * 1024)
+        ctx_meta = model.model_dump(mode="json")
+        ctx = item.get("ctx")
+        if isinstance(ctx, int) and ctx > 0:
+            ctx_meta["defaults"] = {**(ctx_meta.get("defaults") or {}), "context_size": ctx}
+        needed = estimate_file_size_kv_mb(model_mb, ctx_meta)
+        verdict = gtt_feasibility_verdict(needed, gtt_free_mb=free, gtt_total_mb=total)
+        results.append({"model_id": mid, **verdict})
+    return {"results": results}
+
+
+@router.get("/feasibility")
+async def models_feasibility_method_not_allowed() -> None:
+    """``/feasibility`` is POST-only.
+
+    A path-param route always fully matches GET on ANY single path
+    segment (Starlette matches by path+method independently per route,
+    not by "most specific literal wins"), so without this explicit
+    literal GET registered above the ``/{model_id}`` catch-all, a stray
+    GET here would silently resolve as model_id="feasibility" and 404
+    with a misleading "model not found" instead of the correct 405.
+    """
+    raise HTTPException(status_code=405, detail="POST required")
 
 
 @router.get("/{model_id}")

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -24,6 +24,7 @@ from hal0.api._audit import record_action
 from hal0.api.middleware.error_codes import BadRequest, NotFound
 from hal0.config.loader import load_hal0_config
 from hal0.model_meta import derive_model_provider
+from hal0.profiles import ProfileCatalog
 from hal0.registry import pull_jobs as _pull_jobs
 from hal0.registry.curated import CURATED, CuratedModel, HaloaiModel
 from hal0.registry.pull import PullInvalidSource
@@ -647,9 +648,7 @@ async def models_feasibility(request: Request) -> dict[str, Any]:
             needed = estimate_file_size_kv_mb(model_mb, ctx_meta)
             verdict = gtt_feasibility_verdict(needed, gtt_free_mb=free, gtt_total_mb=total)
         except Exception:
-            log.warning(
-                "models.feasibility_row_failed model_id=%s", mid, exc_info=True
-            )
+            log.warning("models.feasibility_row_failed model_id=%s", mid, exc_info=True)
             results.append(
                 {
                     "model_id": mid,
@@ -782,6 +781,61 @@ async def update_model(model_id: str, request: Request) -> dict[str, Any]:
             f"model:{model.id}",
             f"{model.id}: updated ({', '.join(changed) or 'no-op'})",
             data={"id": model.id, "changed_fields": changed},
+        )
+    return _model_to_dict(model)
+
+
+@router.post("/{model_id}/seed-profile")
+async def seed_model_profile(model_id: str, request: Request) -> dict[str, Any]:
+    """Stamp a profile's flags onto a model's tune.
+
+    Body: ``{"profile": "<name>"}``. Resolves the named profile and writes
+    ``defaults.extra_args``/``defaults.profile`` from it — the server-side
+    twin of the old model-drawer template select. The stamp is re-screened
+    through :func:`hal0.services.models_service.screen_model_write` exactly
+    like :func:`update_model`, so a stale or hand-edited profile can never
+    smuggle a slot- or authority-owned flag into the write.
+
+    Emits ``model.updated`` with
+    ``changed_fields=["defaults.extra_args", "defaults.profile"]``.
+
+    Errors:
+      * ``400 profiles.name_required`` — body missing/blank ``profile``.
+      * ``400 slot.managed_arg_denied`` — the profile's flags reach for a
+        managed arg.
+      * ``404 model.not_found`` — ``model_id`` not registered.
+      * ``404 profiles.not_found`` — ``profile`` not in the catalog.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest("body must be valid JSON", details={"error": str(exc)}) from exc
+    if not isinstance(body, dict):
+        raise BadRequest("body must be a JSON object")
+    name = body.get("profile")
+    if not isinstance(name, str) or not name.strip():
+        raise BadRequest("body must carry {'profile': <name>}", code="profiles.name_required")
+
+    profile = ProfileCatalog().resolve(name.strip())  # unknown profile → 404
+
+    registry = request.app.state.model_registry
+    before = registry.get(model_id).model_dump(mode="python")  # unknown model → 404
+
+    updates = {"defaults": {"extra_args": profile.flags or "", "profile": profile.name}}
+    _svc.screen_model_write(updates, runner_images=_RUNNER_IMAGES, existing=before)
+    model = registry.update(model_id, updates)
+
+    event_bus = getattr(request.app.state, "events", None)
+    if event_bus is not None:
+        await event_bus.emit(
+            "model.updated",
+            "info",
+            f"model:{model.id}",
+            f"{model.id}: seeded from profile {profile.name!r}",
+            data={
+                "id": model.id,
+                "changed_fields": ["defaults.extra_args", "defaults.profile"],
+            },
         )
     return _model_to_dict(model)
 

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -602,8 +602,11 @@ async def models_feasibility(request: Request) -> dict[str, Any]:
 
     Never 404s, never blocks — an unknown model id or missing host GPU
     truth (no ``hardware_stats`` wired, or the sample failed) yields a
-    ``verdict: "unknown"`` row rather than an error. This is a batch
-    advisory endpoint for the drawer's model picker, not a gate.
+    ``verdict: "unknown"`` row rather than an error. A non-dict item in
+    ``models`` also degrades to an ``"unknown"`` row in place rather than
+    being dropped, so the response row count always matches the request
+    row count (after the soft cap below). This is a batch advisory
+    endpoint for the drawer's model picker, not a gate.
     """
     try:
         body = await request.json()
@@ -611,7 +614,15 @@ async def models_feasibility(request: Request) -> dict[str, Any]:
         raise BadRequest("body must be valid JSON", details={"error": str(exc)}) from exc
     if not isinstance(body, dict):
         raise BadRequest("body must be a JSON object")
-    items = body.get("models") or []
+    items = body.get("models")
+    if items is None:
+        items = []
+    elif not isinstance(items, list):
+        raise BadRequest("'models' must be a list", code="models.feasibility_body_invalid")
+    # Soft cap: this is an advisory batch endpoint for the drawer's model
+    # picker, not a gate — an oversized batch is processed up to a sane
+    # limit rather than rejected outright.
+    items = items[:256]
 
     registry = request.app.state.model_registry
     stats = getattr(request.app.state, "hardware_stats", None)
@@ -628,6 +639,15 @@ async def models_feasibility(request: Request) -> dict[str, Any]:
     results: list[dict[str, Any]] = []
     for item in items:
         if not isinstance(item, dict):
+            results.append(
+                {
+                    "model_id": "",
+                    "verdict": "unknown",
+                    "needed_mb": 0.0,
+                    "gtt_free_mb": free,
+                    "gtt_total_mb": total,
+                }
+            )
             continue
         mid = str(item.get("model_id") or "")
         # The WHOLE per-row computation is guarded, not just the registry

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -819,6 +819,9 @@ async def seed_model_profile(model_id: str, request: Request) -> dict[str, Any]:
     profile = ProfileCatalog().resolve(name.strip())  # unknown profile → 404
 
     registry = request.app.state.model_registry
+    # Fail-fast here (unlike update_model's try/except-to-{}): this route has
+    # nothing sparse to resolve a body against, so an unknown model_id should
+    # 404 immediately rather than silently screen against an empty ``before``.
     before = registry.get(model_id).model_dump(mode="python")  # unknown model → 404
 
     updates = {"defaults": {"extra_args": profile.flags or "", "profile": profile.name}}

--- a/src/hal0/slots/capacity.py
+++ b/src/hal0/slots/capacity.py
@@ -844,6 +844,6 @@ __all__ = [
     "_host_has_capable_gpu",
     "build_per_slot",
     "estimate_file_size_kv_mb",
-    "gtt_fit_warning",
     "gtt_feasibility_verdict",
+    "gtt_fit_warning",
 ]

--- a/src/hal0/slots/capacity.py
+++ b/src/hal0/slots/capacity.py
@@ -250,6 +250,36 @@ def gtt_fit_warning(
     )
 
 
+_TIGHT_FRACTION = 0.9  # within 10% of free = load may succeed with swap pressure
+
+
+def gtt_feasibility_verdict(
+    needed_mb: float, *, gtt_free_mb: float | None, gtt_total_mb: float | None
+) -> dict[str, Any]:
+    """Advisory GTT verdict for a projected footprint. Never blocks.
+
+    "unknown" when host truth is unavailable (None counters) or the
+    projection is empty — the caller renders NO hint for unknown, never
+    a fake verdict.
+    """
+    needed = round(float(needed_mb), 1)
+    out: dict[str, Any] = {
+        "needed_mb": needed, "gtt_free_mb": gtt_free_mb, "gtt_total_mb": gtt_total_mb,
+    }
+    if gtt_free_mb is None or gtt_total_mb is None or needed <= 0:
+        out["verdict"] = "unknown"
+        return out
+    if needed > gtt_total_mb:
+        out["verdict"] = "exceeds_total"
+    elif needed > gtt_free_mb:
+        out["verdict"] = "exceeds"
+    elif needed > _TIGHT_FRACTION * gtt_free_mb:
+        out["verdict"] = "tight"
+    else:
+        out["verdict"] = "fits"
+    return out
+
+
 def _ctx_tokens_for(model_meta: dict[str, Any] | None) -> int:
     """Resolve the effective context window (tokens) for a model.
 
@@ -813,4 +843,5 @@ __all__ = [
     "build_per_slot",
     "estimate_file_size_kv_mb",
     "gtt_fit_warning",
+    "gtt_feasibility_verdict",
 ]

--- a/src/hal0/slots/capacity.py
+++ b/src/hal0/slots/capacity.py
@@ -264,7 +264,9 @@ def gtt_feasibility_verdict(
     """
     needed = round(float(needed_mb), 1)
     out: dict[str, Any] = {
-        "needed_mb": needed, "gtt_free_mb": gtt_free_mb, "gtt_total_mb": gtt_total_mb,
+        "needed_mb": needed,
+        "gtt_free_mb": gtt_free_mb,
+        "gtt_total_mb": gtt_total_mb,
     }
     if gtt_free_mb is None or gtt_total_mb is None or needed <= 0:
         out["verdict"] = "unknown"

--- a/tests/api/test_models_feasibility.py
+++ b/tests/api/test_models_feasibility.py
@@ -163,3 +163,45 @@ def test_feasibility_row_error_degrades_to_unknown_without_500ing_batch(
     assert rows[bad_id]["verdict"] == "unknown"
     assert rows[bad_id]["needed_mb"] == 0.0
     assert rows[good_id]["verdict"] in {"fits", "tight", "exceeds", "exceeds_total"}
+
+
+def test_feasibility_non_list_models_is_400(crud_client: TestClient) -> None:
+    """``models`` present but not a list is a client error, not a silent no-op."""
+    r = crud_client.post("/api/models/feasibility", json={"models": "not-a-list"})
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "models.feasibility_body_invalid"
+    assert "list" in r.json()["error"]["message"]
+
+
+def test_feasibility_missing_models_key_returns_empty_results(crud_client: TestClient) -> None:
+    r = crud_client.post("/api/models/feasibility", json={})
+    assert r.status_code == 200, r.text
+    assert r.json() == {"results": []}
+
+
+def test_feasibility_batch_soft_capped_at_256(crud_client: TestClient) -> None:
+    """More than 256 items is not an error — only the first 256 are processed."""
+    items = [{"model_id": f"m{i}"} for i in range(300)]
+    r = crud_client.post("/api/models/feasibility", json={"models": items})
+    assert r.status_code == 200, r.text
+    results = r.json()["results"]
+    assert len(results) == 256
+    assert results[0]["model_id"] == "m0"
+    assert results[-1]["model_id"] == "m255"
+
+
+def test_feasibility_non_dict_item_degrades_in_place(crud_client: TestClient) -> None:
+    """A non-dict entry degrades to an 'unknown' row in place rather than being
+    dropped — response row count always equals request row count (capped)."""
+    good_id = "whatever"
+    r = crud_client.post(
+        "/api/models/feasibility",
+        json={"models": [{"model_id": good_id}, 42, {"model_id": "other"}]},
+    )
+    assert r.status_code == 200, r.text
+    results = r.json()["results"]
+    assert len(results) == 3
+    middle = results[1]
+    assert middle["model_id"] == ""
+    assert middle["verdict"] == "unknown"
+    assert middle["needed_mb"] == 0.0

--- a/tests/api/test_models_feasibility.py
+++ b/tests/api/test_models_feasibility.py
@@ -106,3 +106,60 @@ def test_feasibility_empty_batch_returns_empty_results(crud_client: TestClient) 
     r = crud_client.post("/api/models/feasibility", json={"models": []})
     assert r.status_code == 200, r.text
     assert r.json() == {"results": []}
+
+
+def test_feasibility_row_error_degrades_to_unknown_without_500ing_batch(
+    crud_client: TestClient,
+    crud_models_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row whose downstream computation raises (corrupt/unexpected stored
+    data — ``model_dump``/``estimate_file_size_kv_mb``/
+    ``gtt_feasibility_verdict`` are all reachable failure points past a
+    successful ``registry.get``) degrades to 'unknown' for just that row —
+    the rest of the batch still computes and the request never 500s.
+
+    Simulates the downstream failure by monkeypatching
+    ``estimate_file_size_kv_mb`` (imported into ``routes.models``) to raise
+    only for the "bad" model id, leaving the real implementation in place
+    for every other row — this exercises the route's own try/except rather
+    than a registry-internals quirk.
+    """
+    from hal0.api.routes import models as models_route
+
+    good_id = _create_minimal_model(crud_client, crud_models_root)
+    bad_id = "feas-bad"
+    fpath = crud_models_root / "feas-bad.gguf"
+    fpath.write_bytes(b"\x00" * 32)
+    r = crud_client.post("/api/models", json={"id": bad_id, "path": str(fpath)})
+    assert r.status_code == 201, r.text
+
+    class _Gpu:  # duck-type GPUMemorySample
+        gtt_free_mb = 69632.0
+        gtt_total_mb = 98304.0
+        is_uma = True
+
+    class _Stats:
+        def gpu_sample(self) -> _Gpu:
+            return _Gpu()
+
+    crud_client.app.state.hardware_stats = _Stats()
+
+    real_estimate = models_route.estimate_file_size_kv_mb
+
+    def _boom(model_mb: float, ctx_meta: dict | None, **kw: object) -> float:
+        if isinstance(ctx_meta, dict) and ctx_meta.get("id") == bad_id:
+            raise ValueError("simulated corrupt row")
+        return real_estimate(model_mb, ctx_meta, **kw)
+
+    monkeypatch.setattr(models_route, "estimate_file_size_kv_mb", _boom)
+
+    resp = crud_client.post(
+        "/api/models/feasibility",
+        json={"models": [{"model_id": good_id}, {"model_id": bad_id}]},
+    )
+    assert resp.status_code == 200, resp.text
+    rows = {row["model_id"]: row for row in resp.json()["results"]}
+    assert rows[bad_id]["verdict"] == "unknown"
+    assert rows[bad_id]["needed_mb"] == 0.0
+    assert rows[good_id]["verdict"] in {"fits", "tight", "exceeds", "exceeds_total"}

--- a/tests/api/test_models_feasibility.py
+++ b/tests/api/test_models_feasibility.py
@@ -1,0 +1,108 @@
+"""Tests for POST /api/models/feasibility — batch GTT preflight.
+
+Advisory-only: never 404s, never blocks. Unknown model ids or a missing
+GPU sample (no ``hardware_stats`` wired) yield ``verdict: "unknown"`` rows
+rather than an error.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+
+# ── isolated app fixture (mirrors test_models_crud.py:~90-110) ──────────────
+
+
+@pytest.fixture
+def crud_app(tmp_hal0_home: str) -> FastAPI:
+    extra_root = Path(tmp_hal0_home) / "crud-models"
+    extra_root.mkdir(parents=True)
+    etc = Path(tmp_hal0_home) / "etc" / "hal0"
+    etc.mkdir(parents=True, exist_ok=True)
+    (etc / "hal0.toml").write_text(
+        f'[models]\nroots = ["{extra_root}"]\nauto_scan_on_start = false\n',
+        encoding="utf-8",
+    )
+    return create_app()
+
+
+@pytest.fixture
+def crud_client(crud_app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(crud_app) as c:
+        yield c
+
+
+@pytest.fixture
+def crud_models_root(tmp_hal0_home: str) -> Path:
+    return Path(tmp_hal0_home) / "crud-models"
+
+
+def _create_minimal_model(client: TestClient, models_root: Path) -> str:
+    """Register a minimal model and return its id."""
+    fpath = models_root / "feas-test.gguf"
+    fpath.write_bytes(b"\x00" * 64)
+    mid = "feas-test"
+    r = client.post("/api/models", json={"id": mid, "path": str(fpath)})
+    assert r.status_code == 201, r.text
+    return mid
+
+
+# ── tests ─────────────────────────────────────────────────────────────────
+
+
+def test_feasibility_unknown_without_gpu_sample(crud_client: TestClient) -> None:
+    """No hardware_stats on app.state → every verdict is 'unknown', 200 always."""
+    r = crud_client.post("/api/models/feasibility", json={"models": [{"model_id": "nope"}]})
+    assert r.status_code == 200, r.text
+    row = r.json()["results"][0]
+    assert row["model_id"] == "nope"
+    assert row["verdict"] == "unknown"
+
+
+def test_feasibility_ctx_override_raises_need(
+    crud_client: TestClient, crud_models_root: Path
+) -> None:
+    mid = _create_minimal_model(crud_client, crud_models_root)
+
+    class _Gpu:  # duck-type GPUMemorySample
+        gtt_free_mb = 69632.0
+        gtt_total_mb = 98304.0
+        is_uma = True
+
+    class _Stats:
+        def gpu_sample(self) -> _Gpu:
+            return _Gpu()
+
+    crud_client.app.state.hardware_stats = _Stats()
+
+    small = crud_client.post(
+        "/api/models/feasibility",
+        json={"models": [{"model_id": mid, "ctx": 8192}]},
+    ).json()["results"][0]
+    big = crud_client.post(
+        "/api/models/feasibility",
+        json={"models": [{"model_id": mid, "ctx": 200000}]},
+    ).json()["results"][0]
+
+    assert big["needed_mb"] > small["needed_mb"]
+    assert small["verdict"] in {"fits", "tight", "exceeds", "exceeds_total"}
+
+
+def test_feasibility_route_ordering_get_is_405_not_model_lookup(
+    crud_client: TestClient,
+) -> None:
+    """GET /api/models/feasibility must 405 — never resolve as model_id='feasibility'."""
+    r = crud_client.get("/api/models/feasibility")
+    assert r.status_code == 405, r.text
+
+
+def test_feasibility_empty_batch_returns_empty_results(crud_client: TestClient) -> None:
+    r = crud_client.post("/api/models/feasibility", json={"models": []})
+    assert r.status_code == 200, r.text
+    assert r.json() == {"results": []}

--- a/tests/api/test_models_seed_profile.py
+++ b/tests/api/test_models_seed_profile.py
@@ -1,0 +1,114 @@
+"""Tests for POST /api/models/{model_id}/seed-profile — profile stamp route.
+
+Server-side twin of the old model-drawer template select: resolves a named
+profile and stamps its flags onto ``defaults.extra_args``/``defaults.profile``,
+re-screening through ``screen_model_write`` so a stale/hand-edited profile can
+never smuggle a managed flag into the stamp.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+
+# ── isolated app fixture (mirrors test_models_feasibility.py) ───────────────
+
+
+@pytest.fixture
+def crud_app(tmp_hal0_home: str) -> FastAPI:
+    extra_root = Path(tmp_hal0_home) / "crud-models"
+    extra_root.mkdir(parents=True)
+    etc = Path(tmp_hal0_home) / "etc" / "hal0"
+    etc.mkdir(parents=True, exist_ok=True)
+    (etc / "hal0.toml").write_text(
+        f'[models]\nroots = ["{extra_root}"]\nauto_scan_on_start = false\n',
+        encoding="utf-8",
+    )
+    return create_app()
+
+
+@pytest.fixture
+def crud_client(crud_app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(crud_app) as c:
+        yield c
+
+
+@pytest.fixture
+def crud_models_root(tmp_hal0_home: str) -> Path:
+    return Path(tmp_hal0_home) / "crud-models"
+
+
+def _create_minimal_model(client: TestClient, models_root: Path) -> str:
+    """Register a minimal model and return its id."""
+    fpath = models_root / "seed-profile-test.gguf"
+    fpath.write_bytes(b"\x00" * 64)
+    mid = "seed-profile-test"
+    r = client.post("/api/models", json={"id": mid, "path": str(fpath)})
+    assert r.status_code == 201, r.text
+    return mid
+
+
+# ── tests ─────────────────────────────────────────────────────────────────
+
+
+def test_seed_profile_stamps_flags_and_provenance(
+    crud_client: TestClient, crud_models_root: Path
+) -> None:
+    mid = _create_minimal_model(crud_client, crud_models_root)
+    # "chat" is a seed profile shipped in every install (seed_profiles.toml).
+    r = crud_client.post(f"/api/models/{mid}/seed-profile", json={"profile": "chat"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["defaults"]["profile"] == "chat"
+    assert (
+        "--jinja" in body["defaults"]["extra_args"]
+    )  # chat's flags: -fa auto --jinja -b 2048 -ub 512
+
+
+def test_seed_profile_unknown_model_404(crud_client: TestClient) -> None:
+    r = crud_client.post("/api/models/no-such-model/seed-profile", json={"profile": "chat"})
+    assert r.status_code == 404
+
+
+def test_seed_profile_unknown_profile_404(crud_client: TestClient, crud_models_root: Path) -> None:
+    mid = _create_minimal_model(crud_client, crud_models_root)
+    r = crud_client.post(f"/api/models/{mid}/seed-profile", json={"profile": "no-such"})
+    assert r.status_code == 404
+
+
+def test_seed_profile_requires_profile_name(
+    crud_client: TestClient, crud_models_root: Path
+) -> None:
+    mid = _create_minimal_model(crud_client, crud_models_root)
+    r = crud_client.post(f"/api/models/{mid}/seed-profile", json={})
+    assert r.status_code == 400
+
+
+def test_seed_profile_rescreens_managed_flags(
+    crud_client: TestClient, crud_models_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A stale/hand-edited profile whose stored flags smuggle a managed arg
+    # must be rejected at stamp time (spec decision 1).
+    mid = _create_minimal_model(crud_client, crud_models_root)
+    from hal0 import profiles as profiles_mod
+
+    real_resolve = profiles_mod.ProfileCatalog.resolve
+
+    def bad_resolve(self: profiles_mod.ProfileCatalog, name: str) -> profiles_mod.ResolvedProfile:
+        rp = real_resolve(self, "chat")
+        return dataclasses.replace(rp, flags="--port 9999 -fa auto")
+
+    monkeypatch.setattr(profiles_mod.ProfileCatalog, "resolve", bad_resolve)
+    r = crud_client.post(f"/api/models/{mid}/seed-profile", json={"profile": "chat"})
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "slot.managed_arg_denied"
+    # And nothing persisted (a freshly-created model has no defaults at all):
+    after_defaults = crud_client.get(f"/api/models/{mid}").json().get("defaults") or {}
+    assert after_defaults.get("profile") != "chat"

--- a/tests/api/test_models_seed_profile.py
+++ b/tests/api/test_models_seed_profile.py
@@ -55,6 +55,19 @@ def _create_minimal_model(client: TestClient, models_root: Path) -> str:
     return mid
 
 
+def _events_since(client: TestClient, since: int, type_glob: str | None = None) -> list[dict]:
+    """Mirrors test_models_crud.py's event-polling idiom."""
+    params = f"?since={since}&limit=1000"
+    if type_glob:
+        params += f"&type={type_glob}"
+    return client.get(f"/api/events{params}").json().get("events", [])
+
+
+def _max_event_id(client: TestClient) -> int:
+    body = client.get("/api/events?limit=1000").json()
+    return max((ev["id"] for ev in body.get("events", [])), default=0)
+
+
 # ── tests ─────────────────────────────────────────────────────────────────
 
 
@@ -70,6 +83,40 @@ def test_seed_profile_stamps_flags_and_provenance(
     assert (
         "--jinja" in body["defaults"]["extra_args"]
     )  # chat's flags: -fa auto --jinja -b 2048 -ub 512
+
+
+def test_seed_profile_emits_model_updated_with_changed_fields(
+    crud_client: TestClient, crud_models_root: Path
+) -> None:
+    mid = _create_minimal_model(crud_client, crud_models_root)
+    pre = _max_event_id(crud_client)
+    r = crud_client.post(f"/api/models/{mid}/seed-profile", json={"profile": "chat"})
+    assert r.status_code == 200, r.text
+
+    events = _events_since(crud_client, pre, "model.updated")
+    assert events, "expected a model.updated event"
+    payload = next(ev for ev in events if ev["data"].get("id") == mid)
+    assert payload["data"]["changed_fields"] == ["defaults.extra_args", "defaults.profile"]
+
+
+def test_seed_profile_merge_preserves_sibling_defaults_keys(
+    crud_client: TestClient, crud_models_root: Path
+) -> None:
+    """``defaults`` is a 1-level merged subtable (registry/store.py) — a stamp
+    that only names ``extra_args``/``profile`` must leave a sibling default
+    (here ``context_size``) that was set earlier untouched."""
+    mid = _create_minimal_model(crud_client, crud_models_root)
+    r = crud_client.put(f"/api/models/{mid}", json={"defaults": {"context_size": 4096}})
+    assert r.status_code == 200, r.text
+    assert r.json()["defaults"]["context_size"] == 4096
+
+    r = crud_client.post(f"/api/models/{mid}/seed-profile", json={"profile": "chat"})
+    assert r.status_code == 200, r.text
+
+    body = crud_client.get(f"/api/models/{mid}").json()
+    assert body["defaults"]["profile"] == "chat"
+    assert "--jinja" in body["defaults"]["extra_args"]
+    assert body["defaults"]["context_size"] == 4096
 
 
 def test_seed_profile_unknown_model_404(crud_client: TestClient) -> None:

--- a/tests/slots/test_capacity.py
+++ b/tests/slots/test_capacity.py
@@ -464,15 +464,23 @@ class TestGttFitWarning:
 class TestGttFeasibilityVerdict:
     def test_gtt_feasibility_verdict_states(self) -> None:
         from hal0.slots.capacity import gtt_feasibility_verdict as v
+
         assert v(1000.0, gtt_free_mb=None, gtt_total_mb=98304.0)["verdict"] == "unknown"
         assert v(0.0, gtt_free_mb=50000.0, gtt_total_mb=98304.0)["verdict"] == "unknown"
         assert v(40000.0, gtt_free_mb=69632.0, gtt_total_mb=98304.0)["verdict"] == "fits"
-        assert v(64000.0, gtt_free_mb=69632.0, gtt_total_mb=98304.0)["verdict"] == "tight"      # > 0.9 * free
+        assert (
+            v(64000.0, gtt_free_mb=69632.0, gtt_total_mb=98304.0)["verdict"] == "tight"
+        )  # > 0.9 * free
         assert v(75000.0, gtt_free_mb=69632.0, gtt_total_mb=98304.0)["verdict"] == "exceeds"
         assert v(131072.0, gtt_free_mb=69632.0, gtt_total_mb=98304.0)["verdict"] == "exceeds_total"
 
     def test_gtt_feasibility_verdict_echoes_inputs(self) -> None:
         from hal0.slots.capacity import gtt_feasibility_verdict as v
+
         out = v(40000.0, gtt_free_mb=69632.0, gtt_total_mb=98304.0)
-        assert out == {"verdict": "fits", "needed_mb": 40000.0,
-                       "gtt_free_mb": 69632.0, "gtt_total_mb": 98304.0}
+        assert out == {
+            "verdict": "fits",
+            "needed_mb": 40000.0,
+            "gtt_free_mb": 69632.0,
+            "gtt_total_mb": 98304.0,
+        }

--- a/tests/slots/test_capacity.py
+++ b/tests/slots/test_capacity.py
@@ -453,3 +453,26 @@ class TestGttFitWarning:
         msg = gtt_fit_warning(1024.0, gtt_free_mb=0.0, gtt_total_mb=98304.0)
         assert msg is not None
         assert "0.0 GiB" in msg
+
+
+# ── gtt_feasibility_verdict — advisory verdict over host GTT truth (pure) ──
+#
+# Provides verdict states ("fits", "tight", "exceeds", "exceeds_total", "unknown")
+# for the dashboard form and pre-load capacity estimation paths. Never blocks.
+
+
+class TestGttFeasibilityVerdict:
+    def test_gtt_feasibility_verdict_states(self) -> None:
+        from hal0.slots.capacity import gtt_feasibility_verdict as v
+        assert v(1000.0, gtt_free_mb=None, gtt_total_mb=98304.0)["verdict"] == "unknown"
+        assert v(0.0, gtt_free_mb=50000.0, gtt_total_mb=98304.0)["verdict"] == "unknown"
+        assert v(40000.0, gtt_free_mb=69632.0, gtt_total_mb=98304.0)["verdict"] == "fits"
+        assert v(64000.0, gtt_free_mb=69632.0, gtt_total_mb=98304.0)["verdict"] == "tight"      # > 0.9 * free
+        assert v(75000.0, gtt_free_mb=69632.0, gtt_total_mb=98304.0)["verdict"] == "exceeds"
+        assert v(131072.0, gtt_free_mb=69632.0, gtt_total_mb=98304.0)["verdict"] == "exceeds_total"
+
+    def test_gtt_feasibility_verdict_echoes_inputs(self) -> None:
+        from hal0.slots.capacity import gtt_feasibility_verdict as v
+        out = v(40000.0, gtt_free_mb=69632.0, gtt_total_mb=98304.0)
+        assert out == {"verdict": "fits", "needed_mb": 40000.0,
+                       "gtt_free_mb": 69632.0, "gtt_total_mb": 98304.0}


### PR DESCRIPTION
PR-2 of the slot+model drawer overhaul (follows #2196).

## What

- `POST /api/models/{id}/seed-profile` `{"profile": name}` — server-side stamp of a profile's flags onto the model tune (`defaults.extra_args` + `defaults.profile`), through the same `screen_model_write` + `registry.update` path as PUT: a stale/hand-edited profile can never smuggle managed flags (400 `slot.managed_arg_denied`, nothing persisted). Emits `model.updated`. Replaces the model drawer's template-select stamp gesture (UI swap lands in PR-3) and is the surface the future profile-edit re-stamp / import-time stamping flows will call.
- `POST /api/models/feasibility` — advisory batch GTT preflight: `{"models": [{model_id, ctx?}]}` → per-row `{verdict: fits|tight|exceeds|exceeds_total|unknown, needed_mb, gtt_free_mb, gtt_total_mb}` from host-truth GTT counters + the weights+KV estimator. Never blocks, never 404s: unknown model, missing host truth, or any per-row error degrades that row to `unknown` (logged). Non-list body 400s; batches soft-cap at 256. Explicit `GET /feasibility` → 405 (would otherwise resolve as `GET /{model_id}` — Starlette matches full path+method per route). Powers the ceiling hint + model-dropdown fit chips in PR-4.
- `gtt_feasibility_verdict` pure helper in `slots/capacity.py` alongside `gtt_fit_warning`.

## Tests

200 targeted post-rebase; branch sweeps 2910 passed with only the pre-existing updater/slot-logs flakes (#2166 family) in untouched files. TDD per task; adversarial task reviews + whole-branch final review applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hXYtiC9A1iyLeFnQxs68v