### PR TITLE
fix(ui): dedupe Advanced image rows — one ref, live-state chip, no overflow

### DIFF
--- a/ui/src/dash/__tests__/image-live-state.test.ts
+++ b/ui/src/dash/__tests__/image-live-state.test.ts
@@ -1,0 +1,49 @@
+// image-dedupe (slot drawer Advanced): the drawer used to render the
+// resolved Image row (slot-hw-advanced-image) AND a separate "Image status"
+// row (slot-image-status) that repeated the same ref plus a " · #id"
+// suffix — two stacked rows, same digest, both overflowing the drawer.
+// The fix merges them into one row: the resolved ref stays, and the old
+// status row's job (what's the container ACTUALLY running, right now)
+// becomes a small state chip instead of a second text line.
+//
+// imageLiveState() is the pure comparison behind that chip, pinned here the
+// same way breakerChip's classifier is pinned in breaker-chip.test.ts —
+// the JSX only renders whatever this returns.
+import { describe, expect, it } from 'vitest'
+
+import { imageLiveState } from '../slot-status.js'
+
+const REF = 'ghcr.io/hal0ai/hal0-promptforge@sha256:abc123'
+const OLD_REF = 'ghcr.io/hal0ai/hal0-promptforge@sha256:def456'
+
+describe('imageLiveState', () => {
+  it('is null when the slot is not running — nothing to compare against', () => {
+    expect(imageLiveState(REF, REF, 'off')).toBeNull()
+    expect(imageLiveState(OLD_REF, REF, 'off')).toBeNull()
+    expect(imageLiveState(REF, REF, 'transitional')).toBeNull()
+  })
+
+  it('running + actual matches resolved → live chip (ok tone)', () => {
+    const chip = imageLiveState(REF, REF, 'running')
+    expect(chip).not.toBeNull()
+    expect(chip!.cls).toBe('chip ok')
+    expect(chip!.label).toBe('live')
+  })
+
+  it('running + actual differs from resolved → restart-pending chip (warn tone)', () => {
+    const chip = imageLiveState(OLD_REF, REF, 'running')
+    expect(chip).not.toBeNull()
+    expect(chip!.cls).toBe('chip warn')
+    expect(chip!.label).toBe('restart pending')
+    // the tooltip must explain WHY: the running container hasn't picked up
+    // the resolved ref yet, not that something is broken.
+    expect(chip!.tooltip.toLowerCase()).toContain('restart')
+    expect(chip!.tooltip).toContain(OLD_REF)
+  })
+
+  it('running but the actual image is unknown (null/undefined) → no chip, not a guess', () => {
+    expect(imageLiveState(null, REF, 'running')).toBeNull()
+    expect(imageLiveState(undefined, REF, 'running')).toBeNull()
+    expect(imageLiveState('', REF, 'running')).toBeNull()
+  })
+})

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -51,7 +51,11 @@ import { diffFlags } from "./flags-tune.js";
 import { useSlotLogsStream } from "@/api/hooks/useLogs";
 import { ENDPOINTS } from "@/api/endpoints";
 import { normalizeApiModel, isUpstreamModel } from "@/lib/normalizeApiModel";
-import { stateChipClassForSlot, slotButtonPhase } from "./slot-status.js";
+import {
+	stateChipClassForSlot,
+	slotButtonPhase,
+	imageLiveState,
+} from "./slot-status.js";
 import { SlotBreakerChip } from "./breaker-chip.jsx";
 import { npuModalityOn } from "./npu-modality.js";
 import { slotModelRow, npuAnchorSlot } from "./slots/slot-shared.js";
@@ -2776,36 +2780,39 @@ function EditSlotDrawer({ open, slot, onClose }) {
 											>
 												{effectiveImage}
 											</span>
+											{(() => {
+												// The old, separate "Image status" row's job — what's
+												// ACTUALLY running vs. what the next (re)start would
+												// use — collapses into this chip instead of a second
+												// stacked row repeating the same ref (image-dedupe).
+												// Same actual_image/image_pin/image precedence the
+												// deleted row used to render.
+												const actualImage =
+													slot.actual_image ||
+													slot.image_pin ||
+													slot.image ||
+													null;
+												const chip = imageLiveState(
+													actualImage,
+													effectiveImage,
+													slotButtonPhase(slot),
+												);
+												if (!chip) return null;
+												return (
+													<span
+														className={chip.cls}
+														style={{ marginLeft: 8 }}
+														title={chip.tooltip}
+													>
+														{chip.label}
+													</span>
+												);
+											})()}
 											<div className="hint">
 												{pinActive
 													? "debug pin"
 													: "pinned by release · reconciled by hal0 update"}
 											</div>
-										</div>
-									</div>
-
-									<div className="form-row">
-										<div className="form-lbl">
-											<span>Image status</span>
-											<FieldInfoIcon description="The image this slot is ACTUALLY running right now,
-												while it's up — distinct from the resolved release
-												image above, which is what the next (re)start
-												would use." />
-										</div>
-										<div className="form-ctl">
-											<span className="mono" data-testid="slot-image-status">
-												{slotButtonPhase(slot) === "running"
-													? (slot.actual_image ||
-															slot.image_pin ||
-															slot.image ||
-															"present") +
-														(slot.id != null
-															? ` · #${slot.id}`
-															: slot.slot_id != null
-																? ` · #${slot.slot_id}`
-																: "")
-													: "—"}
-											</span>
 										</div>
 									</div>
 

--- a/ui/src/dash/slot-status.js
+++ b/ui/src/dash/slot-status.js
@@ -366,6 +366,49 @@ export function breakerChip(slot, elapsedS = 0) {
 }
 
 /**
+ * Chip for the slot drawer's Advanced "Image" row (image-dedupe task).
+ *
+ * The drawer used to render this as a second, separate row ("Image status")
+ * repeating the same ref the resolved-Image row above it already showed,
+ * plus a " · #id" suffix — two stacked rows, same digest, both overflowing
+ * the drawer. This collapses that second row's JOB (what is the container
+ * actually running, right now, vs. what would launch on next (re)start)
+ * into a small chip that decorates the single remaining Image row.
+ *
+ *   not running                       → null (nothing running to compare)
+ *   actual image unknown (null/'')    → null (don't know ≠ don't match)
+ *   actual === resolved               → "live"            (ok / green)
+ *   actual !== resolved (both known)  → "restart pending"  (warn / amber)
+ *
+ * @param {string|null|undefined} actualImage - the ref backing the slot's
+ *   RUNNING container right now (actual_image / image_pin / image
+ *   precedence — see slot-modals.jsx).
+ * @param {string|null|undefined} resolvedRef - the ref the drawer resolves
+ *   to right now (a debug pin, else the picked Runtime's release image).
+ * @param {string} slotButtonState - "off" | "running" | "transitional",
+ *   from slotButtonPhase(slot).
+ * @returns {{cls: string, label: string, tooltip: string}|null}
+ */
+export function imageLiveState(actualImage, resolvedRef, slotButtonState) {
+  if (slotButtonState !== "running") return null;
+  if (!actualImage) return null;
+  if (actualImage === resolvedRef) {
+    return {
+      cls: "chip ok",
+      label: "live",
+      tooltip: "The running container is already on this exact image.",
+    };
+  }
+  return {
+    cls: "chip warn",
+    label: "restart pending",
+    tooltip:
+      `The running container still uses ${actualImage} — it switches to ` +
+      `this resolved image on the slot's next restart.`,
+  };
+}
+
+/**
  * Project slotPhase() → stateChipClass-compatible CSS class.
  * Used in slot-modals.jsx to color lifecycle state chips.
  */

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -149,6 +149,12 @@ a { color: inherit; text-decoration: none; }
 .mono {
   font-family: var(--jbm);
   font-feature-settings: "zero" 1, "ss02" 1, "calt" 0;
+  /* Long refs (image digests, resolved commands) must wrap inside whatever
+     panel/drawer they sit in rather than push it wider — the slot drawer's
+     Advanced image row (image-dedupe) is the case that surfaced this, but
+     the fix belongs on the class every mono ref span already shares. */
+  overflow-wrap: anywhere;
+  word-break: break-all;
 }
 .num { font-variant-numeric: tabular-nums; font-feature-settings: "zero" 1, "tnum" 1; }
 


### PR DESCRIPTION
Operator-reported (ct150 nightly review): the slot drawer's Advanced disclosure showed the same image digest twice — the resolved Image row and the relocated old image-status fact — with both refs overflowing the drawer width.

- The separate "Image status" row is gone; its job (what's ACTUALLY running vs what the next restart uses) collapses into a state chip on the single Image row: `live` (running, refs match), `restart pending` (running an older ref, warn tone + tooltip), no chip when the slot is down. Same actual_image/image_pin/image precedence, minus the pointless `· #id` suffix (slot id lives in the header).
- Pure helper `imageLiveState` in slot-status.js with unit coverage (3 states + null actual).
- Mono ref containers get `overflow-wrap:anywhere` so digests wrap inside the drawer (debug-pin row benefits too).

Gates: vitest 370/370, tsc clean, eslint clean, affected Playwright specs 38/38 (drawer-save-errors flaked only under parallel batch load, 7/7 alone — pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hXYtiC9A1iyLeFnQxs68v