### PR TITLE
feat(ui): slot drawer Option B — task regroup, rich rows, GTT hints, inline pull

### DIFF
--- a/ui/src/dash/__tests__/rich-select-core.test.ts
+++ b/ui/src/dash/__tests__/rich-select-core.test.ts
@@ -1,0 +1,202 @@
+// Task 10 — RichSelect shared listbox. @testing-library/react is not a ui
+// dependency (grep confirms 0 hits in package.json), so — same split as
+// slot-status.js/breaker-chip.jsx — every stateful rule (open/close,
+// keyboard navigation, disabled-skip, commit-on-Enter, aria-activedescendant
+// id derivation) lives in this pure module and is pinned here. rich-select.jsx
+// is a thin rendering shell over it with nothing left to unit-test in
+// isolation from a DOM.
+import { describe, expect, it } from 'vitest'
+
+import {
+  activeDescendantId,
+  closeList,
+  commit,
+  firstEnabledId,
+  handleKey,
+  lastEnabledId,
+  openList,
+  optionDomId,
+  selectedOption,
+  stepActive,
+  toggle,
+  type RichSelectOption,
+} from '../rich-select-core'
+
+const OPTIONS: RichSelectOption[] = [
+  { id: 'a' },
+  { id: 'b', disabled: true },
+  { id: 'c' },
+  { id: 'd', disabled: true },
+  { id: 'e' },
+]
+
+describe('firstEnabledId / lastEnabledId', () => {
+  it('skip leading/trailing disabled options', () => {
+    expect(firstEnabledId(OPTIONS)).toBe('a')
+    expect(lastEnabledId(OPTIONS)).toBe('e')
+  })
+
+  it('return null when every option is disabled', () => {
+    const all = [{ id: 'x', disabled: true }, { id: 'y', disabled: true }]
+    expect(firstEnabledId(all)).toBeNull()
+    expect(lastEnabledId(all)).toBeNull()
+  })
+})
+
+describe('stepActive', () => {
+  it('steps forward to the next enabled option, skipping disabled', () => {
+    expect(stepActive(OPTIONS, 'a', 1)).toBe('c')
+    expect(stepActive(OPTIONS, 'c', 1)).toBe('e')
+  })
+
+  it('steps backward to the previous enabled option, skipping disabled', () => {
+    expect(stepActive(OPTIONS, 'e', -1)).toBe('c')
+    expect(stepActive(OPTIONS, 'c', -1)).toBe('a')
+  })
+
+  it('clamps at the boundary instead of wrapping', () => {
+    expect(stepActive(OPTIONS, 'a', -1)).toBe('a')
+    expect(stepActive(OPTIONS, 'e', 1)).toBe('e')
+  })
+
+  it('starts from the direction-appropriate boundary when nothing is active', () => {
+    expect(stepActive(OPTIONS, null, 1)).toBe('a')
+    expect(stepActive(OPTIONS, null, -1)).toBe('e')
+  })
+})
+
+describe('openList / toggle', () => {
+  it('opens with the current value as active when the value is a selectable option', () => {
+    expect(openList(OPTIONS, 'c')).toEqual({ open: true, activeId: 'c' })
+  })
+
+  it('falls back to the first enabled option when the value is unset', () => {
+    expect(openList(OPTIONS, null)).toEqual({ open: true, activeId: 'a' })
+  })
+
+  it('falls back to the first enabled option when the value is itself disabled', () => {
+    expect(openList(OPTIONS, 'b')).toEqual({ open: true, activeId: 'a' })
+  })
+
+  it('toggle opens a closed list and closes an open one', () => {
+    const closed = { open: false, activeId: 'c' }
+    const opened = toggle(closed, OPTIONS, 'c')
+    expect(opened.open).toBe(true)
+    const reclosed = toggle(opened, OPTIONS, 'c')
+    expect(reclosed).toEqual({ open: false, activeId: 'c' })
+  })
+})
+
+describe('closeList', () => {
+  it('closes and resets activeId to the given value', () => {
+    expect(closeList('c')).toEqual({ open: false, activeId: 'c' })
+    expect(closeList(null)).toEqual({ open: false, activeId: null })
+  })
+})
+
+describe('commit', () => {
+  it('commits the active option when it is enabled, closing the list', () => {
+    const result = commit({ open: true, activeId: 'c' }, OPTIONS)
+    expect(result.committedId).toBe('c')
+    expect(result.nextState).toEqual({ open: false, activeId: 'c' })
+  })
+
+  it('refuses to commit a disabled active option', () => {
+    const result = commit({ open: true, activeId: 'b' }, OPTIONS)
+    expect(result.committedId).toBeNull()
+    expect(result.nextState).toEqual({ open: true, activeId: 'b' })
+  })
+
+  it('refuses to commit when nothing is active', () => {
+    const result = commit({ open: true, activeId: null }, OPTIONS)
+    expect(result.committedId).toBeNull()
+  })
+
+  it('commits an explicit target id (mouse click), ignoring what was active', () => {
+    const result = commit({ open: true, activeId: 'a' }, OPTIONS, 'e')
+    expect(result.committedId).toBe('e')
+    expect(result.nextState).toEqual({ open: false, activeId: 'e' })
+  })
+
+  it('refuses an explicit target id that is disabled', () => {
+    const result = commit({ open: true, activeId: 'a' }, OPTIONS, 'b')
+    expect(result.committedId).toBeNull()
+    expect(result.nextState).toEqual({ open: true, activeId: 'a' })
+  })
+})
+
+describe('handleKey', () => {
+  it('ArrowDown on a closed list opens it, activating the value', () => {
+    const outcome = handleKey('ArrowDown', { open: false, activeId: 'c' }, OPTIONS, 'c')
+    expect(outcome).toEqual({ kind: 'state', state: { open: true, activeId: 'c' } })
+  })
+
+  it('ArrowDown/ArrowUp while open move the active id, skipping disabled', () => {
+    const down = handleKey('ArrowDown', { open: true, activeId: 'a' }, OPTIONS, 'a')
+    expect(down).toEqual({ kind: 'state', state: { open: true, activeId: 'c' } })
+    const up = handleKey('ArrowUp', { open: true, activeId: 'c' }, OPTIONS, 'a')
+    expect(up).toEqual({ kind: 'state', state: { open: true, activeId: 'a' } })
+  })
+
+  it('Home/End jump to the first/last enabled option while open', () => {
+    expect(handleKey('Home', { open: true, activeId: 'c' }, OPTIONS, 'c')).toEqual({
+      kind: 'state',
+      state: { open: true, activeId: 'a' },
+    })
+    expect(handleKey('End', { open: true, activeId: 'c' }, OPTIONS, 'c')).toEqual({
+      kind: 'state',
+      state: { open: true, activeId: 'e' },
+    })
+  })
+
+  it('Enter commits the active enabled option and closes', () => {
+    const outcome = handleKey('Enter', { open: true, activeId: 'c' }, OPTIONS, 'a')
+    expect(outcome).toEqual({ kind: 'commit', state: { open: false, activeId: 'c' }, id: 'c' })
+  })
+
+  it('Enter on a disabled active option does nothing', () => {
+    const outcome = handleKey('Enter', { open: true, activeId: 'b' }, OPTIONS, 'a')
+    expect(outcome).toEqual({ kind: 'none' })
+  })
+
+  it('Escape closes without committing and resets to the current value', () => {
+    const outcome = handleKey('Escape', { open: true, activeId: 'c' }, OPTIONS, 'a')
+    expect(outcome).toEqual({ kind: 'close', state: { open: false, activeId: 'a' } })
+  })
+
+  it('Tab closes without committing, leaving focus free to move', () => {
+    const outcome = handleKey('Tab', { open: true, activeId: 'c' }, OPTIONS, 'a')
+    expect(outcome).toEqual({ kind: 'close', state: { open: false, activeId: 'a' } })
+  })
+
+  it('ignores keys it does not handle', () => {
+    expect(handleKey('a', { open: true, activeId: 'c' }, OPTIONS, 'a')).toEqual({ kind: 'none' })
+    expect(handleKey('Escape', { open: false, activeId: 'c' }, OPTIONS, 'a')).toEqual({ kind: 'none' })
+  })
+})
+
+describe('activeDescendantId / optionDomId', () => {
+  it('derives a stable per-option DOM id from a base id', () => {
+    expect(optionDomId('slot-profile', 'c')).toBe('slot-profile-option-c')
+  })
+
+  it('is undefined while closed, and the active option id while open', () => {
+    expect(activeDescendantId('slot-profile', { open: false, activeId: 'c' })).toBeUndefined()
+    expect(activeDescendantId('slot-profile', { open: true, activeId: 'c' })).toBe('slot-profile-option-c')
+  })
+
+  it('is undefined while open with nothing active', () => {
+    expect(activeDescendantId('slot-profile', { open: true, activeId: null })).toBeUndefined()
+  })
+})
+
+describe('selectedOption', () => {
+  it('returns the option matching the current value', () => {
+    expect(selectedOption(OPTIONS, 'c')).toBe(OPTIONS[2])
+  })
+
+  it('returns null when the value is unset or matches nothing', () => {
+    expect(selectedOption(OPTIONS, null)).toBeNull()
+    expect(selectedOption(OPTIONS, 'zzz')).toBeNull()
+  })
+})

--- a/ui/src/dash/__tests__/rich-select.test.tsx
+++ b/ui/src/dash/__tests__/rich-select.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+//
+// RichSelect trigger passthrough (Task 11 review fix): the shell used to
+// hardcode `className="rsel-trigger"` and drop any `aria-label` a caller
+// passed, which silently regressed the slot drawer's Runtime error-border
+// styling and the Model select's screen-reader label when Task 11c swapped
+// their native <select>s for RichSelect. Both are now optional props merged
+// onto the trigger <button> — this pins that the merge actually happens.
+//
+// This repo has no @testing-library — mount with createRoot/act directly
+// (mirrors runner-images-pull-terminal.test.tsx's own note on this).
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { RichSelect } from '../rich-select'
+
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  if (container) {
+    act(() => {
+      createRoot(container!).unmount()
+    })
+    container.remove()
+    container = null
+  }
+})
+
+function mount(el: React.ReactElement) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(el)
+  })
+  return container
+}
+
+const OPTIONS = [{ id: 'a', row: 'Option A' }]
+
+describe('RichSelect trigger passthrough', () => {
+  it('merges an optional className onto the hardcoded rsel-trigger class', () => {
+    const el = mount(
+      <RichSelect
+        data-testid="probe"
+        value="a"
+        options={OPTIONS}
+        onChange={() => {}}
+        className="rsel-err"
+      />,
+    )
+    const trigger = el.querySelector('[data-testid="probe"]') as HTMLButtonElement
+    expect(trigger.classList.contains('rsel-trigger')).toBe(true)
+    expect(trigger.classList.contains('rsel-err')).toBe(true)
+  })
+
+  it('renders no extra class when className is omitted', () => {
+    const el = mount(
+      <RichSelect data-testid="probe" value="a" options={OPTIONS} onChange={() => {}} />,
+    )
+    const trigger = el.querySelector('[data-testid="probe"]') as HTMLButtonElement
+    expect(trigger.className).toBe('rsel-trigger')
+  })
+
+  it('forwards aria-label onto the trigger button', () => {
+    const el = mount(
+      <RichSelect
+        data-testid="probe"
+        value="a"
+        options={OPTIONS}
+        onChange={() => {}}
+        aria-label="Model for agent"
+      />,
+    )
+    const trigger = el.querySelector('[data-testid="probe"]') as HTMLButtonElement
+    expect(trigger.getAttribute('aria-label')).toBe('Model for agent')
+  })
+
+  it('omits the aria-label attribute when none is passed', () => {
+    const el = mount(
+      <RichSelect data-testid="probe" value="a" options={OPTIONS} onChange={() => {}} />,
+    )
+    const trigger = el.querySelector('[data-testid="probe"]') as HTMLButtonElement
+    expect(trigger.hasAttribute('aria-label')).toBe(false)
+  })
+})

--- a/ui/src/dash/profiles.jsx
+++ b/ui/src/dash/profiles.jsx
@@ -226,7 +226,11 @@ export function pullTargetFor(runnerRow, images) {
   return { id: row.id, tag: known ? tag : undefined };
 }
 
-function useRunnerPull(runnerKey, backends) {
+// Exported (Task 11c, issue #2185): the slot drawer's Runtime RichSelect
+// reuses this SAME pull mutation for its own not-pulled rows, instead of
+// wiring a second pull hook that could drift from this one's target
+// resolution (splitImageRef/pullTargetFor above).
+export function useRunnerPull(runnerKey, backends) {
   const imagesQuery = useRunnerImages();
   const job = useRunnerImagePullJob();
   const target = pullTargetFor(backends?.[runnerKey], imagesQuery.data?.images);

--- a/ui/src/dash/rich-select-core.ts
+++ b/ui/src/dash/rich-select-core.ts
@@ -1,0 +1,158 @@
+// rich-select-core.ts — Task 10: pure state/logic for the shared RichSelect
+// listbox (drawer Runtime/Profile/Model selects, Task 11). No React, no DOM —
+// same split as slot-status.js/breaker-chip.jsx: every stateful rule lives
+// here and is vitest-pinned directly; rich-select.jsx is a thin rendering
+// shell that calls into these functions and owns nothing but markup, focus,
+// and the click-outside listener.
+//
+// Arrow/Home/End navigation does not wrap (mirrors command-palette.jsx's
+// `Math.min/Math.max` clamp) and always skips disabled options — an active id
+// only ever lands on an option that is actually selectable.
+
+export interface RichSelectOption {
+  id: string
+  disabled?: boolean
+  // row / desc / right are opaque render content the shell owns (ReactNode in
+  // practice); the core never looks past id/disabled.
+}
+
+export interface RichSelectState {
+  open: boolean
+  activeId: string | null
+}
+
+export type KeyOutcome =
+  | { kind: 'none' }
+  | { kind: 'state'; state: RichSelectState }
+  | { kind: 'commit'; state: RichSelectState; id: string }
+  | { kind: 'close'; state: RichSelectState }
+
+const isEnabled = (o: RichSelectOption): boolean => !o.disabled
+
+export function firstEnabledId(options: RichSelectOption[]): string | null {
+  const found = options.find(isEnabled)
+  return found ? found.id : null
+}
+
+export function lastEnabledId(options: RichSelectOption[]): string | null {
+  for (let i = options.length - 1; i >= 0; i--) {
+    if (isEnabled(options[i])) return options[i].id
+  }
+  return null
+}
+
+// Move from `currentId` one step in `dir` (1 = forward, -1 = backward),
+// skipping disabled options, clamped at the boundary (no wrap). When
+// `currentId` is null/unmatched, starts from the boundary `dir` points at.
+export function stepActive(
+  options: RichSelectOption[],
+  currentId: string | null,
+  dir: 1 | -1,
+): string | null {
+  const idx = currentId == null ? -1 : options.findIndex((o) => o.id === currentId)
+  if (idx === -1) return dir === 1 ? firstEnabledId(options) : lastEnabledId(options)
+  let i = idx + dir
+  while (i >= 0 && i < options.length) {
+    if (isEnabled(options[i])) return options[i].id
+    i += dir
+  }
+  return currentId
+}
+
+export function initialState(value: string | null): RichSelectState {
+  return { open: false, activeId: value }
+}
+
+// Opening activates `value` when it names a selectable option, else the
+// first enabled option (never lands on a disabled row).
+export function openList(options: RichSelectOption[], value: string | null): RichSelectState {
+  const valueSelectable = value != null && options.some((o) => o.id === value && isEnabled(o))
+  return { open: true, activeId: valueSelectable ? value : firstEnabledId(options) }
+}
+
+export function closeList(value: string | null): RichSelectState {
+  return { open: false, activeId: value }
+}
+
+export function toggle(
+  state: RichSelectState,
+  options: RichSelectOption[],
+  value: string | null,
+): RichSelectState {
+  return state.open ? closeList(value) : openList(options, value)
+}
+
+export interface CommitResult {
+  nextState: RichSelectState
+  committedId: string | null
+}
+
+// Commits a target option (the active one by default, e.g. Enter — but a
+// mouse click commits whichever row it lands on regardless of what was last
+// active) if — and only if — it is currently enabled. onChange(id) is the
+// shell's job to fire, driven off `committedId`.
+export function commit(
+  state: RichSelectState,
+  options: RichSelectOption[],
+  targetId: string | null = state.activeId,
+): CommitResult {
+  const active = targetId != null ? options.find((o) => o.id === targetId) : undefined
+  if (!active || !isEnabled(active)) return { nextState: state, committedId: null }
+  return { nextState: closeList(active.id), committedId: active.id }
+}
+
+// Single entry point for onKeyDown. `value` is the select's committed value
+// (used to seed opening from a closed state, and to restore on Escape/Tab).
+export function handleKey(
+  key: string,
+  state: RichSelectState,
+  options: RichSelectOption[],
+  value: string | null,
+): KeyOutcome {
+  if (!state.open) {
+    if (key === 'ArrowDown' || key === 'ArrowUp' || key === 'Enter' || key === ' ') {
+      return { kind: 'state', state: openList(options, value) }
+    }
+    return { kind: 'none' }
+  }
+  switch (key) {
+    case 'ArrowDown':
+      return { kind: 'state', state: { open: true, activeId: stepActive(options, state.activeId, 1) } }
+    case 'ArrowUp':
+      return { kind: 'state', state: { open: true, activeId: stepActive(options, state.activeId, -1) } }
+    case 'Home':
+      return { kind: 'state', state: { open: true, activeId: firstEnabledId(options) } }
+    case 'End':
+      return { kind: 'state', state: { open: true, activeId: lastEnabledId(options) } }
+    case 'Enter':
+    case ' ': {
+      const result = commit(state, options)
+      if (result.committedId == null) return { kind: 'none' }
+      return { kind: 'commit', state: result.nextState, id: result.committedId }
+    }
+    case 'Escape':
+      return { kind: 'close', state: closeList(value) }
+    case 'Tab':
+      return { kind: 'close', state: closeList(value) }
+    default:
+      return { kind: 'none' }
+  }
+}
+
+export function optionDomId(baseId: string, optionId: string): string {
+  return `${baseId}-option-${optionId}`
+}
+
+export function activeDescendantId(baseId: string, state: RichSelectState): string | undefined {
+  if (!state.open || state.activeId == null) return undefined
+  return optionDomId(baseId, state.activeId)
+}
+
+// The closed trigger renders this option's row inline.
+export function selectedOption(
+  options: RichSelectOption[],
+  value: string | null,
+): RichSelectOption | null {
+  if (value == null) return null
+  return options.find((o) => o.id === value) ?? null
+}

--- a/ui/src/dash/rich-select.jsx
+++ b/ui/src/dash/rich-select.jsx
@@ -100,10 +100,16 @@ export function RichSelect({
 
   const onKeyDown = (e) => {
     if (disabled) return;
+    const wasOpen = state.open;
     const outcome = handleKey(e.key, state, options, value ?? null);
     if (outcome.kind === 'none') return;
     // Tab must keep moving focus per normal browser behaviour — only close.
     if (e.key !== 'Tab') e.preventDefault();
+    // Escape on an OPEN listbox is consumed here: it closes only the
+    // dropdown, and must not also reach the drawer's document-level
+    // Escape→close listener (primitives.jsx). Escape while closed still
+    // bubbles so the drawer keeps its normal dismiss behaviour.
+    if (e.key === 'Escape' && wasOpen) e.stopPropagation();
     setState(outcome.state);
     if (outcome.kind === 'commit') fireChange(outcome.id);
   };

--- a/ui/src/dash/rich-select.jsx
+++ b/ui/src/dash/rich-select.jsx
@@ -26,7 +26,28 @@ import {
 
 const { useEffect, useId, useRef, useState } = React
 
-export function RichSelect({ value, options, onChange, disabled, onOpenChange, 'data-testid': testId }) {
+/**
+ * @param {{
+ *   value: string|null,
+ *   options: Array<{id: string, disabled?: boolean, row?: unknown, desc?: unknown, right?: unknown}>,
+ *   onChange: (id: string) => void,
+ *   disabled?: boolean,
+ *   onOpenChange?: (open: boolean) => void,
+ *   className?: string,
+ *   'aria-label'?: string,
+ *   'data-testid'?: string,
+ * }} props
+ */
+export function RichSelect({
+  value,
+  options,
+  onChange,
+  disabled = false,
+  onOpenChange,
+  className,
+  'aria-label': ariaLabel,
+  'data-testid': testId,
+}) {
   const generatedId = useId()
   const baseId = testId || generatedId
   const rootRef = useRef(null)
@@ -99,7 +120,7 @@ export function RichSelect({ value, options, onChange, disabled, onOpenChange, '
     <div className="rsel" ref={rootRef}>
       <button
         type="button"
-        className="rsel-trigger"
+        className={className ? `rsel-trigger ${className}` : 'rsel-trigger'}
         data-testid={testId}
         disabled={!!disabled}
         role="combobox"
@@ -107,6 +128,7 @@ export function RichSelect({ value, options, onChange, disabled, onOpenChange, '
         aria-expanded={state.open}
         aria-controls={`${baseId}-listbox`}
         aria-activedescendant={activeDescendantId(baseId, state)}
+        aria-label={ariaLabel}
         onClick={onTriggerClick}
         onKeyDown={onKeyDown}
       >

--- a/ui/src/dash/rich-select.jsx
+++ b/ui/src/dash/rich-select.jsx
@@ -1,0 +1,143 @@
+// rich-select.jsx — Task 10: shared multi-row listbox for drawer selects
+// (Runtime / Profile / Model, wired in by Task 11 without touching their
+// data-testids). Replaces a native <select> with a real `role="listbox"`
+// popover so each option can carry a title row, right-aligned state chips,
+// and a full-width description line (operator-approved two-line mockups,
+// PR-4 canvas).
+//
+// Every stateful rule — open/close, arrow/Home/End navigation skipping
+// disabled options, commit-on-Enter/click, aria-activedescendant id
+// derivation — lives in rich-select-core.ts and is vitest-pinned there. This
+// file is a thin rendering shell: it owns markup, the click-outside
+// listener, and active-option scroll-into-view; it makes no navigation or
+// selection decisions of its own.
+import React from 'react'
+
+import {
+  activeDescendantId,
+  closeList,
+  commit,
+  handleKey,
+  initialState,
+  optionDomId,
+  selectedOption,
+  toggle,
+} from './rich-select-core'
+
+const { useEffect, useId, useRef, useState } = React
+
+export function RichSelect({ value, options, onChange, disabled, 'data-testid': testId }) {
+  const generatedId = useId()
+  const baseId = testId || generatedId
+  const rootRef = useRef(null)
+  const listRef = useRef(null)
+  const [state, setState] = useState(() => initialState(value ?? null))
+
+  // A `value` change from outside while closed (e.g. a sibling control
+  // driving this select, or the initial load resolving) re-seeds activeId
+  // so the next open starts on the right row. While open, an in-flight
+  // keyboard/mouse navigation owns activeId and is left alone.
+  useEffect(() => {
+    setState((s) => (s.open ? s : closeList(value ?? null)))
+  }, [value]);
+
+  useEffect(() => {
+    if (!state.open) return undefined;
+    const onDocMouseDown = (e) => {
+      if (rootRef.current && !rootRef.current.contains(e.target)) {
+        setState(closeList(value ?? null));
+      }
+    };
+    document.addEventListener('mousedown', onDocMouseDown);
+    return () => document.removeEventListener('mousedown', onDocMouseDown);
+  }, [state.open, value]);
+
+  useEffect(() => {
+    if (!state.open || !listRef.current || state.activeId == null) return;
+    const escaped = typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(state.activeId) : state.activeId;
+    const el = listRef.current.querySelector(`[data-option-id="${escaped}"]`);
+    if (el) el.scrollIntoView({ block: 'nearest' });
+  }, [state.open, state.activeId]);
+
+  const fireChange = (id) => {
+    if (onChange) onChange(id);
+  };
+
+  const onTriggerClick = () => {
+    if (disabled) return;
+    setState((s) => toggle(s, options, value ?? null));
+  };
+
+  const onKeyDown = (e) => {
+    if (disabled) return;
+    const outcome = handleKey(e.key, state, options, value ?? null);
+    if (outcome.kind === 'none') return;
+    // Tab must keep moving focus per normal browser behaviour — only close.
+    if (e.key !== 'Tab') e.preventDefault();
+    setState(outcome.state);
+    if (outcome.kind === 'commit') fireChange(outcome.id);
+  };
+
+  const onOptionClick = (optionId) => {
+    const result = commit(state, options, optionId);
+    setState(result.nextState);
+    if (result.committedId != null) fireChange(result.committedId);
+  };
+
+  const selected = selectedOption(options, value ?? null);
+
+  return (
+    <div className="rsel" ref={rootRef}>
+      <button
+        type="button"
+        className="rsel-trigger"
+        data-testid={testId}
+        disabled={!!disabled}
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={state.open}
+        aria-controls={`${baseId}-listbox`}
+        aria-activedescendant={activeDescendantId(baseId, state)}
+        onClick={onTriggerClick}
+        onKeyDown={onKeyDown}
+      >
+        <span className="rsel-trigger-row">
+          {selected ? (
+            <span className="rsel-trigger-row-main">{selected.row}</span>
+          ) : (
+            <span className="rsel-trigger-placeholder">— select —</span>
+          )}
+          {selected && selected.right}
+        </span>
+        <span className="rsel-trigger-caret" aria-hidden="true">▾</span>
+      </button>
+      {state.open && (
+        <ul className="rsel-listbox" role="listbox" id={`${baseId}-listbox`} ref={listRef}>
+          {options.length === 0 && <li className="rsel-empty">No options</li>}
+          {options.map((opt) => (
+            <li
+              key={opt.id}
+              id={optionDomId(baseId, opt.id)}
+              data-option-id={opt.id}
+              role="option"
+              aria-selected={opt.id === value}
+              aria-disabled={!!opt.disabled}
+              data-active={opt.id === state.activeId}
+              className="rsel-option"
+              onMouseEnter={() => {
+                if (!opt.disabled) setState((s) => ({ ...s, activeId: opt.id }));
+              }}
+              onClick={() => onOptionClick(opt.id)}
+            >
+              <div className="rsel-option-row">
+                <span className="rsel-option-row-main">{opt.row}</span>
+                {opt.right && <span className="rsel-option-right">{opt.right}</span>}
+              </div>
+              {opt.desc && <div className="rsel-option-desc">{opt.desc}</div>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/ui/src/dash/rich-select.jsx
+++ b/ui/src/dash/rich-select.jsx
@@ -26,12 +26,21 @@ import {
 
 const { useEffect, useId, useRef, useState } = React
 
-export function RichSelect({ value, options, onChange, disabled, 'data-testid': testId }) {
+export function RichSelect({ value, options, onChange, disabled, onOpenChange, 'data-testid': testId }) {
   const generatedId = useId()
   const baseId = testId || generatedId
   const rootRef = useRef(null)
   const listRef = useRef(null)
   const [state, setState] = useState(() => initialState(value ?? null))
+
+  // Optional open/close notification (Task 11d) — the Model select's caller
+  // fires its one-shot batch feasibility probe here, on the transition into
+  // `open`, rather than on every render while open. No consumer is required
+  // to pass this; the effect is a no-op without it.
+  useEffect(() => {
+    if (onOpenChange) onOpenChange(state.open)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.open])
 
   // A `value` change from outside while closed (e.g. a sibling control
   // driving this select, or the initial load resolving) re-seeds activeId

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -18,6 +18,11 @@ import {
 } from "@/api/hooks/useSlots";
 import { useHardware } from "@/api/hooks/useHardware";
 import { useModels, usePullJob } from "@/api/hooks/useModels";
+// Host-truth GTT feasibility signal (993ea3b6, drawer overhaul Task 7/11d) —
+// same hook + copy mapper the PR-3 branch's model drawer uses; copied
+// verbatim rather than redesigned so the two branches dedupe at merge.
+import { useModelsFeasibility } from "@/api/hooks/useModelsFeasibility";
+import { feasibilityHint } from "./feasibility-copy";
 import { useProfiles } from "@/api/hooks/useProfiles";
 import { useSystemInfo, deviceBackend } from "@/api/hooks/useRuntimes";
 import {
@@ -947,6 +952,51 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	useEffectSM(() => {
 		setNameDraft(slot?.name || "");
 	}, [slot?.name]);
+
+	// GTT feasibility (Task 11d) — TWO separate mutation instances, not one
+	// shared between them: the ceiling hint and the model-row batch each hold
+	// their own `.data`, and a shared instance would let whichever fired last
+	// clobber the other's result.
+	const ceilingFeasibility = useModelsFeasibility();
+	const modelListFeasibility = useModelsFeasibility();
+	const ceilingFeasibilityTimer = useRefSM(null);
+	// Debounced 400ms probe for the bound model at the STAGED ceiling — fires
+	// on drawer open (curModelRow/ctx seed on mount) and again on every ctx
+	// edit. Advisory only (warn-never-block, 993ea3b6): a stale in-flight
+	// probe superseded by a newer keystroke is harmless — the render below
+	// always reads the mutation's latest `.data`.
+	useEffectSM(() => {
+		if (ceilingFeasibilityTimer.current) clearTimeout(ceilingFeasibilityTimer.current);
+		if (!open || !curModelRow?.id) return undefined;
+		const ctxNum = Number(ctx);
+		if (!Number.isFinite(ctxNum) || ctxNum <= 0) return undefined;
+		ceilingFeasibilityTimer.current = setTimeout(() => {
+			ceilingFeasibility.mutate({ models: [{ model_id: curModelRow.id, ctx: ctxNum }] });
+		}, 400);
+		return () => clearTimeout(ceilingFeasibilityTimer.current);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [open, curModelRow?.id, ctx]);
+	// The bound model's row from the last successful ceiling probe (or none —
+	// `feasibilityHint`'s default branch renders no hint for an absent row,
+	// same as an explicit "unknown" verdict).
+	const ctxFeasibilityRow = (ceilingFeasibility.data?.results || []).find(
+		(r) => r.model_id === curModelRow?.id,
+	);
+	const ctxHint = ctxFeasibilityRow ? feasibilityHint(ctxFeasibilityRow) : null;
+	// Per-row chip for the Model RichSelect's `right` slot, from the last
+	// batch probe (fired on dropdown open — see the Model select below). A
+	// row with no verdict in the batch (still loading, or the batch hasn't
+	// fired yet) renders no chip — never a stale/guessed one.
+	const modelFeasibilityChipFor = (id) => {
+		const row = (modelListFeasibility.data?.results || []).find((r) => r.model_id === id);
+		if (!row) return null;
+		const gb = Math.round((row.needed_mb ?? 0) / 1024);
+		if (row.verdict === "fits") return <span className="chip ok">● fits · ~{gb} GB</span>;
+		if (row.verdict === "tight") return <span className="chip warn">◐ tight</span>;
+		if (row.verdict === "exceeds" || row.verdict === "exceeds_total")
+			return <span className="chip err">○ won't fit</span>;
+		return null;
+	};
 
 	// Screen-reader descriptions for the header toggles — the hover `title`
 	// alone is unreachable for keyboard/touch/SR users (Codex review, #1638).
@@ -1963,9 +2013,25 @@ function EditSlotDrawer({ open, slot, onClose }) {
 															allSlots: Array.isArray(slotsQuery.data)
 																? slotsQuery.data
 																: [],
-															// Task 11d wires the real per-row fit chip here.
-															verdictChipFor: null,
+															verdictChipFor: modelFeasibilityChipFor,
 														})}
+														// Task 11d: one batch feasibility call for every listed
+														// model at the slot's CURRENT (persisted/staged) ceiling,
+														// fired once per dropdown open — not per keystroke, not
+														// per row. `has` rows with no verdict in the response
+														// render no chip (see modelFeasibilityChipFor above).
+														onOpenChange={(isOpen) => {
+															if (!isOpen || compatible.length === 0) return;
+															const ctxNum = Number(ctx);
+															modelListFeasibility.mutate({
+																models: compatible.map((m) => ({
+																	model_id: m.id,
+																	...(Number.isFinite(ctxNum) && ctxNum > 0
+																		? { ctx: ctxNum }
+																		: {}),
+																})),
+															});
+														}}
 														onChange={(id) => {
 															if (!id || id === cur) return;
 															const picked = compatible.find((m) => m.id === id);
@@ -2225,6 +2291,38 @@ function EditSlotDrawer({ open, slot, onClose }) {
 								{fieldErrs.ctx && (
 									<div className="hint" style={{ color: "var(--err)" }}>
 										{fieldErrs.ctx}
+									</div>
+								)}
+								{/* GTT feasibility hint (Task 11d, mockup panel 06) — host-truth,
+								    warn-never-block (993ea3b6): ok is a plain hint, warn/err are
+								    boxed. An absent/unknown verdict renders nothing at all. */}
+								{ctxHint?.tone && (
+									<div
+										className="hint"
+										data-testid="slot-ctx-feasibility"
+										style={
+											ctxHint.tone === "warn"
+												? {
+														marginTop: 6,
+														padding: "6px 10px",
+														borderRadius: "var(--rad-sm)",
+														color: "var(--warn)",
+														border: "1px solid var(--warn-line)",
+														background: "var(--warn-soft)",
+													}
+												: ctxHint.tone === "err"
+													? {
+															marginTop: 6,
+															padding: "6px 10px",
+															borderRadius: "var(--rad-sm)",
+															color: "var(--err)",
+															border: "1px solid var(--err-line)",
+															background: "var(--err-soft)",
+														}
+													: undefined
+										}
+									>
+										{ctxHint.text}
 									</div>
 								)}
 							</div>

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -14,6 +14,7 @@ import {
 	useSlotResolved,
 	useSlotDetail,
 	useSlots,
+	useSlotRename,
 } from "@/api/hooks/useSlots";
 import { useHardware } from "@/api/hooks/useHardware";
 import { useModels, usePullJob } from "@/api/hooks/useModels";
@@ -150,6 +151,14 @@ function crossDeviceTarget(profile, devBackend) {
 		return null;
 	return targetDevice;
 }
+
+// Slot display-name validity — mirrors RenameSlotDialog.jsx's own NAME_RE
+// (lowercase + dashes, ≤31 chars). Two copies rather than a shared export
+// because RenameSlotDialog is a window-global component file, not an ESM
+// module this file imports from; the pattern is small and stable enough
+// that keeping it inline here (Task 11a's inline-editable name field) costs
+// less than wiring a new export across that boundary.
+const SLOT_NAME_RE = /^[a-z][a-z0-9-]{0,30}$/;
 
 // Lane token → display title, for the Runtime select's option suffix and the
 // Lane pills (hw-cascade.js's runnerOptions/laneValues deal only in the raw
@@ -380,9 +389,22 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// them; render the drawer shell with a sentinel slot instead.
 	const editMut = useSlotEdit();
 	const defaultsMut = useSlotDefaults();
-	// Delete + rename are owned by their extracted dialogs (D2 decomposition):
-	// dash/slots/DeleteSlotDialog.jsx and dash/slots/RenameSlotDialog.jsx.
+	// Delete is owned by its extracted dialog (D2 decomposition):
+	// dash/slots/DeleteSlotDialog.jsx. Rename used to be too
+	// (dash/slots/RenameSlotDialog.jsx) — Task 11a replaces the "Rename…"
+	// button ceremony with an inline-editable title field (slot-name-inline,
+	// below), committing on blur/Enter through the SAME useSlotRename
+	// mutation the dialog used. RenameSlotDialog.jsx keeps its own
+	// mutation+validation logic (still used as a component in its own
+	// right); this drawer no longer opens it, but the API plumbing it
+	// wraps is exactly what renameMut below also calls.
 	const [renameOpen, setRenameOpen] = useStateSM(false);
+	const renameMut = useSlotRename();
+	// Inline name draft — seeded from the persisted name, resynced whenever
+	// the slot identity changes (a poll refresh mid-edit must not clobber an
+	// in-flight keystroke, same rule RenameSlotDialog's own seed effect
+	// follows).
+	const [nameDraft, setNameDraft] = useStateSM(slot?.name || "");
 	// Inline model edit — stacks the reusable ModelDrawer over this drawer
 	// (equal z-index; later DOM order wins) so model-tune edits don't force a
 	// close → Models page → reopen round-trip. The slot drawer and its
@@ -719,6 +741,12 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	useEffectSM(() => {
 		if (Number.isInteger(slot?.priority)) setPrio(slot.priority);
 	}, [slot?.priority]);
+	// Re-seed the inline name draft from server truth on identity change only
+	// — NOT on every poll re-reference, or an in-flight keystroke would be
+	// wiped every ~2.5s (same guard RenameSlotDialog's seed effect uses).
+	useEffectSM(() => {
+		setNameDraft(slot?.name || "");
+	}, [slot?.name]);
 
 	// Screen-reader descriptions for the header toggles — the hover `title`
 	// alone is unreachable for keyboard/touch/SR users (Codex review, #1638).
@@ -1011,6 +1039,27 @@ function EditSlotDrawer({ open, slot, onClose }) {
 					err?.message ? `${slot.name}: ${err.message}` : `${slot.name}: toggle failed`,
 					"warn",
 				);
+		}
+	};
+	// Slot rename requires the systemd unit OFFLINE (it re-templates
+	// hal0-slot@{name}) — same gate RenameSlotDialog enforces via
+	// slotButtonPhase. Committed on blur/Enter from the inline title field;
+	// an invalid or unchanged value reverts silently (no dialog, no modal
+	// round-trip) rather than surfacing a submit error for a no-op edit.
+	const nameRunning = slotButtonPhase(slot) !== "off";
+	const commitName = async () => {
+		const next = String(nameDraft).trim();
+		if (nameRunning || !next || !SLOT_NAME_RE.test(next) || next === slot.name) {
+			setNameDraft(slot.name);
+			return;
+		}
+		try {
+			await renameMut.mutateAsync({ name: slot.name, new_name: next });
+			window.__hal0Toast && window.__hal0Toast(`Renamed to ${next}`, "ok");
+		} catch (err) {
+			setNameDraft(slot.name);
+			window.__hal0Toast &&
+				window.__hal0Toast(err?.message || `${slot.name}: rename failed`, "warn");
 		}
 	};
 	const commitPriority = async () => {
@@ -1458,6 +1507,33 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		);
 	})();
 
+	// Runtime cascade (hw-cascade.js, D3) — hoisted out of the old Hardware
+	// FieldGroup's render-local IIFE (Task 11a regroup) so BOTH the "How it
+	// runs" Runtime/Lane rows and the consolidated Advanced disclosure's
+	// Image/Debug-pin/Supersession rows (which used to sit in that same
+	// IIFE) can read the same computation — the split moved Threads/NGL/
+	// Advanced out of the Hardware group without duplicating this cascade.
+	// Reads `pendingDevice` (#1636 Codex fix) so a pending cross-backend
+	// profile switch previews the POST-save fit.
+	const hwBackends = systemInfoQuery.data?.backends ?? {};
+	const hwFlags = hostHwFlags(systemInfoQuery.data?.hardware);
+	const { options: runtimeOptions } = runnerOptions({
+		backends: hwBackends,
+		device: pendingDevice,
+		slotType: slot.type,
+		hw: hwFlags,
+	});
+	const runtimeSel = selectedRunnerKey({ binary, options: runtimeOptions });
+	// '' = Auto (no binary pinned); a real key = that option; null = a
+	// persisted binary this catalog doesn't offer for this slot right now —
+	// kept as its own option so the drawer never silently rewrites persisted
+	// state.
+	const runtimeValue = runtimeSel === null ? binary : runtimeSel;
+	const selectedRuntimeOption = runtimeSel
+		? runtimeOptions.find((o) => o.key === runtimeSel)
+		: null;
+	const laneVals = laneValues(selectedRuntimeOption);
+
 	return (
 		<>
 			{/* The Drawer's Esc/backdrop/✕ paths call onClose — routed through
@@ -1469,17 +1545,98 @@ function EditSlotDrawer({ open, slot, onClose }) {
 				open={open}
 				onClose={requestClose}
 				eyebrow={`Slots · /slots/${slot.name}`}
-				title={`Edit ${slot.name}`}
+				title={
+					<span
+						style={{ display: "inline-flex", alignItems: "center", gap: 8, minWidth: 0 }}
+					>
+						{/* Inline-editable name (Task 11a) — replaces the disabled
+						    "Name" field + "Rename…" button ceremony. Commits through
+						    the SAME useSlotRename mutation on blur/Enter; Esc reverts
+						    the draft without saving. Disabled while the slot is
+						    running — a rename re-templates the systemd unit, same
+						    gate RenameSlotDialog enforces. */}
+						<input
+							className="mono drawer-title-input"
+							data-testid="slot-name-inline"
+							value={nameDraft}
+							disabled={nameRunning || renameMut.isPending}
+							onChange={(e) => setNameDraft(e.target.value)}
+							onBlur={commitName}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") e.currentTarget.blur();
+								if (e.key === "Escape") {
+									setNameDraft(slot.name);
+									e.currentTarget.blur();
+								}
+							}}
+							title={
+								nameRunning
+									? "Stop the slot to rename — the systemd unit is name-keyed"
+									: "Click to rename"
+							}
+							aria-label="Slot name"
+							size={Math.max(6, nameDraft.length)}
+						/>
+						<span className="chip outlined" title={`Type is fixed once created — make a new slot for a different kind.`}>
+							{slot.type || "—"}
+						</span>
+					</span>
+				}
 				width={SLOT_DRAWER_WIDTH}
 				headRight={
 					<>
+						{/* Identity + state facts (Task 11a): the two ReadOnlyStrip
+						    fact strips this used to be are gone — everything they
+						    carried either moved here (state/breaker/specialty chips,
+						    the #id·:port chip), onto the title (type), or into
+						    Advanced (image status). "runner · binary" was dropped
+						    outright: the Runtime select below already names it. */}
+						<span
+							className="drawer-h-facts"
+							style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
+						>
+							<span
+								data-testid="slot-state-readonly"
+								className={stateChipClass(slot)}
+							>
+								{slot.state}
+							</span>
+							<SlotBreakerChip s={slot} />
+							{specialtyDegraded && (
+								<span
+									className="tag-chip"
+									data-testid="slot-specialty-degraded"
+									title={specialtyDegraded.detail || "Specialty distribution degraded to GGUF-only"}
+									style={{
+										color: "var(--warn)",
+										borderColor: "var(--warn-line)",
+										background: "var(--warn-soft)",
+									}}
+								>
+									⚠ {specialtyDegraded.specialty || "specialty"} degraded
+								</span>
+							)}
+							<span className="chip mono">
+								<span data-testid="slot-id-readonly">
+									{(slot.id != null ? slot.id : slot.slot_id) != null
+										? `#${slot.id != null ? slot.id : slot.slot_id}`
+										: "—"}
+								</span>
+								{" · "}
+								<span data-testid="slot-port-readonly" title="assigned by PortAuthority">
+									{`:${slot.port || "—"}`}
+								</span>
+							</span>
+						</span>
 						{/* Lifecycle pair (spec 2026-08-02 consolidation): Auto-Load =
 						    boot start only, Pin = residency only. Side by side so they
 						    read as one story instead of competing features. NPU trio
 						    shadows (flm-stt / flm-embed) have no unit or container of
 						    their own — the anchor's FLM process serves them — so
 						    Auto-Load is hidden there: writing { autoload } to a shadow
-						    TOML configures a boot start that can never happen. */}
+						    TOML configures a boot start that can never happen.
+						    (Task 11b moves this pill down into the "When it unloads"
+						    row — kept here unchanged for the 11a regroup commit.) */}
 						{!isNpuShadow && (
 							<label
 								className="slot-enable-toggle drawer-enable"
@@ -1574,578 +1731,155 @@ function EditSlotDrawer({ open, slot, onClose }) {
 					</>
 				}
 			>
-				{/* Identity strip — read-only: stable slot id, PortAuthority-assigned
-          port, and state. The id is the API key for debugging (stable across a
-          rename); the port is display-only (assigned by PortAuthority). */}
-				<div
-					style={{
-						display: "grid",
-						gridTemplateColumns: "1fr 1fr 1fr",
-						gap: 0,
-						border: "1px solid var(--line-soft)",
-						borderRadius: "var(--rad-sm)",
-						overflow: "hidden",
-						marginBottom: 16,
-					}}
-				>
-					<ReadOnlyStrip
-						k="slot_id"
-						v={
-							<span data-testid="slot-id-readonly">
-								{(slot.id != null ? slot.id : slot.slot_id) != null
-									? `#${slot.id != null ? slot.id : slot.slot_id}`
-									: "—"}
-							</span>
-						}
-					/>
-					<ReadOnlyStrip
-						k="port · PortAuthority"
-						v={
-							<span
-								data-testid="slot-port-readonly"
-								title="assigned by PortAuthority"
-							>{`:${slot.port || "—"}`}</span>
-						}
-					/>
-					<ReadOnlyStrip
-						k="state"
-						v={
-							<span
-								style={{ display: "inline-flex", gap: 6, alignItems: "center" }}
-							>
-								<span
-									data-testid="slot-state-readonly"
-									className={stateChipClass(slot)}
-								>
-									{slot.state}
-								</span>
-								{/* #2038: breaker view rides next to the lifecycle state so
-								    "error" + "parked · N failures" read as one story. */}
-								<SlotBreakerChip s={slot} />
-								{/* Specialty guard verdict (spec 2026-08-29 #1946): the runner
-								    serving this slot doesn't list the model's specialty, so it
-								    launched GGUF-only (degraded, not blocked) — loud amber badge,
-								    same warn tokens as SlotBreakerChip/backend-mismatch chips.
-								    `.detail` carries the human-readable reason as the tooltip. */}
-								{specialtyDegraded && (
-									<span
-										className="tag-chip"
-										data-testid="slot-specialty-degraded"
-										title={specialtyDegraded.detail || "Specialty distribution degraded to GGUF-only"}
-										style={{
-											color: "var(--warn)",
-											borderColor: "var(--warn-line)",
-											background: "var(--warn-soft)",
-										}}
-									>
-										⚠ {specialtyDegraded.specialty || "specialty"} degraded
-									</span>
-								)}
-							</span>
-						}
-					/>
-				</div>
-
-				{/* Runner + type + image status strip — read-only. Runner (BINARY)
-          resolves the launch image (RUNNER_IMAGES[binary]); image_pin overrides
-          it (§3). `type` sits between the two: it is fixed at creation (it rides
-          the model, exactly like device), so it belongs in the read-only strip
-          rather than as a disabled form control down in the Slot group.
-          image status keyed to slot_id so the operator knows which slot owns it. */}
-				<div
-					style={{
-						display: "grid",
-						gridTemplateColumns: "1fr 1fr 1fr",
-						gap: 0,
-						border: "1px solid var(--line-soft)",
-						borderRadius: "var(--rad-sm)",
-						overflow: "hidden",
-						marginBottom: 16,
-					}}
-				>
-					<ReadOnlyStrip
-						k="runner · binary"
-						v={slot.binary || `auto · ${deviceBackend(device) || device}`}
-					/>
-					<ReadOnlyStrip
-						k="type"
-						v={
-							<span
-								data-testid="slot-type-readonly"
-								title="Type is fixed once created — make a new slot for a different kind."
-							>
-								{slot.type || "—"}
-							</span>
-						}
-					/>
-					<ReadOnlyStrip
-						k="image status"
-						v={
-							<span data-testid="slot-image-status">
-								{slotButtonPhase(slot) === "running"
-									? (slot.actual_image ||
-											slot.image_pin ||
-											slot.image ||
-											"present") +
-										(slot.id != null
-											? ` · #${slot.id}`
-											: slot.slot_id != null
-												? ` · #${slot.slot_id}`
-												: "")
-									: "—"}
-							</span>
-						}
-					/>
-				</div>
-
-				{/* Slot identity — names are mutable labels; the stable slot id is not. */}
-				<FieldGroup label="Slot">
-					<div className="form-row">
-						<div className="form-lbl">
-							<span>Name</span>
-							<FieldInfoIcon description="A display label. Rename any time — the stable slot number never
-								changes." />
-						</div>
-						<div
-							className="form-ctl"
-							style={{ display: "flex", gap: 8, alignItems: "center" }}
-						>
-							<input
-								className="input mono"
-								value={slot.name}
-								disabled
-								style={{ flex: 1 }}
-							/>
-							<button
-								className="btn ghost sm"
-								data-testid="slot-rename-open"
-								onClick={() => setRenameOpen(true)}
-							>
-								Rename…
-							</button>
-						</div>
-					</div>
-					{/* Type moved to the read-only strip above — it is fixed at
-					    creation, so a disabled select here was a control that could
-					    never do anything. */}
-				</FieldGroup>
+				{/* Task 11a: both ReadOnlyStrip fact strips (slot_id/port/state and
+				    runner·binary/type/image-status) are gone. state/breaker/
+				    specialty chips and the #id·:port chip moved into the drawer
+				    header row above; type became a title chip; "runner · binary"
+				    was dropped outright (the Runtime select below already names
+				    it); image status now lives in Advanced only (see below). The
+				    "Slot" FieldGroup's Name field + "Rename…" button are gone too
+				    — the title's inline-editable name field replaces both. */}
 
 
-				{/* Hardware ownership — changes apply on Save and require a restart. */}
-				<FieldGroup label="Hardware">
-					{(() => {
-						const backends = systemInfoQuery.data?.backends ?? {};
-						const hw = hostHwFlags(systemInfoQuery.data?.hardware);
-						// Runner-first cascade (hw-cascade.js, D3): one option per
-						// runtime, each carrying the lane(s) it can serve. Reads
-						// `pendingDevice` (#1636 Codex fix) so a pending cross-backend
-						// profile switch previews the POST-save fit.
-						const { options } = runnerOptions({
-							backends,
-							device: pendingDevice,
-							slotType: slot.type,
-							hw,
-						});
-						const runtimeSel = selectedRunnerKey({ binary, options });
-						// '' = Auto (no binary pinned); a real key = that option;
-						// null = a persisted binary this catalog doesn't offer for
-						// this slot right now — kept as its own option so the drawer
-						// never silently rewrites persisted state.
-						const runtimeValue = runtimeSel === null ? binary : runtimeSel;
-						const selectedOption = runtimeSel
-							? options.find((o) => o.key === runtimeSel)
-							: null;
-						const laneVals = laneValues(selectedOption);
-						return (
-							<>
-								{/* Device select removed: `device` is now DERIVED from the
-								    Runtime pick below (a single-lane runner's lane rides the
-								    pick; a dual-lane runner's Lane pills, further down) —
-								    the old standalone select let Device and Binary disagree.
-								    Save still persists it via PUT /config { device } and
-								    cold-restarts; non-GPU devices (npu/cpu/img) route to
-								    different runtime families, so they never flip here. */}
-								<div className="form-row">
-									<div className="form-lbl">
-										<span>Runtime</span>
-										<FieldInfoIcon description="Which engine build this slot launches. Options are what
-											this box's hardware can run; versions are managed on
-											the Runner Images page." />
-									</div>
-									<div className="form-ctl">
-										<select
-											className={
-												"input mono" + (fieldErrs.device ? " input-err" : "")
-											}
-											data-testid="slot-hw-runtime"
-											value={runtimeValue}
-											onChange={(e) => {
-												const pick = applyRunnerChoice({
-													options,
-													key: e.target.value,
-													currentDevice: device,
-												});
-												setBinary(pick.binary);
-												setDevice(pick.device);
-												setFieldErrs((p) => ({ ...p, device: undefined }));
-											}}
-										>
-											{/* Auto entry only while nothing is pinned — picking a
-											    real runtime is one-way, same as the old Backend
-											    select. */}
-											{!binary && (
-												<option value="">
-													— auto · resolved from device —
-												</option>
-											)}
-											{/* An out-of-vocab persisted binary (older release,
-											    hand-edited TOML, a runtime this box no longer offers
-											    for the slot) keeps its own option so the drawer
-											    never silently rewrites it. */}
-											{runtimeSel === null && (
-												<option value={binary}>
-													{binary} · not in this catalog
-												</option>
-											)}
-											{options.map((o) => (
-												<option key={o.key} value={o.key}>
-													{o.title}
-													{laneLabel(o) ? ` · ${laneLabel(o)}` : ""}
-													{o.state === "installable" ? " · not pulled" : ""}
-												</option>
-											))}
-										</select>
-										{selectedOption?.blurb ? (
-											<div className="hint">{selectedOption.blurb}</div>
-										) : null}
-										{deviceIsLiveEdit && (
-											<div
-												className="hint"
-												data-testid="slot-hw-consequence"
-												style={{
-													marginTop: 6,
-													padding: "6px 10px",
-													borderRadius: "var(--rad-sm)",
-													color: "var(--info)",
-													border: "1px solid var(--info-line)",
-													background: "var(--info-soft)",
-												}}
-											>
-												Switching moves this slot to the{" "}
-												{laneTitle(deviceBackend(device))} lane and restarts
-												it on Save.
-											</div>
-										)}
-										{fieldErrs.device && (
-											<div
-												className="hint"
-												data-testid="slot-hw-device-err"
-												style={{ color: "var(--err)" }}
-											>
-												{fieldErrs.device}
-											</div>
-										)}
-									</div>
-								</div>
-
-								{laneVals.length > 0 && (
+				{/* Task 11a regroup (mockup panel 03): "What runs" first — model +
+				    tune is the operator's first question. Model select + arch-fit
+				    warning are unchanged internals; the Profile row (+ apply
+				    preview) is unchanged too, just regrouped here. NPU slots have
+				    no Model select (the capability matrix further down replaces
+				    it) but their Profile row folds into this same section instead
+				    of keeping its own now-redundant group. */}
+				<FieldGroup label="What runs" hint="model & tune">
+					{device === "npu" ? (
+						profileRow
+					) : (
+						<>
+							{/* Task 1: live model swap — mirrors the card's ModelPicker but with the
+          full type+rocmfp4 compatibility filter (same as InlineSwapPopover).
+          Swap is its own POST /slots/{name}/swap (not part of the batched
+          Save); container slots cold-restart to load, so we toast like the
+          popover does. */}
+							{(() => {
+								const isContainer = slot.runtime === "container";
+								// Derive the backend from the SELECTED device (reactive) so the rocmfp4
+								// filter re-evaluates immediately when the operator switches the HW-grid
+								// device — before Save is clicked. (Device is the single owner of the
+								// rocm/vulkan axis now — spec-hw-slot-ownership §2.)
+								//
+								// Codex P1: deliberately `device` here, NOT `pendingDevice`. Swap fires
+								// its own immediate POST /slots/{name}/swap, independent of the batched
+								// Save — a pending cross-backend profile pick hasn't reached the server
+								// yet, so previewing the post-Save backend here would offer a model the
+								// CURRENTLY persisted runner can't load (the live swap has no idea a
+								// device switch is staged). Gate the whole control instead (below) while
+								// a switch is pending, and keep this list honest about the real device.
+								const selBackend = deviceBackend(device) || slot.backend;
+								const compatible = compatibleModels(modelsQuery.data, {
+									type: slot.type,
+									backend: selBackend,
+								});
+								const cur = slot.model_id || slot.model || "";
+								const has = compatible.some((m) => m.id === cur);
+								// A background swap is in flight — the select stays usable, but show a
+								// "Swapping…" hint so the operator knows the load is happening.
+								const swapping = swapMut.isPending;
+								return (
 									<div className="form-row">
 										<div className="form-lbl">
-											<span>Lane</span>
-											<FieldInfoIcon description="Which GPU stack the Standard runtime uses. Auto
-												follows the device." />
+											<span>Model</span>
+											<FieldInfoIcon description={isContainer ? "Swap restarts the container to load the new model" : "Applies immediately"} />
 										</div>
 										<div className="form-ctl">
 											<div
-												data-testid="slot-hw-lane"
-												style={{ display: "flex", gap: 6 }}
+												style={{ display: "flex", gap: 8, alignItems: "center" }}
 											>
-												{laneVals.map((lane) => {
-													const active = lane
-														? deviceBackend(pendingDevice) === lane
-														: !laneVals
-																.slice(1)
-																.includes(deviceBackend(pendingDevice));
-													return (
-														<button
-															key={lane || "auto"}
-															type="button"
-															className="btn ghost sm"
-															aria-pressed={active}
-															style={
-																active
-																	? {
-																			color: "var(--accent)",
-																			borderColor: "var(--accent-line)",
-																			background: "var(--accent-soft)",
-																		}
-																	: undefined
-															}
-															onClick={() =>
-																setDevice(
-																	lane
-																		? BACKEND_DEVICE[lane]
-																		: pendingDevice,
-																)
-															}
-														>
-															{lane ? laneTitle(lane) : "Auto"}
-														</button>
-													);
-												})}
+												<select
+													className="input mono"
+													style={{ flex: 1 }}
+													value={cur}
+													disabled={saving || !!pendingCrossDevice}
+													data-testid="slot-model-swap"
+													aria-label={`Model for ${slot.name}`}
+													onChange={(e) => {
+														const id = e.target.value;
+														if (!id || id === cur) return;
+														const picked = compatible.find((m) => m.id === id);
+														const label = picked?.longName || id;
+														// UI-5: swapping the model on a LIVE container slot cold-restarts
+														// it (~model-load seconds). Confirm through the shared
+														// ConfirmDialog before firing — stashing the pick re-renders the
+														// select back to `cur` (value={cur}), so cancel needs no manual
+														// revert. Mirrors the delete/dirty-close confirm gates.
+														const live = slotButtonPhase(slot) === "running";
+														if (isContainer && live) {
+															setPendingSwap({ id, label });
+															return;
+														}
+														fireSwap(id, label);
+													}}
+												>
+													{cur && !has && (
+														<option value={cur}>
+															{slot.modelLong || slot.model || cur}
+														</option>
+													)}
+													{!cur && <option value="">—</option>}
+													{compatible.map((m) => (
+														<option key={m.id} value={m.id}>
+															{m.longName || m.id}
+														</option>
+													))}
+												</select>
+												{/* Inline model edit — the app-wide pencil affordance
+												    (Icons.edit), same bare `btn ghost sm` icon-button
+												    convention as the slot card. Opens the model drawer
+												    DOCKED to the left of this one, so the slot's unsaved
+												    edits stay visible and editable underneath. */}
+												<button
+													className="btn ghost sm"
+													data-testid="slot-model-edit-open"
+													disabled={!curModelRow}
+													title="Edit the bound model's tune (flags, template, caps) in place"
+													aria-label={`Edit model ${curModelRow?.longName || curModelRow?.name || ""}`.trim()}
+													onClick={(e) => {
+														e.stopPropagation();
+														setModelEditOpen(true);
+													}}
+												>
+													{Icons.edit}
+												</button>
 											</div>
-										</div>
-									</div>
-								)}
-
-								<div className="form-row">
-									<div className="form-lbl">
-										<span>Threads</span>
-										<FieldInfoIcon description="CPU thread count for the runner. 0 = let the runtime
-											decide." />
-									</div>
-									<div className="form-ctl">
-										<input
-											className={
-												"input mono" + (fieldErrs.threads ? " input-err" : "")
-											}
-											data-testid="slot-hw-threads"
-											value={threads}
-											onChange={(e) => {
-												setThreads(e.target.value);
-												setFieldErrs((p) => ({ ...p, threads: undefined }));
-											}}
-											placeholder="0"
-											inputMode="numeric"
-										/>
-										{fieldErrs.threads && (
-											<div className="hint" style={{ color: "var(--err)" }}>
-												{fieldErrs.threads}
-											</div>
-										)}
-									</div>
-								</div>
-
-								<div className="form-row">
-									<div className="form-lbl">
-										<span>NGL</span>
-										<FieldInfoIcon description="GPU layers to offload — emits -ngl to the runner.
-											-1 = all layers, 0 = CPU only." />
-									</div>
-									<div className="form-ctl">
-										<input
-											className={
-												"input mono" + (fieldErrs.ngl ? " input-err" : "")
-											}
-											data-testid="slot-hw-ngl"
-											value={nGpuLayers}
-											onChange={(e) => {
-												setNGpuLayers(e.target.value);
-												setFieldErrs((p) => ({ ...p, ngl: undefined }));
-											}}
-											placeholder="-1"
-											inputMode="numeric"
-										/>
-										{fieldErrs.ngl && (
-											<div className="hint" style={{ color: "var(--err)" }}>
-												{fieldErrs.ngl}
-											</div>
-										)}
-									</div>
-								</div>
-
-								{/* Task 9: Advanced disclosure — image truth, debug pin,
-								    supersession banner. Collapsed by default; a controlled
-								    toggle (not native <details>) so the exact "▸"/"▾" glyph
-								    and label text are ours to own — mirrors the PanelHeader
-								    ▸/▾ pattern in
-								    dash/settings/pages/capabilities/shared.jsx. Everything
-								    inside is read-only or debug-only: the operator-facing
-								    hardware surface is Runtime/Lane above, and a pin here
-								    never widens or narrows those options (D1/D6 — no
-								    enumeration). "image"/"digest" language is permitted only
-								    inside this disclosure — the carve-out from the
-								    operator-noun rule that governs the rest of the group. */}
-								<div
-									className="form-section"
-									data-testid="slot-hw-advanced"
-									role="button"
-									tabIndex={0}
-									aria-expanded={advOpen}
-									style={{
-										cursor: "pointer",
-										userSelect: "none",
-										marginTop: 4,
-									}}
-									onClick={() => setAdvOpen((o) => !o)}
-									onKeyDown={(e) => {
-										if (e.key === "Enter" || e.key === " ") {
-											e.preventDefault();
-											setAdvOpen((o) => !o);
-										}
-									}}
-								>
-									<span
-										className="mono"
-										style={{ marginRight: 6, color: "var(--fg-4)" }}
-									>
-										{advOpen ? "▾" : "▸"}
-									</span>
-									Advanced — image & version
-								</div>
-								{advOpen &&
-									(() => {
-										// The effective ref this slot actually runs: a debug
-										// pin (persisted server-side) beats the Runtime's
-										// catalog image, which beats an honest "unresolved
-										// yet" sentinel — never fabricate a ref nothing backs.
-										const effectiveImage =
-											slot.image_pin ||
-											backends[binary]?.image ||
-											"resolved at launch";
-										const pinActive = !!imagePin.trim();
-										const supersededByCombinedUpstream = imagePin.includes(
-											"hal0-combined-upstream",
-										);
-										// The one-click fix commits binary="strix" — only offer
-										// it when "strix" is actually a live pick in the SAME
-										// `options` list the Runtime select above renders (already
-										// filtered by device_class/slotType/hw feasibility). Firing
-										// setBinary("strix") when it isn't would land the operator
-										// on an unresolvable "strix · not in this catalog" pick —
-										// worse than the pin they started with.
-										const strixAvailable = options.some(
-											(o) => o.key === "strix",
-										);
-										return (
-											<>
-												<div className="form-row">
-													<div className="form-lbl">
-														<span>Image</span>
-														<FieldInfoIcon description="The exact runtime image resolved for this
-															slot — a debug pin when one is set, otherwise
-															the release image for the picked Runtime." />
-													</div>
-													<div className="form-ctl">
-														<span
-															className="mono"
-															data-testid="slot-hw-advanced-image"
-														>
-															{effectiveImage}
-														</span>
-														<div className="hint">
-															{pinActive
-																? "debug pin"
-																: "pinned by release · reconciled by hal0 update"}
-														</div>
-													</div>
+											{swapping && <div className="hint">Swapping…</div>}
+											{!swapping && pendingCrossDevice && (
+												<div
+													className="hint"
+													data-testid="slot-model-swap-blocked"
+												>
+													Model swap is unavailable while the profile pick
+													above is staged to switch this slot's device — Save
+													that change (or revert the profile) before swapping.
 												</div>
-
-												<div className="form-row">
-													<div className="form-lbl">
-														<span>Version</span>
-													</div>
-													<div className="form-ctl">
-														<div className="hint">
-															Versions and rollback are managed per-runtime
-															on the{" "}
-															<a href="#slots/runner-images">
-																Runner Images page
-															</a>
-															.
-														</div>
-													</div>
-												</div>
-
-												<div className="form-row">
-													<div className="form-lbl">
-														<span>Debug pin</span>
-														<FieldInfoIcon description="Optional: pin this slot to an exact build
-															reference instead of the Runtime's release
-															default. Debug/rollback use only — cleared by
-															leaving it empty." />
-													</div>
-													<div className="form-ctl">
-														{!pinActive && !pinCustom && (
-															<button
-																type="button"
-																className="btn ghost sm"
-																data-testid="slot-hw-debug-pin-open"
-																onClick={() => setPinCustom(true)}
-															>
-																Pin a custom image ref…
-															</button>
-														)}
-														{(pinCustom || pinActive) && (
-															<>
-																<input
-																	className={
-																		"input mono" +
-																		(fieldErrs.imagePin
-																			? " input-err"
-																			: "")
-																	}
-																	data-testid="slot-hw-image-pin"
-																	value={imagePin}
-																	onChange={(e) => {
-																		setImagePin(e.target.value);
-																		setFieldErrs((p) => ({
-																			...p,
-																			imagePin: undefined,
-																		}));
-																	}}
-																	placeholder={
-																		binary && backends[binary]?.image
-																			? backends[binary].image
-																			: "will resolve from the Runtime pick"
-																	}
-																	spellCheck={false}
-																/>
-																{fieldErrs.imagePin ? (
-																	<div
-																		className="hint"
-																		style={{ color: "var(--err)" }}
-																	>
-																		{fieldErrs.imagePin}
-																	</div>
-																) : null}
-															</>
-														)}
-														{pinActive && (
-															<>
-																<div
-																	className="hint"
-																	data-testid="slot-hw-debug-pin-warning"
-																	style={{ color: "var(--warn)" }}
-																>
-																	Debug-only. hal0 can't verify what a
-																	custom ref ships — the slot keeps its
-																	current runtime binary and may fail at
-																	spawn.
-																</div>
-																<button
-																	type="button"
-																	className="btn ghost sm"
-																	data-testid="slot-hw-image-pin-clear"
-																	onClick={() => {
-																		setImagePin("");
-																		setPinCustom(false);
-																		setFieldErrs((p) => ({
-																			...p,
-																			imagePin: undefined,
-																		}));
-																	}}
-																>
-																	Use release image
-																</button>
-															</>
-														)}
-													</div>
-												</div>
-
-												{supersededByCombinedUpstream && (
+											)}
+											{(() => {
+												// Model↔runner GGUF-arch fit-check (hal0#2118) — warn,
+												// never block, same idiom as the HW-grid fit warning
+												// below the Backend select. Reads the bound model's
+												// detected `architecture` against the effective
+												// runner's `unsupported_archs` denylist (system-info);
+												// an image_pin disarms it (the pin IS the escape
+												// hatch). Previews the post-save device/binary/pin so
+												// a live HW edit updates the verdict before Save.
+												const archWarn = archFitWarning({
+													arch: curModelRow?.architecture,
+													device: pendingDevice,
+													binary,
+													imagePin,
+													backends: systemInfoQuery.data?.backends ?? {},
+												});
+												if (!archWarn) return null;
+												return (
 													<div
-														data-testid="slot-hw-supersession-banner"
+														className="hint"
+														data-testid="slot-model-arch-fit-warning"
 														style={{
 															marginTop: 6,
 															padding: "6px 10px",
@@ -2153,198 +1887,188 @@ function EditSlotDrawer({ open, slot, onClose }) {
 															color: "var(--warn)",
 															border: "1px solid var(--warn-line)",
 															background: "var(--warn-soft)",
-															display: "flex",
-															alignItems: "center",
-															justifyContent: "space-between",
-															gap: 8,
 														}}
 													>
-														<span>
-															⚠{" "}
-															{strixAvailable
-																? "Superseded by the Strix runtime"
-																: "Superseded by the Strix runtime — available after the next update"}
-														</span>
-														{strixAvailable && (
-															<button
-																type="button"
-																className="btn ghost sm"
-																data-testid="slot-hw-supersession-fix"
-																onClick={() => {
-																	setBinary("strix");
-																	setDevice("gpu-vulkan");
-																	setImagePin("");
-																}}
-															>
-																Switch to Strix
-															</button>
-														)}
+														{archWarn}
 													</div>
-												)}
-											</>
-										);
-									})()}
-							</>
-						);
-					})()}
+												);
+											})()}
+										</div>
+									</div>
+								);
+							})()}
+
+							{profileRow}
+
+							{/* #1379: Template / Parallel / Extra Args were removed here.
+          All three persisted to the slot TOML and reached nothing —
+          `providers/container.py` does `del profile_flags, slot_parallel,
+          extra_args`, and `resolve_chat_template` no longer consults the
+          per-slot key. spec-flags-ownership §1/§4 puts the launch tune on the
+          MODEL; spec-hw-slot-ownership §8 prescribes this editor as the HW grid
+          + image_pin only. Removed outright rather than left read-only, the
+          same call made for Reasoning/MTP/Vision under §1. Anything already on
+          disk is folded into the bound model by `hal0 slot migrate-flags`
+          (#1396/#1397) — this drawer neither reads nor clears it. */}
+							<div className="hint" data-testid="slot-launch-tune-note">
+								Chat template and launch flags belong to the model — edit them
+								with “Edit model…” above. Flags set on a slot are not applied
+								at launch.
+							</div>
+						</>
+					)}
 				</FieldGroup>
 
-				{/* NPU slots have no Model group (the capability matrix replaces it),
-				    so the profile keeps its own group there. Everywhere else the row
-				    lives inside Model, under the model select. */}
-				{device === "npu" && (
-					<FieldGroup label="Profile">{profileRow}</FieldGroup>
-				)}
-
-				{device !== "npu" && (
-					<FieldGroup label="Model">
-						{/* Task 1: live model swap — mirrors the card's ModelPicker but with the
-          full type+rocmfp4 compatibility filter (same as InlineSwapPopover).
-          Swap is its own POST /slots/{name}/swap (not part of the batched
-          Save); container slots cold-restart to load, so we toast like the
-          popover does. */}
-						{(() => {
-							const isContainer = slot.runtime === "container";
-							// Derive the backend from the SELECTED device (reactive) so the rocmfp4
-							// filter re-evaluates immediately when the operator switches the HW-grid
-							// device — before Save is clicked. (Device is the single owner of the
-							// rocm/vulkan axis now — spec-hw-slot-ownership §2.)
-							//
-							// Codex P1: deliberately `device` here, NOT `pendingDevice`. Swap fires
-							// its own immediate POST /slots/{name}/swap, independent of the batched
-							// Save — a pending cross-backend profile pick hasn't reached the server
-							// yet, so previewing the post-Save backend here would offer a model the
-							// CURRENTLY persisted runner can't load (the live swap has no idea a
-							// device switch is staged). Gate the whole control instead (below) while
-							// a switch is pending, and keep this list honest about the real device.
-							const selBackend = deviceBackend(device) || slot.backend;
-							const compatible = compatibleModels(modelsQuery.data, {
-								type: slot.type,
-								backend: selBackend,
-							});
-							const cur = slot.model_id || slot.model || "";
-							const has = compatible.some((m) => m.id === cur);
-							// A background swap is in flight — the select stays usable, but show a
-							// "Swapping…" hint so the operator knows the load is happening.
-							const swapping = swapMut.isPending;
-							return (
-								<div className="form-row">
-									<div className="form-lbl">
-										<span>Model</span>
-										<FieldInfoIcon description={isContainer ? "Swap restarts the container to load the new model" : "Applies immediately"} />
-									</div>
-									<div className="form-ctl">
-										<div
-											style={{ display: "flex", gap: 8, alignItems: "center" }}
-										>
-											<select
-												className="input mono"
-												style={{ flex: 1 }}
-												value={cur}
-												disabled={saving || !!pendingCrossDevice}
-												data-testid="slot-model-swap"
-												aria-label={`Model for ${slot.name}`}
-												onChange={(e) => {
-													const id = e.target.value;
-													if (!id || id === cur) return;
-													const picked = compatible.find((m) => m.id === id);
-													const label = picked?.longName || id;
-													// UI-5: swapping the model on a LIVE container slot cold-restarts
-													// it (~model-load seconds). Confirm through the shared
-													// ConfirmDialog before firing — stashing the pick re-renders the
-													// select back to `cur` (value={cur}), so cancel needs no manual
-													// revert. Mirrors the delete/dirty-close confirm gates.
-													const live = slotButtonPhase(slot) === "running";
-													if (isContainer && live) {
-														setPendingSwap({ id, label });
-														return;
-													}
-													fireSwap(id, label);
-												}}
-											>
-												{cur && !has && (
-													<option value={cur}>
-														{slot.modelLong || slot.model || cur}
-													</option>
-												)}
-												{!cur && <option value="">—</option>}
-												{compatible.map((m) => (
-													<option key={m.id} value={m.id}>
-														{m.longName || m.id}
-													</option>
-												))}
-											</select>
-											{/* Inline model edit — the app-wide pencil affordance
-											    (Icons.edit), same bare `btn ghost sm` icon-button
-											    convention as the slot card. Opens the model drawer
-											    DOCKED to the left of this one, so the slot's unsaved
-											    edits stay visible and editable underneath. */}
-											<button
-												className="btn ghost sm"
-												data-testid="slot-model-edit-open"
-												disabled={!curModelRow}
-												title="Edit the bound model's tune (flags, template, caps) in place"
-												aria-label={`Edit model ${curModelRow?.longName || curModelRow?.name || ""}`.trim()}
-												onClick={(e) => {
-													e.stopPropagation();
-													setModelEditOpen(true);
-												}}
-											>
-												{Icons.edit}
-											</button>
-										</div>
-										{swapping && <div className="hint">Swapping…</div>}
-										{!swapping && pendingCrossDevice && (
-											<div
-												className="hint"
-												data-testid="slot-model-swap-blocked"
-											>
-												Model swap is unavailable while the profile pick
-												above is staged to switch this slot's device — Save
-												that change (or revert the profile) before swapping.
-											</div>
-										)}
-										{(() => {
-											// Model↔runner GGUF-arch fit-check (hal0#2118) — warn,
-											// never block, same idiom as the HW-grid fit warning
-											// below the Backend select. Reads the bound model's
-											// detected `architecture` against the effective
-											// runner's `unsupported_archs` denylist (system-info);
-											// an image_pin disarms it (the pin IS the escape
-											// hatch). Previews the post-save device/binary/pin so
-											// a live HW edit updates the verdict before Save.
-											const archWarn = archFitWarning({
-												arch: curModelRow?.architecture,
-												device: pendingDevice,
-												binary,
-												imagePin,
-												backends: systemInfoQuery.data?.backends ?? {},
-											});
-											if (!archWarn) return null;
-											return (
-												<div
-													className="hint"
-													data-testid="slot-model-arch-fit-warning"
-													style={{
-														marginTop: 6,
-														padding: "6px 10px",
-														borderRadius: "var(--rad-sm)",
-														color: "var(--warn)",
-														border: "1px solid var(--warn-line)",
-														background: "var(--warn-soft)",
-													}}
-												>
-													{archWarn}
-												</div>
-											);
-										})()}
-									</div>
+				{/* How it runs — this slot's hardware. Runtime + Lane are
+				    unchanged internals (cascade hoisted above, Task 11a); Context
+				    ceiling moves IN from the old Model group — a hardware ceiling
+				    reads better beside the hardware that enforces it than the
+				    model whose window it clamps. Threads/NGL and the image-facing
+				    disclosure move OUT, into the single consolidated Advanced
+				    section further down (threads, NGL, image block, debug pin,
+				    supersession banner, resolved command all live there now). */}
+				<FieldGroup label="How it runs" hint="this slot's hardware">
+					{/* Device select removed: `device` is now DERIVED from the
+					    Runtime pick below (a single-lane runner's lane rides the
+					    pick; a dual-lane runner's Lane pills, further down) —
+					    the old standalone select let Device and Binary disagree.
+					    Save still persists it via PUT /config { device } and
+					    cold-restarts; non-GPU devices (npu/cpu/img) route to
+					    different runtime families, so they never flip here. */}
+					<div className="form-row">
+						<div className="form-lbl">
+							<span>Runtime</span>
+							<FieldInfoIcon description="Which engine build this slot launches. Options are what
+								this box's hardware can run; versions are managed on
+								the Runner Images page." />
+						</div>
+						<div className="form-ctl">
+							<select
+								className={
+									"input mono" + (fieldErrs.device ? " input-err" : "")
+								}
+								data-testid="slot-hw-runtime"
+								value={runtimeValue}
+								onChange={(e) => {
+									const pick = applyRunnerChoice({
+										options: runtimeOptions,
+										key: e.target.value,
+										currentDevice: device,
+									});
+									setBinary(pick.binary);
+									setDevice(pick.device);
+									setFieldErrs((p) => ({ ...p, device: undefined }));
+								}}
+							>
+								{/* Auto entry only while nothing is pinned — picking a
+								    real runtime is one-way, same as the old Backend
+								    select. */}
+								{!binary && (
+									<option value="">
+										— auto · resolved from device —
+									</option>
+								)}
+								{/* An out-of-vocab persisted binary (older release,
+								    hand-edited TOML, a runtime this box no longer offers
+								    for the slot) keeps its own option so the drawer
+								    never silently rewrites it. */}
+								{runtimeSel === null && (
+									<option value={binary}>
+										{binary} · not in this catalog
+									</option>
+								)}
+								{runtimeOptions.map((o) => (
+									<option key={o.key} value={o.key}>
+										{o.title}
+										{laneLabel(o) ? ` · ${laneLabel(o)}` : ""}
+										{o.state === "installable" ? " · not pulled" : ""}
+									</option>
+								))}
+							</select>
+							{selectedRuntimeOption?.blurb ? (
+								<div className="hint">{selectedRuntimeOption.blurb}</div>
+							) : null}
+							{deviceIsLiveEdit && (
+								<div
+									className="hint"
+									data-testid="slot-hw-consequence"
+									style={{
+										marginTop: 6,
+										padding: "6px 10px",
+										borderRadius: "var(--rad-sm)",
+										color: "var(--info)",
+										border: "1px solid var(--info-line)",
+										background: "var(--info-soft)",
+									}}
+								>
+									Switching moves this slot to the{" "}
+									{laneTitle(deviceBackend(device))} lane and restarts
+									it on Save.
 								</div>
-							);
-						})()}
+							)}
+							{fieldErrs.device && (
+								<div
+									className="hint"
+									data-testid="slot-hw-device-err"
+									style={{ color: "var(--err)" }}
+								>
+									{fieldErrs.device}
+								</div>
+							)}
+						</div>
+					</div>
 
-						{profileRow}
+					{laneVals.length > 0 && (
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>Lane</span>
+								<FieldInfoIcon description="Which GPU stack the Standard runtime uses. Auto
+									follows the device." />
+							</div>
+							<div className="form-ctl">
+								<div
+									data-testid="slot-hw-lane"
+									style={{ display: "flex", gap: 6 }}
+								>
+									{laneVals.map((lane) => {
+										const active = lane
+											? deviceBackend(pendingDevice) === lane
+											: !laneVals
+													.slice(1)
+													.includes(deviceBackend(pendingDevice));
+										return (
+											<button
+												key={lane || "auto"}
+												type="button"
+												className="btn ghost sm"
+												aria-pressed={active}
+												style={
+													active
+														? {
+																color: "var(--accent)",
+																borderColor: "var(--accent-line)",
+																background: "var(--accent-soft)",
+															}
+														: undefined
+												}
+												onClick={() =>
+													setDevice(
+														lane
+															? BACKEND_DEVICE[lane]
+															: pendingDevice,
+													)
+												}
+											>
+												{lane ? laneTitle(lane) : "Auto"}
+											</button>
+										);
+									})}
+								</div>
+							</div>
+						</div>
+					)}
 
+					{device !== "npu" && (
 						<div className="form-row">
 							<div className="form-lbl">
 								<span>Context (ceiling)</span>
@@ -2371,24 +2095,8 @@ function EditSlotDrawer({ open, slot, onClose }) {
 								)}
 							</div>
 						</div>
-
-						{/* #1379: Template / Parallel / Extra Args were removed here.
-          All three persisted to the slot TOML and reached nothing —
-          `providers/container.py` does `del profile_flags, slot_parallel,
-          extra_args`, and `resolve_chat_template` no longer consults the
-          per-slot key. spec-flags-ownership §1/§4 puts the launch tune on the
-          MODEL; spec-hw-slot-ownership §8 prescribes this editor as the HW grid
-          + image_pin only. Removed outright rather than left read-only, the
-          same call made for Reasoning/MTP/Vision under §1. Anything already on
-          disk is folded into the bound model by `hal0 slot migrate-flags`
-          (#1396/#1397) — this drawer neither reads nor clears it. */}
-						<div className="hint" data-testid="slot-launch-tune-note">
-							Chat template and launch flags belong to the model — edit them
-							with “Edit model…” above. Flags set on a slot are not applied
-							at launch.
-						</div>
-					</FieldGroup>
-				)}
+					)}
+				</FieldGroup>
 				{/* NPU trio SHADOW (flm-stt / flm-embed): its own [npu] table is
 				    inert — the anchor's FLM process owns all three modalities, so
 				    editing toggles here wrote config the launcher never reads and
@@ -2571,51 +2279,348 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						);
 					})()}
 
-				{/* Task 4: Advanced fields (mostly read-only, profile-owned) are
-          collapsed by default — minimal native <details> disclosure (no
-          disclosure primitive exists in primitives.jsx). */}
-				<details className="adv-disclosure">
-					<summary
-						className="form-section"
-						style={{ cursor: "pointer", listStyle: "revert" }}
-					>
-						Advanced
-					</summary>
-
-					{/* Eviction priority (spec 2026-08-02) lives under Advanced: its
-					    lifecycle siblings (Auto-Load / Pin) are header toggles, and it
-					    only matters for unpinned slots under memory pressure. Hidden
-					    for NPU trio shadows — no process of their own to evict. */}
-					{!isNpuShadow && (
-					<div className="form-row">
-						<div className="form-lbl">
-							<span>Eviction priority</span>
-							<FieldInfoIcon description="0-100 — lower unloads first when memory is needed.
-								Ties go to the least recently used. Pin the slot to exempt
-								it entirely." />
+				{/* Task 11a: the two Advanced surfaces this used to be (a controlled
+				    slot-hw-advanced disclosure for image/debug-pin/supersession, and
+				    a separate native <details> for priority/resolved-command) are
+				    consolidated into ONE disclosure — threads, NGL, image block,
+				    debug pin, supersession banner and resolved command all live
+				    here now (mockup panel 03's "▸ Advanced — threads, layers,
+				    image, command"). Controlled (not native <details>) so the
+				    "▸"/"▾" glyph and label stay ours to own, same reasoning Task 9
+				    gave for the image sub-disclosure it replaces. Eviction
+				    priority stays here for this commit — Task 11b moves it out
+				    into the new "When it unloads" lifecycle row. */}
+				<div
+					className="form-section"
+					data-testid="slot-hw-advanced"
+					role="button"
+					tabIndex={0}
+					aria-expanded={advOpen}
+					style={{ cursor: "pointer", userSelect: "none", marginTop: 4 }}
+					onClick={() => setAdvOpen((o) => !o)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter" || e.key === " ") {
+							e.preventDefault();
+							setAdvOpen((o) => !o);
+						}
+					}}
+				>
+					<span className="mono" style={{ marginRight: 6, color: "var(--fg-4)" }}>
+						{advOpen ? "▾" : "▸"}
+					</span>
+					Advanced — threads, layers, image, command
+				</div>
+				{advOpen && (
+					<>
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>Threads</span>
+								<FieldInfoIcon description="CPU thread count for the runner. 0 = let the runtime
+									decide." />
+							</div>
+							<div className="form-ctl">
+								<input
+									className={
+										"input mono" + (fieldErrs.threads ? " input-err" : "")
+									}
+									data-testid="slot-hw-threads"
+									value={threads}
+									onChange={(e) => {
+										setThreads(e.target.value);
+										setFieldErrs((p) => ({ ...p, threads: undefined }));
+									}}
+									placeholder="0"
+									inputMode="numeric"
+								/>
+								{fieldErrs.threads && (
+									<div className="hint" style={{ color: "var(--err)" }}>
+										{fieldErrs.threads}
+									</div>
+								)}
+							</div>
 						</div>
-						<div className="form-ctl">
-							<input
-								className="input mono"
-								data-testid="slot-priority-input"
-								type="number"
-								min={0}
-								max={100}
-								step={1}
-								value={prio}
-								onChange={(e) => setPrio(e.target.value)}
-								onBlur={commitPriority}
-								onKeyDown={(e) => {
-									if (e.key === "Enter") e.currentTarget.blur();
-								}}
-								style={{ width: 90 }}
-							/>
-							<div className="hint">lower unloads first</div>
-						</div>
-					</div>
-					)}
 
-					{/* Flags preview — backend-provided resolved_command (real podman argv),
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>NGL</span>
+								<FieldInfoIcon description="GPU layers to offload — emits -ngl to the runner.
+									-1 = all layers, 0 = CPU only." />
+							</div>
+							<div className="form-ctl">
+								<input
+									className={
+										"input mono" + (fieldErrs.ngl ? " input-err" : "")
+									}
+									data-testid="slot-hw-ngl"
+									value={nGpuLayers}
+									onChange={(e) => {
+										setNGpuLayers(e.target.value);
+										setFieldErrs((p) => ({ ...p, ngl: undefined }));
+									}}
+									placeholder="-1"
+									inputMode="numeric"
+								/>
+								{fieldErrs.ngl && (
+									<div className="hint" style={{ color: "var(--err)" }}>
+										{fieldErrs.ngl}
+									</div>
+								)}
+							</div>
+						</div>
+
+						{(() => {
+							// The effective ref this slot actually runs: a debug
+							// pin (persisted server-side) beats the Runtime's
+							// catalog image, which beats an honest "unresolved
+							// yet" sentinel — never fabricate a ref nothing backs.
+							const effectiveImage =
+								slot.image_pin ||
+								hwBackends[binary]?.image ||
+								"resolved at launch";
+							const pinActive = !!imagePin.trim();
+							const supersededByCombinedUpstream = imagePin.includes(
+								"hal0-combined-upstream",
+							);
+							// The one-click fix commits binary="strix" — only offer
+							// it when "strix" is actually a live pick in the SAME
+							// `runtimeOptions` list the Runtime select above renders
+							// (already filtered by device_class/slotType/hw
+							// feasibility). Firing setBinary("strix") when it isn't
+							// would land the operator on an unresolvable "strix ·
+							// not in this catalog" pick — worse than the pin they
+							// started with.
+							const strixAvailable = runtimeOptions.some(
+								(o) => o.key === "strix",
+							);
+							return (
+								<>
+									<div className="form-row">
+										<div className="form-lbl">
+											<span>Image</span>
+											<FieldInfoIcon description="The exact runtime image resolved for this
+												slot — a debug pin when one is set, otherwise
+												the release image for the picked Runtime." />
+										</div>
+										<div className="form-ctl">
+											<span
+												className="mono"
+												data-testid="slot-hw-advanced-image"
+											>
+												{effectiveImage}
+											</span>
+											<div className="hint">
+												{pinActive
+													? "debug pin"
+													: "pinned by release · reconciled by hal0 update"}
+											</div>
+										</div>
+									</div>
+
+									<div className="form-row">
+										<div className="form-lbl">
+											<span>Image status</span>
+											<FieldInfoIcon description="The image this slot is ACTUALLY running right now,
+												while it's up — distinct from the resolved release
+												image above, which is what the next (re)start
+												would use." />
+										</div>
+										<div className="form-ctl">
+											<span className="mono" data-testid="slot-image-status">
+												{slotButtonPhase(slot) === "running"
+													? (slot.actual_image ||
+															slot.image_pin ||
+															slot.image ||
+															"present") +
+														(slot.id != null
+															? ` · #${slot.id}`
+															: slot.slot_id != null
+																? ` · #${slot.slot_id}`
+																: "")
+													: "—"}
+											</span>
+										</div>
+									</div>
+
+									<div className="form-row">
+										<div className="form-lbl">
+											<span>Version</span>
+										</div>
+										<div className="form-ctl">
+											<div className="hint">
+												Versions and rollback are managed per-runtime
+												on the{" "}
+												<a href="#slots/runner-images">
+													Runner Images page
+												</a>
+												.
+											</div>
+										</div>
+									</div>
+
+									<div className="form-row">
+										<div className="form-lbl">
+											<span>Debug pin</span>
+											<FieldInfoIcon description="Optional: pin this slot to an exact build
+												reference instead of the Runtime's release
+												default. Debug/rollback use only — cleared by
+												leaving it empty." />
+										</div>
+										<div className="form-ctl">
+											{!pinActive && !pinCustom && (
+												<button
+													type="button"
+													className="btn ghost sm"
+													data-testid="slot-hw-debug-pin-open"
+													onClick={() => setPinCustom(true)}
+												>
+													Pin a custom image ref…
+												</button>
+											)}
+											{(pinCustom || pinActive) && (
+												<>
+													<input
+														className={
+															"input mono" +
+															(fieldErrs.imagePin
+																? " input-err"
+																: "")
+														}
+														data-testid="slot-hw-image-pin"
+														value={imagePin}
+														onChange={(e) => {
+															setImagePin(e.target.value);
+															setFieldErrs((p) => ({
+																...p,
+																imagePin: undefined,
+															}));
+														}}
+														placeholder={
+															binary && hwBackends[binary]?.image
+																? hwBackends[binary].image
+																: "will resolve from the Runtime pick"
+														}
+														spellCheck={false}
+													/>
+													{fieldErrs.imagePin ? (
+														<div
+															className="hint"
+															style={{ color: "var(--err)" }}
+														>
+															{fieldErrs.imagePin}
+														</div>
+													) : null}
+												</>
+											)}
+											{pinActive && (
+												<>
+													<div
+														className="hint"
+														data-testid="slot-hw-debug-pin-warning"
+														style={{ color: "var(--warn)" }}
+													>
+														Debug-only. hal0 can't verify what a
+														custom ref ships — the slot keeps its
+														current runtime binary and may fail at
+														spawn.
+													</div>
+													<button
+														type="button"
+														className="btn ghost sm"
+														data-testid="slot-hw-image-pin-clear"
+														onClick={() => {
+															setImagePin("");
+															setPinCustom(false);
+															setFieldErrs((p) => ({
+																...p,
+																imagePin: undefined,
+															}));
+														}}
+													>
+														Use release image
+													</button>
+												</>
+											)}
+										</div>
+									</div>
+
+									{supersededByCombinedUpstream && (
+										<div
+											data-testid="slot-hw-supersession-banner"
+											style={{
+												marginTop: 6,
+												padding: "6px 10px",
+												borderRadius: "var(--rad-sm)",
+												color: "var(--warn)",
+												border: "1px solid var(--warn-line)",
+												background: "var(--warn-soft)",
+												display: "flex",
+												alignItems: "center",
+												justifyContent: "space-between",
+												gap: 8,
+											}}
+										>
+											<span>
+												⚠{" "}
+												{strixAvailable
+													? "Superseded by the Strix runtime"
+													: "Superseded by the Strix runtime — available after the next update"}
+											</span>
+											{strixAvailable && (
+												<button
+													type="button"
+													className="btn ghost sm"
+													data-testid="slot-hw-supersession-fix"
+													onClick={() => {
+														setBinary("strix");
+														setDevice("gpu-vulkan");
+														setImagePin("");
+													}}
+												>
+													Switch to Strix
+												</button>
+											)}
+										</div>
+									)}
+								</>
+							);
+						})()}
+
+						{/* Eviction priority (spec 2026-08-02) lives under Advanced for
+						    this commit: its lifecycle siblings (Auto-Load / Pin) are
+						    header toggles, and it only matters for unpinned slots under
+						    memory pressure. Hidden for NPU trio shadows — no process of
+						    their own to evict. (Task 11b moves this row out into "When
+						    it unloads".) */}
+						{!isNpuShadow && (
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>Eviction priority</span>
+								<FieldInfoIcon description="0-100 — lower unloads first when memory is needed.
+									Ties go to the least recently used. Pin the slot to exempt
+									it entirely." />
+							</div>
+							<div className="form-ctl">
+								<input
+									className="input mono"
+									data-testid="slot-priority-input"
+									type="number"
+									min={0}
+									max={100}
+									step={1}
+									value={prio}
+									onChange={(e) => setPrio(e.target.value)}
+									onBlur={commitPriority}
+									onKeyDown={(e) => {
+										if (e.key === "Enter") e.currentTarget.blur();
+									}}
+									style={{ width: 90 }}
+								/>
+								<div className="hint">lower unloads first</div>
+							</div>
+						</div>
+						)}
+
+						{/* Flags preview — backend-provided resolved_command (real podman argv),
           computed SERVER-SIDE (profile + MTP + image resolution). #1379 removed
           the dim + Regenerate overlay that used to sit on top: it promised to
           "fold your slot extra_args into the resolved command", but the launch
@@ -2813,7 +2818,8 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						flags + slot hardware flags. Restart the slot to run with new
 						flags.
 					</div>
-				</details>
+					</>
+				)}
 			</Drawer>
 			<DeleteSlotDialog
 				open={delOpen}

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -319,7 +319,7 @@ function modelRichOptions({ compatible, cur, has, slotLong, allSlots, verdictChi
 				</span>
 			),
 			right: verdictChipFor ? verdictChipFor(m.id) : null,
-			desc: `${quant || "—"} · ${caps.length ? caps.join(" + ") : "—"} · used by ${usedBy} slot${usedBy === 1 ? "" : "s"}`,
+			desc: `${m.params || "—"} · ${caps.length ? caps.join(" + ") : "—"} · used by ${usedBy} slot${usedBy === 1 ? "" : "s"}`,
 		});
 	}
 	return opts;
@@ -601,15 +601,21 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// below), committing on blur/Enter through the SAME useSlotRename
 	// mutation the dialog used. RenameSlotDialog.jsx keeps its own
 	// mutation+validation logic (still used as a component in its own
-	// right); this drawer no longer opens it, but the API plumbing it
-	// wraps is exactly what renameMut below also calls.
-	const [renameOpen, setRenameOpen] = useStateSM(false);
+	// right); this drawer no longer opens or mounts it — the API plumbing
+	// it wraps is exactly what renameMut below also calls.
 	const renameMut = useSlotRename();
 	// Inline name draft — seeded from the persisted name, resynced whenever
 	// the slot identity changes (a poll refresh mid-edit must not clobber an
 	// in-flight keystroke, same rule RenameSlotDialog's own seed effect
 	// follows).
 	const [nameDraft, setNameDraft] = useStateSM(slot?.name || "");
+	// Escape-cancel flag for the inline name field. The Escape branch calls
+	// blur() synchronously, so commitName (the blur handler) runs BEFORE the
+	// setNameDraft(slot.name) revert re-renders — it would still read the
+	// stale edited draft and commit the rename Escape meant to throw away.
+	// The ref is the synchronous channel: Escape sets it, commitName checks
+	// and clears it first thing and reverts without mutating.
+	const nameCancelRef = useRefSM(false);
 	// Inline model edit — stacks the reusable ModelDrawer over this drawer
 	// (equal z-index; later DOM order wins) so model-tune edits don't force a
 	// close → Models page → reopen round-trip. The slot drawer and its
@@ -1003,6 +1009,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// Hooks: must sit ABOVE the `!slot` early return (positional counting).
 	const autoloadDescId = React.useId();
 	const pinDescId = React.useId();
+	const nameDescId = React.useId();
 
 	if (!slot) return null;
 
@@ -1298,6 +1305,14 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// round-trip) rather than surfacing a submit error for a no-op edit.
 	const nameRunning = slotButtonPhase(slot) !== "off";
 	const commitName = async () => {
+		// Escape-cancel: the Escape keydown blurred us synchronously, before
+		// its draft revert could re-render — nameDraft may still hold the
+		// edited text here. Honour the cancel: revert, never mutate.
+		if (nameCancelRef.current) {
+			nameCancelRef.current = false;
+			setNameDraft(slot.name);
+			return;
+		}
 		const next = String(nameDraft).trim();
 		if (nameRunning || !next || !SLOT_NAME_RE.test(next) || next === slot.name) {
 			setNameDraft(slot.name);
@@ -1306,6 +1321,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		try {
 			await renameMut.mutateAsync({ name: slot.name, new_name: next });
 			window.__hal0Toast && window.__hal0Toast(`Renamed to ${next}`, "ok");
+			// The route still names the old slot (#slots/<old>); without this
+			// the drawer unmounts silently on the next poll because no slot
+			// matches the old name any more. Follow the rename in the URL.
+			window.location.hash = "#slots/" + next;
 		} catch (err) {
 			setNameDraft(slot.name);
 			window.__hal0Toast &&
@@ -1802,6 +1821,15 @@ function EditSlotDrawer({ open, slot, onClose }) {
 							onKeyDown={(e) => {
 								if (e.key === "Enter") e.currentTarget.blur();
 								if (e.key === "Escape") {
+									// Cancel the edit: flag first (the blur below runs
+									// commitName synchronously, before the revert
+									// re-renders — see nameCancelRef), then revert and
+									// drop focus. Consumed here so the drawer's
+									// document-level Escape→close listener never sees
+									// this press — Escape in the field cancels the
+									// rename, it must not also close the drawer.
+									e.stopPropagation();
+									nameCancelRef.current = true;
 									setNameDraft(slot.name);
 									e.currentTarget.blur();
 								}
@@ -1812,8 +1840,14 @@ function EditSlotDrawer({ open, slot, onClose }) {
 									: "Click to rename"
 							}
 							aria-label="Slot name"
+							aria-describedby={nameRunning ? nameDescId : undefined}
 							size={Math.max(6, nameDraft.length)}
 						/>
+						{nameRunning && (
+							<span id={nameDescId} className="sr-only">
+								Stop the slot to rename — the systemd unit is name-keyed.
+							</span>
+						)}
 						<span className="chip outlined" title={`Type is fixed once created — make a new slot for a different kind.`}>
 							{slot.type || "—"}
 						</span>
@@ -3130,11 +3164,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
 				slot={slot}
 				onClose={() => setDelOpen(false)}
 				onDeleted={onClose}
-			/>
-			<RenameSlotDialog
-				open={renameOpen}
-				slot={slot}
-				onClose={() => setRenameOpen(false)}
 			/>
 			{/* Stacked model editor — the reusable ModelDrawer (window-global,
 	        same instance contract as models.jsx). DrawerDock reaches the

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -1875,7 +1875,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 							data-testid="slot-pin-toggle"
 							title={
 								pinned
-									? "Unpin slot — idle/pressure eviction applies again (order set by Eviction priority under Advanced)"
+									? "Unpin slot — idle/pressure eviction applies again (order set by the priority under \"When it unloads\")"
 									: "Pin slot — once loaded it stays resident: exempt from idle/pressure eviction, and unload/delete require ?force=true. Pinning never starts a slot — boot start is the Auto-Load toggle."
 							}
 						>
@@ -2003,6 +2003,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 												<div style={{ flex: 1, minWidth: 0 }}>
 													<RichSelect
 														data-testid="slot-model-swap"
+														aria-label={`Model for ${slot.name}`}
 														value={cur}
 														disabled={saving || !!pendingCrossDevice}
 														options={modelRichOptions({
@@ -2166,6 +2167,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						<div className="form-ctl">
 							<RichSelect
 								data-testid="slot-hw-runtime"
+								className={fieldErrs.device ? "rsel-err" : undefined}
 								value={runtimeValue}
 								disabled={false}
 								options={runtimeRichOptions({
@@ -3206,33 +3208,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	);
 }
 
-function ReadOnlyStrip({ k, v }) {
-	return (
-		<div
-			style={{
-				padding: "10px 12px",
-				borderRight: "1px solid var(--line-soft)",
-				background: "var(--bg)",
-			}}
-		>
-			<div
-				className="mono"
-				style={{
-					fontSize: 9,
-					color: "var(--fg-4)",
-					textTransform: "uppercase",
-					letterSpacing: "0.08em",
-					marginBottom: 3,
-				}}
-			>
-				{k}
-			</div>
-			<div className="mono" style={{ fontSize: 12, color: "var(--fg)" }}>
-				{v}
-			</div>
-		</div>
-	);
-}
+// (ReadOnlyStrip, the two fact-grid cells Task 11a's regroup replaced, is
+// gone — its last callers moved into the drawer header/title/Advanced in
+// that commit, leaving this with no callers at all.)
 
 // ─── Inline swap popover ────────────────────────────────────────
 function InlineSwapPopover({ slot, open, onClose, onPick }) {

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -1628,40 +1628,11 @@ function EditSlotDrawer({ open, slot, onClose }) {
 								</span>
 							</span>
 						</span>
-						{/* Lifecycle pair (spec 2026-08-02 consolidation): Auto-Load =
-						    boot start only, Pin = residency only. Side by side so they
-						    read as one story instead of competing features. NPU trio
-						    shadows (flm-stt / flm-embed) have no unit or container of
-						    their own — the anchor's FLM process serves them — so
-						    Auto-Load is hidden there: writing { autoload } to a shadow
-						    TOML configures a boot start that can never happen.
-						    (Task 11b moves this pill down into the "When it unloads"
-						    row — kept here unchanged for the 11a regroup commit.) */}
-						{!isNpuShadow && (
-							<label
-								className="slot-enable-toggle drawer-enable"
-								data-testid="slot-autoload-toggle"
-								title="Auto-Load — start this slot automatically at boot. Only controls startup; eviction protection is the Pin toggle."
-							>
-								<span className="drawer-enable-label mono">Auto-Load</span>
-								<input
-									type="checkbox"
-									checked={autoload}
-									onChange={() => onToggleAutoload(!autoload)}
-									aria-label={
-										autoload
-											? "Disable auto-load on start"
-											: "Enable auto-load on start"
-									}
-									aria-describedby={autoloadDescId}
-								/>
-								<span className="slot-enable-track" aria-hidden="true" />
-								<span id={autoloadDescId} className="sr-only">
-									Start this slot automatically at boot. Only controls
-									startup; eviction protection is the Pin toggle.
-								</span>
-							</label>
-						)}
+						{/* Task 11b: Auto-Load moves out of the header into the "When it
+						    unloads" lifecycle row below, next to Eviction priority — the
+						    two read as one "how this slot comes and goes" story there.
+						    Pin stays here: it's a mode of the whole slot (residency),
+						    not a lifecycle knob that trades off against priority. */}
 						<label
 							className="slot-enable-toggle drawer-enable"
 							data-testid="slot-pin-toggle"
@@ -2097,6 +2068,106 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						</div>
 					)}
 				</FieldGroup>
+
+				{/* Task 11b: lifecycle gets its own section — one row, "Unloading":
+				    Auto-Load pill (moved down from the header) + a compact
+				    Eviction-priority input (moved up from Advanced), same handlers
+				    as before. Pinning greys ONLY the priority input — priority has
+				    no effect while pinned, but Auto-Load still controls whether the
+				    slot starts at boot, pinned or not, so it stays live. Hidden
+				    entirely for NPU trio shadows: they have no unit/container of
+				    their own to start or evict (the anchor's FLM process owns
+				    lifecycle for all three). */}
+				{!isNpuShadow && (
+					<FieldGroup label="When it unloads" hint="lifecycle">
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>Unloading</span>
+								<FieldInfoIcon description="Auto-Load starts this slot at boot. Eviction priority
+									(0-100, lower unloads first) only matters while unpinned —
+									pin the slot to exempt it from idle/pressure eviction
+									entirely." />
+							</div>
+							<div className="form-ctl">
+								<div
+									style={{
+										display: "flex",
+										gap: 14,
+										alignItems: "center",
+										flexWrap: "wrap",
+									}}
+								>
+									<label
+										className="slot-enable-toggle drawer-enable"
+										data-testid="slot-autoload-toggle"
+										title="Auto-Load — start this slot automatically at boot. Only controls startup; eviction protection is the Pin toggle."
+									>
+										<span className="drawer-enable-label mono">Auto-Load</span>
+										<input
+											type="checkbox"
+											checked={autoload}
+											onChange={() => onToggleAutoload(!autoload)}
+											aria-label={
+												autoload
+													? "Disable auto-load on start"
+													: "Enable auto-load on start"
+											}
+											aria-describedby={autoloadDescId}
+										/>
+										<span className="slot-enable-track" aria-hidden="true" />
+										<span id={autoloadDescId} className="sr-only">
+											Start this slot automatically at boot. Only controls
+											startup; eviction protection is the Pin toggle.
+										</span>
+									</label>
+									<span
+										style={{
+											display: "inline-flex",
+											gap: 8,
+											alignItems: "center",
+											opacity: pinned ? 0.45 : 1,
+										}}
+									>
+										<span
+											className="mono"
+											style={{ fontSize: 12, color: "var(--fg-3)" }}
+										>
+											priority
+										</span>
+										<input
+											className="input mono"
+											data-testid="slot-priority-input"
+											type="number"
+											min={0}
+											max={100}
+											step={1}
+											value={prio}
+											disabled={pinned}
+											onChange={(e) => setPrio(e.target.value)}
+											onBlur={commitPriority}
+											onKeyDown={(e) => {
+												if (e.key === "Enter") e.currentTarget.blur();
+											}}
+											style={{ width: 64 }}
+										/>
+									</span>
+								</div>
+								{pinned ? (
+									<div className="hint">
+										📌 Pinned — never evicted; priority has no effect while
+										pinned.
+									</div>
+								) : (
+									<div className="hint">
+										lower priority unloads first · ties go to least recently
+										used
+									</div>
+								)}
+							</div>
+						</div>
+					</FieldGroup>
+				)}
+
 				{/* NPU trio SHADOW (flm-stt / flm-embed): its own [npu] table is
 				    inert — the anchor's FLM process owns all three modalities, so
 				    editing toggles here wrote config the launcher never reads and
@@ -2585,40 +2656,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
 							);
 						})()}
 
-						{/* Eviction priority (spec 2026-08-02) lives under Advanced for
-						    this commit: its lifecycle siblings (Auto-Load / Pin) are
-						    header toggles, and it only matters for unpinned slots under
-						    memory pressure. Hidden for NPU trio shadows — no process of
-						    their own to evict. (Task 11b moves this row out into "When
-						    it unloads".) */}
-						{!isNpuShadow && (
-						<div className="form-row">
-							<div className="form-lbl">
-								<span>Eviction priority</span>
-								<FieldInfoIcon description="0-100 — lower unloads first when memory is needed.
-									Ties go to the least recently used. Pin the slot to exempt
-									it entirely." />
-							</div>
-							<div className="form-ctl">
-								<input
-									className="input mono"
-									data-testid="slot-priority-input"
-									type="number"
-									min={0}
-									max={100}
-									step={1}
-									value={prio}
-									onChange={(e) => setPrio(e.target.value)}
-									onBlur={commitPriority}
-									onKeyDown={(e) => {
-										if (e.key === "Enter") e.currentTarget.blur();
-									}}
-									style={{ width: 90 }}
-								/>
-								<div className="hint">lower unloads first</div>
-							</div>
-						</div>
-						)}
+						{/* Task 11b: Eviction priority moved out to the "When it
+						    unloads" lifecycle row (with Auto-Load) — Advanced no
+						    longer carries any lifecycle controls, only hardware/image
+						    facts and the resolved-command debug view. */}
 
 						{/* Flags preview — backend-provided resolved_command (real podman argv),
           computed SERVER-SIDE (profile + MTP + image resolution). #1379 removed

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -35,7 +35,12 @@ import { formatProvenanceShort } from "./runner-images.jsx";
 // the apply preview below chips a lane exactly the way the profile card and
 // the profile drawer do (one solid single-hue chip PER lane, muted AUTO for
 // a profile that pins nothing) — one authority, no third dialect.
-import { runtimeChips } from "./profiles.jsx";
+// useRunnerPull (issue #2185, Task 11c): the SAME pull mutation the
+// Profiles view's not-pulled runtime chip uses — reused verbatim here for
+// the Runtime RichSelect's inline Pull affordance rather than a second
+// hook that could resolve a pull target differently.
+import { runtimeChips, useRunnerPull } from "./profiles.jsx";
+import { RichSelect } from "./rich-select.jsx";
 // shlex-lite flag diff — the apply preview's "replaces N flags" count.
 import { diffFlags } from "./flags-tune.js";
 import { useSlotLogsStream } from "@/api/hooks/useLogs";
@@ -168,13 +173,208 @@ function laneTitle(lane) {
 	return LANE_TITLE[lane] || lane;
 }
 
-// Runtime select suffix for one runnerOptions() row: 'ROCm + Vulkan' for a
-// dual-lane runner, the single lane's title for one, '' for a backend-
-// agnostic runner (no lanes declared — it takes whatever device it's given).
-function laneLabel(option) {
-	return (option?.lanes || []).map(laneTitle).join(" + ");
+// ── Runtime RichSelect rows (Task 11c) ────────────────────────────────────
+// (laneLabel(), the old plain-text " · ROCm + Vulkan" suffix helper, is gone
+// with the native <select> it decorated — the RichSelect rows below chip
+// each lane instead, via profiles.jsx's runtimeChips.)
+// Plain install-state indicator — NOT a button. Lives in both the closed
+// trigger (RichSelect's `right`) and the open row, so it must never be
+// interactive (a nested <button> inside the trigger's own <button> would be
+// invalid HTML and double-fire clicks). The inline Pull action below lives
+// in `desc` instead, which only ever renders inside the <li> row.
+function runtimeInstallBadge(state) {
+	if (state === "installed") return <span className="chip ok">● installed</span>;
+	if (state === "installable") return <span className="chip warn">○ not pulled</span>;
+	if (!state) return null;
+	return <span className="chip">{state}</span>;
 }
 
+// Runtime row description: the runner's blurb, plus an inline Pull button
+// (issue #2185) for an `installable` (not-pulled) runtime — reusing
+// profiles.jsx's `useRunnerPull`, the SAME mutation the Profiles view's own
+// not-pulled chip fires, so a pull kicked off from either surface lands in
+// the same job. `e.stopPropagation()` keeps the click from also committing
+// this option (the <li> it lives in fires onOptionClick on any click).
+function RuntimeRowDesc({ runnerKey, blurb, installable, backends }) {
+	const pull = useRunnerPull(runnerKey, backends);
+	if (!blurb && !installable) return null;
+	return (
+		<span style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+			{blurb ? <span>{blurb}</span> : null}
+			{installable && (
+				<button
+					type="button"
+					className="btn ghost sm"
+					style={{ alignSelf: "flex-start" }}
+					disabled={pull.inFlight || !pull.target}
+					onClick={(e) => {
+						e.stopPropagation();
+						pull.start();
+					}}
+					title={pull.error ? `Pull failed — ${pull.error}` : "Pull this runtime image now"}
+				>
+					{pull.inFlight ? "◌ pulling…" : "⇩ Pull now"}
+				</button>
+			)}
+		</span>
+	);
+}
+
+// Build the Runtime RichSelect's options from a runnerOptions() list — one
+// solid `.pf-be` chip per lane (via profiles.jsx's `runtimeChips`, fed a
+// bare `{runner: key}` "profile" shape so it reuses the exact lane/hue
+// logic the Profiles view and the profile-apply preview already use — one
+// authority for what a lane chip looks like), the install-state chip, and
+// the blurb+Pull desc. The Auto entry and an out-of-vocab persisted binary
+// keep their EXACT current plain-text copy — no chips, no desc — per the
+// "out-of-vocab rows keep current copy" rule.
+function runtimeRichOptions({ binary, runtimeSel, runtimeOptions, backends }) {
+	const opts = [];
+	if (!binary) {
+		opts.push({ id: "", row: "— auto · resolved from device —" });
+	}
+	if (runtimeSel === null) {
+		opts.push({ id: binary, row: `${binary} · not in this catalog` });
+	}
+	for (const o of runtimeOptions) {
+		opts.push({
+			id: o.key,
+			row: (
+				<span style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+					<span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{o.title}</span>
+					<span className="pf-be-row">
+						{runtimeChips({ runner: o.key }, backends).map((c) => (
+							<span
+								key={c.key}
+								className="pf-be mono"
+								style={c.hue ? { "--bk": c.hue } : null}
+							>
+								{c.label}
+							</span>
+						))}
+					</span>
+				</span>
+			),
+			right: runtimeInstallBadge(o.state),
+			desc: (
+				<RuntimeRowDesc
+					runnerKey={o.key}
+					blurb={o.blurb}
+					installable={o.state === "installable"}
+					backends={backends}
+				/>
+			),
+		});
+	}
+	return opts;
+}
+
+// ── Model RichSelect rows (Task 11c) ──────────────────────────────────────
+// The one non-"chat" capability worth calling out as a modality tag on the
+// row's name line (mockup panel 05: "qwen3.8-vl-8b … <tag mod>vision</tag>").
+// Plain chat/tool-calling/coding models get no modality tag — those are
+// covered in the desc line's capability list instead.
+const MODEL_MODALITY_CAPS = ["vision", "image", "embed", "rerank", "transcription", "tts"];
+function modelModalityTag(m) {
+	const caps = Array.isArray(m?.capabilities) ? m.capabilities : [];
+	return MODEL_MODALITY_CAPS.find((c) => caps.includes(c)) || null;
+}
+
+// Build the Model RichSelect's options from the already-filtered compatible
+// list. `verdictChipFor(modelId)` returns the right-aligned GTT feasibility
+// chip (`● fits · ~N GB` / `◐ tight` / `○ won't fit`, or null for an
+// unverdicted/unknown row) — a no-op placeholder here; Task 11d wires it to
+// the batch `useModelsFeasibility` call fired on dropdown open. `usedByCount`
+// is read from the slots list already queried in this drawer (`slotsQuery`),
+// never a second fetch.
+function modelRichOptions({ compatible, cur, has, slotLong, allSlots, verdictChipFor }) {
+	const opts = [];
+	if (cur && !has) {
+		opts.push({ id: cur, row: slotLong || cur });
+	}
+	if (!cur) {
+		opts.push({ id: "", row: "—" });
+	}
+	const countUsedBy = (id) =>
+		(allSlots || []).filter((s) => (s.model_id || s.model) === id).length;
+	for (const m of compatible) {
+		const quant = m.quant || null;
+		const modTag = modelModalityTag(m);
+		const caps = Array.isArray(m.capabilities) ? m.capabilities : [];
+		const usedBy = countUsedBy(m.id);
+		opts.push({
+			id: m.id,
+			row: (
+				<span style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+					<span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+						{m.longName || m.id}
+					</span>
+					{quant && <span className="chip amber">{quant}</span>}
+					{modTag && <span className="chip info">{modTag}</span>}
+				</span>
+			),
+			right: verdictChipFor ? verdictChipFor(m.id) : null,
+			desc: `${quant || "—"} · ${caps.length ? caps.join(" + ") : "—"} · used by ${usedBy} slot${usedBy === 1 ? "" : "s"}`,
+		});
+	}
+	return opts;
+}
+
+// ── Profile RichSelect rows (Task 11c) ────────────────────────────────────
+// name + the runtime it carries (title/chips, via profiles.jsx's shared
+// runtimeChips) + an intent line — mirrors how the Profiles view itself
+// names a runtime (runnerTitleFor/runtimeLine there), so the slot drawer's
+// Profile row can't describe a runtime differently than the Profiles page
+// does for the same profile.
+function profileRuntimeTitle(key, backends) {
+	return key ? backends?.[key]?.title || key : "Auto";
+}
+function profileRichOptions({ none, outOfVocab, fit, crossFit, backends, BACKEND_DEVICE: deviceMap }) {
+	const opts = [];
+	// keep a none/out-of-vocab persisted profile selectable — exact current
+	// copy, no chips/desc (out-of-vocab rows keep their plain-text row).
+	if (none) opts.push({ id: "", row: "— none —" });
+	if (outOfVocab) opts.push({ id: outOfVocab, row: outOfVocab });
+	const rowFor = (p, crossTarget) => ({
+		id: p.name,
+		row: (
+			<span style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+				<span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+					{p.name}
+					{crossTarget ? ` · → ${crossTarget}` : ""}
+				</span>
+				<span className="pf-be-row">
+					{runtimeChips(p, backends).map((c) => (
+						<span
+							key={c.key}
+							className="pf-be mono"
+							style={c.hue ? { "--bk": c.hue } : null}
+						>
+							{c.label}
+						</span>
+					))}
+				</span>
+			</span>
+		),
+		desc: p.intent
+			? `${profileRuntimeTitle(p.runner, backends)} — ${p.intent}`
+			: profileRuntimeTitle(p.runner, backends),
+	});
+	for (const p of fit) opts.push(rowFor(p, null));
+	// RichSelect has no <optgroup> — a disabled marker row stands in for the
+	// old "Other backend — switches slot device" group label (disabled rows
+	// are skipped by arrow/Home/End nav and unclickable, same as a group
+	// header would be).
+	if (crossFit.length > 0) {
+		opts.push({
+			id: "__crossfit_header__",
+			disabled: true,
+			row: "— other backend — switches slot device —",
+		});
+		for (const p of crossFit) opts.push(rowFor(p, deviceMap[p.backend]));
+	}
+	return opts;
+}
 
 // Concatenate a flag base with an overlay the way the launcher does: the
 // profile's tune is appended AFTER the model tune, and diffFlags' pair map is
@@ -1320,12 +1520,21 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						slot's device on save." />
 				</div>
 				<div className="form-ctl">
-					<select
-						className="input mono"
+					<RichSelect
 						data-testid="slot-profile"
 						value={profileSel}
-						onChange={(e) => {
-							const nextName = e.target.value;
+						options={profileRichOptions({
+							none: !slot.profile,
+							outOfVocab:
+								profileSel && !listedNames.includes(profileSel)
+									? profileSel
+									: null,
+							fit,
+							crossFit,
+							backends: runnerCat,
+							BACKEND_DEVICE,
+						})}
+						onChange={(nextName) => {
 							setProfileSel(nextName);
 							setFieldErrs((p) => ({ ...p, profile: undefined }));
 							// Profile wins (D4): a picked profile carrying `runner`
@@ -1345,29 +1554,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 								setDevice(pick.device);
 							}
 						}}
-					>
-						{/* keep a none/out-of-vocab persisted profile selectable */}
-						{!slot.profile && <option value="">— none —</option>}
-						{profileSel && !listedNames.includes(profileSel) && (
-							<option value={profileSel}>{profileSel}</option>
-						)}
-						{fit.map((p) => (
-							<option key={p.name} value={p.name} title={p.intent}>
-								{p.name}
-								{p.intent ? ` · ${p.intent}` : ""}
-							</option>
-						))}
-						{crossFit.length > 0 && (
-							<optgroup label="Other backend — switches slot device">
-								{crossFit.map((p) => (
-									<option key={p.name} value={p.name} title={p.intent}>
-										{p.name} · → {BACKEND_DEVICE[p.backend]}
-										{p.intent ? ` · ${p.intent}` : ""}
-									</option>
-								))}
-							</optgroup>
-						)}
-					</select>
+					/>
 					{applyPreview && (
 						<div
 							className="hint sl-apply"
@@ -1763,43 +1950,40 @@ function EditSlotDrawer({ open, slot, onClose }) {
 											<div
 												style={{ display: "flex", gap: 8, alignItems: "center" }}
 											>
-												<select
-													className="input mono"
-													style={{ flex: 1 }}
-													value={cur}
-													disabled={saving || !!pendingCrossDevice}
-													data-testid="slot-model-swap"
-													aria-label={`Model for ${slot.name}`}
-													onChange={(e) => {
-														const id = e.target.value;
-														if (!id || id === cur) return;
-														const picked = compatible.find((m) => m.id === id);
-														const label = picked?.longName || id;
-														// UI-5: swapping the model on a LIVE container slot cold-restarts
-														// it (~model-load seconds). Confirm through the shared
-														// ConfirmDialog before firing — stashing the pick re-renders the
-														// select back to `cur` (value={cur}), so cancel needs no manual
-														// revert. Mirrors the delete/dirty-close confirm gates.
-														const live = slotButtonPhase(slot) === "running";
-														if (isContainer && live) {
-															setPendingSwap({ id, label });
-															return;
-														}
-														fireSwap(id, label);
-													}}
-												>
-													{cur && !has && (
-														<option value={cur}>
-															{slot.modelLong || slot.model || cur}
-														</option>
-													)}
-													{!cur && <option value="">—</option>}
-													{compatible.map((m) => (
-														<option key={m.id} value={m.id}>
-															{m.longName || m.id}
-														</option>
-													))}
-												</select>
+												<div style={{ flex: 1, minWidth: 0 }}>
+													<RichSelect
+														data-testid="slot-model-swap"
+														value={cur}
+														disabled={saving || !!pendingCrossDevice}
+														options={modelRichOptions({
+															compatible,
+															cur,
+															has,
+															slotLong: slot.modelLong || slot.model || cur,
+															allSlots: Array.isArray(slotsQuery.data)
+																? slotsQuery.data
+																: [],
+															// Task 11d wires the real per-row fit chip here.
+															verdictChipFor: null,
+														})}
+														onChange={(id) => {
+															if (!id || id === cur) return;
+															const picked = compatible.find((m) => m.id === id);
+															const label = picked?.longName || id;
+															// UI-5: swapping the model on a LIVE container slot cold-restarts
+															// it (~model-load seconds). Confirm through the shared
+															// ConfirmDialog before firing — stashing the pick re-renders the
+															// select back to `cur` (value={cur}), so cancel needs no manual
+															// revert. Mirrors the delete/dirty-close confirm gates.
+															const live = slotButtonPhase(slot) === "running";
+															if (isContainer && live) {
+																setPendingSwap({ id, label });
+																return;
+															}
+															fireSwap(id, label);
+														}}
+													/>
+												</div>
 												{/* Inline model edit — the app-wide pencil affordance
 												    (Icons.edit), same bare `btn ghost sm` icon-button
 												    convention as the slot card. Opens the model drawer
@@ -1914,48 +2098,27 @@ function EditSlotDrawer({ open, slot, onClose }) {
 								the Runner Images page." />
 						</div>
 						<div className="form-ctl">
-							<select
-								className={
-									"input mono" + (fieldErrs.device ? " input-err" : "")
-								}
+							<RichSelect
 								data-testid="slot-hw-runtime"
 								value={runtimeValue}
-								onChange={(e) => {
+								disabled={false}
+								options={runtimeRichOptions({
+									binary,
+									runtimeSel,
+									runtimeOptions,
+									backends: hwBackends,
+								})}
+								onChange={(key) => {
 									const pick = applyRunnerChoice({
 										options: runtimeOptions,
-										key: e.target.value,
+										key,
 										currentDevice: device,
 									});
 									setBinary(pick.binary);
 									setDevice(pick.device);
 									setFieldErrs((p) => ({ ...p, device: undefined }));
 								}}
-							>
-								{/* Auto entry only while nothing is pinned — picking a
-								    real runtime is one-way, same as the old Backend
-								    select. */}
-								{!binary && (
-									<option value="">
-										— auto · resolved from device —
-									</option>
-								)}
-								{/* An out-of-vocab persisted binary (older release,
-								    hand-edited TOML, a runtime this box no longer offers
-								    for the slot) keeps its own option so the drawer
-								    never silently rewrites it. */}
-								{runtimeSel === null && (
-									<option value={binary}>
-										{binary} · not in this catalog
-									</option>
-								)}
-								{runtimeOptions.map((o) => (
-									<option key={o.key} value={o.key}>
-										{o.title}
-										{laneLabel(o) ? ` · ${laneLabel(o)}` : ""}
-										{o.state === "installable" ? " · not pulled" : ""}
-									</option>
-								))}
-							</select>
+							/>
 							{selectedRuntimeOption?.blurb ? (
 								<div className="hint">{selectedRuntimeOption.blurb}</div>
 							) : null}

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -3029,6 +3029,26 @@ select.npu-sel {
 /* Drawer header internals (migrated from the deleted mcp.css; the <Drawer>
    primitive in primitives.jsx renders an h2 + eyebrow + close button). */
 .drawer-h h2 { font-size: 18px; font-weight: 500; margin: 0; letter-spacing: -0.02em; }
+/* Inline-editable slot name (Task 11a) — reads as title text until focused,
+   replacing the old disabled "Name" field + "Rename…" button. Sized via the
+   `size` attribute (JS-computed from the draft length) rather than a fixed
+   width, so it never clips or over-reserves relative to the actual name. */
+.drawer-title-input {
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--rad-sm);
+  padding: 1px 4px;
+  margin: -1px -4px;
+}
+.drawer-title-input:hover:not(:disabled) { border-color: var(--line-soft); }
+.drawer-title-input:focus {
+  outline: none;
+  border-color: var(--accent-line);
+  background: var(--bg-2);
+}
+.drawer-title-input:disabled { color: var(--fg-4); cursor: not-allowed; }
 .drawer-h .modal-h-eye { font-size: 10px; color: var(--accent); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 4px; }
 .drawer-h .modal-close {
   position: absolute;

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -3472,6 +3472,12 @@ select.npu-sel {
   outline: none;
 }
 .rsel-trigger[disabled] { opacity: 0.45; cursor: not-allowed; }
+/* Field-error state, passed via RichSelect's `className` prop (Task 11
+   review fix) — same error tokens the plain `.input-err` inputs elsewhere
+   in the drawer use (border/err color), since `.input-err` itself carries
+   no rule of its own to reuse here. */
+.rsel-trigger.rsel-err { border-color: var(--err-line); }
+.rsel-trigger.rsel-err:focus-visible { box-shadow: 0 0 0 3px var(--err-soft); }
 .rsel-trigger-row { flex: 1; min-width: 0; display: flex; align-items: center; gap: 8px; }
 .rsel-trigger-placeholder { color: var(--fg-4); }
 .rsel-trigger-caret { color: var(--fg-3); flex-shrink: 0; display: inline-flex; transition: transform 0.12s ease; }

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -3425,6 +3425,72 @@ select.npu-sel {
   outline-offset: 1px;
 }
 
+/* ─── RichSelect (Task 10 — shared drawer listbox) ──────────────────
+   Two-line option rows: a top line (row content, chips right-aligned)
+   and a full-width muted desc line beneath. Trigger mirrors `.input`;
+   the popover mirrors `.swap-pop`/`.cp-shell` (same surface + shadow
+   vocabulary, sized to its own content instead of a fixed grid). */
+.rsel { position: relative; width: 100%; }
+.rsel-trigger {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  color: var(--fg);
+  font-family: var(--geist);
+  font-size: 13px;
+  padding: 8px 11px;
+  border-radius: var(--rad);
+  cursor: pointer;
+  text-align: left;
+}
+.rsel-trigger:focus-visible, .rsel-trigger[aria-expanded="true"] {
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+  outline: none;
+}
+.rsel-trigger[disabled] { opacity: 0.45; cursor: not-allowed; }
+.rsel-trigger-row { flex: 1; min-width: 0; display: flex; align-items: center; gap: 8px; }
+.rsel-trigger-placeholder { color: var(--fg-4); }
+.rsel-trigger-caret { color: var(--fg-3); flex-shrink: 0; display: inline-flex; transition: transform 0.12s ease; }
+.rsel-trigger[aria-expanded="true"] .rsel-trigger-caret { transform: rotate(180deg); color: var(--accent); }
+
+.rsel-listbox {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  background: var(--bg-2);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--rad);
+  box-shadow: var(--shadow-menu, 0 16px 48px -8px rgba(0, 0, 0, 0.65));
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+.rsel-option {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--line-soft);
+}
+.rsel-option:last-child { border-bottom: none; }
+.rsel-option-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; font-size: 12.5px; color: var(--fg); }
+.rsel-option-row-main { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rsel-option-right { flex-shrink: 0; display: flex; align-items: center; gap: 6px; }
+.rsel-option-desc { font-size: 10.5px; color: var(--fg-4); line-height: 1.35; }
+.rsel-option:hover, .rsel-option[data-active="true"] { background: var(--bg-3); }
+.rsel-option[aria-selected="true"] { background: var(--accent-bg); }
+.rsel-option[aria-selected="true"] .rsel-option-row { color: var(--accent); }
+.rsel-option[aria-disabled="true"] { cursor: not-allowed; opacity: 0.4; }
+.rsel-option[aria-disabled="true"]:hover { background: transparent; }
+.rsel-empty { padding: 10px 12px; font-size: 11.5px; color: var(--fg-4); font-family: var(--jbm); }
+
 /* ─── Variant filter chips (HF coords modal) ────────────────────── */
 .variant-row {
   display: grid;

--- a/ui/tests/e2e/fixtures/richSelect.ts
+++ b/ui/tests/e2e/fixtures/richSelect.ts
@@ -1,0 +1,79 @@
+/**
+ * richSelect — shared interaction helpers for `RichSelect` (Task 10,
+ * `ui/src/dash/rich-select.jsx`), the button+listbox popover that replaced
+ * the slot drawer's native `<select>`s for Runtime (`slot-hw-runtime`),
+ * Profile (`slot-profile`) and Model (`slot-model-swap`) — Task 11c.
+ *
+ * A RichSelect trigger is a `<button role="combobox">`, never a `<select>`,
+ * so `.selectOption()` / `.toHaveValue()` don't apply to it. Every spec that
+ * drives one goes through these three helpers instead of re-deriving the
+ * open/click/close mechanics inline:
+ *
+ *   - `openRichSelect(trigger)`  — click the trigger open (no-op if already
+ *     open) and return its listbox `Locator`.
+ *   - `richSelectOption(trigger, id)` — the `<li role="option">` for a given
+ *     `RichSelect` option id (opens the listbox first).
+ *   - `pickRichOption(trigger, id)` — open + click that option, the
+ *     RichSelect equivalent of `.selectOption(id)`.
+ *
+ * All three take the TRIGGER LOCATOR, not a testid string, so a spec can
+ * still reach it via `page.getByTestId(...)` (asserting the plumbing this
+ * file's own contract pins) or `page.getByLabel(...)` (asserting the
+ * `aria-label` passthrough task-11's fix report restored) — whichever the
+ * spec already needed for its own assertions. The listbox id is read off
+ * the trigger's own `aria-controls`, so this never hardcodes the
+ * `{testid}-listbox` derivation `rich-select.jsx` happens to use today.
+ *
+ * A closed trigger already renders its selected option's `row` + `right`
+ * content (`rich-select.jsx`'s `selected` branch) — so verifying the CURRENT
+ * value of a RichSelect rarely needs to open it at all; prefer
+ * `expect(trigger).toContainText(...)` for that over opening + reading
+ * `aria-selected`.
+ */
+import type { Locator } from '@playwright/test'
+
+async function listboxFor(trigger: Locator): Promise<Locator> {
+  const id = await trigger.getAttribute('aria-controls')
+  if (!id) {
+    throw new Error(
+      'richSelect helper: trigger has no aria-controls — is this actually a RichSelect button?',
+    )
+  }
+  return trigger.page().locator(`[id="${id}"]`)
+}
+
+/** Open a RichSelect's listbox (no-op if already open); returns the listbox. */
+export async function openRichSelect(trigger: Locator): Promise<Locator> {
+  if ((await trigger.getAttribute('aria-expanded')) !== 'true') {
+    await trigger.click()
+  }
+  return listboxFor(trigger)
+}
+
+/**
+ * Close a RichSelect's listbox (no-op if already closed), via Escape.
+ *
+ * Caution: the slot/model drawer (`primitives.jsx`'s `Drawer`) attaches its
+ * OWN `document`-level Escape handler that closes the whole drawer, and
+ * `rich-select.jsx`'s own Escape handling doesn't (can't, from a separate
+ * listener) stop that from also firing. Inside a drawer, prefer closing via
+ * a click on a neutral element instead (RichSelect's click-outside
+ * listener) so this doesn't take the drawer down with it.
+ */
+export async function closeRichSelect(trigger: Locator): Promise<void> {
+  if ((await trigger.getAttribute('aria-expanded')) === 'true') {
+    await trigger.page().keyboard.press('Escape')
+  }
+}
+
+/** The `<li role="option">` for one RichSelect option id — opens the listbox first. */
+export async function richSelectOption(trigger: Locator, optionId: string): Promise<Locator> {
+  const listbox = await openRichSelect(trigger)
+  return listbox.locator(`[data-option-id="${optionId}"]`)
+}
+
+/** Open + click an option by id — the RichSelect equivalent of `.selectOption(id)`. */
+export async function pickRichOption(trigger: Locator, optionId: string): Promise<void> {
+  const option = await richSelectOption(trigger, optionId)
+  await option.click()
+}

--- a/ui/tests/e2e/fixtures/richSelect.ts
+++ b/ui/tests/e2e/fixtures/richSelect.ts
@@ -53,12 +53,12 @@ export async function openRichSelect(trigger: Locator): Promise<Locator> {
 /**
  * Close a RichSelect's listbox (no-op if already closed), via Escape.
  *
- * Caution: the slot/model drawer (`primitives.jsx`'s `Drawer`) attaches its
- * OWN `document`-level Escape handler that closes the whole drawer, and
- * `rich-select.jsx`'s own Escape handling doesn't (can't, from a separate
- * listener) stop that from also firing. Inside a drawer, prefer closing via
- * a click on a neutral element instead (RichSelect's click-outside
- * listener) so this doesn't take the drawer down with it.
+ * Safe inside a drawer: `rich-select.jsx` consumes Escape on an OPEN
+ * listbox (`stopPropagation()` in its trigger keydown), so the drawer's
+ * `document`-level Escape handler (`primitives.jsx`'s `Drawer`) never sees
+ * the press — only the dropdown closes. Escape on an already-closed
+ * RichSelect still bubbles to the drawer, which is why this helper checks
+ * `aria-expanded` before pressing.
  */
 export async function closeRichSelect(trigger: Locator): Promise<void> {
   if ((await trigger.getAttribute('aria-expanded')) === 'true') {

--- a/ui/tests/e2e/specs/drawer-save-errors-v3.spec.ts
+++ b/ui/tests/e2e/specs/drawer-save-errors-v3.spec.ts
@@ -21,6 +21,7 @@
  * raises when a second device=npu llm anchor is enabled.
  */
 import { test, expect, type Page } from '../fixtures/apiMock'
+import { pickRichOption } from '../fixtures/richSelect'
 
 const PRIMARY = {
   name: 'primary', type: 'llm', device: 'gpu-rocm', profile: 'rocm',
@@ -73,6 +74,8 @@ test.describe('Slot drawer — rejected writes', () => {
     await seedSlots(page, [PRIMARY])
 
     await page.goto('/#slots/primary')
+    // NGL lives behind the Advanced disclosure now (Task 11a).
+    await page.getByTestId('slot-hw-advanced').click()
     await page.getByTestId('slot-hw-ngl').fill('24')
     await drawer(page).locator('button:has-text("Save")').click()
 
@@ -102,15 +105,18 @@ test.describe('Slot drawer — rejected writes', () => {
     await seedSlots(page, [PRIMARY])
 
     await page.goto('/#slots/primary')
-    // Touch BOTH legs: ctx_size rides /defaults, NGL rides /config.
-    const modelGroup = page.locator('.drawer .field-group').filter({
-      has: page.locator('.field-group-label', { hasText: /^Model$/ }),
+    // Touch BOTH legs: ctx_size rides /defaults, NGL rides /config. Context
+    // (ceiling) lives in the "How it runs" group now (Task 11a moved it IN
+    // from the old Model group); NGL is behind the Advanced disclosure.
+    const hwGroup = page.locator('.drawer .field-group').filter({
+      has: page.locator('.field-group-label', { hasText: /^How it runs$/ }),
     })
-    await modelGroup
+    await hwGroup
       .locator('.form-row')
       .filter({ has: page.locator('.form-lbl > span', { hasText: /^Context \(ceiling\)$/ }) })
       .locator('input')
       .fill('16384')
+    await page.getByTestId('slot-hw-advanced').click()
     await page.getByTestId('slot-hw-ngl').fill('24')
     await drawer(page).locator('button:has-text("Save")').click()
 
@@ -139,7 +145,7 @@ test.describe('Slot drawer — rejected writes', () => {
     ])
 
     await page.goto('/#slots/primary')
-    await drawer(page).getByLabel('Model for primary').selectOption('qwen3-coder-30b')
+    await pickRichOption(drawer(page).getByLabel('Model for primary'), 'qwen3-coder-30b')
 
     await expect(drawer(page)).toContainText('slot primary is warming — retry once it is ready')
     await expect(drawer(page)).toBeVisible()

--- a/ui/tests/e2e/specs/slot-drawer-dirty-baseline-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-dirty-baseline-v3.spec.ts
@@ -113,10 +113,12 @@ const saveBtn = (page: Page) => page.locator('.drawer button:has-text("Save")')
 const stateChip = (page: Page) => page.getByTestId('slot-state-readonly')
 
 function ctxInput(page: Page) {
-  const modelGroup = page.locator('.drawer .field-group').filter({
-    has: page.locator('.field-group-label', { hasText: /^Model$/ }),
+  // Context (ceiling) lives in the "How it runs" group now (Task 11a moved
+  // it IN from the old Model group, beside the hardware that enforces it).
+  const hwGroup = page.locator('.drawer .field-group').filter({
+    has: page.locator('.field-group-label', { hasText: /^How it runs$/ }),
   })
-  return modelGroup
+  return hwGroup
     .locator('.form-row')
     .filter({ has: page.locator('.form-lbl > span', { hasText: /^Context \(ceiling\)$/ }) })
     .locator('input')
@@ -238,6 +240,8 @@ test.describe('Slot drawer — frozen persisted-config baseline', () => {
 
     await page.goto('/#slots/primary')
     await expect(drawer(page)).toBeVisible()
+    // NGL lives behind the Advanced disclosure now (Task 11a).
+    await page.getByTestId('slot-hw-advanced').click()
     await page.getByTestId('slot-hw-ngl').fill('24')
 
     await page.evaluate(() => {

--- a/ui/tests/e2e/specs/slot-drawer-field-wiring-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-field-wiring-v3.spec.ts
@@ -27,6 +27,7 @@
  * surface is owned by slot-pin-toggle-v3.spec.ts.
  */
 import { test, expect, type Page } from '../fixtures/apiMock'
+import { openRichSelect, pickRichOption } from '../fixtures/richSelect'
 
 const PRIMARY = {
   name: 'primary', type: 'llm', device: 'gpu-rocm', profile: 'rocm',
@@ -108,8 +109,10 @@ test.describe('Slot drawer — model swap wiring', () => {
     await page.goto('/#slots/primary')
     await expect(page.locator('.drawer')).toBeVisible()
     const select = page.locator('.drawer').getByLabel('Model for primary')
-    await expect(select).toHaveValue('qwen3.6-27b-mtp')
-    await select.selectOption(SWAP_TARGET)
+    // RichSelect's closed trigger renders the selected row's text directly
+    // (Task 11c) — `longName` here, not a native <select> value.
+    await expect(select).toContainText('Qwen3.6-27B-MTP')
+    await pickRichOption(select, SWAP_TARGET)
 
     await expect.poll(() => swaps.length).toBe(1)
     expect(swaps[0]).toEqual({ model_id: SWAP_TARGET })
@@ -123,7 +126,7 @@ test.describe('Slot drawer — model swap wiring', () => {
 
     await page.goto('/#slots/primary')
     const select = page.locator('.drawer').getByLabel('Model for primary')
-    await select.selectOption('qwen3.6-27b-mtp')
+    await pickRichOption(select, 'qwen3.6-27b-mtp')
     await page.waitForTimeout(200)
     expect(swaps).toEqual([])
   })
@@ -136,7 +139,7 @@ test.describe('Slot drawer — model swap wiring', () => {
     ])
 
     await page.goto('/#slots/primary')
-    await page.locator('.drawer').getByLabel('Model for primary').selectOption(SWAP_TARGET)
+    await pickRichOption(page.locator('.drawer').getByLabel('Model for primary'), SWAP_TARGET)
 
     const dialog = page.locator('.modal-shell', { hasText: 'Swap model' })
     await expect(dialog).toBeVisible()
@@ -147,7 +150,7 @@ test.describe('Slot drawer — model swap wiring', () => {
     await page.waitForTimeout(200)
     expect(swaps).toEqual([])
     // Cancelling reverts the select to the bound model (value={cur}).
-    await expect(page.locator('.drawer').getByLabel('Model for primary')).toHaveValue('qwen3.6-27b-mtp')
+    await expect(page.locator('.drawer').getByLabel('Model for primary')).toContainText('Qwen3.6-27B-MTP')
   })
 
   test('W2 — confirming the live-swap dialog POSTs /swap { model_id }', async ({ page }) => {
@@ -158,11 +161,117 @@ test.describe('Slot drawer — model swap wiring', () => {
     ])
 
     await page.goto('/#slots/primary')
-    await page.locator('.drawer').getByLabel('Model for primary').selectOption(SWAP_TARGET)
+    await pickRichOption(page.locator('.drawer').getByLabel('Model for primary'), SWAP_TARGET)
     await page.locator('.modal-shell').getByRole('button', { name: 'Swap model' }).click()
 
     await expect.poll(() => swaps.length).toBe(1)
     expect(swaps[0]).toEqual({ model_id: SWAP_TARGET })
+  })
+})
+
+// ─── GTT feasibility (Task 11d, host-truth signal 993ea3b6) ────────────────
+//
+// Task 12: cascades the drawer's two feasibility call sites into this file
+// (rather than a new spec) since both hang off the same Model group this
+// file already exercises. Mocked at the Playwright layer, following the
+// mockProfiles/mockChatTemplates idiom (page.route per spec, request body
+// captured/echoed rather than a fixed canned response) — the wire contract
+// is `POST /api/models/feasibility {models:[{model_id, ctx?}]}` →
+// `{results: [{model_id, verdict, needed_mb, gtt_free_mb, gtt_total_mb}]}`
+// (`useModelsFeasibility.ts`). warn-never-block: a `fits`/`tight`/`exceeds`/
+// `exceeds_total` verdict maps to `feasibility-copy.ts`'s exact hint text;
+// this file only pins that the right verdict reaches the right surface, not
+// the copy itself (already vitest-pinned in `feasibility-hint.test.ts`).
+test.describe('Slot drawer — GTT feasibility (ceiling hint + model-row fit chips)', () => {
+  /** Echo a per-model-id verdict for every probed model in the request body. */
+  function mockFeasibility(page: Page, verdictById: Record<string, string>) {
+    return page.route('**/api/models/feasibility', async (route) => {
+      const body = route.request().postDataJSON() as { models: { model_id: string; ctx?: number }[] }
+      const results = body.models.map((m) => ({
+        model_id: m.model_id,
+        verdict: verdictById[m.model_id] ?? 'unknown',
+        needed_mb: 14_000,
+        gtt_free_mb: 15_000,
+        gtt_total_mb: 24_000,
+      }))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ results }) })
+    })
+  }
+
+  function ctxCeilingInput(page: Page) {
+    const hwGroup = page.locator('.drawer .field-group').filter({
+      has: page.locator('.field-group-label', { hasText: /^How it runs$/ }),
+    })
+    return hwGroup
+      .locator('.form-row')
+      .filter({ has: page.locator('.form-lbl > span', { hasText: /^Context \(ceiling\)$/ }) })
+      .locator('input')
+  }
+
+  test('the ceiling hint renders per verdict and re-probes (debounced) on a ctx edit', async ({ page }) => {
+    await mockFeasibility(page, { 'qwen3.6-27b-mtp': 'fits' })
+    await seedSlots(page, [OFFLINE_PRIMARY, EMBED])
+    await page.goto('/#slots/primary')
+    await expect(page.locator('.drawer')).toBeVisible()
+
+    const hint = page.getByTestId('slot-ctx-feasibility')
+    // Fires on drawer open (400ms debounce) — no keystroke needed yet.
+    await expect(hint).toContainText('fits', { timeout: 2_000 })
+    await expect(hint).toContainText('14 GB')
+
+    // Re-mock to a verdict that maps to the "exceeds" copy, then edit ctx —
+    // the SAME probe re-fires (debounced) for the new ceiling.
+    await mockFeasibility(page, { 'qwen3.6-27b-mtp': 'exceeds' })
+    await ctxCeilingInput(page).fill('32768')
+    await expect(hint).toContainText('exceeds', { timeout: 2_000 })
+  })
+
+  test('an absent/unknown verdict renders no hint at all (warn-never-block)', async ({ page }) => {
+    // No model_id in the map ⇒ every probed row echoes back 'unknown'.
+    await mockFeasibility(page, {})
+    await seedSlots(page, [OFFLINE_PRIMARY, EMBED])
+    await page.goto('/#slots/primary')
+    await expect(page.locator('.drawer')).toBeVisible()
+    await page.waitForTimeout(700) // past the 400ms debounce
+    await expect(page.getByTestId('slot-ctx-feasibility')).toHaveCount(0)
+  })
+
+  test('model dropdown rows carry a per-model fit chip from ONE batch probe fired on open', async ({ page }) => {
+    const probes: any[] = []
+    await page.route('**/api/models/feasibility', async (route) => {
+      const body = route.request().postDataJSON() as { models: { model_id: string }[] }
+      probes.push(body)
+      const verdictById: Record<string, string> = {
+        'qwen3.6-27b-mtp': 'fits',
+        [SWAP_TARGET]: 'exceeds',
+      }
+      const results = body.models.map((m) => ({
+        model_id: m.model_id,
+        verdict: verdictById[m.model_id] ?? 'unknown',
+        needed_mb: 14_000,
+        gtt_free_mb: 15_000,
+        gtt_total_mb: 24_000,
+      }))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ results }) })
+    })
+    await seedSlots(page, [OFFLINE_PRIMARY, EMBED])
+    await page.goto('/#slots/primary')
+    await expect(page.locator('.drawer')).toBeVisible()
+
+    const trigger = page.locator('.drawer').getByLabel('Model for primary')
+    const listbox = await openRichSelect(trigger)
+    // Fired once on the open transition — never per keystroke, never per row.
+    await expect.poll(() => probes.length).toBe(1)
+    await expect(listbox.locator('[data-option-id="qwen3.6-27b-mtp"]')).toContainText('● fits · ~14 GB')
+    await expect(listbox.locator(`[data-option-id="${SWAP_TARGET}"]`)).toContainText("○ won't fit")
+    // Each fresh open→true transition fires exactly one more probe (still
+    // never per keystroke/per row); closing itself fires nothing. Click a
+    // plain label (not Escape — the drawer's OWN document-level Escape
+    // handler closes the whole drawer, not just the open listbox) to close
+    // it via RichSelect's click-outside listener instead.
+    await page.locator('.drawer .form-lbl', { hasText: 'Runtime' }).first().click()
+    await openRichSelect(trigger)
+    await expect.poll(() => probes.length).toBe(2)
   })
 })
 

--- a/ui/tests/e2e/specs/slot-drawer-lifecycle.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-lifecycle.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * slot-drawer-lifecycle — the "When it unloads" section (Task 11b) that
+ * pairs Auto-Load with Eviction priority.
+ *
+ * Companion to slot-pin-toggle-v3.spec.ts (which owns the header Pin/
+ * Auto-Load toggle wiring itself — PUT /config { pinned } / { autoload }).
+ * This file owns the CROSS-CONTROL contract the lifecycle regroup
+ * introduced: pinning a slot disables the priority input (with an
+ * explainer) but leaves Auto-Load fully live, because Auto-Load answers "did
+ * this slot start at boot" while priority answers "who unloads first under
+ * pressure" — orthogonal questions the operator ruling (Task 11b) says a
+ * pinned slot only silences the second one.
+ *
+ *   L1. pin ON  ⇒ priority input disabled + the "Pinned — never evicted…"
+ *       explainer replaces the unpinned hint; Auto-Load stays enabled and
+ *       toggling it still fires PUT /config { autoload }.
+ *   L2. pin OFF ⇒ priority input enabled, "lower priority unloads first…"
+ *       hint shown.
+ *   L3. a pinned anchor SEEDS disabled (no click needed) — the disabled
+ *       state is a property of `slot.pinned`, not of having just clicked Pin.
+ *
+ * List seeding mirrors slot-pin-toggle-v3.spec.ts (in-bundle HAL0_DATA;
+ * mutations fall through to page.route).
+ */
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+const PRIMARY = {
+  name: 'primary', type: 'llm', device: 'gpu-rocm', profile: 'rocm',
+  model: 'qwen3.6-27b', model_id: 'qwen3.6-27b', modelLong: 'qwen3.6-27b',
+  group: 'chat', state: 'serving', port: 8092, isDefault: true,
+  pinned: false, n_gpu_layers: -1,
+  metrics: { ctx: 8192, toks: 42, ttft: 180, kv: 35 },
+}
+const PINNED_ANCHOR = { ...PRIMARY, name: 'utility', pinned: true, isDefault: false, port: 8090 }
+
+async function seedSlots(page: Page, slots: any[]) {
+  await page.addInitScript((slots) => {
+    let real: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true,
+      get() {
+        return real
+      },
+      set(v) {
+        real = v
+        if (v && typeof v === 'object') v.slots = slots
+      },
+    })
+  }, slots)
+}
+
+async function capturePuts(page: Page, name: string) {
+  const puts: any[] = []
+  await page.route(`**/api/slots/${name}/config`, async (route) => {
+    if (route.request().method() === 'PUT') {
+      puts.push(JSON.parse(route.request().postData() || '{}'))
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  })
+  return puts
+}
+
+const priorityInput = (page: Page) => page.getByTestId('slot-priority-input')
+const pinToggle = (page: Page) => page.locator('label[data-testid="slot-pin-toggle"]')
+const autoloadToggle = (page: Page) => page.locator('label[data-testid="slot-autoload-toggle"]')
+
+test.describe('Slot drawer — lifecycle row ("When it unloads", Task 11b)', () => {
+  test('L1 — pinning ON disables priority + shows the pinned explainer, Auto-Load stays live', async ({ page }) => {
+    const puts = await capturePuts(page, 'primary')
+    await seedSlots(page, [PRIMARY])
+    await page.goto('/#slots/primary')
+    await expect(page.locator('.drawer')).toBeVisible()
+
+    // Unpinned baseline: enabled, "lower priority unloads first" hint.
+    await expect(priorityInput(page)).toBeEnabled()
+    const lifecycleRow = page.locator('.form-row').filter({
+      has: page.getByTestId('slot-priority-input'),
+    })
+    await expect(lifecycleRow).toContainText(/lower priority unloads first/i)
+    await expect(lifecycleRow).not.toContainText(/pinned — never evicted/i)
+
+    await pinToggle(page).click()
+    await expect.poll(() => puts.length).toBeGreaterThan(0)
+    expect(puts[0]).toEqual({ pinned: true })
+
+    // The drawer prop is poll-driven; flip HAL0_DATA to reflect the write so
+    // the next poll carries `pinned: true` back down, same as a real PUT
+    // round-trip would.
+    await page.evaluate(() => {
+      ;(window as any).HAL0_DATA.slots = [{ ...(window as any).HAL0_DATA.slots[0], pinned: true }]
+    })
+
+    await expect(priorityInput(page)).toBeDisabled({ timeout: 20_000 })
+    await expect(lifecycleRow).toContainText(/pinned — never evicted; priority has no effect while pinned/i)
+    await expect(lifecycleRow).not.toContainText(/lower priority unloads first/i)
+
+    // Auto-Load is untouched by pinning — still enabled and still wired.
+    const autoload = autoloadToggle(page)
+    await expect(autoload.locator('input[type="checkbox"]')).toBeEnabled()
+    await autoload.click()
+    await expect.poll(() => puts.length).toBeGreaterThan(1)
+    expect(puts[puts.length - 1]).toEqual({ autoload: true })
+  })
+
+  test('L2 — pin OFF leaves priority enabled with the unpinned hint', async ({ page }) => {
+    await seedSlots(page, [PRIMARY])
+    await page.goto('/#slots/primary')
+    await expect(page.locator('.drawer')).toBeVisible()
+
+    await expect(priorityInput(page)).toBeEnabled()
+    const lifecycleRow = page.locator('.form-row').filter({
+      has: page.getByTestId('slot-priority-input'),
+    })
+    await expect(lifecycleRow).toContainText(/lower priority unloads first · ties go to least recently used/i)
+  })
+
+  test('L3 — a pinned anchor seeds priority disabled with no click needed', async ({ page }) => {
+    await seedSlots(page, [PINNED_ANCHOR])
+    await page.goto('/#slots/utility')
+    await expect(page.locator('.drawer')).toBeVisible()
+
+    await expect(
+      page.locator('[data-testid="slot-pin-toggle"] input[type="checkbox"]'),
+    ).toBeChecked()
+    await expect(priorityInput(page)).toBeDisabled()
+    const lifecycleRow = page.locator('.form-row').filter({
+      has: page.getByTestId('slot-priority-input'),
+    })
+    await expect(lifecycleRow).toContainText(/pinned — never evicted/i)
+    // Auto-Load is still a live, enabled control on a pinned slot.
+    await expect(
+      autoloadToggle(page).locator('input[type="checkbox"]'),
+    ).toBeEnabled()
+  })
+})

--- a/ui/tests/e2e/specs/slot-drawer-lifecycle.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-lifecycle.spec.ts
@@ -18,11 +18,16 @@
  *       hint shown.
  *   L3. a pinned anchor SEEDS disabled (no click needed) — the disabled
  *       state is a property of `slot.pinned`, not of having just clicked Pin.
+ *   L4. Escape layering: Escape inside an OPEN RichSelect closes only the
+ *       dropdown (rich-select.jsx consumes it via stopPropagation); the
+ *       drawer's document-level Escape handler only fires when no dropdown
+ *       is open. One press = one layer.
  *
  * List seeding mirrors slot-pin-toggle-v3.spec.ts (in-bundle HAL0_DATA;
  * mutations fall through to page.route).
  */
 import { test, expect, type Page } from '../fixtures/apiMock'
+import { openRichSelect, closeRichSelect } from '../fixtures/richSelect'
 
 const PRIMARY = {
   name: 'primary', type: 'llm', device: 'gpu-rocm', profile: 'rocm',
@@ -131,5 +136,28 @@ test.describe('Slot drawer — lifecycle row ("When it unloads", Task 11b)', () 
     await expect(
       autoloadToggle(page).locator('input[type="checkbox"]'),
     ).toBeEnabled()
+  })
+
+  test('L4 — Escape in an open RichSelect closes only the dropdown; the drawer needs its own press', async ({ page }) => {
+    await seedSlots(page, [PRIMARY])
+    await page.goto('/#slots/primary')
+    await expect(page.locator('.drawer')).toBeVisible()
+
+    const trigger = page.getByTestId('slot-hw-runtime')
+    const listbox = await openRichSelect(trigger)
+    await expect(listbox).toBeVisible()
+
+    // First Escape (closeRichSelect): consumed by the RichSelect — the
+    // dropdown unmounts, the drawer stays.
+    await closeRichSelect(trigger)
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    await expect(listbox).toHaveCount(0)
+    await expect(page.locator('.drawer')).toBeVisible()
+
+    // Second Escape, with no dropdown open, DOES reach the drawer's
+    // document-level handler and closes it — proving the first press was
+    // consumed by the dropdown, not merely lagging behind an animation.
+    await page.keyboard.press('Escape')
+    await expect(page.locator('.drawer')).toBeHidden()
   })
 })

--- a/ui/tests/e2e/specs/slot-drawer-model-stack-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-model-stack-v3.spec.ts
@@ -147,6 +147,8 @@ test.describe('Slot drawer — stacked model editor', () => {
 
     // A slot HARDWARE control and a MODEL control are both visible together —
     // the old behaviour hid the slot drawer entirely behind the model drawer.
+    // NGL lives behind the slot drawer's Advanced disclosure (Task 11a).
+    await page.getByTestId('slot-hw-advanced').click()
     const ngl = page.getByTestId('slot-hw-ngl')
     const flags = modelDrawer(page).getByTestId('model-flags-input')
     await expect(ngl).toBeVisible()
@@ -218,7 +220,9 @@ test.describe('Slot drawer — stacked model editor', () => {
     await openStack(page)
 
     // Dirty the slot drawer first — a single Esc used to fire BOTH drawers'
-    // document-level keydown handlers.
+    // document-level keydown handlers. Threads lives behind the slot
+    // drawer's Advanced disclosure (Task 11a).
+    await page.getByTestId('slot-hw-advanced').click()
     await page.getByTestId('slot-hw-threads').fill('12')
 
     await page.keyboard.press('Escape')

--- a/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
@@ -9,6 +9,7 @@
  * (i3). Its save/restart contract lives in slot-drawer-inline-model-v3.
  */
 import { test, expect, MOCK_DATA, type Page } from '../fixtures/apiMock'
+import { pickRichOption, richSelectOption } from '../fixtures/richSelect'
 
 // ─── Slot fixtures ──────────────────────────────────────────────────────────
 
@@ -53,7 +54,13 @@ test.describe('C7 — slot-owned hardware grid; no drawer profile selector', () 
   test('C7a2 — slot card still surfaces the bound profile chip', async ({ page }) => {
     await seedSlots(page, [CHAT_CONTAINER])
     await page.goto('/#slots/chat')
-    await expect(page.locator('button', { hasText: CHAT_CONTAINER.profile || '' })).toBeVisible()
+    // Scoped to the InferencePane card's own chip (`infer-profile-{slot}`) —
+    // a plain `button` text match now also catches the drawer's `slot-profile`
+    // RichSelect trigger (Task 11c turned it from a <select> into a
+    // `<button role="combobox">` whose closed-state text includes the same
+    // profile name), which strict-mode-violates on two matches.
+    await expect(page.getByTestId('infer-profile-chat')).toBeVisible()
+    await expect(page.getByTestId('infer-profile-chat')).toContainText(CHAT_CONTAINER.profile || '')
   })
 
   test.skip('C7b — obsolete: profile changes no longer drive slot config/restart', async ({ page }) => {
@@ -343,10 +350,12 @@ test.describe('slot profile divergence (#1636)', () => {
     await expect(page.locator('.drawer')).toBeVisible()
 
     // The gpu-rocm slot is offered the vulkan-backend profile (was filtered
-    // out pre-#1636) under the "Other backend" group…
+    // out pre-#1636) under the "Other backend" disabled-marker row (RichSelect
+    // has no <optgroup> — Task 11c's profileRichOptions stands in a disabled
+    // marker option instead; see rich-select.jsx).
     const sel = page.getByTestId('slot-profile')
-    await expect(sel.locator('optgroup option[value="vulkan"]')).toHaveCount(1)
-    await sel.selectOption('vulkan')
+    await expect(await richSelectOption(sel, 'vulkan')).toHaveCount(1)
+    await pickRichOption(sel, 'vulkan')
 
     // …and selecting it announces the device switch.
     await expect(page.getByTestId('slot-profile-device-switch')).toBeVisible()
@@ -361,7 +370,7 @@ test.describe('slot profile divergence (#1636)', () => {
     await seedSlotsAndModels(page, [CHAT], CHAT_MODEL('rocm-mtp'))
     await page.goto('/#slots/chat')
     await expect(page.locator('.drawer')).toBeVisible()
-    await page.getByTestId('slot-profile').selectOption('rocm')
+    await pickRichOption(page.getByTestId('slot-profile'), 'rocm')
     await expect(page.getByTestId('slot-profile-device-switch')).toHaveCount(0)
   })
 })
@@ -478,7 +487,7 @@ test.describe('profile apply flow — runner-carrying profile applies a new runt
     // no preview yet.
     await expect(page.getByTestId('slot-profile-preview')).toHaveCount(0)
 
-    await page.getByTestId('slot-profile').selectOption('promptforge-apply')
+    await pickRichOption(page.getByTestId('slot-profile'), 'promptforge-apply')
 
     // Applying this profile previews the runtime it carries and that the
     // slot restarts on Save.
@@ -489,8 +498,10 @@ test.describe('profile apply flow — runner-carrying profile applies a new runt
 
     // The Hardware group's Runtime select mirrors the SAME pick immediately
     // (both read from the one hw-cascade.js cascade) — proving the preview
-    // isn't a display-only fiction.
-    await expect(page.getByTestId('slot-hw-runtime')).toHaveValue('promptforge')
+    // isn't a display-only fiction. A RichSelect trigger isn't a <select>, so
+    // this reads the closed trigger's rendered title text instead of
+    // `.toHaveValue()`.
+    await expect(page.getByTestId('slot-hw-runtime')).toContainText('Promptforge')
 
     await page.locator('.drawer button:has-text("Save")').click()
     await expect.poll(() => puts.length).toBeGreaterThan(0)

--- a/ui/tests/e2e/specs/slot-drawer-sunset-removal-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-sunset-removal-v3.spec.ts
@@ -138,8 +138,10 @@ test.describe('Slot drawer — sunset launch controls are gone (#1379)', () => {
     await page.goto('/#slots/primary')
     await expect(drawer(page)).toBeVisible()
 
-    const details = page.locator('.drawer details')
-    await details.first().click()
+    // The resolved-command preview is physically merged into the single
+    // consolidated Advanced disclosure now (Task 11a) — a controlled div,
+    // not a native <details>.
+    await page.getByTestId('slot-hw-advanced').click()
     const preview = page.locator('.drawer', { hasText: 'Resolved command' })
     await expect(preview).toBeVisible()
     await expect(page.locator('.drawer', { hasText: 'llama-server' }).first()).toBeVisible()
@@ -153,7 +155,9 @@ test.describe('Slot drawer — sunset launch controls are gone (#1379)', () => {
     await page.goto('/#slots/primary')
     await expect(drawer(page)).toBeVisible()
 
-    // Touch a field that IS slot-owned, so a real write happens.
+    // Touch a field that IS slot-owned, so a real write happens. NGL lives
+    // behind the Advanced disclosure now (Task 11a).
+    await page.getByTestId('slot-hw-advanced').click()
     await page.getByTestId('slot-hw-ngl').fill('24')
     await page.locator('.drawer button:has-text("Save")').click()
 
@@ -201,6 +205,8 @@ test.describe('Slot drawer — sunset launch controls are gone (#1379)', () => {
     await page.goto('/#slots/primary')
     await expect(drawer(page)).toBeVisible()
 
+    // Threads lives behind the Advanced disclosure now (Task 11a).
+    await page.getByTestId('slot-hw-advanced').click()
     await page.getByTestId('slot-hw-threads').fill('8')
     await page.locator('.drawer button:has-text("Save")').click()
 

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -43,6 +43,7 @@
  * through to real fetch and page.route captures their bodies.
  */
 import { test, expect, type Page } from '../fixtures/apiMock'
+import { openRichSelect, pickRichOption } from '../fixtures/richSelect'
 
 const PRIMARY = {
   name: 'primary', type: 'llm', device: 'gpu-rocm', profile: 'rocm',
@@ -89,6 +90,18 @@ async function seedSlots(page: Page, slots: any[]) {
   }, slots)
 }
 
+/**
+ * Open the drawer's single consolidated Advanced disclosure
+ * (`data-testid="slot-hw-advanced"`, Task 11a) — no-op if already open.
+ * Threads/NGL/the image block/debug pin all moved OUT of the top-level
+ * Hardware grid and behind this disclosure in the Option B regroup, so
+ * every test below that edits one of those fields opens it first.
+ */
+async function openAdvanced(page: Page) {
+  const adv = page.getByTestId('slot-hw-advanced')
+  if ((await adv.getAttribute('aria-expanded')) !== 'true') await adv.click()
+}
+
 // NOTE: the per-card enable toggle, the fade modifier, and the
 // configured-first sort were SlotCard-grid features. Both grids (Chat +
 // Capabilities) were retired in favour of the InferencePane, so those tests
@@ -123,6 +136,7 @@ test.describe('Slot edit controls (/slots)', () => {
     )
     await seedSlots(page, [PRIMARY, EMBED])
     await page.goto('/#slots/primary')
+    await openAdvanced(page)
     await page.getByTestId('slot-hw-ngl').fill('24')
     await page.locator('.drawer button:has-text("Save")').click()
     await expect.poll(() => puts.length).toBeGreaterThan(0)
@@ -131,12 +145,13 @@ test.describe('Slot edit controls (/slots)', () => {
     }
   })
 
-  test('C5 — NGL lives in the HW grid, editable with the -1 default', async ({ page }) => {
+  test('C5 — NGL lives behind Advanced, editable with the -1 default', async ({ page }) => {
     await seedSlots(page, [PRIMARY, EMBED])
 
     await page.goto('/#slots/primary')
-    // NGL moved out of Advanced into the top-level Hardware grid
-    // (spec-hw-slot-ownership §2) — no disclosure to open.
+    // Task 11a consolidation: NGL moved from the top-level Hardware grid into
+    // the single Advanced disclosure (slot-hw-advanced) — open it first.
+    await openAdvanced(page)
     const input = page.getByTestId('slot-hw-ngl')
     await expect(input).toBeVisible()
     await expect(input).not.toHaveAttribute('readonly', '')
@@ -172,6 +187,7 @@ test.describe('Slot edit controls (/slots)', () => {
     await seedSlots(page, [PRIMARY, EMBED])
 
     await page.goto('/#slots/primary')
+    await openAdvanced(page)
     await page.getByTestId('slot-hw-ngl').fill('24')
     await page.locator('.drawer button:has-text("Save")').click()
     await expect.poll(() => puts.length).toBeGreaterThan(0)
@@ -197,13 +213,14 @@ test.describe('Slot edit controls (/slots)', () => {
     await seedSlots(page, [{ ...PRIMARY, n_gpu_layers: 24 }, EMBED])
 
     await page.goto('/#slots/primary')
+    await openAdvanced(page)
     await page.getByTestId('slot-hw-ngl').fill('')
     await page.locator('.drawer button:has-text("Save")').click()
     await expect.poll(() => puts.length).toBeGreaterThan(0)
     expect(puts[0]).toHaveProperty('n_gpu_layers', -1)
   })
 
-  test('HW grid — Runtime + Threads + NGL render; Device select is gone; image pin hidden until Advanced opens (§2)', async ({ page }) => {
+  test('HW grid — Runtime renders top-level; Device select is gone; Threads/NGL/image pin live behind Advanced', async ({ page }) => {
     await seedSlots(page, [PRIMARY, EMBED])
     await page.goto('/#slots/primary')
     // The standalone Device select is GONE (hw-cascade): `device` is derived
@@ -213,14 +230,17 @@ test.describe('Slot edit controls (/slots)', () => {
     // gone too — replaced by the single Runtime select.
     await expect(page.locator('.drawer')).toBeVisible()
     await expect(page.getByTestId('slot-hw-device')).toHaveCount(0)
-    await expect(page.getByTestId('slot-hw-ngl')).toBeVisible()
-    await expect(page.getByTestId('slot-hw-threads')).toBeVisible()
     await expect(page.getByTestId('slot-hw-runtime')).toBeVisible()
     await expect(page.getByTestId('slot-hw-binary')).toHaveCount(0)
-    // The image/version truth + debug pin live behind the collapsed
-    // Advanced disclosure — not visible until it's opened.
+    // Task 11a consolidation: Threads/NGL moved OUT of the top-level grid
+    // alongside the image/version truth + debug pin, all behind the single
+    // collapsed Advanced disclosure — none visible until it's opened.
+    await expect(page.getByTestId('slot-hw-threads')).toHaveCount(0)
+    await expect(page.getByTestId('slot-hw-ngl')).toHaveCount(0)
     await expect(page.getByTestId('slot-hw-image-pin')).toHaveCount(0)
-    await page.getByTestId('slot-hw-advanced').click()
+    await openAdvanced(page)
+    await expect(page.getByTestId('slot-hw-threads')).toBeVisible()
+    await expect(page.getByTestId('slot-hw-ngl')).toBeVisible()
     await expect(page.getByTestId('slot-hw-advanced-image')).toBeVisible()
   })
 
@@ -265,8 +285,10 @@ test.describe('Slot edit controls (/slots)', () => {
     // rocmfpx is a dual-lane runner (rocm + vulkan) — the Runtime select
     // already resolves to it (the slot's persisted binary), so the Lane
     // pills render immediately; picking the Vulkan lane derives
-    // device=gpu-vulkan without touching Runtime at all.
-    await expect(page.getByTestId('slot-hw-runtime')).toHaveValue('rocmfpx')
+    // device=gpu-vulkan without touching Runtime at all. RichSelect's closed
+    // trigger renders the selected option's title text (no declared `title`
+    // on this backend row, so it falls back to the raw key).
+    await expect(page.getByTestId('slot-hw-runtime')).toContainText('rocmfpx')
     await page.getByTestId('slot-hw-lane').getByRole('button', { name: 'Vulkan' }).click()
     await page.locator('.drawer button:has-text("Save")').click()
     await expect.poll(() => puts.length).toBeGreaterThan(0)
@@ -313,12 +335,13 @@ test.describe('Slot edit controls (/slots)', () => {
 
     await page.goto('/#slots/primary')
     // Pick the Runtime — a single-lane runner's device is derived from it.
-    await page.getByTestId('slot-hw-runtime').selectOption('rocmfpx')
+    await pickRichOption(page.getByTestId('slot-hw-runtime'), 'rocmfpx')
+    // Threads/NGL/the debug pin (a free-text escape hatch, never an
+    // enumerated catalog dropdown) all live behind the single Advanced
+    // disclosure now (Task 11a) — open it once before touching any of them.
+    await openAdvanced(page)
     await page.getByTestId('slot-hw-ngl').fill('0')
     await page.getByTestId('slot-hw-threads').fill('8')
-    // The debug pin is a free-text escape hatch behind the Advanced
-    // disclosure now — never an enumerated catalog dropdown.
-    await page.getByTestId('slot-hw-advanced').click()
     await page.getByTestId('slot-hw-debug-pin-open').click()
     await page.getByTestId('slot-hw-image-pin').fill('ghcr.io/example/runner:test')
     await page.locator('.drawer button:has-text("Save")').click()
@@ -378,10 +401,15 @@ test.describe('Slot edit controls (/slots)', () => {
     await expect(sel).toBeVisible()
     // Registry entries by TITLE — no optgroup split (the old
     // "catalogued · downloaded" grouping is gone) and no separate Runner
-    // Image / Backend selects.
-    await expect(sel.locator('option', { hasText: 'ROCm FPX (default)' })).toHaveCount(1)
-    await expect(sel.locator('option', { hasText: 'Strix (Vulkan optional)' })).toHaveCount(1)
-    await expect(sel.locator('optgroup')).toHaveCount(0)
+    // Image / Backend selects. RichSelect has no <optgroup>/<option> DOM —
+    // open the listbox and read its rows instead.
+    const listbox = await openRichSelect(sel)
+    await expect(listbox.getByText('ROCm FPX (default)')).toHaveCount(1)
+    await expect(listbox.getByText('Strix (Vulkan optional)')).toHaveCount(1)
+    // No disabled-marker "group header" row either (Task 11c's stand-in for
+    // <optgroup>, used only by the Profile select's cross-backend group) —
+    // a plain Runtime list has nothing to group.
+    await expect(listbox.locator('[aria-disabled="true"]')).toHaveCount(0)
     await expect(page.getByTestId('slot-hw-binary')).toHaveCount(0)
   })
 
@@ -419,8 +447,8 @@ test.describe('Slot edit controls (/slots)', () => {
     ])
     await page.goto('/#slots/primary')
 
-    await expect(page.getByTestId('slot-hw-runtime')).toHaveValue('rocmfpx')
-    await page.getByTestId('slot-hw-advanced').click()
+    await expect(page.getByTestId('slot-hw-runtime')).toContainText('ROCm FPX')
+    await openAdvanced(page)
     await expect(page.getByTestId('slot-hw-image-pin')).toHaveValue(
       'ghcr.io/hal0ai/hal0-combined-upstream:0829',
     )
@@ -462,8 +490,14 @@ test.describe('Slot edit controls (/slots)', () => {
     await seedSlots(page, [{ ...PRIMARY, device: 'cpu', binary: 'rocmfpx' }, EMBED])
     await page.goto('/#slots/primary')
     const sel = page.getByTestId('slot-hw-runtime')
-    await expect(sel).toHaveValue('rocmfpx')
-    await expect(sel.locator('option', { hasText: 'not in this catalog' })).toHaveCount(1)
+    // The closed trigger renders the persisted binary's own "· not in this
+    // catalog" row text directly (Task 11c) — no silent rewrite to auto.
+    await expect(sel).toContainText('rocmfpx')
+    await expect(sel).toContainText('not in this catalog')
+    const listbox = await openRichSelect(sel)
+    await expect(listbox.locator('[data-option-id="rocmfpx"]')).toContainText(
+      'not in this catalog',
+    )
   })
 
   test('NPU modality controls remain visible and wire ASR updates', async ({ page }) => {
@@ -513,14 +547,16 @@ test.describe('Slot edit controls (/slots)', () => {
     await seedSlots(page, [PRIMARY, EMBED])
 
     await page.goto('/#slots/primary')
-    // Context is directly visible in the Model group (not inside Advanced).
-    // Label reads "Context (ceiling)": the bound model's own default
-    // context_size is authoritative; this slot value only clamps it down for
-    // lighter hardware, it never overrides it upward.
-    const modelGroup = page.locator('.drawer .field-group').filter({
-      has: page.locator('.field-group-label', { hasText: /^Model$/ }),
+    // Context is directly visible in the "How it runs" group (not inside
+    // Advanced) — Task 11a moved the ceiling IN from the old Model group
+    // beside the hardware that enforces it. Label reads "Context (ceiling)":
+    // the bound model's own default context_size is authoritative; this
+    // slot value only clamps it down for lighter hardware, it never
+    // overrides it upward.
+    const hwGroup = page.locator('.drawer .field-group').filter({
+      has: page.locator('.field-group-label', { hasText: /^How it runs$/ }),
     })
-    const contextRow = modelGroup.locator('.form-row').filter({
+    const contextRow = hwGroup.locator('.form-row').filter({
       has: page.locator('.form-lbl > span', { hasText: /^Context \(ceiling\)$/ }),
     })
     await expect(contextRow).toBeVisible()
@@ -586,21 +622,25 @@ test.describe('Slot edit controls (/slots)', () => {
     await expect(page.locator('.drawer .form-row', { hasText: 'workers' })).toHaveCount(0)
   })
 
-  test('drawer fields are grouped under SLOT / HARDWARE / MODEL (no Inference group)', async ({ page }) => {
+  test('drawer fields are grouped under What runs / How it runs / When it unloads (no separate Profile/Inference group)', async ({ page }) => {
+    // Task 11a's Option B regroup replaced the old SLOT / HARDWARE / MODEL
+    // FieldGroups with three task-oriented sections; the underlying claims
+    // this test protects survive verbatim under the new names: no separate
+    // Inference or Profile group, and Model + Profile both live together.
     await seedSlots(page, [PRIMARY, EMBED])
     await page.goto('/#slots/primary')
     await expect(page.locator('.drawer')).toBeVisible()
-    for (const label of ['Slot', 'Hardware', 'Model']) {
+    for (const label of ['What runs', 'How it runs', 'When it unloads']) {
       await expect(page.locator('.field-group-label', { hasText: new RegExp(`^${label}$`, 'i') })).toHaveCount(1)
     }
     // spec-hw-slot-ownership §1: the former "Inference" group (Reasoning/MTP/
     // Vision) was removed outright — those caps moved to the model drawer.
     await expect(page.locator('.field-group-label', { hasText: /^Inference$/i })).toHaveCount(0)
-    const modelGroup = page.locator('.field-group', { has: page.locator('.field-group-label', { hasText: /^Model$/i }) })
-    await expect(modelGroup.getByLabel('Model for primary')).toBeVisible()
-    // The Profile row moved INTO the Model group (under the model select) —
+    const whatRuns = page.locator('.field-group', { has: page.locator('.field-group-label', { hasText: /^What runs$/i }) })
+    await expect(whatRuns.getByLabel('Model for primary')).toBeVisible()
+    // The Profile row lives INSIDE "What runs" (under the model select) —
     // no standalone Profile group on non-NPU slots.
-    await expect(modelGroup.getByTestId('slot-profile')).toBeVisible()
+    await expect(whatRuns.getByTestId('slot-profile')).toBeVisible()
     await expect(page.locator('.field-group-label', { hasText: /^Profile$/i })).toHaveCount(0)
   })
 
@@ -617,6 +657,7 @@ test.describe('Slot edit controls (/slots)', () => {
     await expect(page.locator('.drawer')).toBeVisible()
     await expect(page.locator('.drawer .form-row', { hasText: 'Default for type' })).toHaveCount(0)
     // Make a real config change so the emitted body can prove `default` stays absent.
+    await openAdvanced(page)
     await page.getByTestId('slot-hw-ngl').fill('24')
     await page.locator('.drawer button:has-text("Save")').click()
     await expect.poll(() => puts.length).toBeGreaterThan(0)

--- a/ui/tests/e2e/specs/slot-npu-dead-save-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-npu-dead-save-v3.spec.ts
@@ -64,6 +64,8 @@ test.describe('NPU slot Save with malformed persisted extra_args (#1389)', () =>
     await page.goto('/#slots/agent')
     await expect(page.locator('.drawer')).toBeVisible()
 
+    // Threads moved behind the single Advanced disclosure (Task 11a).
+    await page.getByTestId('slot-hw-advanced').click()
     await page.getByTestId('slot-hw-threads').fill('4')
     await page.locator('.drawer button:has-text("Save")').click()
 

--- a/ui/tests/e2e/specs/slot-pin-toggle-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-pin-toggle-v3.spec.ts
@@ -52,7 +52,7 @@ async function seedSlots(page: Page, slots: any[]) {
 }
 
 test.describe('Slot pin toggle (/slots drawer header)', () => {
-  test('P1 — header shows Auto-Load + Pinned/Unpinned, Enabled/Disabled copy is gone', async ({ page }) => {
+  test('P1 — header shows Pinned/Unpinned, lifecycle row shows Auto-Load, Enabled/Disabled copy is gone', async ({ page }) => {
     await seedSlots(page, [PRIMARY, UTILITY])
     await page.goto('/#slots/primary')
     await expect(page.locator('.drawer')).toBeVisible()
@@ -94,7 +94,7 @@ test.describe('Slot pin toggle (/slots drawer header)', () => {
     ).toBeChecked()
   })
 
-  test('P4 — flipping the header Auto-Load toggle PUTs { autoload }', async ({ page }) => {
+  test('P4 — flipping the lifecycle-row Auto-Load toggle PUTs { autoload }', async ({ page }) => {
     const puts: any[] = []
     await page.route('**/api/slots/primary/config', async (route) => {
       if (route.request().method() === 'PUT')

--- a/ui/tests/e2e/specs/slot-pin-toggle-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-pin-toggle-v3.spec.ts
@@ -11,8 +11,9 @@
  *       { enabled }.
  *   P3. a pinned slot (fresh-install utility anchor) seeds the toggle on.
  *   P4. flipping the header Auto-Load toggle fires PUT /config { autoload }.
- *   P5. Eviction priority lives under the Advanced disclosure (not in the
- *       Model section) and commits PUT /config { priority } on blur.
+ *   P5. Eviction priority lives in the "When it unloads" lifecycle row
+ *       (Task 11b re-homed it OUT of Advanced, next to Auto-Load) and
+ *       commits PUT /config { priority } on blur.
  *
  * List seeding mirrors slot-edit-controls-v3.spec.ts (in-bundle HAL0_DATA,
  * mutations fall through to page.route).
@@ -108,7 +109,7 @@ test.describe('Slot pin toggle (/slots drawer header)', () => {
     expect(puts[0]).toEqual({ autoload: true })
   })
 
-  test('P5 — Eviction priority lives under Advanced and PUTs { priority } on blur', async ({ page }) => {
+  test('P5 — Eviction priority lives in the lifecycle row, visible+editable while unpinned, and PUTs { priority } on blur', async ({ page }) => {
     const puts: any[] = []
     await page.route('**/api/slots/primary/config', async (route) => {
       if (route.request().method() === 'PUT')
@@ -118,11 +119,12 @@ test.describe('Slot pin toggle (/slots drawer header)', () => {
     await seedSlots(page, [PRIMARY, UTILITY])
     await page.goto('/#slots/primary')
     await expect(page.locator('.drawer')).toBeVisible()
+    // Task 11b: the priority input now lives in the "When it unloads"
+    // lifecycle row, always rendered (no disclosure to open) — only pinning
+    // the slot disables it. PRIMARY is unpinned, so it starts enabled.
     const prio = page.locator('[data-testid="slot-priority-input"]')
-    // Collapsed by default — the row sits inside the Advanced disclosure.
-    await expect(prio).toBeHidden()
-    await page.locator('details.adv-disclosure > summary').click()
     await expect(prio).toBeVisible()
+    await expect(prio).toBeEnabled()
     await prio.fill('10')
     await prio.blur()
     await expect.poll(() => puts.length).toBeGreaterThan(0)

--- a/ui/tests/e2e/specs/slot-rename-delete-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-rename-delete-v3.spec.ts
@@ -10,14 +10,13 @@
  * disabled Name field with an inline-editable title field
  * (`slot-name-inline`) that commits on blur/Enter through the identical
  * `useSlotRename` mutation, gated offline-only exactly like the retired
- * dialog gated it (RenameSlotDialog.jsx is still mounted per the task's own
- * report, but nothing in the drawer opens it any more — `slot-rename-open`
- * no longer exists). One casualty of the move: the dialog's disabled state
- * used to surface a VISIBLE inline reason panel ("never a bare tooltip", per
- * its own header comment) naming both the stop-first requirement and the
- * stable slot_id; the inline field only carries that as a plain `title`
- * (hover) attribute now. Flagged as a concern in this task's report — out of
- * scope to fix here (this file only touches tests/e2e).
+ * dialog gated it (the drawer no longer mounts RenameSlotDialog at all —
+ * `slot-rename-open` no longer exists). Escape cancels the edit: it reverts
+ * the draft WITHOUT committing (the blur that follows must not fire the
+ * stale draft — nameCancelRef in slot-modals.jsx) and never bubbles to the
+ * drawer's own Escape→close handler. The disabled state carries its
+ * stop-first reason both as the `title` attribute and as an
+ * `aria-describedby` sr-only description for non-hover access.
  *
  * Delete (DeleteSlotDialog): unaffected by the drawer restructure — the
  * confirm states the true blast radius (unit, port → PortAuthority, state)
@@ -82,6 +81,36 @@ test.describe('Slot rename', () => {
     await nameField.fill('primary-2')
     await nameField.press('Enter')
     await expect.poll(() => body?.new_name).toBe('primary-2')
+  })
+
+  test('offline slot: Escape cancels the edit — draft reverts, no rename POST, drawer stays open', async ({ page }) => {
+    const posts: any[] = []
+    await page.route('**/api/slots/primary/rename', async (route) => {
+      posts.push(JSON.parse(route.request().postData() || '{}'))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await seedSlots(page, [OFFLINE])
+    await page.goto('/#slots/primary')
+    await expect(page.locator('.drawer')).toBeVisible()
+
+    const nameField = page.getByTestId('slot-name-inline')
+    await nameField.fill('primary-2')
+    await nameField.press('Escape')
+
+    // The draft reverts to the persisted name…
+    await expect(nameField).toHaveValue('primary')
+    // …the drawer survives (Escape in the field is consumed, it must not
+    // reach the drawer's document-level Escape→close handler)…
+    await expect(page.locator('.drawer')).toBeVisible()
+    // …and the blur Escape triggers must NOT commit the stale edited draft
+    // (the cancel-then-blur ordering bug this test pins).
+    expect(posts).toHaveLength(0)
+
+    // The field still works after a cancel: a fresh edit + Enter commits.
+    await nameField.fill('primary-3')
+    await nameField.press('Enter')
+    await expect.poll(() => posts.length).toBeGreaterThan(0)
+    expect(posts[0]).toEqual({ new_name: 'primary-3' })
   })
 })
 

--- a/ui/tests/e2e/specs/slot-rename-delete-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-rename-delete-v3.spec.ts
@@ -1,14 +1,28 @@
 /**
  * slot-rename-delete-v3 — D2 decomposed rename + delete dialogs.
  *
- * Rename (RenameSlotDialog): the slot name is a mutable display label; the
- * stable slot_id never changes. Rename requires the unit OFFLINE — while the
- * slot runs, the field + Save are disabled with an inline reason (not a bare
- * tooltip). Offline, a rename POSTs /api/slots/{name}/rename { new_name }.
+ * Rename: the slot name is a mutable display label; the stable slot_id never
+ * changes. Rename requires the unit OFFLINE — while the slot runs, the field
+ * is disabled. Offline, a rename commits through the SAME wire contract:
+ * POST /api/slots/{name}/rename { new_name }.
  *
- * Delete (DeleteSlotDialog): the confirm states the true blast radius (unit,
- * port → PortAuthority, state) and that the model + weights are untouched;
- * type-to-confirm the name, then DELETE /api/slots/{name}.
+ * Task 11a replaced the standalone RenameSlotDialog's "Rename…" button +
+ * disabled Name field with an inline-editable title field
+ * (`slot-name-inline`) that commits on blur/Enter through the identical
+ * `useSlotRename` mutation, gated offline-only exactly like the retired
+ * dialog gated it (RenameSlotDialog.jsx is still mounted per the task's own
+ * report, but nothing in the drawer opens it any more — `slot-rename-open`
+ * no longer exists). One casualty of the move: the dialog's disabled state
+ * used to surface a VISIBLE inline reason panel ("never a bare tooltip", per
+ * its own header comment) naming both the stop-first requirement and the
+ * stable slot_id; the inline field only carries that as a plain `title`
+ * (hover) attribute now. Flagged as a concern in this task's report — out of
+ * scope to fix here (this file only touches tests/e2e).
+ *
+ * Delete (DeleteSlotDialog): unaffected by the drawer restructure — the
+ * confirm states the true blast radius (unit, port → PortAuthority, state)
+ * and that the model + weights are untouched; type-to-confirm the name, then
+ * DELETE /api/slots/{name}.
  *
  * Slot GETs are served from the in-bundle mock (VITE_MOCK_HAL0) off
  * window.HAL0_DATA, so we seed slot STATE via addInitScript; the mutations
@@ -42,20 +56,17 @@ const OFFLINE = {
 }
 
 test.describe('Slot rename', () => {
-  test('running slot: rename disabled with an inline stop-first reason', async ({ page }) => {
+  test('running slot: the inline name field is disabled with a stop-first title', async ({ page }) => {
     await seedSlots(page, [RUNNING])
     await page.goto('/#slots/primary')
-    await page.getByTestId('slot-rename-open').click()
+    await expect(page.locator('.drawer')).toBeVisible()
 
-    await expect(page.getByTestId('rename-slot-input')).toBeDisabled()
-    await expect(page.getByTestId('rename-slot-save')).toBeDisabled()
-    const reason = page.getByTestId('rename-slot-reason')
-    await expect(reason).toBeVisible()
-    await expect(reason).toContainText(/Stop the slot to rename/i)
-    await expect(reason).toContainText(/slot_id/i)
+    const nameField = page.getByTestId('slot-name-inline')
+    await expect(nameField).toBeDisabled()
+    await expect(nameField).toHaveAttribute('title', /Stop the slot to rename/i)
   })
 
-  test('offline slot: rename POSTs /api/slots/{name}/rename', async ({ page }) => {
+  test('offline slot: committing the inline name field POSTs /api/slots/{name}/rename', async ({ page }) => {
     let body: any = null
     await page.route('**/api/slots/primary/rename', async (route) => {
       body = JSON.parse(route.request().postData() || '{}')
@@ -63,12 +74,13 @@ test.describe('Slot rename', () => {
     })
     await seedSlots(page, [OFFLINE])
     await page.goto('/#slots/primary')
-    await page.getByTestId('slot-rename-open').click()
+    await expect(page.locator('.drawer')).toBeVisible()
 
-    const input = page.getByTestId('rename-slot-input')
-    await expect(input).toBeEnabled()
-    await input.fill('primary-2')
-    await page.getByTestId('rename-slot-save').click()
+    const nameField = page.getByTestId('slot-name-inline')
+    await expect(nameField).toBeEnabled()
+    await expect(nameField).toHaveAttribute('title', /click to rename/i)
+    await nameField.fill('primary-2')
+    await nameField.press('Enter')
     await expect.poll(() => body?.new_name).toBe('primary-2')
   })
 })

--- a/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
@@ -94,13 +94,15 @@ test.describe('Slots v3 wire-up (/slots)', () => {
     )
 
     await page.goto('/#slots/primary')
-    const modelGroup = page.locator('.drawer .field-group').filter({
-      has: page.locator('.field-group-label', { hasText: /^Model$/ }),
+    // Context (ceiling) lives in the "How it runs" group (Task 11a moved it
+    // IN from the old Model group, beside the hardware that enforces it).
+    const hwGroup = page.locator('.drawer .field-group').filter({
+      has: page.locator('.field-group-label', { hasText: /^How it runs$/ }),
     })
     // Label reads "Context (ceiling)": the bound model's own default
     // context_size is authoritative; this slot value only clamps it down for
     // lighter hardware, it never overrides it upward.
-    const contextRow = modelGroup.locator('.form-row').filter({
+    const contextRow = hwGroup.locator('.form-row').filter({
       has: page.locator('.form-lbl > span', { hasText: /^Context \(ceiling\)$/ }),
     })
     const ctxInput = contextRow.locator('input')


### PR DESCRIPTION
PR-4 of the slot+model drawer overhaul (follows #2206; backend in #2196/#2198). Closes #2185.

## What

- **Section regroup (Option B)**: the slot drawer reorganizes around operator questions — "What runs" (model & tune), "How it runs" (this slot's hardware: Runtime + Lane), "When it unloads" (lifecycle: Auto-Load + Eviction priority). The old field-dump ordering is gone.
- **Fact strips → header chips**: both ReadOnlyStrip fact strips are retired; state/breaker/specialty and the `#id·:port` facts ride the header as chips, type sits on the title, image status moved to Advanced.
- **Pin in header, priority-only greying**: Pin/Unpin is a header toggle; pinning greys ONLY Eviction priority (with a "pinned — never evicted" explainer) — Auto-Load stays fully live, since boot-start and eviction order are orthogonal.
- **Inline name**: the disabled Name field + "Rename…" dialog ceremony becomes an inline-editable title field committing through the same `useSlotRename` mutation on blur/Enter. Escape cancels (reverts without committing — pinned by e2e — and never closes the drawer); a successful rename follows itself in the URL (`#slots/<new_name>`). The disabled state carries its stop-first reason as both `title` and an `aria-describedby` sr-only description. The permanently-closed RenameSlotDialog mount is gone from the drawer.
- **RichSelect rich rows**: Runtime / Profile / Model selects become real `role="listbox"` popovers (shared `RichSelect`, state machine vitest-pinned in `rich-select-core.ts`) with two-line rows — per-lane chips + install state for runtimes, runtime title + intent line for profiles, quant/modality chips with a `params · caps · used by N slots` description for models. Escape in an OPEN dropdown closes only the dropdown (consumed before the drawer's document-level Escape handler); one press = one layer.
- **Inline Pull (#2185)**: an `installable` (not-pulled) runtime row renders an inline "⇩ Pull now" button reusing `useRunnerPull` — the SAME mutation the Profiles view uses — with in-flight/error states, no second pull path.
- **GTT feasibility inline**: host-truth ceiling hint under context size (warn/err boxed, ok a plain hint) + right-aligned fit chips on model rows (`● fits · ~N GB` / `◐ tight` / `○ won't fit`) fed by a one-shot batch probe on dropdown open. Warn, never block; an unknown verdict renders nothing at all (993ea3b6).
- E2e: the slot-drawer spec family migrated to the Option B surface, incl. the new `slot-drawer-lifecycle.spec.ts` (pin↔priority cross-control contract + Escape layering) and an Escape-cancel rename spec; no assertions weakened.

## Rebase notes

- `ui/src/dash/feasibility-copy.ts` add/add: resolved to main's (#2206's) version wholesale — its fix wave added the `FeasibilityVerdict` import-type dedupe and it re-exports `feasibilityHint` unchanged; this drawer only imports `feasibilityHint`.
- `useModelsFeasibility.ts` / `feasibility-hint.test.ts` deduped content-identical; `endpoints.ts` keeps both `modelSeedProfile` and `modelsFeasibility` entries once each.

## Known gap (deferred)

- Keyboard users cannot reach the inline Pull button — it renders inside a `role="option"` row whose interaction is click/Enter-to-commit, so there is no tab stop for the nested button. Added to the #2204 RichSelect polish batch rather than blocking here (the Profiles view keeps a fully keyboard-reachable pull path for the same runtimes).

## Tests

Post-rebase on 2f94b6b7 (#2206 merged): vitest 362/362, tsc clean, eslint clean, Playwright chromium 677 passed / 14 skipped with only the pre-existing board-render-v3 family failing (14, unrelated to this PR) — slot-drawer, model-drawer, lifecycle, rename and pin specs all green. TDD per task; adversarial per-task reviews + whole-branch final review + fix wave applied.

Follow-up filed: #2207 (`.input-err` class has no CSS rule anywhere — pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hXYtiC9A1iyLeFnQxs68v
