### PR TITLE
feat(proxmox): privileged GPU-passthrough LXC by default in the pve script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,26 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Added
 
+- The Proxmox VE quick-start script (`scripts/proxmox-ve/hal0.sh`) now builds
+  the production hal0 container shape instead of a vanilla CPU-only one: a
+  **privileged Ubuntu 26.04** LXC with `nesting/keyctl/fuse/mknod`, every
+  GPU/NPU device node the host exposes forwarded as `devN`, the matching
+  `lxc.cgroup2.devices.allow` rules, `lxc.prlimit.memlock: unlimited`, and
+  `lxc.apparmor.profile: unconfined`. It verifies the forwarded nodes are
+  actually visible inside the container before installing anything, so a
+  broken passthrough fails loudly instead of quietly seeding CPU slots. New
+  env knobs: `IP_CIDR`/`GATEWAY`, `NAMESERVER`, `SEARCHDOMAIN`, `TIMEZONE`,
+  `TAGS`, `ONBOOT`, `STARTUP`, `MOUNTS`, `FEATURES`, `GPU_PASSTHROUGH`,
+  `RUN_BOOTSTRAP`. `UNPRIVILEGED=1 GPU_PASSTHROUGH=0 OS_TYPE=debian
+  OS_VERSION=13` reproduces the previous behaviour. Guest prerequisites are
+  no longer pre-staged by the script — bootstrap and install.sh install
+  their own (curl excepted: it is what fetches the bootstrap).
+- `hal0_lxc_kind` in `installer/lib/preflight.sh` classifies the platform as
+  `none` / `lxc-privileged` / `lxc-unprivileged` from `/proc/self/uid_map`,
+  and the installer's `/dev/kfd` gid-repair fallback and container-runtime
+  gate now narrate the remedy that is actually possible on the container at
+  hand instead of always describing the unprivileged one.
+
 - The dashboard now surfaces the decisive crash line when a slot container
   dies during model load. On a load failure the slot manager tails the
   unit's journal, extracts the one line that names the fault (e.g.

--- a/docs/getting-started/proxmox.mdx
+++ b/docs/getting-started/proxmox.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install on Proxmox
-description: Run hal0 on Proxmox VE — the unprivileged one-liner for CPU-only, and the full GPU/NPU passthrough recipe for AMD Strix Halo LXCs.
+description: Run hal0 on Proxmox VE — the one-liner that creates a privileged Ubuntu LXC with GPU/NPU passthrough already wired, and the manual recipe behind it.
 sidebar:
   order: 13
 ---
@@ -10,9 +10,9 @@ import { Steps, Aside, Tabs, TabItem, Code, LinkCard, CardGrid } from '@astrojs/
 Proxmox VE is a common host for hal0, especially on AMD Strix Halo (Ryzen
 AI Max+) hardware where an LXC shares the host kernel and the iGPU + XDNA
 NPU pass through as ordinary device nodes — no VM, no vGPU shim, near-native
-throughput. This guide covers the unprivileged quick-start script for
-CPU-only trials, the full GPU/NPU passthrough recipe, and running hal0 in
-a Proxmox VM instead of a container.
+throughput. This guide covers the quick-start script — which creates that
+container and forwards the accelerators for you — the manual passthrough
+recipe it automates, and running hal0 in a Proxmox VM instead.
 
 ## 1. Prepare the PVE host
 
@@ -24,10 +24,11 @@ Size the GTT pool section for
 the GRUB parameters that raise the amdgpu GTT window — both are set on the
 **Proxmox host**, not inside the container.
 
-If you only want a CPU-only trial, skip straight to the quick path below;
-GTT sizing and driver checks only matter once you attach a GPU.
+If you only want a CPU-only trial, skip straight to the quick path below
+and pass `GPU_PASSTHROUGH=0`; GTT sizing and driver checks only matter once
+you attach a GPU.
 
-## 2. Quick path: unprivileged CT, no GPU
+## 2. Quick path: one command
 
 The fastest way to get hal0 running on Proxmox is the bundled installer
 script, run **on the Proxmox host**:
@@ -36,35 +37,52 @@ script, run **on the Proxmox host**:
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/Hal0ai/hal0/main/scripts/proxmox-ve/hal0.sh)"
 ```
 
-It creates an **unprivileged Debian 13** LXC (default CTID from
+It creates a **privileged Ubuntu 26.04** LXC (default CTID from
 `pvesh get /cluster/nextid`, 4 cores, 8 GB RAM, 20 GB disk — all
-overridable via env vars) and runs the standard hal0 bootstrap inside it.
-This path intentionally has **no GPU passthrough** — it's the generic,
-hardware-agnostic homelab case, CPU-only inference. For Strix Halo
-iGPU/NPU passthrough, use the recipe in the next section instead.
+overridable via env vars), forwards every GPU/NPU device node the host
+actually has, writes the matching cgroup2 device rules, `memlock` limit and
+AppArmor profile, and then runs the standard hal0 bootstrap inside it. The
+guest installs its own prerequisites (curl, jq, Python + venv, podman,
+cosign) — there is nothing to pre-stage by hand.
+
+Two defaults worth knowing before you run it:
+
+- **Privileged.** hal0's slots are rootful podman containers that open the
+  GPU compute node directly, and a privileged CT can repair a mis-mapped
+  `/dev/kfd` from inside (see §3). The trade is real: a privileged
+  container's root is effectively host root. Pass `UNPRIVILEGED=1` for the
+  older, narrower container — GPU passthrough still works, but device
+  ownership is host-mapped and repairs must happen on the host.
+- **GPU passthrough on by default** (`GPU_PASSTHROUGH=auto`). On a host with
+  no accelerator nodes it warns and builds a CPU-only container; set
+  `GPU_PASSTHROUGH=0` to skip passthrough deliberately.
 
 <Aside type="tip">
 Pass `--advanced` to open `whiptail` prompts for CTID, hostname, cores,
-RAM, disk, storage, and bridge instead of accepting the defaults.
+RAM, disk, storage, bridge, static IP, privilege and passthrough instead of
+accepting the defaults. Everything is also settable per-run as an env var —
+see the [script's README](https://github.com/Hal0ai/hal0/blob/main/scripts/proxmox-ve/README.md).
 </Aside>
 
-## 3. GPU/NPU passthrough CT
+## 3. Manual GPU/NPU passthrough
 
-To get the iGPU and XDNA NPU into a container, create the LXC yourself and
-forward the accelerator device nodes from the host (PVE 8.2+ `devN`
-syntax). A minimal, generic starting point:
+The script in §2 does all of this for you; this section is what it
+automates, for anyone building the container by hand or retrofitting an
+existing one. To get the iGPU and XDNA NPU into a container, create the LXC
+and forward the accelerator device nodes from the host (PVE 8.2+ `devN`
+syntax). A minimal starting point:
 
 ```sh
-pct create <CTID> local:vztmpl/debian-13-standard_13.0-1_amd64.tar.zst \
-  --unprivileged 1 --cores 4 --memory 8192 --rootfs local-lvm:20
+pct create <CTID> local:vztmpl/ubuntu-26.04-standard_26.04-1_amd64.tar.zst \
+  --unprivileged 0 --features nesting=1,keyctl=1,fuse=1,mknod=1 \
+  --cores 4 --memory 8192 --rootfs local-lvm:20
 ```
 
-(the quick-path script in §2 automates exactly this step, plus the
-hal0 bootstrap, in one command). This GPU/NPU passthrough recipe
-assumes an **unprivileged** CT — the `devN` gid-mapping mechanism below
-is designed for the unprivileged uid/gid shift; the AppArmor purge note
-later in this section applies only when you're migrating an older
-**privileged** CT onto this path.
+The `devN` gid-mapping mechanism below works on both privileged and
+unprivileged containers. The difference is who can repair a wrong mapping
+afterwards: on a privileged CT hal0 aligns `/dev/kfd` to the render gid
+itself, while on an unprivileged one the node's ownership is host-mapped
+and only the host's `devN:` entry can fix it.
 
 Append this to `/etc/pve/lxc/<CTID>.conf` on the host:
 
@@ -73,6 +91,14 @@ Append this to `/etc/pve/lxc/<CTID>.conf` on the host:
 dev0: /dev/dri/renderD128,gid=<render gid INSIDE this container>
 dev1: /dev/kfd                    # ROCm compute (optional)
 dev2: /dev/accel/accel0,gid=<render gid>   # XDNA NPU (Strix Halo only)
+
+# Device-cgroup rules for the majors above (226 = dri, 234 = kfd,
+# 261 = accel on most kernels — read yours with `stat -c %t`), plus the
+# memlock limit ROCm needs to pin buffers.
+lxc.cgroup2.devices.allow: c 226:* rwm
+lxc.cgroup2.devices.allow: c 234:* rwm
+lxc.cgroup2.devices.allow: c 261:* rwm
+lxc.prlimit.memlock: unlimited
 ```
 
 Then apply it:
@@ -110,12 +136,13 @@ then re-run `install.sh` inside the container. Persist the values in
 
 ### AppArmor
 
-GPU/NPU passthrough needs an unconfined AppArmor profile
-(`lxc.apparmor.profile: unconfined` in the container's `.conf`) for the
-container runtime to launch slots inside the LXC. If you previously ran a
-**privileged** container for this, purge that config when moving to the
-unprivileged CT this section assumes — an unconfined profile on a
-privileged container is a wider trust boundary than you need.
+GPU/NPU passthrough on a **privileged** container needs an unconfined
+AppArmor profile (`lxc.apparmor.profile: unconfined` in the container's
+`.conf`) for the container runtime to launch slots inside the LXC — the
+quick-path script writes it for you, and the installer detects and repairs
+the in-guest half of the same failure (#1563). On an **unprivileged**
+container leave the stock profile in place: it is a narrower trust boundary
+and the runtime works without the override.
 
 ### Unprivileged podman network fix
 

--- a/docs/getting-started/proxmox.mdx
+++ b/docs/getting-started/proxmox.mdx
@@ -107,6 +107,15 @@ Then apply it:
 pct stop <CTID> && pct start <CTID>
 ```
 
+<Aside type="tip">
+The quick-path script resolves this for you: it boots the container once,
+reads the guest's `render` gid, re-points every `devN` entry at it, and
+restarts. That step exists because the correct gid cannot be known before
+the container exists — and on a **privileged** container there is no idmap
+to paper over the difference, so a host gid of 993 stays 993 inside a guest
+whose render group is 991.
+</Aside>
+
 <Aside type="caution" title="gid means the CONTAINER's gid, not the host's">
 The `gid=` value must be the render group's id **inside the container**,
 not on the host — the two gid spaces can disagree. See the Render-group

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -508,8 +508,26 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
             # serving (the identity fix in #1953 is what changed this).
             warn "gpu: ${_kfd_path} has a different group (${_render_gid:-?} expected) and could not be changed from inside this container."
             warn "  GPU slots still work — they run rootful — but hal0-user probes and diagnostics cannot read the compute node."
-            warn "  To fix, set it on the Proxmox host: dev1: ${_kfd_path},gid=${_render_gid:-<render gid inside the container>}"
-            warn "  (the gid INSIDE the container), then: pct stop <CTID> && pct start <CTID>. See hal0 issue #1953."
+            case "$(hal0_lxc_kind)" in
+                lxc-unprivileged)
+                    warn "  Unprivileged LXC: the node's ownership is host-mapped, so this can only be fixed on the Proxmox"
+                    warn "  host: dev1: ${_kfd_path},gid=${_render_gid:-<render gid inside the container>}"
+                    warn "  (the gid INSIDE the container), then: pct stop <CTID> && pct start <CTID>. See hal0 issue #1953."
+                    ;;
+                lxc-privileged)
+                    # Privileged: chgrp should have worked. It didn't, so the
+                    # cause is local (read-only /dev, a stale gid that no group
+                    # owns, an LSM denial) — sending the operator to re-forward
+                    # the device would fix nothing.
+                    warn "  Privileged LXC: chgrp is normally permitted here, so this is a local condition rather than the"
+                    warn "  host's dev entry — check that /dev is writable, that gid ${_render_gid:-?} exists, and that no"
+                    warn "  LSM denial is logged. See hal0 issue #1953."
+                    ;;
+                *)
+                    warn "  Set the owning group of ${_kfd_path} to ${_render_gid:-<render node gid>} (matching the render"
+                    warn "  node) so hal0-user probes can open it. See hal0 issue #1953."
+                    ;;
+            esac
         fi
     elif (( gpu_rc == HAL0_GPU_RC_NO_DEVICE )); then
         if [[ "${HAL0_ALLOW_CPU_ONLY:-0}" == "1" ]]; then

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -8,6 +8,12 @@
 #
 # Public API (all functions return 0 on success, non-zero on failure;
 # none of them exit the calling shell):
+#   hal0_lxc_kind              — platform classification: none |
+#                                lxc-privileged | lxc-unprivileged. Decides
+#                                which remedies are possible from inside (a
+#                                privileged LXC can repair a forwarded device
+#                                node itself; an unprivileged one cannot).
+#                                hal0_in_lxc is the "any LXC?" predicate.
 #   preflight_systemd          — systemctl on PATH
 #   preflight_python           — `${PY:-python3}` resolvable + version 3.12–3.14
 #                                (matches pyproject.toml's requires-python
@@ -124,6 +130,51 @@ if ! declare -F pkg_install_cmd >/dev/null 2>&1; then
     # shellcheck source=distro.sh
     source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/distro.sh"
 fi
+
+# ── platform classification ─────────────────────────────────────────────────
+
+# hal0_lxc_kind — where is this install running?
+#
+#   none              — bare metal, a VM, or any container that is not LXC
+#   lxc-privileged    — an LXC whose root IS host root (no uid remap)
+#   lxc-unprivileged  — an LXC behind a uid/gid remap
+#
+# The distinction is not cosmetic: it decides which remedies are even
+# possible from inside. A privileged container can chgrp a forwarded device
+# node and repair a mis-mapped /dev/kfd itself (#1953); an unprivileged one
+# gets EPERM on the same call because the node's ownership belongs to the
+# host's idmap, so the only real fix is on the Proxmox host's `devN:` entry.
+# Emitting the unprivileged remedy on a privileged box (or the reverse) sends
+# operators to change something that was never the cause.
+#
+# The uid_map test: a privileged container maps the whole host uid range
+# 1:1 ("0 0 4294967295"); an unprivileged one maps a slice starting at the
+# host offset ("0 100000 65536").
+#
+# HAL0_LXC_KIND_OVERRIDE is a test seam (unit tests cannot fake /proc).
+hal0_lxc_kind() {
+    if [[ -n "${HAL0_LXC_KIND_OVERRIDE:-}" ]]; then
+        printf '%s\n' "${HAL0_LXC_KIND_OVERRIDE}"
+        return 0
+    fi
+    if [[ ! -f /run/systemd/container ]] \
+        && ! grep -qa 'container=lxc' /proc/1/environ 2>/dev/null; then
+        printf 'none\n'
+        return 0
+    fi
+    local inside outside length
+    if read -r inside outside length < /proc/self/uid_map 2>/dev/null \
+        && [[ "${inside}" == "0" && "${outside}" == "0" && "${length}" == "4294967295" ]]; then
+        printf 'lxc-privileged\n'
+        return 0
+    fi
+    printf 'lxc-unprivileged\n'
+}
+
+# Convenience predicate for the common "is this any LXC at all" question.
+hal0_in_lxc() {
+    [[ "$(hal0_lxc_kind)" != "none" ]]
+}
 
 # ── individual checks ───────────────────────────────────────────────────────
 
@@ -615,9 +666,13 @@ _container_runtime_gate() {
         warn "  remedy: reboot this container to clear leaked session keyrings, or as root: keyctl clear @s /"
         warn "  find + kill the leaked keyring holders, or raise the quota: sysctl kernel.keys.maxbytes (and"
         warn "  kernel.keys.maxkeys) higher on the PROXMOX HOST, then re-run install.sh"
-    elif grep -qa 'container=lxc' /proc/1/environ 2>/dev/null; then
+    elif [[ "$(hal0_lxc_kind)" == "lxc-unprivileged" ]]; then
         warn "  inside an unprivileged Proxmox/LXC container this needs 'features: nesting=1' (and often keyctl=1)"
         warn "  set it in /etc/pve/lxc/<CTID>.conf on the PROXMOX HOST, then: pct stop <CTID> && pct start <CTID>"
+    elif [[ "$(hal0_lxc_kind)" == "lxc-privileged" ]]; then
+        warn "  inside a PRIVILEGED Proxmox/LXC container the usual cause is missing container features rather"
+        warn "  than the uid map: set 'features: nesting=1,keyctl=1,fuse=1,mknod=1' in /etc/pve/lxc/<CTID>.conf"
+        warn "  on the PROXMOX HOST, then: pct stop <CTID> && pct start <CTID>"
     else
         warn "  inspect the error above (cgroup/mount-namespace setup, subuid/newuidmap, or a daemon issue)"
     fi
@@ -939,10 +994,9 @@ HAL0_GPU_RC_KFD_GID=6
 preflight_gpu() {
     local gate="${HAL0_GPU_GATE:-0}"
 
-    local in_container=""
-    if [[ -f /run/systemd/container ]] || grep -qa 'container=lxc' /proc/1/environ 2>/dev/null; then
-        in_container="lxc"
-    fi
+    local lxc_kind in_container=""
+    lxc_kind="$(hal0_lxc_kind)"
+    [[ "${lxc_kind}" != "none" ]] && in_container="lxc"
     # Test seam: force the container classification (unit tests can't fake
     # /proc/1/environ). Never set in production.
     [[ -n "${HAL0_GPU_CONTAINER_OVERRIDE:-}" ]] && in_container="${HAL0_GPU_CONTAINER_OVERRIDE}"

--- a/scripts/proxmox-ve/README.md
+++ b/scripts/proxmox-ve/README.md
@@ -1,9 +1,10 @@
 # hal0 on Proxmox VE
 
-One-line helper that creates an unprivileged Debian 13 LXC and runs the
-standard hal0 bootstrap inside it. Aimed at homelab Proxmox hosts that
-just want to try hal0 — see the [Strix Halo passthrough recipe](../../docs/getting-started/proxmox.mdx)
-for the privileged-LXC + iGPU/NPU setup that powers production hal0.
+One-line helper that creates a privileged Ubuntu 26.04 LXC, forwards
+whatever GPU/NPU device nodes the host has, and runs the standard hal0
+bootstrap inside it. This is the production hal0 container shape — see the
+[Proxmox guide](../../docs/getting-started/proxmox.mdx) for the manual
+recipe it automates and for the host-side driver/GTT prerequisites.
 
 ## Quick start
 
@@ -15,13 +16,22 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/Hal0ai/hal0/main/scripts
 
 That will:
 
-1. Pick the next free CTID and download the Debian 13 LXC template if missing
-2. Print the resolved plan (CTID, hostname, cores, RAM, disk, network)
-3. Wait 5s so you can ctrl-C if anything looks wrong
-4. Create + start the LXC, install `curl ca-certificates tar jq python3 sudo`,
-   install `cosign` (for release signature verification), and pipe
-   `https://hal0.dev/install.sh` into `bash`
-5. Print the dashboard URL (`http://<lxc-ip>:8080`)
+1. Probe the host for `/dev/dri/renderD*`, `/dev/dri/amdgpu`, `/dev/kfd` and
+   `/dev/accel/accel*`
+2. Pick the next free CTID and download the Ubuntu 26.04 LXC template if missing
+3. Print the resolved plan (CTID, hostname, cores, RAM, disk, network, devices)
+4. Wait 5s so you can ctrl-C if anything looks wrong
+5. Create the LXC privileged, with `nesting/keyctl/fuse/mknod`, every probed
+   device as `devN`, the matching `lxc.cgroup2.devices.allow` rules,
+   `lxc.prlimit.memlock: unlimited`, and `lxc.apparmor.profile: unconfined`
+6. Start it, wait for network, and verify the forwarded devices are actually
+   visible inside the container before installing anything
+7. Install `curl` if the template lacks it (the one package that cannot be
+   fetched by the thing it fetches), then pipe `https://hal0.dev/install.sh`
+   into `bash`. Everything else the guest installs itself — bootstrap pulls
+   tar/jq/python3 and a pinned `cosign`, the installer adds podman and the
+   Python venv stdlib
+8. Print the dashboard URL (`http://<lxc-ip>:8080`)
 
 ## Interactive prompts
 
@@ -47,31 +57,47 @@ or templating multiple hosts.
 | `STORAGE`                 | `local-lvm` if present, else first rootdir pool | |
 | `BRIDGE`                  | first `vmbr*` in `/etc/network/interfaces` | |
 | `NET_CONFIG`              | `name=eth0,bridge=$BRIDGE,ip=dhcp`       | full `--net0` arg if you need static IP / VLAN |
-| `OS_TYPE` / `OS_VERSION`  | `debian` / `13`                          | |
+| `IP_CIDR` / `GATEWAY`     | *(empty → DHCP)*                         | static IPv4, e.g. `10.0.1.90/24` + `10.0.1.1` |
+| `NAMESERVER`              | *(pve default)*                          | space-separated resolvers |
+| `SEARCHDOMAIN`            | *(pve default)*                          | |
+| `TIMEZONE`                | *(pve default)*                          | |
+| `TAGS`                    | `hal0`                                   | semicolon-separated pve tags |
+| `ONBOOT`                  | `1`                                      | start with the host |
+| `STARTUP`                 | *(empty)*                                | pve startup order, e.g. `order=3` |
+| `MOUNTS`                  | *(empty)*                                | `;`-separated `--mpN` values, e.g. `/mnt/ai-models,mp=/mnt/ai-models,backup=0` |
+| `OS_TYPE` / `OS_VERSION`  | `ubuntu` / `26.04`                       | |
 | `TEMPLATE_STORAGE`        | `local`                                  | where to keep the template |
-| `UNPRIVILEGED`            | `1`                                      | `0` for privileged container |
+| `UNPRIVILEGED`            | `0`                                      | `1` for the narrower unprivileged container |
+| `FEATURES`                | `nesting=1,keyctl=1,fuse=1,mknod=1`      | podman-in-LXC needs these |
+| `GPU_PASSTHROUGH`         | `auto`                                   | `1` = require a device, `0` = CPU-only container |
 | `PASSWORD`                | *(empty)*                                | blank = no root password; use `pct enter` |
 | `SSH_AUTHORIZED_KEYS`     | *(empty)*                                | path to a public-key file on the pve host |
 | `HAL0_CHANNEL`            | `stable`                                 | passes through to the hal0 bootstrap |
-| `INSTALL_COSIGN`          | `1`                                      | `0` skips cosign install (bootstrap will then refuse to verify) |
-| `COSIGN_VERSION`          | `v3.0.0`                                 | cosign 3.x required for keyless verify-blob |
+| `RUN_BOOTSTRAP`           | `1`                                      | `0` creates the container and stops there |
 
-Example — pinned CTID, static IP, no cosign:
+Example — pinned CTID, static IP, model store bind-mounted:
 
 ```bash
 CTID=210 \
 HOSTNAME=hal0-test \
-NET_CONFIG="name=eth0,bridge=vmbr0,ip=192.0.2.50/24,gw=192.0.2.1" \
-INSTALL_COSIGN=0 \
+IP_CIDR=192.0.2.50/24 GATEWAY=192.0.2.1 \
+MOUNTS='/mnt/ai-models,mp=/mnt/ai-models,backup=0' \
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/Hal0ai/hal0/main/scripts/proxmox-ve/hal0.sh)"
+```
+
+Example — the old vanilla shape (unprivileged, no passthrough):
+
+```bash
+UNPRIVILEGED=1 GPU_PASSTHROUGH=0 OS_TYPE=debian OS_VERSION=13 \
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/Hal0ai/hal0/main/scripts/proxmox-ve/hal0.sh)"
 ```
 
 ## What the script does NOT do
 
-- **No GPU/NPU passthrough.** This is a vanilla unprivileged LXC for
-  CPU/Vulkan inference. For hardware-accelerated hal0 on AMD Strix Halo
-  see the privileged-LXC + apparmor unconfined + `dev0`–`dev3` recipe
-  in the main hal0 docs.
+- **No host-side driver or GTT setup.** `amdgpu`/`amdxdna` and the GTT
+  window are the host kernel's business; see the drivers guide. The script
+  forwards the nodes that already exist and fails loudly when they don't
+  appear inside the container.
 - **No reverse proxy / TLS.** The dashboard listens on `0.0.0.0:8080`
   with no auth (per ADR-0012). Treat the LXC as LAN-only.
 - **No backup / migration.** Standard `pct` / Proxmox tooling applies.
@@ -81,6 +107,12 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/Hal0ai/hal0/main/scripts
 Manual; needs a Proxmox VE host since `pct` only works there:
 
 1. On a fresh pve, `bash -c "$(curl … hal0.sh)"` — should land at a hal0 dashboard.
-2. `--advanced` — should open whiptail prompts and honour them.
-3. `CTID=… STORAGE=… bash hal0.sh` non-interactive — should silently respect overrides.
-4. `pct destroy <CTID>` — clean teardown leaves no leaked storage.
+2. On a GPU host, `pct config <CTID>` should show `dev0…devN` plus the
+   cgroup/memlock/apparmor lines, and `hal0 doctor` inside the CT should see
+   the GPU (and the NPU where present).
+3. On a GPU-less host, the run should warn once and finish CPU-only.
+4. `--advanced` — should open whiptail prompts and honour them.
+5. `CTID=… STORAGE=… bash hal0.sh` non-interactive — should silently respect overrides.
+6. Re-running `apply_raw_config` against an existing CTID must not duplicate
+   any `lxc.*` line.
+7. `pct destroy <CTID>` — clean teardown leaves no leaked storage.

--- a/scripts/proxmox-ve/README.md
+++ b/scripts/proxmox-ve/README.md
@@ -24,8 +24,11 @@ That will:
 5. Create the LXC privileged, with `nesting/keyctl/fuse/mknod`, every probed
    device as `devN`, the matching `lxc.cgroup2.devices.allow` rules,
    `lxc.prlimit.memlock: unlimited`, and `lxc.apparmor.profile: unconfined`
-6. Start it, wait for network, and verify the forwarded devices are actually
-   visible inside the container before installing anything
+6. Start it, read the guest's `render` gid, re-point every `devN` entry at it
+   and restart if it differed (the host's gid is only correct by coincidence,
+   and a privileged container has no idmap to shift it), then wait for network
+   and verify each forwarded device is visible **and carries the expected gid**
+   before installing anything
 7. Install `curl` if the template lacks it (the one package that cannot be
    fetched by the thing it fetches), then pipe `https://hal0.dev/install.sh`
    into `bash`. Everything else the guest installs itself — bootstrap pulls

--- a/scripts/proxmox-ve/hal0.sh
+++ b/scripts/proxmox-ve/hal0.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
-# hal0 Proxmox VE installer — creates an unprivileged Debian 13 LXC and
-# runs the standard hal0 bootstrap inside it.
+# hal0 Proxmox VE installer — creates a privileged Ubuntu 26.04 LXC, wires up
+# GPU/NPU passthrough when the host has any, and runs the standard hal0
+# bootstrap inside it.
 #
 # Run on a Proxmox VE host (NOT inside a container):
 #
@@ -12,9 +13,27 @@
 # silently. Every default is printed before container creation, with a
 # 5s grace window to ctrl-C and re-run with overrides.
 #
-# Hardware-agnostic. For Strix Halo iGPU/NPU passthrough see the
-# privileged-LXC recipe at https://github.com/Hal0ai/hal0 — this script
-# intentionally targets the generic homelab case.
+# Defaults are the production hal0 shape:
+#
+#   * PRIVILEGED container. hal0 runs rootful podman slots that open the
+#     GPU compute node directly; an unprivileged container maps device
+#     ownership through the host's idmap, which costs hal0-user probes
+#     their GPU visibility and makes /dev/kfd gid repair impossible from
+#     inside (#1953). Set UNPRIVILEGED=1 for a CPU-only/Vulkan container.
+#     A privileged container's root is effectively host root — that is the
+#     trade this default makes, deliberately, for hardware access.
+#   * Ubuntu 26.04. The FastFlowLM .deb and the toolbox images track it,
+#     and it ships a Python new enough for hal0's venv without backports.
+#   * nesting/keyctl/fuse/mknod features — podman-in-LXC needs them.
+#   * GPU/NPU passthrough (GPU_PASSTHROUGH=auto): every AMD compute/render
+#     node the HOST actually has is forwarded, with matching cgroup2 device
+#     rules, unlimited memlock and (privileged only) an unconfined apparmor
+#     profile. Nothing to hand-edit in /etc/pve/lxc/<CTID>.conf afterwards.
+#
+# Everything the guest needs (tar, jq, python3, python3-venv, podman,
+# cosign) is installed by the hal0 bootstrap/installer itself. The single
+# exception this script stages is curl — the tool that downloads the
+# bootstrap cannot be downloaded by the bootstrap.
 
 set -euo pipefail
 IFS=$'\n\t'
@@ -32,6 +51,7 @@ HOLD=" "
 
 msg_info()  { printf "%b%s %s%s..." "${BFR}" "${HOLD}" "${YW}" "$*${CL}"; }
 msg_ok()    { printf "%b%s%s %s%s\n" "${BFR}" "${CM}" "${GN}" "$*" "${CL}"; }
+msg_warn()  { printf "%b%s %s%s\n" "${BFR}" "${HOLD}" "${YW}" "$*${CL}" >&2; }
 msg_error() { printf "%b%s%s %s%s\n" "${BFR}" "${CROSS}" "${RD}" "$*" "${CL}" >&2; }
 die()       { msg_error "$*"; exit 1; }
 
@@ -85,16 +105,37 @@ SWAP_MB="${SWAP_MB:-1024}"
 DISK_GB="${DISK_GB:-20}"
 STORAGE="${STORAGE:-$(default_storage)}"
 BRIDGE="${BRIDGE:-$(default_bridge)}"
-NET_CONFIG="${NET_CONFIG:-name=eth0,bridge=${BRIDGE},ip=dhcp}"
-OS_TYPE="${OS_TYPE:-debian}"
-OS_VERSION="${OS_VERSION:-13}"
+# Static addressing without hand-writing NET_CONFIG: set IP_CIDR (+GATEWAY).
+IP_CIDR="${IP_CIDR:-}"
+GATEWAY="${GATEWAY:-}"
+if [[ -n "${IP_CIDR}" ]]; then
+    NET_CONFIG="${NET_CONFIG:-name=eth0,bridge=${BRIDGE},ip=${IP_CIDR}${GATEWAY:+,gw=${GATEWAY}}}"
+else
+    NET_CONFIG="${NET_CONFIG:-name=eth0,bridge=${BRIDGE},ip=dhcp}"
+fi
+NAMESERVER="${NAMESERVER:-}"
+SEARCHDOMAIN="${SEARCHDOMAIN:-}"
+TIMEZONE="${TIMEZONE:-}"
+TAGS="${TAGS:-hal0}"
+ONBOOT="${ONBOOT:-1}"
+STARTUP="${STARTUP:-}"
+# MOUNTS: newline- or semicolon-separated `--mpN` values, e.g.
+#   MOUNTS='/mnt/ai-models,mp=/mnt/ai-models,backup=0;/srv/data,mp=/mnt/data'
+MOUNTS="${MOUNTS:-}"
+OS_TYPE="${OS_TYPE:-ubuntu}"
+OS_VERSION="${OS_VERSION:-26.04}"
 TEMPLATE_STORAGE="${TEMPLATE_STORAGE:-local}"
-UNPRIVILEGED="${UNPRIVILEGED:-1}"
+# Privileged by default — see the header comment for why. UNPRIVILEGED=1
+# still produces the old vanilla container.
+UNPRIVILEGED="${UNPRIVILEGED:-0}"
+FEATURES="${FEATURES:-nesting=1,keyctl=1,fuse=1,mknod=1}"
+# auto = forward whatever the host actually has; 1 = same but fail if the
+# host has no GPU/NPU node at all; 0 = skip passthrough entirely.
+GPU_PASSTHROUGH="${GPU_PASSTHROUGH:-auto}"
 PASSWORD="${PASSWORD:-}"  # empty = no root password set; use `pct enter` from host
 SSH_AUTHORIZED_KEYS="${SSH_AUTHORIZED_KEYS:-}"
 HAL0_CHANNEL="${HAL0_CHANNEL:-stable}"
-INSTALL_COSIGN="${INSTALL_COSIGN:-1}"
-COSIGN_VERSION="${COSIGN_VERSION:-v3.0.0}"
+RUN_BOOTSTRAP="${RUN_BOOTSTRAP:-1}"
 
 # ── advanced (whiptail) prompts ───────────────────────────────────────────
 ADVANCED=0
@@ -119,17 +160,100 @@ prompt_advanced() {
     DISK_GB=$(whiptail --inputbox "Disk (GB)" 8 60 "${DISK_GB}" --title "hal0 LXC" 3>&1 1>&2 2>&3) || exit 1
     STORAGE=$(whiptail --inputbox "Storage pool" 8 60 "${STORAGE}" --title "hal0 LXC" 3>&1 1>&2 2>&3) || exit 1
     BRIDGE=$(whiptail --inputbox "Network bridge" 8 60 "${BRIDGE}" --title "hal0 LXC" 3>&1 1>&2 2>&3) || exit 1
-    NET_CONFIG="name=eth0,bridge=${BRIDGE},ip=dhcp"
+    IP_CIDR=$(whiptail --inputbox "IPv4 CIDR (blank = DHCP)" 8 60 "${IP_CIDR}" --title "hal0 LXC" 3>&1 1>&2 2>&3) || exit 1
+    if [[ -n "${IP_CIDR}" ]]; then
+        GATEWAY=$(whiptail --inputbox "Gateway" 8 60 "${GATEWAY}" --title "hal0 LXC" 3>&1 1>&2 2>&3) || exit 1
+        NET_CONFIG="name=eth0,bridge=${BRIDGE},ip=${IP_CIDR}${GATEWAY:+,gw=${GATEWAY}}"
+    else
+        NET_CONFIG="name=eth0,bridge=${BRIDGE},ip=dhcp"
+    fi
     PASSWORD=$(whiptail --passwordbox "Root password (blank = none, use pct enter)" 8 60 "" --title "hal0 LXC" 3>&1 1>&2 2>&3) || exit 1
 
-    if whiptail --yesno "Use unprivileged container? (recommended)" 8 60 --title "hal0 LXC"; then
-        UNPRIVILEGED=1
-    else
+    if whiptail --yesno "Use a PRIVILEGED container? (recommended — required for GPU/NPU passthrough)" 8 70 --title "hal0 LXC"; then
         UNPRIVILEGED=0
+    else
+        UNPRIVILEGED=1
+    fi
+
+    if whiptail --yesno "Forward the host's GPU/NPU devices into the container?" 8 70 --title "hal0 LXC"; then
+        GPU_PASSTHROUGH=auto
+    else
+        GPU_PASSTHROUGH=0
     fi
 }
 
 [[ $ADVANCED -eq 1 ]] && prompt_advanced
+
+# ── host GPU/NPU discovery ────────────────────────────────────────────────
+# Everything below reads the HOST's device nodes. Nothing here can be done
+# from inside the container (install.sh detects the result and reports it,
+# but a guest cannot forward its own devices) — which is exactly why this
+# script, not the installer, owns passthrough.
+#
+# Collected into two arrays:
+#   GPU_DEV_ARGS   — `--devN` values for pct create
+#   GPU_CGROUP_MAJ — device majors needing an lxc.cgroup2.devices.allow rule
+GPU_DEV_ARGS=()
+GPU_CGROUP_MAJ=()
+
+_dev_major() {
+    # stat prints the major in hex; cgroup rules want decimal.
+    local hex
+    hex="$(stat -c '%t' "$1" 2>/dev/null)" || return 1
+    [[ -n "${hex}" ]] || return 1
+    printf '%d\n' "$((16#${hex}))"
+}
+
+_add_gpu_device() {
+    local path="$1" with_gid="${2:-1}" gid=""
+    [[ -e "${path}" ]] || return 1
+    if [[ "${with_gid}" == "1" ]]; then
+        gid="$(stat -c '%g' "${path}" 2>/dev/null || true)"
+    fi
+    # gid= makes the node readable by that group INSIDE the container. On a
+    # privileged container host gid == container gid, so this is the same
+    # number; on an unprivileged one pct maps it. Root-owned nodes (gid 0,
+    # e.g. /dev/kfd on stock kernels) are forwarded without a gid so hal0's
+    # own repair path (#1953) can align them.
+    if [[ -n "${gid}" && "${gid}" != "0" ]]; then
+        GPU_DEV_ARGS+=("${path},gid=${gid}")
+    else
+        GPU_DEV_ARGS+=("${path}")
+    fi
+    local maj
+    if maj="$(_dev_major "${path}")"; then
+        GPU_CGROUP_MAJ+=("${maj}")
+    fi
+    return 0
+}
+
+discover_gpu_devices() {
+    [[ "${GPU_PASSTHROUGH}" != "0" ]] || { msg_warn "GPU passthrough disabled (GPU_PASSTHROUGH=0) — CPU-only container"; return 0; }
+
+    msg_info "probing host for GPU/NPU devices"
+    local node
+    # Render nodes first: hal0 derives the render gid from these.
+    for node in /dev/dri/renderD*; do
+        [[ -e "${node}" ]] && _add_gpu_device "${node}" 1
+    done
+    # Strix Halo exposes /dev/dri/amdgpu (no card0); forward it when present.
+    [[ -e /dev/dri/amdgpu ]] && _add_gpu_device /dev/dri/amdgpu 1
+    # ROCm compute node.
+    [[ -e /dev/kfd ]] && _add_gpu_device /dev/kfd 1
+    # XDNA/NPU accelerators (FastFlowLM lane).
+    for node in /dev/accel/accel*; do
+        [[ -e "${node}" ]] && _add_gpu_device "${node}" 1
+    done
+
+    if [[ ${#GPU_DEV_ARGS[@]} -eq 0 ]]; then
+        if [[ "${GPU_PASSTHROUGH}" == "1" ]]; then
+            die "GPU_PASSTHROUGH=1 but this host exposes no /dev/dri, /dev/kfd or /dev/accel node"
+        fi
+        msg_warn "no GPU/NPU devices on this host — creating a CPU-only container"
+        return 0
+    fi
+    msg_ok "host devices: ${GPU_DEV_ARGS[*]}"
+}
 
 # ── locate or download the LXC template ───────────────────────────────────
 locate_template() {
@@ -152,14 +276,26 @@ locate_template() {
 
 # ── confirm + countdown ───────────────────────────────────────────────────
 print_plan() {
+    local privlabel="privileged"
+    [[ "${UNPRIVILEGED}" == "1" ]] && privlabel="unprivileged"
     printf "\n%shal0 LXC plan%s\n"  "${BL}" "${CL}"
     printf "  CTID         %s\n" "${CTID}"
     printf "  Hostname     %s\n" "${HOSTNAME}"
-    printf "  OS           %s %s (unprivileged=%s)\n" "${OS_TYPE}" "${OS_VERSION}" "${UNPRIVILEGED}"
+    printf "  OS           %s %s (%s)\n" "${OS_TYPE}" "${OS_VERSION}" "${privlabel}"
+    printf "  Features     %s\n" "${FEATURES}"
     printf "  Cores/RAM    %s / %sMB\n" "${CORES}" "${RAM_MB}"
     printf "  Disk         %sGB on %s\n" "${DISK_GB}" "${STORAGE}"
     printf "  Network      %s\n" "${NET_CONFIG}"
+    if [[ ${#GPU_DEV_ARGS[@]} -gt 0 ]]; then
+        printf "  Devices      %s\n" "${GPU_DEV_ARGS[*]}"
+    else
+        printf "  Devices      none (CPU-only)\n"
+    fi
+    [[ -n "${MOUNTS}" ]] && printf "  Mounts       %s\n" "${MOUNTS//$'\n'/ }"
     printf "  hal0 channel %s\n" "${HAL0_CHANNEL}"
+    if [[ "${UNPRIVILEGED}" != "1" ]]; then
+        printf "\n  %sPrivileged container: its root is effectively host root.%s\n" "${YW}" "${CL}"
+    fi
     printf "\n  Ctrl-C within 5s to abort.\n\n"
     sleep 5
 }
@@ -177,10 +313,33 @@ create_lxc() {
         --net0 "${NET_CONFIG}"
         --ostype "${OS_TYPE}"
         --unprivileged "${UNPRIVILEGED}"
-        --features "nesting=1"
-        --onboot 1
-        --start 1
+        --features "${FEATURES}"
+        --onboot "${ONBOOT}"
+        --tags "${TAGS}"
     )
+
+    [[ -n "${NAMESERVER}" ]]   && args+=(--nameserver "${NAMESERVER}")
+    [[ -n "${SEARCHDOMAIN}" ]] && args+=(--searchdomain "${SEARCHDOMAIN}")
+    [[ -n "${TIMEZONE}" ]]     && args+=(--timezone "${TIMEZONE}")
+    [[ -n "${STARTUP}" ]]      && args+=(--startup "${STARTUP}")
+
+    # Devices go on `pct create` itself so the container never boots once
+    # without them (a first boot without /dev/kfd makes hal0 seed CPU slots).
+    local i=0 dev
+    for dev in ${GPU_DEV_ARGS[@]+"${GPU_DEV_ARGS[@]}"}; do
+        args+=(--dev"${i}" "${dev}")
+        i=$((i + 1))
+    done
+
+    local m
+    i=0
+    if [[ -n "${MOUNTS}" ]]; then
+        while IFS= read -r m; do
+            [[ -n "${m}" ]] || continue
+            args+=(--mp"${i}" "${m}")
+            i=$((i + 1))
+        done < <(printf '%s\n' "${MOUNTS//;/$'\n'}")
+    fi
 
     if [[ -n "${PASSWORD}" ]]; then
         args+=(--password "${PASSWORD}")
@@ -192,14 +351,56 @@ create_lxc() {
     pct create "${CTID}" "${TEMPLATE}" "${args[@]}" >/dev/null \
         || die "pct create failed"
 
-    msg_ok "LXC ${CTID} created and started"
+    msg_ok "LXC ${CTID} created"
+}
+
+# ── raw lxc.* config pct has no flag for ──────────────────────────────────
+# cgroup2 device rules, memlock and the apparmor profile can only be
+# expressed as raw lxc keys in /etc/pve/lxc/<CTID>.conf. Idempotent: each
+# line is appended only if it is not already there, so re-running the
+# script against an existing CTID does not duplicate rules.
+apply_raw_config() {
+    local conf="/etc/pve/lxc/${CTID}.conf"
+    [[ -f "${conf}" ]] || die "expected ${conf} after pct create"
+
+    local -a lines=()
+    if [[ ${#GPU_CGROUP_MAJ[@]} -gt 0 ]]; then
+        local maj
+        for maj in $(printf '%s\n' "${GPU_CGROUP_MAJ[@]}" | sort -un); do
+            lines+=("lxc.cgroup2.devices.allow: c ${maj}:* rwm")
+        done
+        # memlock: ROCm pins large host buffers; the default 64K limit makes
+        # allocation fail inside a container long before host RAM runs out.
+        lines+=("lxc.prlimit.memlock: unlimited")
+    fi
+    if [[ "${UNPRIVILEGED}" != "1" && ${#GPU_DEV_ARGS[@]} -gt 0 ]]; then
+        # Privileged + GPU: the stock lxc-container-default-cgns profile
+        # blocks the mounts podman needs for rootful slots (#1563 covers the
+        # in-guest half of this).
+        lines+=("lxc.apparmor.profile: unconfined")
+    fi
+
+    [[ ${#lines[@]} -gt 0 ]] || return 0
+
+    msg_info "applying raw lxc config (${#lines[@]} lines)"
+    local line
+    for line in "${lines[@]}"; do
+        grep -qxF "${line}" "${conf}" || printf '%s\n' "${line}" >> "${conf}"
+    done
+    msg_ok "raw lxc config applied"
+}
+
+start_lxc() {
+    msg_info "starting LXC ${CTID}"
+    pct start "${CTID}" >/dev/null || die "pct start failed"
+    msg_ok "LXC ${CTID} started"
 }
 
 # ── wait for network ──────────────────────────────────────────────────────
 wait_for_net() {
     msg_info "waiting for network in LXC"
     for _ in $(seq 1 30); do
-        if pct exec "${CTID}" -- bash -c 'getent hosts deb.debian.org >/dev/null 2>&1'; then
+        if pct exec "${CTID}" -- bash -c 'getent hosts github.com >/dev/null 2>&1'; then
             msg_ok "LXC network up"
             return
         fi
@@ -208,28 +409,58 @@ wait_for_net() {
     die "LXC network did not come up in 60s"
 }
 
-# ── install deps + cosign + hal0 ──────────────────────────────────────────
-install_inside_lxc() {
-    msg_info "installing base packages (curl, tar, jq, python3, ca-certificates)"
+# ── verify passthrough landed ─────────────────────────────────────────────
+# Cheap, honest gate: if devices were forwarded, they must be visible in the
+# guest before the bootstrap runs. Catching it here beats discovering it as
+# CPU-seeded slots after a successful-looking install.
+verify_devices() {
+    [[ ${#GPU_DEV_ARGS[@]} -gt 0 ]] || return 0
+    msg_info "verifying devices inside the LXC"
+    local missing=""
+    local dev path
+    for dev in "${GPU_DEV_ARGS[@]}"; do
+        path="${dev%%,*}"
+        pct exec "${CTID}" -- test -e "${path}" || missing="${missing} ${path}"
+    done
+    if [[ -n "${missing}" ]]; then
+        msg_error "forwarded but not visible in the container:${missing}"
+        die "check /etc/pve/lxc/${CTID}.conf, then: pct stop ${CTID} && pct start ${CTID}"
+    fi
+    msg_ok "devices visible in LXC"
+}
+
+# ── install hal0 ──────────────────────────────────────────────────────────
+# No package pre-staging beyond a fetcher: bootstrap.sh installs its own
+# dependencies (curl/tar/jq/python3 via the guest package manager),
+# install.sh installs podman and the python venv stdlib, and bootstrap
+# fetches a pinned, sha256-verified cosign. The one thing the guest cannot
+# install for us is the tool used to DOWNLOAD the bootstrap — stock LXC
+# templates ship without curl — so that single package is staged here.
+ensure_fetcher() {
+    if pct exec "${CTID}" -- bash -c 'command -v curl >/dev/null 2>&1'; then
+        return 0
+    fi
+    msg_info "installing curl in the LXC (needed to fetch the bootstrap)"
     pct exec "${CTID}" -- bash -c '
         set -e
         export DEBIAN_FRONTEND=noninteractive
-        apt-get update -qq
-        apt-get install -y -qq curl ca-certificates tar jq python3 sudo >/dev/null
-    ' || die "apt install failed"
-    msg_ok "base packages installed"
+        if command -v apt-get >/dev/null 2>&1; then
+            apt-get -o DPkg::Lock::Timeout=120 update -qq
+            apt-get -o DPkg::Lock::Timeout=120 install -y -qq curl ca-certificates
+        elif command -v dnf >/dev/null 2>&1; then
+            dnf install -y curl ca-certificates
+        elif command -v apk >/dev/null 2>&1; then
+            apk add curl ca-certificates
+        else
+            echo "no supported package manager to install curl" >&2
+            exit 1
+        fi
+    ' || die "could not install curl inside the LXC"
+    msg_ok "curl available in the LXC"
+}
 
-    if [[ "${INSTALL_COSIGN}" == "1" ]]; then
-        msg_info "installing cosign ${COSIGN_VERSION}"
-        pct exec "${CTID}" -- bash -c "
-            set -e
-            curl -fsSL -o /usr/local/bin/cosign \
-                'https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64'
-            chmod +x /usr/local/bin/cosign
-        " || die "cosign install failed"
-        msg_ok "cosign ${COSIGN_VERSION} installed"
-    fi
-
+install_hal0() {
+    [[ "${RUN_BOOTSTRAP}" == "1" ]] || { msg_warn "RUN_BOOTSTRAP=0 — skipping hal0 install"; return 0; }
     msg_info "running hal0 bootstrap (channel: ${HAL0_CHANNEL})"
     pct exec "${CTID}" -- bash -c "
         set -e
@@ -257,11 +488,16 @@ print_access() {
 main() {
     header
     require_pve
+    discover_gpu_devices
     locate_template
     print_plan
     create_lxc
+    apply_raw_config
+    start_lxc
     wait_for_net
-    install_inside_lxc
+    verify_devices
+    ensure_fetcher
+    install_hal0
     print_access
 }
 

--- a/scripts/proxmox-ve/hal0.sh
+++ b/scripts/proxmox-ve/hal0.sh
@@ -206,7 +206,14 @@ _dev_major() {
 
 _add_gpu_device() {
     local path="$1" with_gid="${2:-1}" gid=""
-    [[ -e "${path}" ]] || return 1
+    # Symlinks are skipped, not resolved: on a Strix Halo host /dev/dri/amdgpu
+    # is a symlink to the render node the glob above already picked up, so
+    # following it would forward the same device twice — and `stat -c %t` on
+    # the link itself reports major 0, which would emit a meaningless
+    # `lxc.cgroup2.devices.allow: c 0:* rwm` rule. Only real character
+    # devices are forwarded.
+    [[ -L "${path}" ]] && return 1
+    [[ -c "${path}" ]] || return 1
     if [[ "${with_gid}" == "1" ]]; then
         gid="$(stat -c '%g' "${path}" 2>/dev/null || true)"
     fi
@@ -236,8 +243,12 @@ discover_gpu_devices() {
     for node in /dev/dri/renderD*; do
         [[ -e "${node}" ]] && _add_gpu_device "${node}" 1
     done
-    # Strix Halo exposes /dev/dri/amdgpu (no card0); forward it when present.
-    [[ -e /dev/dri/amdgpu ]] && _add_gpu_device /dev/dri/amdgpu 1
+    # Some kernels expose /dev/dri/amdgpu as its own node; forward it when it
+    # is a real device (on Strix Halo it is a symlink to the render node and
+    # _add_gpu_device skips it).
+    if [[ -e /dev/dri/amdgpu ]]; then
+        _add_gpu_device /dev/dri/amdgpu 1 || true
+    fi
     # ROCm compute node.
     [[ -e /dev/kfd ]] && _add_gpu_device /dev/kfd 1
     # XDNA/NPU accelerators (FastFlowLM lane).
@@ -396,6 +407,59 @@ start_lxc() {
     msg_ok "LXC ${CTID} started"
 }
 
+# ── align device gids with the container's render group ───────────────────
+# `devN: …,gid=` sets the node's owning group as seen INSIDE the container,
+# and hal0 requires that group to be the guest's `render` group — otherwise
+# preflight_gpu classifies the passthrough as broken and refuses to install
+# (correctly: hal0-user probes could not open the node).
+#
+# The gid this script forwards initially is the HOST's, which is only right
+# by coincidence. On an unprivileged container pct shifts it through the
+# idmap; on a privileged one there is no shift at all, so a host render gid
+# of 993 lands as 993 inside a guest whose render group is 991 (Debian 13 and
+# Ubuntu 24.04/26.04 all number it differently). That mismatch is the single
+# most common broken-passthrough shape, and it cannot be resolved before the
+# container exists — hence this pass: boot once, read the real gid from the
+# guest, rewrite the dev entries, restart.
+align_device_gids() {
+    [[ ${#GPU_DEV_ARGS[@]} -gt 0 ]] || return 0
+    msg_info "reading the render gid inside the container"
+
+    local gid=""
+    local _
+    for _ in $(seq 1 15); do
+        gid="$(pct exec "${CTID}" -- getent group render 2>/dev/null | cut -d: -f3 || true)"
+        [[ -n "${gid}" ]] && break
+        sleep 2
+    done
+    if [[ -z "${gid}" ]]; then
+        msg_warn "no 'render' group inside the container — leaving forwarded gids as they are"
+        return 0
+    fi
+
+    local changed=0 i=0 dev path
+    for dev in "${GPU_DEV_ARGS[@]}"; do
+        path="${dev%%,*}"
+        if [[ "${dev}" != "${path},gid=${gid}" ]]; then
+            pct set "${CTID}" --dev"${i}" "${path},gid=${gid}" >/dev/null \
+                || die "could not re-point dev${i} at gid ${gid}"
+            GPU_DEV_ARGS[i]="${path},gid=${gid}"
+            changed=1
+        fi
+        i=$((i + 1))
+    done
+
+    if [[ "${changed}" -eq 0 ]]; then
+        msg_ok "device gids already match the container's render group (${gid})"
+        return 0
+    fi
+
+    msg_info "re-pointing devices at the container's render gid (${gid}) and restarting"
+    pct stop "${CTID}" >/dev/null || die "pct stop failed"
+    pct start "${CTID}" >/dev/null || die "pct start failed"
+    msg_ok "devices aligned to render gid ${gid}"
+}
+
 # ── wait for network ──────────────────────────────────────────────────────
 wait_for_net() {
     msg_info "waiting for network in LXC"
@@ -416,17 +480,33 @@ wait_for_net() {
 verify_devices() {
     [[ ${#GPU_DEV_ARGS[@]} -gt 0 ]] || return 0
     msg_info "verifying devices inside the LXC"
-    local missing=""
-    local dev path
+    local missing="" wrong_gid=""
+    local dev path want_gid have_gid
     for dev in "${GPU_DEV_ARGS[@]}"; do
         path="${dev%%,*}"
-        pct exec "${CTID}" -- test -e "${path}" || missing="${missing} ${path}"
+        if ! pct exec "${CTID}" -- test -e "${path}"; then
+            missing="${missing} ${path}"
+            continue
+        fi
+        # The gid the entry asked for must be the gid the guest actually sees,
+        # or hal0's preflight classifies the passthrough as broken and refuses
+        # to install (BROKEN_GID) — which is the whole point of the alignment
+        # pass above.
+        want_gid="${dev#*gid=}"
+        [[ "${want_gid}" == "${dev}" ]] && continue
+        have_gid="$(pct exec "${CTID}" -- stat -c '%g' "${path}" 2>/dev/null || true)"
+        [[ "${have_gid}" == "${want_gid}" ]] \
+            || wrong_gid="${wrong_gid} ${path}(want ${want_gid}, got ${have_gid:-?})"
     done
     if [[ -n "${missing}" ]]; then
         msg_error "forwarded but not visible in the container:${missing}"
         die "check /etc/pve/lxc/${CTID}.conf, then: pct stop ${CTID} && pct start ${CTID}"
     fi
-    msg_ok "devices visible in LXC"
+    if [[ -n "${wrong_gid}" ]]; then
+        msg_error "device gid mismatch inside the container:${wrong_gid}"
+        die "hal0 would refuse this passthrough — fix the devN gid in /etc/pve/lxc/${CTID}.conf"
+    fi
+    msg_ok "devices visible in LXC with the expected gid"
 }
 
 # ── install hal0 ──────────────────────────────────────────────────────────
@@ -494,6 +574,7 @@ main() {
     create_lxc
     apply_raw_config
     start_lxc
+    align_device_gids
     wait_for_net
     verify_devices
     ensure_fetcher

--- a/tests/installer/test_preflight_lxc_kind.py
+++ b/tests/installer/test_preflight_lxc_kind.py
@@ -1,0 +1,81 @@
+"""Contract tests for ``hal0_lxc_kind`` in ``installer/lib/preflight.sh``.
+
+The classifier answers "where is this install running" with one of three
+values — ``none``, ``lxc-privileged``, ``lxc-unprivileged`` — because the
+answer decides which remedies are even possible from inside the guest:
+
+* a PRIVILEGED LXC can ``chgrp`` a forwarded device node and repair a
+  mis-mapped ``/dev/kfd`` itself (#1953),
+* an UNPRIVILEGED one gets EPERM on the same call, so the only real fix is
+  the Proxmox host's ``devN:`` entry.
+
+Before this existed, install.sh's kfd-gid fallback and the container-runtime
+gate both narrated the unprivileged remedy unconditionally, sending operators
+of privileged containers to change something that was never the cause.
+
+The classifier reads ``/proc/1/environ`` and ``/proc/self/uid_map``, neither
+of which a test can fake, so the shape under test is driven through the
+``HAL0_LXC_KIND_OVERRIDE`` seam plus a direct check that the real probe
+returns one of the three admitted values on the machine running the suite.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PREFLIGHT = _REPO_ROOT / "installer" / "lib" / "preflight.sh"
+
+_ADMITTED = {"none", "lxc-privileged", "lxc-unprivileged"}
+
+
+def _run(snippet: str, env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    script = f"source {_PREFLIGHT!s} >/dev/null 2>&1\n{snippet}\n"
+    env = {"PATH": "/usr/bin:/bin:/usr/sbin:/sbin", "HOME": "/tmp"}
+    env.update(env_extra or {})
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_real_probe_returns_an_admitted_value() -> None:
+    """Whatever this suite runs on, the classifier must answer in-vocabulary."""
+    result = _run("hal0_lxc_kind")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() in _ADMITTED
+
+
+@pytest.mark.parametrize("kind", sorted(_ADMITTED))
+def test_override_seam_is_honoured(kind: str) -> None:
+    result = _run("hal0_lxc_kind", {"HAL0_LXC_KIND_OVERRIDE": kind})
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == kind
+
+
+def test_in_lxc_predicate_agrees_with_the_classifier() -> None:
+    for kind, expected_rc in (
+        ("none", 1),
+        ("lxc-privileged", 0),
+        ("lxc-unprivileged", 0),
+    ):
+        result = _run("hal0_in_lxc", {"HAL0_LXC_KIND_OVERRIDE": kind})
+        assert result.returncode == expected_rc, f"{kind}: {result.stderr}"
+
+
+def test_classifier_is_used_not_reimplemented() -> None:
+    """The old inline ``grep container=lxc /proc/1/environ`` checks are the
+    thing this function replaces — a stray copy would drift from the
+    privileged/unprivileged split and resurrect the wrong-remedy bug."""
+    preflight = _PREFLIGHT.read_text(encoding="utf-8")
+    # One occurrence remains by design: the probe inside hal0_lxc_kind itself.
+    assert preflight.count("container=lxc") == 1
+
+    install_sh = (_REPO_ROOT / "installer" / "install.sh").read_text(encoding="utf-8")
+    assert "hal0_lxc_kind" in install_sh


### PR DESCRIPTION
## Why

`scripts/proxmox-ve/hal0.sh` created a vanilla **unprivileged Debian 13** container with no accelerator access, and pointed operators at a hand-written recipe for the shape hal0 actually runs in production. Every step of that recipe is host-side work — `devN` entries, cgroup rules, memlock, apparmor — which an in-guest installer can detect but never perform. So it stayed manual, and the "quick path" and the "real path" had nothing in common.

## What changed

**The script builds the production shape itself.**

- Probes the host for `/dev/dri/renderD*`, `/dev/dri/amdgpu`, `/dev/kfd` and `/dev/accel/*`; forwards each as a `devN` entry carrying the node's gid.
- Writes the matching `lxc.cgroup2.devices.allow` rules (majors derived with `stat -c %t`, not hardcoded), `lxc.prlimit.memlock: unlimited`, and — on a privileged container — `lxc.apparmor.profile: unconfined`. The raw-config writer is idempotent, so a re-run never duplicates a line.
- Devices go on `pct create` itself rather than being appended after a first boot: a container that boots once without `/dev/kfd` gets CPU slots seeded, and that is exactly the failure this is meant to prevent.
- After start, each forwarded node is verified **inside** the guest before anything is installed. A broken passthrough now fails loudly instead of producing a successful-looking CPU-only install.

**Default changes (deliberate, called out in the script header, README and docs):**

| | before | after |
|---|---|---|
| privilege | unprivileged | **privileged** (`UNPRIVILEGED=1` restores) |
| OS | debian 13 | **ubuntu 26.04** |
| features | `nesting=1` | `nesting=1,keyctl=1,fuse=1,mknod=1` |
| GPU/NPU | none | `GPU_PASSTHROUGH=auto` |

A privileged container's root is effectively host root. That is the trade this default makes for direct hardware access, and it is stated plainly everywhere the default appears. `UNPRIVILEGED=1 GPU_PASSTHROUGH=0 OS_TYPE=debian OS_VERSION=13` reproduces the previous behaviour exactly.

**Prerequisites are no longer pre-staged by the script.** `bootstrap.sh` already installs curl/tar/jq/python3 and fetches a pinned, sha256-verified cosign; `install.sh` already auto-installs podman (`preflight_container_runtime`) and the venv stdlib (`preflight_venv`). The script's own `apt-get install` + cosign download duplicated all of it. The single package still staged is `curl` — the tool that downloads the bootstrap cannot be downloaded by the bootstrap.

**In-guest platform classification.** New `hal0_lxc_kind` in `installer/lib/preflight.sh` returns `none` / `lxc-privileged` / `lxc-unprivileged`, read from `/proc/self/uid_map`. The `/dev/kfd` gid-repair fallback (#1953) and `_container_runtime_gate` used to narrate the *unprivileged* remedy unconditionally — telling an operator of a privileged container to change a host `devN:` entry that was never the cause. Both now branch on the real classification.

**New env knobs** for headless/static-IP provisioning: `IP_CIDR`, `GATEWAY`, `NAMESERVER`, `SEARCHDOMAIN`, `TIMEZONE`, `TAGS`, `ONBOOT`, `STARTUP`, `MOUNTS`, `FEATURES`, `GPU_PASSTHROUGH`, `RUN_BOOTSTRAP`.

Docs: `docs/getting-started/proxmox.mdx` §2 now describes what the script does; §3 becomes "what it automates, by hand" and keeps the container-gid caution and the keyring/network/AppArmor notes.

## Testing

- `tests/installer/test_preflight_lxc_kind.py` (new, 6 tests) — the override seam, the `hal0_in_lxc` predicate, an in-vocabulary answer from the real probe, and a guard that the old inline `grep container=lxc` checks were not left behind to drift.
- `shellcheck -x scripts/proxmox-ve/hal0.sh` clean; `bash -n` clean on all three shell files.
- `tests/installer/test_preflight_gpu_gate.py` — 2 failures under a root test runner (`chgrp 0` expectation) reproduce identically on unmodified `main`; pre-existing, not from this change.
- End-to-end on a Strix Halo PVE 9.2 host (privileged Ubuntu 26.04 CT, all four device nodes) is in progress; the run log will be posted as a comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQujuL1hQGETQAnrgUnyXf
