### PR TITLE
feat(ui): model drawer second pass — tune pills, rich selects, facts band

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -403,7 +403,15 @@ async def create_model(request: Request) -> dict[str, Any]:
     # permanently provider=None row. Derive only when provider is absent;
     # an explicit ``provider`` keeps flowing through screen_model_write's
     # validity check unchanged.
-    body.setdefault("provider", derive_model_provider(body.get("backends")))
+    #
+    # #2199: a body carrying the key with an explicit ``null``/blank string
+    # is the SAME "no provider supplied" intent as an omitted key —
+    # ``dict.setdefault`` alone is a no-op once the key is PRESENT (even
+    # with value ``None``), so normalize both shapes onto one derivation
+    # path instead of testing key-presence.
+    provider = body.get("provider")
+    if not isinstance(provider, str) or not provider.strip():
+        body["provider"] = derive_model_provider(body.get("backends"))
     # Screen launch-affecting fields at CREATE time too (UI-API-1 item 1): PUT
     # already screened, but create wrote straight to the registry, so a row
     # born with an extra_args that smuggles --port/--model/… would only fail at
@@ -729,7 +737,10 @@ async def update_model(model_id: str, request: Request) -> dict[str, Any]:
     dropped silently before screening/update, logged as
     ``model.backends_write_ignored``. ``provider`` is the write path now —
     the stored tags keep existing as vestigial lane hints (a future column
-    removal), but never change via this endpoint again.
+    removal), but never change via this endpoint again. An explicit
+    ``{"provider": null}`` (or a blank string) re-derives from the stored
+    ``backends`` tags rather than persisting a permanent ``provider=None``
+    row — the same "no provider supplied" convergence create applies (#2199).
 
     ``defaults`` and ``capability_flags`` are the two tables where "any
     subset" reaches INSIDE the object (#1413): an absent sub-key keeps the
@@ -776,6 +787,18 @@ async def update_model(model_id: str, request: Request) -> dict[str, Any]:
         before = registry.get(model_id).model_dump(mode="python")
     except Exception:
         before = {}
+
+    # #2199: an explicit null/blank ``provider`` in a PUT body carries the
+    # same "no provider supplied" intent as create's omitted-key case —
+    # converge it onto the same derive-from-backends path (mirrors the
+    # registration path's Task 3 rule) instead of persisting a permanent
+    # ``provider=None`` row. ``backends`` is retired as a PUT input (popped
+    # above), so the STORED row's tags are the only signal left to derive
+    # from.
+    if "provider" in body:
+        provider = body.get("provider")
+        if not isinstance(provider, str) or not provider.strip():
+            body["provider"] = derive_model_provider(before.get("backends"))
 
     # Validate the launch-affecting fields (defaults.extra_args + the
     # vision↔mmproj pairing) at SAVE time (UI-API-1 items 1/2, #1393). Shared

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -383,7 +383,8 @@ async def create_model(request: Request) -> dict[str, Any]:
     A body carrying tag-era ``backends`` tags but no ``provider`` gets one
     derived (``hal0.model_meta.derive_model_provider``) before screening, so
     create never mints a permanently ``provider=None`` row (Task 3) — an
-    explicit ``provider`` in the body is never overridden.
+    explicit non-empty ``provider`` in the body is never overridden; a null
+    or blank ``provider`` is replaced with the derived value (#2199).
     """
     from hal0.registry.store import Model
 

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -219,6 +219,13 @@ def model_to_dict(model: Any) -> dict[str, Any]:
       below: ``hal0.capabilities.catalog`` imports from ``hal0.registry``,
       which this module is itself imported by, so a module-level import
       here would cycle.
+    * ``provider_effective`` (Task 6) — the stored ``provider`` when set,
+      else :func:`hal0.model_meta.derive_model_provider` off the stored
+      ``backends`` tags. Read-only: the write paths (create/update) never
+      accept this key back, and the derivation itself is total (always a
+      :data:`hal0.model_meta.RUNTIME_FAMILIES` member), so the engine
+      picker always has a concrete "Auto resolves to" preview even for a
+      row with no explicit provider.
     """
     if hasattr(model, "model_dump"):
         dumped = model.model_dump(mode="json")
@@ -239,6 +246,9 @@ def model_to_dict(model: Any) -> dict[str, Any]:
     from hal0.capabilities.catalog import runs_on_for_model
 
     dumped["runs_on"] = runs_on_for_model(model)
+    dumped["provider_effective"] = dumped.get("provider") or derive_model_provider(
+        getattr(model, "backends", None) or dumped.get("backends")
+    )
     return dumped
 
 

--- a/tests/api/test_models_crud.py
+++ b/tests/api/test_models_crud.py
@@ -1142,3 +1142,36 @@ def test_update_model_provider_valid_and_invalid(
     bad = crud_client.put("/api/models/prov1", json={"provider": "whispercpp"})
     assert bad.status_code == 400, bad.text
     assert bad.json()["error"]["code"] == "model.provider_invalid"
+
+
+def test_put_explicit_null_provider_rederives_from_backends_2199(
+    crud_client: TestClient,
+    crud_models_root: Path,
+) -> None:
+    """#2199: a PUT body carrying ``{"provider": null}`` must converge on the
+    same derive-from-backends path as an omitted key, not persist a
+    permanent ``provider=None`` row. Round-trip through an explicit override
+    first so the assertion can't pass by coincidence (the row already being
+    at the derived value)."""
+    fpath = crud_models_root / "null-provider.gguf"
+    fpath.write_bytes(b"\x00" * 16)
+    r = crud_client.post(
+        "/api/models",
+        json={"id": "null-provider", "path": str(fpath), "backends": ["kokoro"]},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["provider"] == "kokoro"  # create-time derivation (Task 3)
+
+    # Override to a different explicit provider first.
+    r = crud_client.put("/api/models/null-provider", json={"provider": "llama-server"})
+    assert r.status_code == 200, r.text
+    assert r.json()["provider"] == "llama-server"
+
+    # An explicit null re-derives from the stored backends tags — it must
+    # neither store None nor leave the prior override in place.
+    r = crud_client.put("/api/models/null-provider", json={"provider": None})
+    assert r.status_code == 200, r.text
+    assert r.json()["provider"] == "kokoro"
+
+    row = crud_client.get("/api/models/null-provider").json()
+    assert row["provider"] == "kokoro"

--- a/tests/api/test_models_routes.py
+++ b/tests/api/test_models_routes.py
@@ -24,8 +24,9 @@ from fastapi.testclient import TestClient
 
 from hal0.api import create_app
 from hal0.api.routes import models as models_route
+from hal0.model_meta import derive_model_provider
 from hal0.registry.model import Model, _derive_ns
-from hal0.services.models_service import lazy_quant
+from hal0.services.models_service import lazy_quant, model_to_dict
 
 # ── _derive_ns ─────────────────────────────────────────────────────────────
 
@@ -146,6 +147,30 @@ def test_get_model_attaches_ns(inspect_client: TestClient, tmp_hal0_home: str) -
     inspect_client.post("/api/models", json={"id": "g1", "path": str(fpath)})
     row = inspect_client.get("/api/models/g1").json()
     assert row["ns"] == "pulled"
+
+
+# ── provider_effective (Task 6 of the slot/model drawer overhaul) ───────────
+
+
+def test_model_to_dict_provider_effective_explicit() -> None:
+    """A row with an explicit ``provider`` surfaces it verbatim as
+    ``provider_effective`` — no re-derivation runs when the field is set."""
+    m = Model(id="explicit-flm", path="/tmp/explicit-flm.gguf", provider="flm", backends=[])
+    assert model_to_dict(m)["provider_effective"] == "flm"
+
+
+def test_model_to_dict_provider_effective_derived() -> None:
+    """A row with ``provider=None`` derives ``provider_effective`` from its
+    stored ``backends`` tags via :func:`derive_model_provider` — same
+    resolution the catalog and create/scan paths already rely on."""
+    m = Model(
+        id="legacy-moonshine",
+        path="/tmp/legacy-moonshine.gguf",
+        provider=None,
+        backends=["moonshine"],
+    )
+    assert derive_model_provider(m.backends) == "moonshine"
+    assert model_to_dict(m)["provider_effective"] == "moonshine"
 
 
 def test_list_models_type_is_dispatcher_vocab_for_local_rows(

--- a/tests/ui_contracts/test_flag_aliases_mirror.py
+++ b/tests/ui_contracts/test_flag_aliases_mirror.py
@@ -1,0 +1,20 @@
+"""The UI mirrors hal0.slots.argv.FLAG_ALIASES for pill canonicalization.
+
+Parses the JS object literal out of flags-tune.js so a server-side alias
+change fails CI here instead of silently desyncing the drawer's pills.
+"""
+
+import json
+import re
+from pathlib import Path
+
+from hal0.slots.argv import FLAG_ALIASES
+
+
+def test_ui_flag_alias_mirror_matches_server():
+    src = Path("ui/src/dash/flags-tune.js").read_text()
+    m = re.search(r"export const FLAG_ALIASES = (\{[^}]*\})", src, re.S)
+    assert m, "FLAG_ALIASES export not found in flags-tune.js"
+    # the literal is written as strict JSON (double-quoted keys/values) by Task 1
+    ui = json.loads(m.group(1))
+    assert ui == dict(FLAG_ALIASES)

--- a/ui/src/dash/__tests__/flags-tune.test.ts
+++ b/ui/src/dash/__tests__/flags-tune.test.ts
@@ -94,6 +94,49 @@ describe("splice helpers preserve spelling, order, untouched text", () => {
   });
 });
 
+// Repeating a flag is legitimate llama-server usage (-ot / --override-kv /
+// --lora), so "the pair for this canon" is not unique and the helpers have to
+// be told WHICH one. Without the occurrence index every affordance on the
+// second pill silently acted on the first.
+describe("splice helpers address a specific occurrence of a repeated flag", () => {
+  const rep = "-ot ffn=CPU -ot attn=GPU --temp 0.4";
+
+  it("defaults to the first occurrence (unchanged contract)", () => {
+    expect(removeFlagFromText(rep, "-ot")).toBe("-ot attn=GPU --temp 0.4");
+    expect(spliceFlagValue(rep, "-ot", "x")).toBe("-ot x -ot attn=GPU --temp 0.4");
+  });
+
+  it("removes the second occurrence and leaves the first intact", () => {
+    expect(removeFlagFromText(rep, "-ot", 1)).toBe("-ot ffn=CPU --temp 0.4");
+  });
+
+  it("edits the second occurrence's value only", () => {
+    expect(spliceFlagValue(rep, "-ot", "attn=CPU", 1))
+      .toBe("-ot ffn=CPU -ot attn=CPU --temp 0.4");
+  });
+
+  it("counts occurrences across mixed spellings via canonFlag", () => {
+    const mixed = "-b 512 --batch-size 2048";
+    expect(spliceFlagValue(mixed, "--batch-size", "1024", 1)).toBe("-b 512 --batch-size 1024");
+    expect(removeFlagFromText(mixed, "--batch-size", 1)).toBe("-b 512");
+  });
+
+  it("counts a bare repetition as its own occurrence", () => {
+    // `--temp --temp 0.5`: the first carries no value (the next token is a
+    // flag), so occurrence 0 is the bare one and occurrence 1 is the valued one.
+    const bare = "--temp --temp 0.5";
+    expect(removeFlagFromText(bare, "--temp", 0)).toBe("--temp 0.5");
+    expect(spliceFlagValue(bare, "--temp", "0.9", 1)).toBe("--temp --temp 0.9");
+    // Occurrence 0 has no value token to replace — still a documented no-op.
+    expect(spliceFlagValue(bare, "--temp", "0.9", 0)).toBe(bare);
+  });
+
+  it("an out-of-range occurrence is a no-op, never a wrong-pair edit", () => {
+    expect(removeFlagFromText(rep, "-ot", 5)).toBe(rep);
+    expect(spliceFlagValue(rep, "-ot", "x", 5)).toBe(rep);
+  });
+});
+
 describe('isFlagToken', () => {
   it('accepts long flags with real content', () => {
     expect(isFlagToken('--threads')).toBe(true)

--- a/ui/src/dash/__tests__/flags-tune.test.ts
+++ b/ui/src/dash/__tests__/flags-tune.test.ts
@@ -78,6 +78,20 @@ describe("splice helpers preserve spelling, order, untouched text", () => {
     expect(spliceFlagValue("--batch-size 2048", canonFlag("-b"), "512"))
       .toBe("--batch-size 512");
   });
+  it("spliceFlagValue replaces a double-quoted multi-word value without corrupting the remainder", () => {
+    expect(spliceFlagValue('--foo "a b" --temp 0.4', "--foo", "x"))
+      .toBe("--foo x --temp 0.4");
+  });
+  it("spliceFlagValue replaces a single-quoted multi-word value without corrupting the remainder", () => {
+    expect(spliceFlagValue("--foo 'a b' --temp 0.4", "--foo", "x"))
+      .toBe("--foo x --temp 0.4");
+  });
+  it("removeFlagFromText drops a double-quoted multi-word value without corrupting the remainder", () => {
+    expect(removeFlagFromText('--foo "a b" --temp 0.4', "--foo")).toBe("--temp 0.4");
+  });
+  it("removeFlagFromText drops a single-quoted multi-word value without corrupting the remainder", () => {
+    expect(removeFlagFromText("--foo 'a b' --temp 0.4", "--foo")).toBe("--temp 0.4");
+  });
 });
 
 describe('isFlagToken', () => {

--- a/ui/src/dash/__tests__/flags-tune.test.ts
+++ b/ui/src/dash/__tests__/flags-tune.test.ts
@@ -21,6 +21,64 @@ import {
   isFlagToken,
   tokenizeFlags,
 } from '../flags-tune.js'
+import {
+  canonFlag, groupFlagPairs, spliceFlagValue,
+  removeFlagFromText, addFlagToText, FLAG_ALIASES, CATEGORY_ORDER,
+} from '../flags-tune.js'
+
+describe("canonFlag", () => {
+  it("folds a short alias to its long form", () => {
+    // pick any real pair from FLAG_ALIASES at implementation time, e.g.:
+    const [short, long] = Object.entries(FLAG_ALIASES)[0];
+    expect(canonFlag(short)).toBe(long);
+  });
+  it("returns unknown flags unchanged", () => {
+    expect(canonFlag("--totally-novel")).toBe("--totally-novel");
+  });
+});
+
+describe("groupFlagPairs", () => {
+  it("groups known flags and routes unknown to template-misc", () => {
+    const { groups, error } = groupFlagPairs("--temp 0.4 --cache-type-k q8_0 --wat 1");
+    expect(error).toBeNull();
+    const ids = groups.map((g) => g.id);
+    expect(ids).toContain("sampling");
+    expect(ids).toContain("cache-kv");
+    const misc = groups.find((g) => g.id === "template-misc");
+    expect(misc.pairs).toEqual([{ flag: "--wat", canon: "--wat", value: "1" }]);
+  });
+  it("omits empty groups and keeps CATEGORY_ORDER order", () => {
+    const { groups } = groupFlagPairs("--temp 0.4");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].id).toBe("sampling");
+    const order = CATEGORY_ORDER.map((c) => c.id);
+    expect(order).toEqual(["sampling", "cache-kv", "memory-batch", "template-misc"]);
+  });
+  it("surfaces tokenizer errors", () => {
+    expect(groupFlagPairs('--temp "0.4').error).toMatch(/unbalanced quote/);
+  });
+});
+
+describe("splice helpers preserve spelling, order, untouched text", () => {
+  const t = "-fa auto --temp 0.4 -b 2048";
+  it("spliceFlagValue replaces one value", () => {
+    expect(spliceFlagValue(t, "--temp", "0.2")).toBe("-fa auto --temp 0.2 -b 2048");
+  });
+  it("removeFlagFromText drops flag+value", () => {
+    expect(removeFlagFromText(t, "--temp")).toBe("-fa auto -b 2048");
+  });
+  it("removeFlagFromText drops a boolean flag alone", () => {
+    expect(removeFlagFromText("--jinja --temp 0.4", "--jinja")).toBe("--temp 0.4");
+  });
+  it("addFlagToText appends, quoting whitespace values", () => {
+    expect(addFlagToText(t, "--override-kv", "a b")).toBe(t + ' --override-kv "a b"');
+    expect(addFlagToText("", "--jinja", null)).toBe("--jinja");
+  });
+  it("splice via a short alias canon hits the long-typed flag and vice versa", () => {
+    expect(spliceFlagValue("--batch-size 2048", canonFlag("-b"), "512"))
+      .toBe("--batch-size 512");
+  });
+});
 
 describe('isFlagToken', () => {
   it('accepts long flags with real content', () => {

--- a/ui/src/dash/__tests__/flags-tune.test.ts
+++ b/ui/src/dash/__tests__/flags-tune.test.ts
@@ -45,7 +45,7 @@ describe("groupFlagPairs", () => {
     expect(ids).toContain("sampling");
     expect(ids).toContain("cache-kv");
     const misc = groups.find((g) => g.id === "template-misc");
-    expect(misc.pairs).toEqual([{ flag: "--wat", canon: "--wat", value: "1" }]);
+    expect(misc!.pairs).toEqual([{ flag: "--wat", canon: "--wat", value: "1" }]);
   });
   it("omits empty groups and keeps CATEGORY_ORDER order", () => {
     const { groups } = groupFlagPairs("--temp 0.4");

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -18,6 +18,7 @@ import { createRoot } from 'react-dom/client'
 import { act } from 'react-dom/test-utils'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { feasibilityHint } from '../feasibility-copy'
 
 ;(globalThis as unknown as { window: typeof globalThis }).window = globalThis
 ;(globalThis as unknown as { React: typeof React }).React = React
@@ -87,6 +88,36 @@ vi.mock('@/api/hooks/useSlots', () => ({
   useSlots: () => ({ data: slotsBox.current, isLoading: false }),
 }))
 
+// GTT feasibility probe (Task 7) — a real useState-backed mutation stand-in
+// so calling `mutate()` from inside model-drawer.jsx's debounced effect
+// genuinely re-renders the component under test, the same way react-query's
+// own mutation state does. `feasibilityHandler.current` lets each test decide
+// what (if anything) a probe resolves to; leaving it unset means `mutate()`
+// records the call but never produces a hint, matching an in-flight/never-
+// responded probe.
+const { feasibilityCalls, feasibilityHandler } = vi.hoisted(() => ({
+  feasibilityCalls: [] as unknown[],
+  feasibilityHandler: {
+    current: undefined as
+      | ((body: { models: { model_id: string; ctx?: number }[] }) => { results: unknown[] } | undefined)
+      | undefined,
+  },
+}))
+
+vi.mock('@/api/hooks/useModelsFeasibility', () => ({
+  useModelsFeasibility: () => {
+    const [data, setData] = React.useState<{ results: unknown[] } | undefined>(undefined)
+    return {
+      data,
+      mutate: (body: { models: { model_id: string; ctx?: number }[] }) => {
+        feasibilityCalls.push(body)
+        const resp = feasibilityHandler.current?.(body)
+        if (resp) setData(resp)
+      },
+    }
+  },
+}))
+
 await import('../primitives.jsx')
 const { ModelDrawer } = await import('../model-drawer.jsx')
 
@@ -146,6 +177,8 @@ beforeEach(() => {
   profilesBox.current = []
   templatesBox.current = []
   enumsBox.current = undefined
+  feasibilityCalls.length = 0
+  feasibilityHandler.current = undefined
 })
 
 afterEach(() => {
@@ -701,6 +734,87 @@ describe('ModelDrawer engine (Task 6)', () => {
 
     const call = updateCalls[0] as { id: string; body: { provider?: string | null } }
     expect(call.body.provider).toBeNull()
+    act(() => root.unmount())
+  })
+})
+
+describe('ModelDrawer context intelligence (Task 7)', () => {
+  it('native chip renders from metadata.context_length; hidden when absent', () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    expect(q(host, 'model-ctx-native-chip').textContent).toBe('native 128K')
+    act(() => root.unmount())
+
+    const noNative = { ...MODEL, metadata: { sha256: MODEL.metadata.sha256 } }
+    const mounted2 = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: noNative }),
+    )
+    expect(mounted2.host.querySelector('[data-testid="model-ctx-native-chip"]')).toBeNull()
+    act(() => mounted2.root.unmount())
+  })
+
+  it('over-native value flips the chip to warn and shows the rope warnbox; Save stays enabled', () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    const input = q<HTMLInputElement>(host, 'model-ctx-input')
+    // MODEL's metadata.context_length is 131072 ("native 128K") — 262144 is
+    // over-native and must never touch saveBlocked (#1378's gate is
+    // untouched by this advisory signal).
+    act(() => typeInto(input, '262144'))
+
+    expect(q(host, 'model-ctx-native-chip').textContent).toBe('> native 128K')
+    const warnBox = q(host, 'model-ctx-rope-warn')
+    expect(warnBox.textContent).toContain('native 128K')
+    expect(warnBox.textContent).toContain('Saves anyway.')
+    expect(host.querySelector('[data-testid="model-ctx-error"]')).toBeNull()
+    expect(q<HTMLButtonElement>(host, 'model-save').disabled).toBe(false)
+
+    act(() => root.unmount())
+  })
+
+  it('feasibility line renders the hint for a verdict and nothing for unknown/empty', async () => {
+    feasibilityHandler.current = (body) => ({
+      results: [
+        {
+          model_id: body.models[0].model_id,
+          verdict: 'tight',
+          needed_mb: 20000,
+          gtt_free_mb: 15000,
+          gtt_total_mb: 24000,
+        },
+      ],
+    })
+
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+
+    // MODEL carries no defaults.context_size, so the ctx input seeds empty —
+    // an empty ctx must never fire a probe at all.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 450))
+    })
+    expect(feasibilityCalls.length).toBe(0)
+    expect(host.querySelector('[data-testid="model-ctx-feasibility"]')).toBeNull()
+
+    const input = q<HTMLInputElement>(host, 'model-ctx-input')
+    await act(async () => {
+      typeInto(input, '4096')
+      await new Promise((r) => setTimeout(r, 450))
+    })
+
+    expect(feasibilityCalls.length).toBe(1)
+    expect(feasibilityCalls[0]).toEqual({ models: [{ model_id: MODEL.id, ctx: 4096 }] })
+    const expected = feasibilityHint({
+      verdict: 'tight',
+      needed_mb: 20000,
+      gtt_free_mb: 15000,
+      gtt_total_mb: 24000,
+    })
+    expect(q(host, 'model-ctx-feasibility').textContent).toBe(expected.text)
+
     act(() => root.unmount())
   })
 })

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -1,7 +1,11 @@
 // @vitest-environment happy-dom
 //
-// Model drawer header (model-drawer-2, Task 3): inline title editor, the
-// single default-toggle chip, and the read-only facts band.
+// Model drawer (model-drawer-2):
+//   · Task 3 — inline title editor, the single default-toggle chip, and the
+//     read-only facts band.
+//   · Task 4 — the structured tune editor: grouped pills over the flags
+//     string, per-pill revert/remove/restore, the value popover, the add-flag
+//     denylist gate, and the raw⇄pills toggle.
 //
 // model-drawer.jsx is a window-globals dash module (bare `Drawer`/
 // `FieldInfoIcon`/`Icons`/... identifiers resolve off `window`), so the
@@ -23,11 +27,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 ;(globalThis as unknown as { ReactDOM: unknown }).ReactDOM = { ...ReactDOMClient, createPortal }
 ;(globalThis as unknown as { Icons: unknown }).Icons = new Proxy({}, { get: () => null })
 
-const { updateCalls, setDefaultCalls, setDefaultResult, slotsBox } = vi.hoisted(() => ({
+const { updateCalls, setDefaultCalls, setDefaultResult, slotsBox, profilesBox } = vi.hoisted(() => ({
   updateCalls: [] as unknown[],
   setDefaultCalls: [] as unknown[],
   setDefaultResult: { current: { default: true, type: 'llm' } as Record<string, unknown> },
   slotsBox: { current: [] as Record<string, unknown>[] },
+  profilesBox: { current: [] as Record<string, unknown>[] },
 }))
 
 vi.mock('@/api/hooks/useModels', () => ({
@@ -56,7 +61,7 @@ vi.mock('@/api/hooks/useChatTemplates', () => ({
 }))
 
 vi.mock('@/api/hooks/useProfiles', () => ({
-  useProfiles: () => ({ data: [], isLoading: false }),
+  useProfiles: () => ({ data: profilesBox.current, isLoading: false }),
 }))
 
 // useMetaEnums resolves the static device taxonomy over the live payload; the
@@ -114,12 +119,21 @@ function typeInto(input: HTMLInputElement, value: string) {
   nativeInputValueSetter.call(input, value)
   input.dispatchEvent(new Event('input', { bubbles: true }))
 }
+const nativeAreaValueSetter = Object.getOwnPropertyDescriptor(
+  window.HTMLTextAreaElement.prototype,
+  'value',
+)!.set!
+function typeIntoArea(area: HTMLTextAreaElement, value: string) {
+  nativeAreaValueSetter.call(area, value)
+  area.dispatchEvent(new Event('input', { bubbles: true }))
+}
 
 beforeEach(() => {
   updateCalls.length = 0
   setDefaultCalls.length = 0
   setDefaultResult.current = { default: true, type: 'llm' }
   slotsBox.current = []
+  profilesBox.current = []
 })
 
 afterEach(() => {
@@ -243,6 +257,215 @@ describe('ModelDrawer header (Task 3)', () => {
     expect(usedBy).toBeTruthy()
     expect(usedBy.textContent).toContain('1 slot')
     expect(usedBy.textContent).toContain('agent')
+    act(() => root.unmount())
+  })
+})
+
+// ─── Task 4 — structured tune editor ────────────────────────────────────────
+// The flags STRING is the single source of truth; the pills are a pure render
+// of it and every interaction splices that string. So each assertion below
+// reads the string back through the raw textarea rather than trusting the
+// pills' own labels — a pill that lies about the string it produced fails.
+
+const TUNE_MODEL = {
+  ...MODEL,
+  defaults: { extra_args: '-fa auto --temp 0.4', profile: 'chat' },
+}
+const CHAT_PROFILE = { name: 'chat', flags: '-fa auto --temp 0.7 --repeat-penalty 1.1' }
+
+const q = <T extends HTMLElement>(host: HTMLElement, testid: string) =>
+  host.querySelector(`[data-testid="${testid}"]`) as T
+const press = (el: HTMLElement, key: string) =>
+  act(() => {
+    el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }))
+  })
+
+// Read the flags string as the drawer actually holds it: flip to raw, read the
+// textarea, flip back. Round-tripping through the toggle on every read also
+// keeps the toggle itself under test in every case.
+function rawFlags(host: HTMLElement) {
+  act(() => q<HTMLButtonElement>(host, 'model-tune-raw-toggle').click())
+  const value = q<HTMLTextAreaElement>(host, 'model-flags-input').value
+  act(() => q<HTMLButtonElement>(host, 'model-tune-raw-toggle').click())
+  return value
+}
+
+describe('ModelDrawer tune pills (Task 4)', () => {
+  it('renders pills grouped, with divergence classes', () => {
+    profilesBox.current = [CHAT_PROFILE]
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: TUNE_MODEL }),
+    )
+
+    const temp = q(host, 'model-tune-pill---temp')
+    expect(temp).toBeTruthy()
+    expect(temp.getAttribute('data-divergence')).toBe('changed')
+    expect(temp.className).toContain('fpill-chg')
+
+    // -fa canonicalises onto --flash-attn, and matches the profile verbatim.
+    const fa = q(host, 'model-tune-pill---flash-attn')
+    expect(fa.getAttribute('data-divergence')).toBe('unchanged')
+
+    // Grouped by category, not one flat row.
+    expect(q(host, 'model-tune-group-sampling').contains(temp)).toBe(true)
+    expect(q(host, 'model-tune-group-cache-kv').contains(fa)).toBe(true)
+
+    // In the profile, missing from the text → a ghost pill offering restore.
+    expect(q(host, 'model-tune-pill-restore---repeat-penalty')).toBeTruthy()
+
+    // 0 added + 1 changed + 1 removed.
+    expect(q(host, 'model-diverged-chip').textContent).toBe('◆ 2 diverged')
+    expect(q(host, 'model-provenance-chip').textContent).toContain('chat')
+    act(() => root.unmount())
+  })
+
+  it('per-pill revert restores the profile value', () => {
+    profilesBox.current = [CHAT_PROFILE]
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: TUNE_MODEL }),
+    )
+    act(() => q<HTMLButtonElement>(host, 'model-tune-pill-revert---temp').click())
+    expect(rawFlags(host)).toBe('-fa auto --temp 0.7')
+    expect(q(host, 'model-tune-pill---temp').getAttribute('data-divergence')).toBe('unchanged')
+    act(() => root.unmount())
+  })
+
+  it('revert falls back to remove+add for a boolean⇄valued flag', () => {
+    // The model dropped -fa's value, so there is no value token to splice onto
+    // — spliceFlagValue is a documented no-op there. Revert has to rebuild the
+    // pair, and the profile's value must come back regardless of position.
+    profilesBox.current = [CHAT_PROFILE]
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, {
+        open: true,
+        onClose: () => {},
+        model: { ...TUNE_MODEL, defaults: { extra_args: '-fa --temp 0.7', profile: 'chat' } },
+      }),
+    )
+    expect(q(host, 'model-tune-pill---flash-attn').getAttribute('data-divergence')).toBe('changed')
+    act(() => q<HTMLButtonElement>(host, 'model-tune-pill-revert---flash-attn').click())
+    expect(rawFlags(host)).toBe('--temp 0.7 -fa auto')
+    expect(q(host, 'model-tune-pill---flash-attn').getAttribute('data-divergence')).toBe(
+      'unchanged',
+    )
+    act(() => root.unmount())
+  })
+
+  it('remove and restore splice the string', () => {
+    profilesBox.current = [CHAT_PROFILE]
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: TUNE_MODEL }),
+    )
+    act(() => q<HTMLButtonElement>(host, 'model-tune-pill-remove---temp').click())
+    expect(rawFlags(host)).toBe('-fa auto')
+    expect(q(host, 'model-tune-pill---temp')).toBeNull()
+
+    act(() => q<HTMLButtonElement>(host, 'model-tune-pill-restore---repeat-penalty').click())
+    expect(rawFlags(host)).toBe('-fa auto --repeat-penalty 1.1')
+    act(() => root.unmount())
+  })
+
+  it('value popover edits one flag; Esc reverts', () => {
+    profilesBox.current = [CHAT_PROFILE]
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: TUNE_MODEL }),
+    )
+    act(() => q<HTMLButtonElement>(host, 'model-tune-pill-value---temp').click())
+    let input = q<HTMLInputElement>(host, 'model-tune-value-input')
+    expect(input).toBeTruthy()
+    expect(input.value).toBe('0.4')
+    act(() => typeInto(input, '0.2'))
+    press(input, 'Enter')
+    expect(q(host, 'model-tune-value-input')).toBeNull()
+    expect(rawFlags(host)).toBe('-fa auto --temp 0.2')
+
+    act(() => q<HTMLButtonElement>(host, 'model-tune-pill-value---temp').click())
+    input = q<HTMLInputElement>(host, 'model-tune-value-input')
+    act(() => typeInto(input, '9'))
+    press(input, 'Escape')
+    expect(q(host, 'model-tune-value-input')).toBeNull()
+    expect(rawFlags(host)).toBe('-fa auto --temp 0.2')
+    act(() => root.unmount())
+  })
+
+  it('add flag guards the managed denylist', () => {
+    profilesBox.current = [CHAT_PROFILE]
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: TUNE_MODEL }),
+    )
+    act(() => q<HTMLButtonElement>(host, 'model-tune-add-flag').click())
+    const input = q<HTMLInputElement>(host, 'model-tune-add-input')
+    expect(input).toBeTruthy()
+    act(() => typeInto(input, '--port 9'))
+    press(input, 'Enter')
+
+    expect(rawFlags(host)).toBe('-fa auto --temp 0.4 --port 9')
+    const port = q(host, 'model-tune-pill---port')
+    expect(port).toBeTruthy()
+    expect(port.getAttribute('data-divergence')).toBe('denied')
+    expect(port.className).toContain('fpill-deny')
+    const err = q(host, 'model-flags-error')
+    expect(err).toBeTruthy()
+    expect(err.textContent).toContain('--port')
+    expect(q<HTMLButtonElement>(host, 'model-save').disabled).toBe(true)
+    act(() => root.unmount())
+  })
+
+  it('unparseable text forces raw mode', () => {
+    profilesBox.current = [CHAT_PROFILE]
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, {
+        open: true,
+        onClose: () => {},
+        model: { ...TUNE_MODEL, defaults: { extra_args: '--chat-template "broken', profile: 'chat' } },
+      }),
+    )
+    expect(q(host, 'model-flags-input')).toBeTruthy()
+    expect(q(host, 'model-tune-pills')).toBeNull()
+    expect(host.querySelector('[data-testid^="model-tune-pill-"]')).toBeNull()
+    expect(q(host, 'model-flags-error').textContent).toContain('unbalanced quote')
+    act(() => root.unmount())
+  })
+
+  it('no seeding profile → no divergence markers, no ghost pills', () => {
+    profilesBox.current = [CHAT_PROFILE]
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, {
+        open: true,
+        onClose: () => {},
+        model: { ...TUNE_MODEL, defaults: { extra_args: '-fa auto --temp 0.4' } },
+      }),
+    )
+    // Only the pills themselves carry data-divergence (the affordances inside
+    // them share the testid prefix but not the attribute).
+    const pills = Array.from(host.querySelectorAll('[data-divergence]')) as HTMLElement[]
+    expect(pills.length).toBe(2)
+    for (const p of pills) expect(p.getAttribute('data-divergence')).toBe('none')
+    expect(host.querySelector('[data-testid^="model-tune-pill-restore-"]')).toBeNull()
+    expect(q(host, 'model-diverged-chip')).toBeNull()
+    act(() => root.unmount())
+  })
+
+  it('raw toggle round-trips', () => {
+    profilesBox.current = [CHAT_PROFILE]
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: TUNE_MODEL }),
+    )
+    act(() => q<HTMLButtonElement>(host, 'model-tune-raw-toggle').click())
+    const area = q<HTMLTextAreaElement>(host, 'model-flags-input')
+    expect(area.value).toBe('-fa auto --temp 0.4')
+    // The diff panel is raw-mode-only; the pills carry the same facts inline.
+    expect(q(host, 'model-divergence-diff')).toBeTruthy()
+
+    act(() => typeIntoArea(area, '-fa auto --temp 0.4 -ctk q8_0'))
+    act(() => q<HTMLButtonElement>(host, 'model-tune-raw-toggle').click())
+
+    expect(q(host, 'model-flags-input')).toBeNull()
+    expect(q(host, 'model-divergence-diff')).toBeNull()
+    const ctk = q(host, 'model-tune-pill---cache-type-k')
+    expect(ctk).toBeTruthy()
+    expect(ctk.getAttribute('data-divergence')).toBe('added')
+    expect(q(host, 'model-diverged-chip').textContent).toBe('◆ 3 diverged')
     act(() => root.unmount())
   })
 })

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -1401,7 +1401,7 @@ describe('footer summary', () => {
 
     const footer = q<HTMLElement>(host, 'model-foot-summary')
     expect(footer).toBeTruthy()
-    expect(footer.textContent).toContain('1 changes')
+    expect(footer.textContent).toContain('1 change')
     expect(footer.textContent).toContain('context')
     expect(footer.textContent).toContain('restarts 2 slots')
     expect(footer.textContent).toContain('agent')
@@ -1419,7 +1419,7 @@ describe('footer summary', () => {
 
     const footer = q<HTMLElement>(host, 'model-foot-summary')
     expect(footer).toBeTruthy()
-    expect(footer.textContent).toContain('1 changes')
+    expect(footer.textContent).toContain('1 change')
     expect(footer.textContent).toContain('context')
     expect(footer.textContent).not.toContain('restarts')
     act(() => root.unmount())

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -1,0 +1,248 @@
+// @vitest-environment happy-dom
+//
+// Model drawer header (model-drawer-2, Task 3): inline title editor, the
+// single default-toggle chip, and the read-only facts band.
+//
+// model-drawer.jsx is a window-globals dash module (bare `Drawer`/
+// `FieldInfoIcon`/`Icons`/... identifiers resolve off `window`), so the
+// globals are installed before the dynamic import — same pattern as
+// profiles.test.tsx / runner-images-view.test.tsx.
+import React from 'react'
+import * as ReactDOMClient from 'react-dom/client'
+import { createPortal } from 'react-dom'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+;(globalThis as unknown as { window: typeof globalThis }).window = globalThis
+;(globalThis as unknown as { React: typeof React }).React = React
+// FieldInfoIcon (primitives.jsx) escapes overflow via ReactDOM.createPortal —
+// mirrors src/globals-install.ts's merge of react-dom/client + createPortal
+// onto one global.
+;(globalThis as unknown as { ReactDOM: unknown }).ReactDOM = { ...ReactDOMClient, createPortal }
+;(globalThis as unknown as { Icons: unknown }).Icons = new Proxy({}, { get: () => null })
+
+const { updateCalls, setDefaultCalls, setDefaultResult, slotsBox } = vi.hoisted(() => ({
+  updateCalls: [] as unknown[],
+  setDefaultCalls: [] as unknown[],
+  setDefaultResult: { current: { default: true, type: 'llm' } as Record<string, unknown> },
+  slotsBox: { current: [] as Record<string, unknown>[] },
+}))
+
+vi.mock('@/api/hooks/useModels', () => ({
+  useModelUpdate: () => ({
+    mutateAsync: async (b: unknown) => {
+      updateCalls.push(b)
+      return b
+    },
+    isPending: false,
+  }),
+  useModelSetDefault: () => ({
+    mutateAsync: async (b: unknown) => {
+      setDefaultCalls.push(b)
+      return setDefaultResult.current
+    },
+    isPending: false,
+  }),
+}))
+
+vi.mock('@/api/hooks/useModelSeedProfile', () => ({
+  useModelSeedProfile: () => ({ mutateAsync: async () => ({}), isPending: false }),
+}))
+
+vi.mock('@/api/hooks/useChatTemplates', () => ({
+  useChatTemplates: () => ({ data: [], isLoading: false }),
+}))
+
+vi.mock('@/api/hooks/useProfiles', () => ({
+  useProfiles: () => ({ data: [], isLoading: false }),
+}))
+
+// useMetaEnums resolves the static device taxonomy over the live payload; the
+// fallback is all this suite needs, and mocking it keeps the run off the
+// network (the real hook fires a fetch at localhost) — same idiom as
+// profiles.test.tsx.
+vi.mock('@/api/hooks/useMeta', async () => {
+  const actual = await vi.importActual<typeof import('@/api/hooks/useMeta')>('@/api/hooks/useMeta')
+  return { ...actual, useMeta: () => ({ data: undefined }), useMetaEnums: () => actual.resolveMetaEnums(undefined) }
+})
+
+vi.mock('@/api/hooks/useSlots', () => ({
+  useSlots: () => ({ data: slotsBox.current, isLoading: false }),
+}))
+
+await import('../primitives.jsx')
+const { ModelDrawer } = await import('../model-drawer.jsx')
+
+const MODEL = {
+  id: 'm1',
+  name: 'qwen',
+  type: 'llm',
+  quant: 'Q8_0',
+  size_bytes: 9771050700,
+  architecture: 'qwen3vl',
+  metadata: {
+    context_length: 131072,
+    sha256: 'a3f19c2e77bb4a8e9e6d5f4c3b2a19080706050403020100090807060504030',
+  },
+  capabilities: ['chat'],
+  defaults: {},
+}
+
+function mount(el: React.ReactElement) {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const root = createRoot(host)
+  act(() => {
+    root.render(React.createElement(QueryClientProvider, { client: qc }, el))
+  })
+  return { host, root }
+}
+
+// React installs a value tracker on a controlled input's `value` property, so
+// a plain `input.value = x` assignment is invisible to onChange (the tracker
+// sees no drift between "last known" and "current"). Going through the
+// prototype's native setter first — the standard RTL/React testing
+// workaround — is what actually exercises onChange here.
+const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+  window.HTMLInputElement.prototype,
+  'value',
+)!.set!
+function typeInto(input: HTMLInputElement, value: string) {
+  nativeInputValueSetter.call(input, value)
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+beforeEach(() => {
+  updateCalls.length = 0
+  setDefaultCalls.length = 0
+  setDefaultResult.current = { default: true, type: 'llm' }
+  slotsBox.current = []
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('ModelDrawer header (Task 3)', () => {
+  it('renders facts band cells and hides absent facts', () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    const facts = host.querySelector('[data-testid="model-facts"]') as HTMLElement
+    expect(facts).toBeTruthy()
+    expect(facts.textContent).toContain('Q8_0')
+    expect(facts.textContent).toContain('9.1 GB')
+    expect(facts.textContent).toContain('qwen3vl')
+    expect(facts.textContent).toContain('128K')
+    expect(facts.textContent).toContain('a3f19c2e')
+
+    act(() => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: new QueryClient({ defaultOptions: { queries: { retry: false } } }) },
+          React.createElement(ModelDrawer, {
+            open: true,
+            onClose: () => {},
+            model: { ...MODEL, metadata: {} },
+          }),
+        ),
+      )
+    })
+    const factsAfter = host.querySelector('[data-testid="model-facts"]') as HTMLElement
+    expect(factsAfter.textContent).not.toContain('128K')
+    expect(factsAfter.textContent).not.toContain('a3f19c2e')
+    act(() => root.unmount())
+  })
+
+  it('title edits inline; Escape reverts without committing', () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    const editBtn = host.querySelector('[data-testid="model-title-edit"]') as HTMLButtonElement
+    expect(editBtn).toBeTruthy()
+    act(() => editBtn.click())
+
+    const input = host.querySelector('[data-testid="model-title-input"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+    expect(input.value).toBe('qwen')
+
+    act(() => {
+      typeInto(input, 'x')
+    })
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      )
+    })
+
+    expect(host.querySelector('[data-testid="model-title-input"]')).toBeNull()
+    expect(host.textContent).toContain('qwen')
+    expect(host.textContent).not.toContain('qwenx')
+
+    const saveBtn = host.querySelector('[data-testid="model-save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    act(() => root.unmount())
+  })
+
+  it('Enter commits the new name into form state', () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    const editBtn = host.querySelector('[data-testid="model-title-edit"]') as HTMLButtonElement
+    act(() => editBtn.click())
+
+    const input = host.querySelector('[data-testid="model-title-input"]') as HTMLInputElement
+    act(() => {
+      typeInto(input, 'qwen2')
+    })
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+      )
+    })
+
+    expect(host.querySelector('[data-testid="model-title-input"]')).toBeNull()
+    expect(host.textContent).toContain('qwen2')
+
+    const saveBtn = host.querySelector('[data-testid="model-save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    act(() => root.unmount())
+  })
+
+  it('default chip toggles via useModelSetDefault', async () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    const toggle = host.querySelector('[data-testid="model-default-toggle"]') as HTMLButtonElement
+    expect(toggle).toBeTruthy()
+    expect(toggle.textContent).toBe('llm default')
+
+    setDefaultResult.current = { default: true, type: 'llm' }
+    await act(async () => {
+      toggle.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(setDefaultCalls).toEqual([{ id: 'm1', default: true }])
+    const toggleAfter = host.querySelector('[data-testid="model-default-toggle"]') as HTMLButtonElement
+    expect(toggleAfter.textContent).toBe('✓ llm default')
+    act(() => root.unmount())
+  })
+
+  it('used-by cell lists slot names from useSlots', () => {
+    slotsBox.current = [{ name: 'agent', model_default: 'm1' }]
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    const usedBy = host.querySelector('[data-testid="model-facts-usedby"]') as HTMLElement
+    expect(usedBy).toBeTruthy()
+    expect(usedBy.textContent).toContain('1 slot')
+    expect(usedBy.textContent).toContain('agent')
+    act(() => root.unmount())
+  })
+})

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -42,6 +42,22 @@ const { updateCalls, setDefaultCalls, setDefaultResult, slotsBox, profilesBox, t
   enumsBox: { current: undefined as Record<string, unknown> | undefined },
 }))
 
+// Task 9: the Source disclosure's lazy repo probe. `useModelInspect` is a
+// react-query MUTATION the drawer fires from an effect on the disclosure's
+// first open, so the stand-in is useState-backed (same reasoning as the
+// feasibility mock below) — `mutate()` must genuinely re-render the component
+// for the picker to appear. `inspectHandler.current` decides what a probe
+// resolves to; returning an Error models the route failing (→ the text-input
+// fallback), leaving it unset models a probe still in flight.
+const { inspectCalls, inspectHandler } = vi.hoisted(() => ({
+  inspectCalls: [] as unknown[],
+  inspectHandler: {
+    current: undefined as
+      | ((body: { hf_repo?: string }) => Record<string, unknown> | Error | undefined)
+      | undefined,
+  },
+}))
+
 vi.mock('@/api/hooks/useModels', () => ({
   useModelUpdate: () => ({
     mutateAsync: async (b: unknown) => {
@@ -57,6 +73,25 @@ vi.mock('@/api/hooks/useModels', () => ({
     },
     isPending: false,
   }),
+  useModelInspect: () => {
+    const [state, setState] = React.useState<{
+      data?: Record<string, unknown>
+      isError: boolean
+    }>({ isError: false })
+    return {
+      data: state.data,
+      isError: state.isError,
+      isSuccess: !!state.data,
+      isPending: false,
+      mutate: (body: { hf_repo?: string }) => {
+        inspectCalls.push(body)
+        const out = inspectHandler.current?.(body)
+        if (out instanceof Error) setState({ isError: true })
+        else if (out) setState({ data: out, isError: false })
+      },
+      reset: () => setState({ isError: false }),
+    }
+  },
 }))
 
 // Task 8: seedCalls records every seedProfile.mutateAsync invocation so a
@@ -203,6 +238,8 @@ beforeEach(() => {
   feasibilityHandler.current = undefined
   seedCalls.length = 0
   seedHandler.current = undefined
+  inspectCalls.length = 0
+  inspectHandler.current = undefined
 })
 
 afterEach(() => {
@@ -994,6 +1031,251 @@ describe('ModelDrawer seed consequence preview (Task 8, #2205)', () => {
     // the existing rule (fitProfiles, :762) keeps it offered regardless.
     expect(q(host, 'model-seed-profile-option-chat')).toBeTruthy()
     expect(q(host, 'model-seed-profile-option-kokoro')).toBeTruthy()
+    act(() => root.unmount())
+  })
+})
+
+// ─── Task 9 — Source disclosure + repo-fed mmproj picker ────────────────────
+// The Source rows (MMProj / HF repo / HF filename) live behind a disclosure
+// now, and MMProj is a RichSelect fed by POST /api/models/inspect whenever the
+// row carries an hf_repo the probe can list projectors for.
+//
+// THE STORED SHAPE (pinned by "picking a variant stores…" below): `model.mmproj`
+// is an ABSOLUTE host path, never a bare filename — see the mmprojDirOf comment
+// in model-drawer.jsx for the source citations. The picker therefore offers
+// repo FILENAMES but writes `<the model's directory>/<filename>`.
+describe('ModelDrawer source disclosure (Task 9)', () => {
+  const MODEL_DIR = '/var/lib/hal0/models/qwen'
+  const SOURCE_MODEL = {
+    ...MODEL,
+    path: `${MODEL_DIR}/qwen-q8.gguf`,
+    hf_repo: 'org/qwen-gguf',
+    hf_filename: 'qwen-q8.gguf',
+    mmproj: null,
+  }
+  const VARIANTS = [
+    { id: 'mmproj-Q8_0.gguf', size_bytes: 966367641, size: '0.9 GB', info: 'mmproj' },
+    { id: 'model-q8.gguf', size_bytes: 9771050700, size: '9.1 GB', info: 'weights' },
+  ]
+  const withVariants = () => {
+    inspectHandler.current = () => ({ repo: 'org/qwen-gguf', variants: VARIANTS })
+  }
+  const openSource = (host: HTMLElement) =>
+    act(() => q<HTMLElement>(host, 'model-source-disclosure').click())
+
+  it('source collapses to a disclosure; opens on click', () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: SOURCE_MODEL }),
+    )
+    const disc = q<HTMLElement>(host, 'model-source-disclosure')
+    expect(disc).toBeTruthy()
+    expect(disc.textContent).toContain('Source')
+    expect(disc.textContent).toContain('repo · file · mmproj · paths')
+    expect(disc.getAttribute('aria-expanded')).toBe('false')
+    // Collapsed: no source control is mounted, and no probe has fired.
+    expect(q(host, 'model-hfrepo-input')).toBeNull()
+    expect(q(host, 'model-hffile-input')).toBeNull()
+    expect(q(host, 'model-source-paths')).toBeNull()
+    expect(inspectCalls).toEqual([])
+
+    openSource(host)
+    expect(q<HTMLElement>(host, 'model-source-disclosure').getAttribute('aria-expanded')).toBe('true')
+    // The two coord inputs keep their testids and stay editable inside.
+    const repo = q<HTMLInputElement>(host, 'model-hfrepo-input')
+    const file = q<HTMLInputElement>(host, 'model-hffile-input')
+    expect(repo.value).toBe('org/qwen-gguf')
+    expect(file.value).toBe('qwen-q8.gguf')
+    act(() => typeInto(repo, 'org/other'))
+    expect(q<HTMLInputElement>(host, 'model-hfrepo-input').value).toBe('org/other')
+    act(() => root.unmount())
+  })
+
+  it('mmproj picker lists repo mmproj variants + none row', () => {
+    withVariants()
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: SOURCE_MODEL }),
+    )
+    openSource(host)
+    // Lazy: the probe fires on the disclosure's first open, not on mount.
+    expect(inspectCalls).toEqual([{ hf_repo: 'org/qwen-gguf' }])
+
+    const trigger = q<HTMLButtonElement>(host, 'model-mmproj-select')
+    expect(trigger).toBeTruthy()
+    // The picker replaces the free-text absolute-path input entirely.
+    expect(q(host, 'model-mmproj-input')).toBeNull()
+
+    act(() => trigger.click())
+    const none = host.querySelector('[data-option-id=""]') as HTMLElement
+    expect(none.textContent).toContain('— none —')
+    const pick = host.querySelector(
+      `[data-option-id="${MODEL_DIR}/mmproj-Q8_0.gguf"]`,
+    ) as HTMLElement
+    expect(pick).toBeTruthy()
+    expect(pick.textContent).toContain('mmproj-Q8_0.gguf')
+    expect(pick.textContent).toContain('0.9 GB')
+    // The repo's non-projector variant is not a projector choice.
+    expect(host.textContent).not.toContain('model-q8.gguf')
+    act(() => root.unmount())
+  })
+
+  it('picking a variant stores the absolute path under the model directory', async () => {
+    withVariants()
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: SOURCE_MODEL }),
+    )
+    openSource(host)
+    act(() => q<HTMLButtonElement>(host, 'model-mmproj-select').click())
+    act(() =>
+      (host.querySelector(`[data-option-id="${MODEL_DIR}/mmproj-Q8_0.gguf"]`) as HTMLElement).click(),
+    )
+
+    // The resolved path is what the paths block reads back…
+    expect(q<HTMLElement>(host, 'model-source-paths').textContent).toContain(
+      `${MODEL_DIR}/mmproj-Q8_0.gguf`,
+    )
+    // …and what the PUT carries — an absolute host path, never the filename.
+    const saveBtn = q<HTMLButtonElement>(host, 'model-save')
+    expect(saveBtn.disabled).toBe(false)
+    await act(async () => {
+      saveBtn.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    const call = updateCalls[0] as { body: { mmproj?: string | null } }
+    expect(call.body.mmproj).toBe(`${MODEL_DIR}/mmproj-Q8_0.gguf`)
+    act(() => root.unmount())
+  })
+
+  it('stored mmproj value missing from the listing renders as its own row', () => {
+    withVariants()
+    const stored = '/srv/projectors/mmproj-handpicked.gguf'
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, {
+        open: true,
+        onClose: () => {},
+        model: { ...SOURCE_MODEL, mmproj: stored },
+      }),
+    )
+    openSource(host)
+    const trigger = q<HTMLButtonElement>(host, 'model-mmproj-select')
+    // The closed control shows the stored value's own row — not a rewrite.
+    expect(trigger.textContent).toContain('mmproj-handpicked.gguf')
+
+    act(() => trigger.click())
+    const own = host.querySelector(`[data-option-id="${stored}"]`) as HTMLElement
+    expect(own).toBeTruthy()
+    expect(own.getAttribute('aria-selected')).toBe('true')
+    // The repo's own projector is offered beside it, resolved against the
+    // STORED projector's directory (it owns the pairing, not model.path).
+    expect(
+      host.querySelector('[data-option-id="/srv/projectors/mmproj-Q8_0.gguf"]'),
+    ).toBeTruthy()
+    // Nothing was saved: an untouched picker leaves the row unchanged.
+    expect(q<HTMLButtonElement>(host, 'model-save').disabled).toBe(true)
+    act(() => root.unmount())
+  })
+
+  it('picking none on a vision model keeps the save gate', () => {
+    withVariants()
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, {
+        open: true,
+        onClose: () => {},
+        model: {
+          ...SOURCE_MODEL,
+          capabilities: ['chat', 'vision'],
+          mmproj: `${MODEL_DIR}/mmproj-Q8_0.gguf`,
+        },
+      }),
+    )
+    openSource(host)
+    expect(q(host, 'model-mmproj-error')).toBeNull()
+
+    act(() => q<HTMLButtonElement>(host, 'model-mmproj-select').click())
+    act(() => (host.querySelector('[data-option-id=""]') as HTMLElement).click())
+
+    const err = q<HTMLElement>(host, 'model-mmproj-error')
+    expect(err).toBeTruthy()
+    expect(err.textContent).toContain('mmproj')
+    expect(q<HTMLButtonElement>(host, 'model-save').disabled).toBe(true)
+
+    // Re-pairing the projector releases the gate again.
+    act(() => q<HTMLButtonElement>(host, 'model-mmproj-select').click())
+    act(() =>
+      (host.querySelector(`[data-option-id="${MODEL_DIR}/mmproj-Q8_0.gguf"]`) as HTMLElement).click(),
+    )
+    expect(q(host, 'model-mmproj-error')).toBeNull()
+    act(() => root.unmount())
+  })
+
+  it('no hf_repo → text input fallback, and no probe fires', () => {
+    withVariants()
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, {
+        open: true,
+        onClose: () => {},
+        model: { ...SOURCE_MODEL, hf_repo: '' },
+      }),
+    )
+    openSource(host)
+    expect(inspectCalls).toEqual([])
+    expect(q(host, 'model-mmproj-select')).toBeNull()
+    const input = q<HTMLInputElement>(host, 'model-mmproj-input')
+    expect(input).toBeTruthy()
+    act(() => typeInto(input, '/srv/mmproj-typed.gguf'))
+    expect(q<HTMLInputElement>(host, 'model-mmproj-input').value).toBe('/srv/mmproj-typed.gguf')
+    act(() => root.unmount())
+  })
+
+  it('inspect failure → text input fallback', () => {
+    inspectHandler.current = () => new Error('inspect unreachable')
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: SOURCE_MODEL }),
+    )
+    openSource(host)
+    expect(inspectCalls).toEqual([{ hf_repo: 'org/qwen-gguf' }])
+    expect(q(host, 'model-mmproj-select')).toBeNull()
+    expect(q(host, 'model-mmproj-input')).toBeTruthy()
+    act(() => root.unmount())
+  })
+
+  it('a repo with no projector files falls back to the text input too', () => {
+    inspectHandler.current = () => ({ repo: 'org/qwen-gguf', variants: [VARIANTS[1]] })
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: SOURCE_MODEL }),
+    )
+    openSource(host)
+    expect(q(host, 'model-mmproj-select')).toBeNull()
+    expect(q(host, 'model-mmproj-input')).toBeTruthy()
+    act(() => root.unmount())
+  })
+
+  it('paths render read-only and copyable', () => {
+    const copied: string[] = []
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      value: { writeText: (t: string) => copied.push(t) },
+      configurable: true,
+    })
+    const stored = `${MODEL_DIR}/mmproj-Q8_0.gguf`
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, {
+        open: true,
+        onClose: () => {},
+        model: { ...SOURCE_MODEL, mmproj: stored },
+      }),
+    )
+    openSource(host)
+    const paths = q<HTMLElement>(host, 'model-source-paths')
+    expect(paths).toBeTruthy()
+    expect(paths.textContent).toContain(`${MODEL_DIR}/qwen-q8.gguf`)
+    expect(paths.textContent).toContain(stored)
+    // Read-only: the block holds no input/textarea at all.
+    expect(paths.querySelector('input')).toBeNull()
+    expect(paths.querySelector('textarea')).toBeNull()
+
+    act(() => q<HTMLButtonElement>(host, 'model-source-copy-path').click())
+    act(() => q<HTMLButtonElement>(host, 'model-source-copy-mmproj').click())
+    expect(copied).toEqual([`${MODEL_DIR}/qwen-q8.gguf`, stored])
     act(() => root.unmount())
   })
 })

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -1146,6 +1146,50 @@ describe('ModelDrawer source disclosure (Task 9)', () => {
     act(() => root.unmount())
   })
 
+  it('a variant nested in a repo subdirectory is basenamed onto the model directory', async () => {
+    // Inspect variant ids are repo-RELATIVE PATHS (huggingface.py:357 `"id": rel`,
+    // recursive tree walk), and nested projector/quant layouts are routine. The
+    // pull worker basenames before persisting (pull.py:1071), so joining the id
+    // verbatim would write a path no pull ever produces — and one that fails
+    // screen_vision_mmproj's on-disk check.
+    inspectHandler.current = () => ({
+      repo: 'org/qwen-gguf',
+      variants: [
+        {
+          id: 'UD-Q4_K_XL/mmproj-F16.gguf',
+          size_bytes: 644245094,
+          size: '0.6 GB',
+          info: 'mmproj sidecar',
+        },
+      ],
+    })
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: SOURCE_MODEL }),
+    )
+    openSource(host)
+    act(() => q<HTMLButtonElement>(host, 'model-mmproj-select').click())
+
+    // The row still shows the full repo-relative id (two projectors that
+    // flatten onto one filename stay distinguishable)…
+    const pick = host.querySelector(
+      `[data-option-id="${MODEL_DIR}/mmproj-F16.gguf"]`,
+    ) as HTMLElement
+    expect(pick).toBeTruthy()
+    expect(pick.textContent).toContain('UD-Q4_K_XL/mmproj-F16.gguf')
+    // …but the directory segment never reaches the stored value.
+    expect(host.querySelector(`[data-option-id="${MODEL_DIR}/UD-Q4_K_XL/mmproj-F16.gguf"]`)).toBeNull()
+
+    act(() => pick.click())
+    await act(async () => {
+      q<HTMLButtonElement>(host, 'model-save').click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    const call = updateCalls[0] as { body: { mmproj?: string | null } }
+    expect(call.body.mmproj).toBe(`${MODEL_DIR}/mmproj-F16.gguf`)
+    act(() => root.unmount())
+  })
+
   it('stored mmproj value missing from the listing renders as its own row', () => {
     withVariants()
     const stored = '/srv/projectors/mmproj-handpicked.gguf'
@@ -1171,6 +1215,19 @@ describe('ModelDrawer source disclosure (Task 9)', () => {
       host.querySelector('[data-option-id="/srv/projectors/mmproj-Q8_0.gguf"]'),
     ).toBeTruthy()
     // Nothing was saved: an untouched picker leaves the row unchanged.
+    expect(q<HTMLButtonElement>(host, 'model-save').disabled).toBe(true)
+
+    // The stored row survives a pick away from it — otherwise "— none —" is a
+    // one-way door and the only way back is closing the drawer, losing every
+    // other unsaved edit with it.
+    act(() => (host.querySelector('[data-option-id=""]') as HTMLElement).click())
+    act(() => q<HTMLButtonElement>(host, 'model-mmproj-select').click())
+    const again = host.querySelector(`[data-option-id="${stored}"]`) as HTMLElement
+    expect(again).toBeTruthy()
+    act(() => again.click())
+    expect(q<HTMLButtonElement>(host, 'model-mmproj-select').textContent).toContain(
+      'mmproj-handpicked.gguf',
+    )
     expect(q<HTMLButtonElement>(host, 'model-save').disabled).toBe(true)
     act(() => root.unmount())
   })
@@ -1276,6 +1333,47 @@ describe('ModelDrawer source disclosure (Task 9)', () => {
     act(() => q<HTMLButtonElement>(host, 'model-source-copy-path').click())
     act(() => q<HTMLButtonElement>(host, 'model-source-copy-mmproj').click())
     expect(copied).toEqual([`${MODEL_DIR}/qwen-q8.gguf`, stored])
+    act(() => root.unmount())
+  })
+
+  it('the mmproj path line flags an unsaved pick instead of implying on-disk truth', () => {
+    withVariants()
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: SOURCE_MODEL }),
+    )
+    openSource(host)
+    // Nothing picked yet: the line is a plain readback of the stored value.
+    expect(q<HTMLElement>(host, 'model-source-paths').textContent).not.toContain('unsaved')
+
+    act(() => q<HTMLButtonElement>(host, 'model-mmproj-select').click())
+    act(() =>
+      (host.querySelector(`[data-option-id="${MODEL_DIR}/mmproj-Q8_0.gguf"]`) as HTMLElement).click(),
+    )
+    const paths = q<HTMLElement>(host, 'model-source-paths')
+    expect(paths.textContent).toContain(`${MODEL_DIR}/mmproj-Q8_0.gguf`)
+    expect(paths.textContent).toContain('unsaved selection')
+    act(() => root.unmount())
+  })
+
+  it('a clipboard that throws reports the failure instead of a false success', () => {
+    const toasts: [string, string][] = []
+    ;(globalThis as unknown as { __hal0Toast: unknown }).__hal0Toast = (m: string, k: string) =>
+      toasts.push([m, k])
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      value: {
+        writeText: () => {
+          throw new Error('NotAllowedError')
+        },
+      },
+      configurable: true,
+    })
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: SOURCE_MODEL }),
+    )
+    openSource(host)
+    act(() => q<HTMLButtonElement>(host, 'model-source-copy-path').click())
+    expect(toasts).toEqual([['Copy failed — clipboard unavailable', 'err']])
+    delete (globalThis as unknown as { __hal0Toast?: unknown }).__hal0Toast
     act(() => root.unmount())
   })
 })

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -27,12 +27,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 ;(globalThis as unknown as { ReactDOM: unknown }).ReactDOM = { ...ReactDOMClient, createPortal }
 ;(globalThis as unknown as { Icons: unknown }).Icons = new Proxy({}, { get: () => null })
 
-const { updateCalls, setDefaultCalls, setDefaultResult, slotsBox, profilesBox } = vi.hoisted(() => ({
+const { updateCalls, setDefaultCalls, setDefaultResult, slotsBox, profilesBox, templatesBox } = vi.hoisted(() => ({
   updateCalls: [] as unknown[],
   setDefaultCalls: [] as unknown[],
   setDefaultResult: { current: { default: true, type: 'llm' } as Record<string, unknown> },
   slotsBox: { current: [] as Record<string, unknown>[] },
   profilesBox: { current: [] as Record<string, unknown>[] },
+  templatesBox: { current: [] as Record<string, unknown>[] },
 }))
 
 vi.mock('@/api/hooks/useModels', () => ({
@@ -57,7 +58,7 @@ vi.mock('@/api/hooks/useModelSeedProfile', () => ({
 }))
 
 vi.mock('@/api/hooks/useChatTemplates', () => ({
-  useChatTemplates: () => ({ data: [], isLoading: false }),
+  useChatTemplates: () => ({ data: templatesBox.current, isLoading: false }),
 }))
 
 vi.mock('@/api/hooks/useProfiles', () => ({
@@ -134,6 +135,7 @@ beforeEach(() => {
   setDefaultResult.current = { default: true, type: 'llm' }
   slotsBox.current = []
   profilesBox.current = []
+  templatesBox.current = []
 })
 
 afterEach(() => {
@@ -521,6 +523,58 @@ describe('ModelDrawer tune pills (Task 4)', () => {
     expect(ctk).toBeTruthy()
     expect(ctk.getAttribute('data-divergence')).toBe('added')
     expect(q(host, 'model-diverged-chip').textContent).toBe('◆ 3 diverged')
+    act(() => root.unmount())
+  })
+})
+
+// ─── Task 5 — chat template RichSelect ──────────────────────────────────────
+// useChatTemplates rows are {id, label, valid, error} (chat_templates.py's
+// _entry); a `valid: false` row carries the render-lint error string. The
+// native <select> became a RichSelect (rich-select.jsx) so a broken template
+// can chip its warning inline instead of hiding it behind a plain <option>
+// label.
+describe('ModelDrawer chat template (Task 5)', () => {
+  const TEMPLATES = [
+    { id: 'auto', label: 'Auto (GGUF embedded)', valid: true, error: null },
+    { id: 'broken', label: 'broken', valid: false, error: 'TemplateSyntaxError: x' },
+  ]
+
+  it('renders rich rows with lint chips', () => {
+    templatesBox.current = TEMPLATES
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    act(() => q<HTMLButtonElement>(host, 'model-chat-template').click())
+
+    const autoRow = host.querySelector('[data-option-id="auto"]') as HTMLElement
+    expect(autoRow.textContent).toContain('GGUF embedded')
+    expect(autoRow.textContent).toContain('use the template the model file ships')
+
+    const brokenRow = host.querySelector('[data-option-id="broken"]') as HTMLElement
+    expect(brokenRow.textContent).toContain('⚠ broken')
+    expect(brokenRow.textContent).toContain('TemplateSyntaxError: x')
+    act(() => root.unmount())
+  })
+
+  it('picking a template updates form state', async () => {
+    templatesBox.current = TEMPLATES
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    act(() => q<HTMLButtonElement>(host, 'model-chat-template').click())
+    act(() => (host.querySelector('[data-option-id="broken"]') as HTMLElement).click())
+
+    const saveBtn = q<HTMLButtonElement>(host, 'model-save')
+    expect(saveBtn.disabled).toBe(false)
+
+    await act(async () => {
+      saveBtn.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const call = updateCalls[0] as { id: string; body: { defaults: Record<string, unknown> } }
+    expect(call.body.defaults.chat_template).toBe('broken')
     act(() => root.unmount())
   })
 })

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -59,8 +59,30 @@ vi.mock('@/api/hooks/useModels', () => ({
   }),
 }))
 
+// Task 8: seedCalls records every seedProfile.mutateAsync invocation so a
+// test can assert the exact {id, profile} the confirm's onConfirm sent.
+// seedHandler.current lets one test simulate a rejection (the "failed seed
+// keeps the dialog open for retry" path) without touching every other test's
+// happy-path default (a response shaped like the real POST — echoes the
+// requested profile name as the new provenance/extra_args).
+const { seedCalls, seedHandler } = vi.hoisted(() => ({
+  seedCalls: [] as unknown[],
+  seedHandler: {
+    current: undefined as
+      | ((body: { id: string; profile: string }) => unknown)
+      | undefined,
+  },
+}))
+
 vi.mock('@/api/hooks/useModelSeedProfile', () => ({
-  useModelSeedProfile: () => ({ mutateAsync: async () => ({}), isPending: false }),
+  useModelSeedProfile: () => ({
+    mutateAsync: async (body: { id: string; profile: string }) => {
+      seedCalls.push(body)
+      if (seedHandler.current) return seedHandler.current(body)
+      return { defaults: { profile: body.profile, extra_args: '' } }
+    },
+    isPending: false,
+  }),
 }))
 
 vi.mock('@/api/hooks/useChatTemplates', () => ({
@@ -179,6 +201,8 @@ beforeEach(() => {
   enumsBox.current = undefined
   feasibilityCalls.length = 0
   feasibilityHandler.current = undefined
+  seedCalls.length = 0
+  seedHandler.current = undefined
 })
 
 afterEach(() => {
@@ -815,6 +839,161 @@ describe('ModelDrawer context intelligence (Task 7)', () => {
     })
     expect(q(host, 'model-ctx-feasibility').textContent).toBe(expected.text)
 
+    act(() => root.unmount())
+  })
+})
+
+// ─── Task 8 — seed consequence preview + provider-aware filter (#2205) ─────
+// EVERY profile pick now routes through the consequence preview confirm; the
+// old wouldClobber shortcut that skipped confirm when the current flags were
+// already empty/matching is gone. The preview IS the confirm's message.
+function confirmButton(host: HTMLElement, label: string) {
+  return Array.from(host.querySelectorAll('button')).find(
+    (b) => b.textContent === label,
+  ) as HTMLButtonElement | undefined
+}
+
+describe('ModelDrawer seed consequence preview (Task 8, #2205)', () => {
+  it('seed confirm shows the diff and restart consequence', async () => {
+    profilesBox.current = [
+      { name: 'brain', flags: '-fa auto --temp 0.2 --reasoning-budget 0' },
+    ]
+    slotsBox.current = [
+      { name: 'agent', model_default: 'm1' },
+      { name: 'brain', model_default: 'm1' },
+    ]
+    const model = {
+      ...MODEL,
+      defaults: { extra_args: '-fa auto --temp 0.4 --top-p 0.9' },
+    }
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model }),
+    )
+
+    act(() => q<HTMLButtonElement>(host, 'model-seed-profile-open').click())
+    act(() => q<HTMLButtonElement>(host, 'model-seed-profile-option-brain').click())
+
+    const preview = q(host, 'model-seed-preview')
+    expect(preview).toBeTruthy()
+    expect(preview.textContent).toContain('1 changed')
+    expect(preview.textContent).toContain('--temp 0.4→0.2')
+    expect(preview.textContent).toContain('1 added')
+    expect(preview.textContent).toContain('--reasoning-budget 0')
+    expect(preview.textContent).toContain('1 removed')
+    expect(preview.textContent).toContain('--top-p')
+    expect(preview.textContent).toContain('seeded from brain')
+    expect(preview.textContent).toContain('2 slots restart')
+    expect(preview.textContent).toContain('agent')
+    expect(preview.textContent).toContain('brain')
+
+    const confirmBtn = confirmButton(host, 'Stamp tune')
+    expect(confirmBtn).toBeTruthy()
+    await act(async () => {
+      confirmBtn!.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(seedCalls).toEqual([{ id: 'm1', profile: 'brain' }])
+    act(() => root.unmount())
+  })
+
+  it("no using slots → 'no slots currently load this model'", () => {
+    profilesBox.current = [{ name: 'brain', flags: '--temp 0.2' }]
+    slotsBox.current = []
+    const model = { ...MODEL, defaults: { extra_args: '--temp 0.4' } }
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model }),
+    )
+
+    act(() => q<HTMLButtonElement>(host, 'model-seed-profile-open').click())
+    act(() => q<HTMLButtonElement>(host, 'model-seed-profile-option-brain').click())
+
+    expect(q(host, 'model-seed-preview').textContent).toContain(
+      'no slots currently load this model',
+    )
+    act(() => root.unmount())
+  })
+
+  it('seed always previews — even from empty flags', () => {
+    profilesBox.current = [{ name: 'brain', flags: '--temp 0.2' }]
+    slotsBox.current = []
+    const model = { ...MODEL, defaults: { extra_args: '' } }
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model }),
+    )
+
+    act(() => q<HTMLButtonElement>(host, 'model-seed-profile-open').click())
+    act(() => q<HTMLButtonElement>(host, 'model-seed-profile-option-brain').click())
+
+    // Picking still opens the preview confirm — no direct doSeed POST fires
+    // before the operator hits "Stamp tune".
+    expect(q(host, 'model-seed-preview')).toBeTruthy()
+    expect(seedCalls).toEqual([])
+    act(() => root.unmount())
+  })
+
+  it('failed seed keeps the dialog open for retry', async () => {
+    profilesBox.current = [{ name: 'brain', flags: '--temp 0.2' }]
+    slotsBox.current = []
+    const model = { ...MODEL, defaults: { extra_args: '--temp 0.4' } }
+    seedHandler.current = () => {
+      throw new Error('network blip')
+    }
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model }),
+    )
+
+    act(() => q<HTMLButtonElement>(host, 'model-seed-profile-open').click())
+    act(() => q<HTMLButtonElement>(host, 'model-seed-profile-option-brain').click())
+
+    const confirmBtn = confirmButton(host, 'Stamp tune')
+    await act(async () => {
+      confirmBtn!.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // The confirm dialog is still up for a retry — the preview box is proof.
+    expect(q(host, 'model-seed-preview')).toBeTruthy()
+    act(() => root.unmount())
+  })
+
+  it('profile menu is provider-aware (#2205)', () => {
+    profilesBox.current = [
+      { name: 'chat', flags: '--temp 0.7', runtime_family: 'llama-server' },
+      { name: 'kokoro', flags: '--voice en', runtime_family: 'kokoro' },
+    ]
+    const model = { ...MODEL, provider_effective: 'kokoro', defaults: {} }
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model }),
+    )
+
+    act(() => q<HTMLButtonElement>(host, 'model-seed-profile-open').click())
+    expect(q(host, 'model-seed-profile-option-kokoro')).toBeTruthy()
+    expect(host.querySelector('[data-testid="model-seed-profile-option-chat"]')).toBeNull()
+    act(() => root.unmount())
+  })
+
+  it('provider filter keeps the current provenance profile even if unfitting', () => {
+    profilesBox.current = [
+      { name: 'chat', flags: '--temp 0.7', runtime_family: 'llama-server' },
+      { name: 'kokoro', flags: '--voice en', runtime_family: 'kokoro' },
+    ]
+    const model = {
+      ...MODEL,
+      provider_effective: 'kokoro',
+      defaults: { extra_args: '--temp 0.7', profile: 'chat' },
+    }
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model }),
+    )
+
+    act(() => q<HTMLButtonElement>(host, 'model-seed-profile-open').click())
+    // "chat" doesn't fit kokoro's provider, but it's the current provenance —
+    // the existing rule (fitProfiles, :762) keeps it offered regardless.
+    expect(q(host, 'model-seed-profile-option-chat')).toBeTruthy()
+    expect(q(host, 'model-seed-profile-option-kokoro')).toBeTruthy()
     act(() => root.unmount())
   })
 })

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -1390,28 +1390,18 @@ describe('footer summary', () => {
     act(() => root.unmount())
   })
 
-  it('staged changes → summary with field names and slot restart info', async () => {
+  it('staged changes → summary with field names and slot restart info', () => {
     slotsBox.current = [{ name: 'agent', model_default: 'm1' }, { name: 'brain', model_default: 'm2', model: 'm1' }]
     const { host, root } = mount(
       React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
     )
-    // Edit extra (flags) and ctx (context)
-    act(() => {
-      const extraInput = q<HTMLTextAreaElement>(host, 'model-extra-input')
-      extraInput.value = '--some-flag'
-      extraInput.dispatchEvent(new Event('change', { bubbles: true }))
-      extraInput.dispatchEvent(new Event('input', { bubbles: true }))
-    })
-    act(() => {
-      const ctxInput = q<HTMLInputElement>(host, 'model-ctx-input')
-      ctxInput.value = '12000'
-      ctxInput.dispatchEvent(new Event('change', { bubbles: true }))
-    })
-    await new Promise((r) => setTimeout(r, 10))
+    // Edit ctx (context) — a staged change with 2 slots using this model
+    const ctxInput = q<HTMLInputElement>(host, 'model-ctx-input')
+    act(() => typeInto(ctxInput, '12000'))
+
     const footer = q<HTMLElement>(host, 'model-foot-summary')
     expect(footer).toBeTruthy()
-    expect(footer.textContent).toContain('2 changes')
-    expect(footer.textContent).toContain('flags')
+    expect(footer.textContent).toContain('1 changes')
     expect(footer.textContent).toContain('context')
     expect(footer.textContent).toContain('restarts 2 slots')
     expect(footer.textContent).toContain('agent')
@@ -1419,22 +1409,18 @@ describe('footer summary', () => {
     act(() => root.unmount())
   })
 
-  it('zero using slots → restart clause omitted', async () => {
+  it('zero using slots → restart clause omitted', () => {
     const { host, root } = mount(
       React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
     )
-    // Edit extra (flags)
-    act(() => {
-      const extraInput = q<HTMLTextAreaElement>(host, 'model-extra-input')
-      extraInput.value = '--some-flag'
-      extraInput.dispatchEvent(new Event('change', { bubbles: true }))
-      extraInput.dispatchEvent(new Event('input', { bubbles: true }))
-    })
-    await new Promise((r) => setTimeout(r, 10))
+    // Edit ctx (context) with no slots using this model
+    const ctxInput = q<HTMLInputElement>(host, 'model-ctx-input')
+    act(() => typeInto(ctxInput, '12000'))
+
     const footer = q<HTMLElement>(host, 'model-foot-summary')
     expect(footer).toBeTruthy()
     expect(footer.textContent).toContain('1 changes')
-    expect(footer.textContent).toContain('flags')
+    expect(footer.textContent).toContain('context')
     expect(footer.textContent).not.toContain('restarts')
     act(() => root.unmount())
   })

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -1377,3 +1377,65 @@ describe('ModelDrawer source disclosure (Task 9)', () => {
     act(() => root.unmount())
   })
 })
+
+// ─── Task 10 — live staged footer ───────────────────────────────────────────
+describe('footer summary', () => {
+  it('clean drawer → "no changes"', () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    const footer = q<HTMLElement>(host, 'model-foot-summary')
+    expect(footer).toBeTruthy()
+    expect(footer.textContent).toBe('no changes')
+    act(() => root.unmount())
+  })
+
+  it('staged changes → summary with field names and slot restart info', async () => {
+    slotsBox.current = [{ name: 'agent', model_default: 'm1' }, { name: 'brain', model_default: 'm2', model: 'm1' }]
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    // Edit extra (flags) and ctx (context)
+    act(() => {
+      const extraInput = q<HTMLTextAreaElement>(host, 'model-extra-input')
+      extraInput.value = '--some-flag'
+      extraInput.dispatchEvent(new Event('change', { bubbles: true }))
+      extraInput.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    act(() => {
+      const ctxInput = q<HTMLInputElement>(host, 'model-ctx-input')
+      ctxInput.value = '12000'
+      ctxInput.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    await new Promise((r) => setTimeout(r, 10))
+    const footer = q<HTMLElement>(host, 'model-foot-summary')
+    expect(footer).toBeTruthy()
+    expect(footer.textContent).toContain('2 changes')
+    expect(footer.textContent).toContain('flags')
+    expect(footer.textContent).toContain('context')
+    expect(footer.textContent).toContain('restarts 2 slots')
+    expect(footer.textContent).toContain('agent')
+    expect(footer.textContent).toContain('brain')
+    act(() => root.unmount())
+  })
+
+  it('zero using slots → restart clause omitted', async () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    // Edit extra (flags)
+    act(() => {
+      const extraInput = q<HTMLTextAreaElement>(host, 'model-extra-input')
+      extraInput.value = '--some-flag'
+      extraInput.dispatchEvent(new Event('change', { bubbles: true }))
+      extraInput.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await new Promise((r) => setTimeout(r, 10))
+    const footer = q<HTMLElement>(host, 'model-foot-summary')
+    expect(footer).toBeTruthy()
+    expect(footer.textContent).toContain('1 changes')
+    expect(footer.textContent).toContain('flags')
+    expect(footer.textContent).not.toContain('restarts')
+    act(() => root.unmount())
+  })
+})

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -411,6 +411,61 @@ describe('ModelDrawer tune pills (Task 4)', () => {
     act(() => root.unmount())
   })
 
+  // Repeating a flag is legitimate llama-server usage (-ot / --override-kv /
+  // --lora). A canon alone does not identify a pill, so every affordance
+  // carries the pill's occurrence index — without it, ✕ on the second pill
+  // removed the first and the popover edited the wrong pair.
+  describe('repeated flags address their own pill', () => {
+    const REPEATED = {
+      ...MODEL,
+      defaults: { extra_args: '-ot ffn=CPU -ot attn=GPU --temp 0.4' },
+    }
+
+    it('removing the second occurrence leaves the first intact', () => {
+      const { host, root } = mount(
+        React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: REPEATED }),
+      )
+      // Occurrence 0 keeps the plain testid; the repeat earns a 1-based suffix.
+      expect(q(host, 'model-tune-pill--ot')).toBeTruthy()
+      expect(q(host, 'model-tune-pill--ot-2')).toBeTruthy()
+
+      act(() => q<HTMLButtonElement>(host, 'model-tune-pill-remove--ot-2').click())
+      expect(rawFlags(host)).toBe('-ot ffn=CPU --temp 0.4')
+      expect(q(host, 'model-tune-pill--ot-2')).toBeNull()
+      act(() => root.unmount())
+    })
+
+    it('editing the second occurrence edits the second', () => {
+      const { host, root } = mount(
+        React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: REPEATED }),
+      )
+      act(() => q<HTMLButtonElement>(host, 'model-tune-pill-value--ot-2').click())
+      const input = q<HTMLInputElement>(host, 'model-tune-value-input')
+      expect(input.value).toBe('attn=GPU')
+      act(() => typeInto(input, 'attn=CPU'))
+      press(input, 'Enter')
+      expect(rawFlags(host)).toBe('-ot ffn=CPU -ot attn=CPU --temp 0.4')
+      act(() => root.unmount())
+    })
+
+    it('only one value input is open at a time', () => {
+      const { host, root } = mount(
+        React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: REPEATED }),
+      )
+      act(() => q<HTMLButtonElement>(host, 'model-tune-pill-value--ot').click())
+      expect(host.querySelectorAll('[data-testid="model-tune-value-input"]').length).toBe(1)
+
+      // Opening the sibling pill's popover moves it, never duplicates it.
+      act(() => q<HTMLButtonElement>(host, 'model-tune-pill-value--ot-2').click())
+      const open = host.querySelectorAll(
+        '[data-testid="model-tune-value-input"]',
+      ) as NodeListOf<HTMLInputElement>
+      expect(open.length).toBe(1)
+      expect(open[0].value).toBe('attn=GPU')
+      act(() => root.unmount())
+    })
+  })
+
   it('unparseable text forces raw mode', () => {
     profilesBox.current = [CHAT_PROFILE]
     const { host, root } = mount(

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -27,13 +27,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 ;(globalThis as unknown as { ReactDOM: unknown }).ReactDOM = { ...ReactDOMClient, createPortal }
 ;(globalThis as unknown as { Icons: unknown }).Icons = new Proxy({}, { get: () => null })
 
-const { updateCalls, setDefaultCalls, setDefaultResult, slotsBox, profilesBox, templatesBox } = vi.hoisted(() => ({
+const { updateCalls, setDefaultCalls, setDefaultResult, slotsBox, profilesBox, templatesBox, enumsBox } = vi.hoisted(() => ({
   updateCalls: [] as unknown[],
   setDefaultCalls: [] as unknown[],
   setDefaultResult: { current: { default: true, type: 'llm' } as Record<string, unknown> },
   slotsBox: { current: [] as Record<string, unknown>[] },
   profilesBox: { current: [] as Record<string, unknown>[] },
   templatesBox: { current: [] as Record<string, unknown>[] },
+  // Task 6: override hook for the one engine test that needs a
+  // runtime_families entry ENGINE_BLURBS doesn't know about — every other
+  // test leaves this undefined so useMetaEnums keeps resolving the same
+  // fallback table it always has.
+  enumsBox: { current: undefined as Record<string, unknown> | undefined },
 }))
 
 vi.mock('@/api/hooks/useModels', () => ({
@@ -71,7 +76,11 @@ vi.mock('@/api/hooks/useProfiles', () => ({
 // profiles.test.tsx.
 vi.mock('@/api/hooks/useMeta', async () => {
   const actual = await vi.importActual<typeof import('@/api/hooks/useMeta')>('@/api/hooks/useMeta')
-  return { ...actual, useMeta: () => ({ data: undefined }), useMetaEnums: () => actual.resolveMetaEnums(undefined) }
+  return {
+    ...actual,
+    useMeta: () => ({ data: undefined }),
+    useMetaEnums: () => actual.resolveMetaEnums(enumsBox.current),
+  }
 })
 
 vi.mock('@/api/hooks/useSlots', () => ({
@@ -136,6 +145,7 @@ beforeEach(() => {
   slotsBox.current = []
   profilesBox.current = []
   templatesBox.current = []
+  enumsBox.current = undefined
 })
 
 afterEach(() => {
@@ -575,6 +585,122 @@ describe('ModelDrawer chat template (Task 5)', () => {
 
     const call = updateCalls[0] as { id: string; body: { defaults: Record<string, unknown> } }
     expect(call.body.defaults.chat_template).toBe('broken')
+    act(() => root.unmount())
+  })
+})
+
+// ─── Task 6 — engine RichSelect ──────────────────────────────────────────────
+// The Engine select (Runner compatibility) was a native <select> keyed off
+// enums.runtime_families; families still come ONLY from that enum (never
+// hand-listed), but the native <select> becomes a RichSelect so the Auto row
+// can preview the server-derived engine (model.provider_effective) instead of
+// a bare "derive from tags" label, and each family row can carry a blurb.
+describe('ModelDrawer engine (Task 6)', () => {
+  it('engine renders rich rows; Auto previews the derived engine', () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, {
+        open: true,
+        onClose: () => {},
+        model: { ...MODEL, provider: '', provider_effective: 'llama-server' },
+      }),
+    )
+    const trigger = q<HTMLButtonElement>(host, 'model-provider-select')
+    // Closed control: "Auto → llama-server".
+    expect(trigger.textContent).toContain('Auto')
+    expect(trigger.textContent).toContain('llama-server')
+
+    act(() => trigger.click())
+
+    const autoRow = host.querySelector('[data-option-id=""]') as HTMLElement
+    expect(autoRow).toBeTruthy()
+    expect(autoRow.textContent).toContain('derived')
+
+    // Every family from enums.runtime_families renders, each with its blurb.
+    const blurbs: Record<string, string> = {
+      'llama-server': 'the default engine',
+      flm: 'FastLLM',
+      kokoro: 'TTS voices',
+      qwen3tts: 'Qwen',
+      moonshine: 'streaming ASR',
+      comfyui: 'ComfyUI catalog',
+    }
+    for (const [rf, snippet] of Object.entries(blurbs)) {
+      const row = host.querySelector(`[data-option-id="${rf}"]`) as HTMLElement
+      expect(row, `missing row for ${rf}`).toBeTruthy()
+      expect(row.textContent).toContain(snippet)
+    }
+    act(() => root.unmount())
+  })
+
+  it('a runtime family absent from ENGINE_BLURBS still renders, with no desc', () => {
+    enumsBox.current = { runtime_families: ['llama-server', 'newfamily'] }
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, {
+        open: true,
+        onClose: () => {},
+        model: { ...MODEL, provider: '', provider_effective: 'llama-server' },
+      }),
+    )
+    act(() => q<HTMLButtonElement>(host, 'model-provider-select').click())
+    const row = host.querySelector('[data-option-id="newfamily"]') as HTMLElement
+    expect(row).toBeTruthy()
+    expect(row.querySelector('.rsel-option-desc')).toBeNull()
+    act(() => root.unmount())
+  })
+
+  it('falls back to llama-server when a mock fixture lacks provider_effective', () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: MODEL }),
+    )
+    const trigger = q<HTMLButtonElement>(host, 'model-provider-select')
+    expect(trigger.textContent).toContain('llama-server')
+    act(() => root.unmount())
+  })
+
+  it('picking an engine ships provider in the save body', async () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, {
+        open: true,
+        onClose: () => {},
+        model: { ...MODEL, provider: '', provider_effective: 'llama-server' },
+      }),
+    )
+    act(() => q<HTMLButtonElement>(host, 'model-provider-select').click())
+    act(() => (host.querySelector('[data-option-id="flm"]') as HTMLElement).click())
+
+    const saveBtn = q<HTMLButtonElement>(host, 'model-save')
+    expect(saveBtn.disabled).toBe(false)
+    await act(async () => {
+      saveBtn.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const call = updateCalls[0] as { id: string; body: { provider?: string | null } }
+    expect(call.body.provider).toBe('flm')
+    act(() => root.unmount())
+  })
+
+  it('picking Auto on a changed row ships provider: null', async () => {
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, {
+        open: true,
+        onClose: () => {},
+        model: { ...MODEL, provider: 'flm', provider_effective: 'flm' },
+      }),
+    )
+    act(() => q<HTMLButtonElement>(host, 'model-provider-select').click())
+    act(() => (host.querySelector('[data-option-id=""]') as HTMLElement).click())
+
+    const saveBtn = q<HTMLButtonElement>(host, 'model-save')
+    await act(async () => {
+      saveBtn.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const call = updateCalls[0] as { id: string; body: { provider?: string | null } }
+    expect(call.body.provider).toBeNull()
     act(() => root.unmount())
   })
 })

--- a/ui/src/dash/__tests__/model-usage.test.ts
+++ b/ui/src/dash/__tests__/model-usage.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { slotsUsingModel } from '../model-usage.js'
+
+describe('slotsUsingModel', () => {
+  it('matches by model_default or live model, dedupes, preserves order', () => {
+    const slots = [
+      { name: 'agent', model_default: 'm1', model: 'm1' },
+      { name: 'brain', model_default: 'm2', model: 'm1' },
+      { name: 'tts', model_default: 'm3', model: null },
+    ]
+    expect(slotsUsingModel(slots, 'm1')).toEqual([{ name: 'agent' }, { name: 'brain' }])
+    expect(slotsUsingModel(slots, 'm4')).toEqual([])
+    expect(slotsUsingModel(undefined, 'm1')).toEqual([])
+  })
+})

--- a/ui/src/dash/__tests__/model-usage.test.ts
+++ b/ui/src/dash/__tests__/model-usage.test.ts
@@ -96,7 +96,7 @@ describe('footSummary', () => {
       any: true,
     }
     const usingSlots = [{ name: 'agent' }]
-    expect(footSummary(changes, usingSlots)).toBe('1 changes — source ⟳ restarts 1 slots: agent')
+    expect(footSummary(changes, usingSlots)).toBe('1 change — source ⟳ restarts 1 slot: agent')
   })
 
   it('override fields (mtp/thinking/jinja/vision) dedupe to one display name', () => {
@@ -117,6 +117,6 @@ describe('footSummary', () => {
       any: true,
     }
     const usingSlots = [{ name: 'agent' }]
-    expect(footSummary(changes, usingSlots)).toBe('1 changes — overrides ⟳ restarts 1 slots: agent')
+    expect(footSummary(changes, usingSlots)).toBe('1 change — overrides ⟳ restarts 1 slot: agent')
   })
 })

--- a/ui/src/dash/__tests__/model-usage.test.ts
+++ b/ui/src/dash/__tests__/model-usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { slotsUsingModel } from '../model-usage.js'
+import { slotsUsingModel, footSummary } from '../model-usage.js'
 
 describe('slotsUsingModel', () => {
   it('matches by model_default or live model, dedupes, preserves order', () => {
@@ -11,5 +11,112 @@ describe('slotsUsingModel', () => {
     expect(slotsUsingModel(slots, 'm1')).toEqual([{ name: 'agent' }, { name: 'brain' }])
     expect(slotsUsingModel(slots, 'm4')).toEqual([])
     expect(slotsUsingModel(undefined, 'm1')).toEqual([])
+  })
+})
+
+describe('footSummary', () => {
+  it("clean drawer → dim 'no changes'", () => {
+    const changes = {
+      name: false,
+      provider: false,
+      mmproj: false,
+      hfRepo: false,
+      hfFilename: false,
+      extra: false,
+      profile: false,
+      ctx: false,
+      chatTemplate: false,
+      mtp: false,
+      thinking: false,
+      jinja: false,
+      vision: false,
+      any: false,
+    }
+    const usingSlots = [{ name: 'agent' }]
+    expect(footSummary(changes, usingSlots)).toBe('no changes')
+  })
+
+  it('staged changes → counted summary with field names and restart set', () => {
+    const changes = {
+      name: false,
+      provider: false,
+      mmproj: false,
+      hfRepo: false,
+      hfFilename: false,
+      extra: true,
+      profile: false,
+      ctx: true,
+      chatTemplate: false,
+      mtp: false,
+      thinking: false,
+      jinja: false,
+      vision: false,
+      any: true,
+    }
+    const usingSlots = [{ name: 'agent' }, { name: 'brain' }]
+    expect(footSummary(changes, usingSlots)).toBe('2 changes — flags · context ⟳ restarts 2 slots: agent · brain')
+  })
+
+  it('zero using slots → restart clause omitted', () => {
+    const changes = {
+      name: false,
+      provider: false,
+      mmproj: false,
+      hfRepo: false,
+      hfFilename: false,
+      extra: true,
+      profile: false,
+      ctx: true,
+      chatTemplate: false,
+      mtp: false,
+      thinking: false,
+      jinja: false,
+      vision: false,
+      any: true,
+    }
+    const usingSlots: { name: string }[] = []
+    expect(footSummary(changes, usingSlots)).toBe('2 changes — flags · context')
+  })
+
+  it('source fields (hfRepo/hfFilename) dedupe to one display name', () => {
+    const changes = {
+      name: false,
+      provider: false,
+      mmproj: false,
+      hfRepo: true,
+      hfFilename: true,
+      extra: false,
+      profile: false,
+      ctx: false,
+      chatTemplate: false,
+      mtp: false,
+      thinking: false,
+      jinja: false,
+      vision: false,
+      any: true,
+    }
+    const usingSlots = [{ name: 'agent' }]
+    expect(footSummary(changes, usingSlots)).toBe('1 changes — source ⟳ restarts 1 slots: agent')
+  })
+
+  it('override fields (mtp/thinking/jinja/vision) dedupe to one display name', () => {
+    const changes = {
+      name: false,
+      provider: false,
+      mmproj: false,
+      hfRepo: false,
+      hfFilename: false,
+      extra: false,
+      profile: false,
+      ctx: false,
+      chatTemplate: false,
+      mtp: true,
+      thinking: true,
+      jinja: false,
+      vision: true,
+      any: true,
+    }
+    const usingSlots = [{ name: 'agent' }]
+    expect(footSummary(changes, usingSlots)).toBe('1 changes — overrides ⟳ restarts 1 slots: agent')
   })
 })

--- a/ui/src/dash/__tests__/rich-select-core.test.ts
+++ b/ui/src/dash/__tests__/rich-select-core.test.ts
@@ -173,6 +173,20 @@ describe('handleKey', () => {
     expect(handleKey('a', { open: true, activeId: 'c' }, OPTIONS, 'a')).toEqual({ kind: 'none' })
     expect(handleKey('Escape', { open: false, activeId: 'c' }, OPTIONS, 'a')).toEqual({ kind: 'none' })
   })
+
+  // #2204: Home/End used to be wired only for the OPEN branch, so a keyboard
+  // user landed on the closed trigger got no jump-to-first/last — mirrors
+  // ArrowDown/ArrowUp's existing "opens the closed list" behaviour instead of
+  // being a silent no-op.
+  it('Home on a closed list opens it, activating the first enabled option', () => {
+    const outcome = handleKey('Home', { open: false, activeId: 'c' }, OPTIONS, 'c')
+    expect(outcome).toEqual({ kind: 'state', state: { open: true, activeId: 'a' } })
+  })
+
+  it('End on a closed list opens it, activating the last enabled option', () => {
+    const outcome = handleKey('End', { open: false, activeId: 'c' }, OPTIONS, 'c')
+    expect(outcome).toEqual({ kind: 'state', state: { open: true, activeId: 'e' } })
+  })
 })
 
 describe('activeDescendantId / optionDomId', () => {

--- a/ui/src/dash/__tests__/rich-select.test.tsx
+++ b/ui/src/dash/__tests__/rich-select.test.tsx
@@ -86,3 +86,28 @@ describe('RichSelect trigger passthrough', () => {
     expect(trigger.hasAttribute('aria-label')).toBe(false)
   })
 })
+
+// #2204: aria-controls used to name the listbox id unconditionally, even
+// while closed and not rendered — pointing assistive tech at a nonexistent
+// element. It should only be present once the listbox actually exists.
+describe('RichSelect aria-controls', () => {
+  it('omits aria-controls while closed (the listbox is not rendered)', () => {
+    const el = mount(
+      <RichSelect data-testid="probe" value="a" options={OPTIONS} onChange={() => {}} />,
+    )
+    const trigger = el.querySelector('[data-testid="probe"]') as HTMLButtonElement
+    expect(trigger.hasAttribute('aria-controls')).toBe(false)
+  })
+
+  it('sets aria-controls to the listbox id once open', () => {
+    const el = mount(
+      <RichSelect data-testid="probe" value="a" options={OPTIONS} onChange={() => {}} />,
+    )
+    const trigger = el.querySelector('[data-testid="probe"]') as HTMLButtonElement
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(trigger.getAttribute('aria-controls')).toBe('probe-listbox')
+    expect(el.querySelector('#probe-listbox')).not.toBeNull()
+  })
+})

--- a/ui/src/dash/flags-tune.js
+++ b/ui/src/dash/flags-tune.js
@@ -89,7 +89,7 @@ export function findNewSlotHardwareFlags(text, storedText = "") {
 // Where each managed flag is actually controlled from — surfaced in the inline
 // rejection so the operator knows why it's off-limits and where to set it.
 export const MANAGED_FLAG_SOURCE = {
-  "--model": "the model's on-disk path (Source · re-pull coords)",
+  "--model": "the model's on-disk path (Source — repo · file · mmproj · paths)",
   "--ctx-size": "the context_size field",
   "--host": "the server bind host (authority-owned)",
   "--port": "PortAuthority (shown read-only on the slot)",

--- a/ui/src/dash/flags-tune.js
+++ b/ui/src/dash/flags-tune.js
@@ -330,20 +330,42 @@ export function groupFlagPairs(text) {
 }
 
 // Split raw flag text into an alternating sequence of whitespace-run and
-// non-whitespace-run segments (mirrors highlightSegments's tokenisation).
-// Unlike tokenizeFlags this is NOT quote-aware — the splice helpers below
-// accept that a quoted value's spacing may get normalized when re-spliced
-// (documented on spliceFlagValue/removeFlagFromText) in exchange for editing
-// the original string segment-wise so every OTHER token's spelling and
-// spacing survives untouched.
+// token segments, quote-aware like tokenizeFlags: a `'...'`/`"..."` run keeps
+// its enclosing quotes and any embedded whitespace as ONE segment, so a
+// `--chat-template-kwargs '{"enable_thinking":false}'`- or `--alias "a b"`-
+// style value round-trips as a single unit instead of being torn into
+// fragments that corrupt everything after them. The segment's `text` keeps
+// the raw quote characters verbatim — callers that replace a segment's text
+// (spliceFlagValue) intentionally drop them, since the replacement value is
+// inserted unquoted.
 function rawSegments(text) {
   const s = String(text || "");
   const segs = [];
-  const re = /(\s+)|(\S+)/g;
-  let m;
-  while ((m = re.exec(s)) !== null) {
-    if (m[1] != null) segs.push({ text: m[1], word: false });
-    else segs.push({ text: m[2], word: true });
+  const n = s.length;
+  let i = 0;
+  while (i < n) {
+    if (/\s/.test(s[i])) {
+      let j = i;
+      while (j < n && /\s/.test(s[j])) j += 1;
+      segs.push({ text: s.slice(i, j), word: false });
+      i = j;
+      continue;
+    }
+    let j = i;
+    let quote = null;
+    while (j < n) {
+      const ch = s[j];
+      if (quote) {
+        j += 1;
+        if (ch === quote) quote = null;
+        continue;
+      }
+      if (ch === '"' || ch === "'") { quote = ch; j += 1; continue; }
+      if (/\s/.test(ch)) break;
+      j += 1;
+    }
+    segs.push({ text: s.slice(i, j), word: true });
+    i = j;
   }
   return segs;
 }

--- a/ui/src/dash/flags-tune.js
+++ b/ui/src/dash/flags-tune.js
@@ -375,18 +375,29 @@ function rawSegments(text) {
 // token and its value token (null when the flag carries no value, i.e. the
 // next word is itself a flag or there is no next word). Returns null when no
 // pair matches.
-function findFlagPairSegIndices(segs, canon) {
+//
+// `occurrence` selects WHICH match, counted in text order from 0. Repeating a
+// flag is legitimate llama-server usage — `-ot ffn=CPU -ot attn=GPU`, and the
+// same for --override-kv / --lora — so "the pair for this canon" is not a
+// unique thing, and a caller editing the second one has to be able to say so.
+// The walk enumerates pairs exactly as flagPairs does (a flag consumes the
+// next token iff that token isn't itself a flag), so the n-th pair here is the
+// n-th pair there.
+function findFlagPairSegIndices(segs, canon, occurrence = 0) {
   const wordIdx = [];
   segs.forEach((seg, i) => { if (seg.word) wordIdx.push(i); });
+  let seen = 0;
   for (let k = 0; k < wordIdx.length; k += 1) {
     const flagIdx = wordIdx[k];
     const tok = segs[flagIdx].text;
     if (!isFlagToken(tok) || canonFlag(tok) !== canon) continue;
     const next = wordIdx[k + 1];
-    if (next != null && !isFlagToken(segs[next].text)) {
-      return { flagIdx, valueIdx: next };
-    }
-    return { flagIdx, valueIdx: null };
+    const hit =
+      next != null && !isFlagToken(segs[next].text)
+        ? { flagIdx, valueIdx: next }
+        : { flagIdx, valueIdx: null };
+    if (seen === occurrence) return hit;
+    seen += 1;
   }
   return null;
 }
@@ -396,10 +407,14 @@ function findFlagPairSegIndices(segs, canon) {
 // and every other token's surrounding whitespace verbatim. A no-op (returns
 // `text` unchanged) when no pair matches canon, or the matched flag carries no
 // value token to replace.
-export function spliceFlagValue(text, canon, nextValue) {
+//
+// `occurrence` picks which repetition of `canon` to edit (0 = the first, the
+// default). Anything holding a per-pair identity — the drawer's tune pills —
+// must pass it, or a text carrying the same flag twice edits the wrong one.
+export function spliceFlagValue(text, canon, nextValue, occurrence = 0) {
   const s = String(text || "");
   const segs = rawSegments(s);
-  const found = findFlagPairSegIndices(segs, canon);
+  const found = findFlagPairSegIndices(segs, canon, occurrence);
   if (!found || found.valueIdx == null) return s;
   segs[found.valueIdx] = { text: String(nextValue), word: true };
   return segs.map((seg) => seg.text).join("");
@@ -409,10 +424,13 @@ export function spliceFlagValue(text, canon, nextValue) {
 // flag) for the pair whose canonFlag(flag) === canon, collapsing the
 // resulting double space so the surrounding tokens read as if the pair had
 // never been there. A no-op when no pair matches canon.
-export function removeFlagFromText(text, canon) {
+//
+// `occurrence` picks which repetition of `canon` to drop (0 = the first, the
+// default) — see spliceFlagValue.
+export function removeFlagFromText(text, canon, occurrence = 0) {
   const s = String(text || "");
   const segs = rawSegments(s);
-  const found = findFlagPairSegIndices(segs, canon);
+  const found = findFlagPairSegIndices(segs, canon, occurrence);
   if (!found) return s;
   const { flagIdx, valueIdx } = found;
   const endIdx = valueIdx != null ? valueIdx : flagIdx;

--- a/ui/src/dash/flags-tune.js
+++ b/ui/src/dash/flags-tune.js
@@ -149,10 +149,73 @@ function canonManaged(flag) {
   return MANAGED_SHORT[flag] || flag;
 }
 
+// Short → long canonicalisation for llama-server's own flag spellings. Mirrors
+// hal0.slots.argv.FLAG_ALIASES verbatim (kept in sync by
+// tests/ui_contracts/test_flag_aliases_mirror.py, which parses this literal
+// as JSON and compares it against the server dict). Written as strict JSON
+// (double-quoted keys/values, no trailing comma) so that parse holds.
+export const FLAG_ALIASES = {
+  "-b": "--batch-size",
+  "-ub": "--ubatch-size",
+  "-ngl": "--n-gpu-layers",
+  "-ctk": "--cache-type-k",
+  "-ctv": "--cache-type-v",
+  "-t": "--threads",
+  "-tb": "--threads-batch",
+  "-fa": "--flash-attn",
+  "-dev": "--device",
+  "-sm": "--split-mode",
+  "-c": "--ctx-size",
+  "-ts": "--tensor-split",
+  "-mg": "--main-gpu",
+  "-np": "--parallel",
+  "-kvu": "--kv-unified",
+  "-ngld": "--n-gpu-layers-draft"
+};
+
+// Fold a flag spelling onto its canonical long form via FLAG_ALIASES, or
+// return it unchanged when it isn't a known short alias (already long, or an
+// unrecognised flag entirely).
+export function canonFlag(flag) {
+  return FLAG_ALIASES[flag] || flag;
+}
+
+// The category a canonical (long) flag belongs to in the model drawer's
+// grouped flags editor. Seeded from the flags the repo's own seed profiles +
+// panel 03 use; anything absent here falls through to "template-misc" in
+// groupFlagPairs. Keyed by canonical long name — callers fold through
+// canonFlag before looking up.
+export const FLAG_CATEGORIES = {
+  "--temp": "sampling",
+  "--top-p": "sampling",
+  "--top-k": "sampling",
+  "--min-p": "sampling",
+  "--repeat-penalty": "sampling",
+  "--presence-penalty": "sampling",
+  "--frequency-penalty": "sampling",
+  "--flash-attn": "cache-kv",
+  "--cache-type-k": "cache-kv",
+  "--cache-type-v": "cache-kv",
+  "--cache-reuse": "cache-kv",
+  "--batch-size": "memory-batch",
+  "--ubatch-size": "memory-batch",
+  "--no-mmap": "memory-batch",
+  "--mlock": "memory-batch",
+  "--parallel": "memory-batch",
+};
+
+// Display order + labels for the model drawer's flag-category sections.
+export const CATEGORY_ORDER = [
+  { id: "sampling", label: "Sampling" },
+  { id: "cache-kv", label: "Cache · KV" },
+  { id: "memory-batch", label: "Memory · batch" },
+  { id: "template-misc", label: "Template · misc" },
+];
+
 // Group a flat token list into { flag, value } pairs (a flag consumes the next
 // token as its value iff that token isn't itself a flag). Bare positionals are
 // dropped from the pair view (they never carry a managed key).
-function pairs(tokens) {
+export function flagPairs(tokens) {
   const out = [];
   let i = 0;
   while (i < tokens.length) {
@@ -211,8 +274,8 @@ export function highlightSegments(text) {
 //   changed:   [{ flag, from, to }] same flag, different value
 //   unchanged: number             identical pairs
 export function diffFlags(modelText, profileText) {
-  const mp = pairs(tokenizeFlags(modelText).tokens);
-  const pp = pairs(tokenizeFlags(profileText).tokens);
+  const mp = flagPairs(tokenizeFlags(modelText).tokens);
+  const pp = flagPairs(tokenizeFlags(profileText).tokens);
   const key = (p) => p.canon;
   const pByFlag = new Map();
   for (const p of pp) pByFlag.set(key(p), p);
@@ -244,4 +307,113 @@ export function diffFlags(modelText, profileText) {
 export function flagsEquivalent(a, b) {
   const d = diffFlags(a, b);
   return !d.diverged;
+}
+
+// Group `text`'s flag pairs by FLAG_CATEGORIES for the model drawer's grouped
+// flags editor. Unknown flags (not in FLAG_CATEGORIES) fall through to
+// "template-misc". Empty groups are omitted; the remaining groups keep
+// CATEGORY_ORDER's order. `error` mirrors tokenizeFlags's — groups are still
+// returned best-effort (from whatever tokens were accumulated before the
+// error) so a mid-edit unbalanced quote doesn't blank the editor.
+export function groupFlagPairs(text) {
+  const { tokens, error } = tokenizeFlags(text);
+  const byCategory = new Map(CATEGORY_ORDER.map((c) => [c.id, []]));
+  for (const p of flagPairs(tokens)) {
+    const canon = canonFlag(p.flag);
+    const catId = FLAG_CATEGORIES[canon] || "template-misc";
+    byCategory.get(catId).push({ flag: p.flag, canon, value: p.value });
+  }
+  const groups = CATEGORY_ORDER
+    .map((c) => ({ id: c.id, label: c.label, pairs: byCategory.get(c.id) }))
+    .filter((g) => g.pairs.length > 0);
+  return { groups, error };
+}
+
+// Split raw flag text into an alternating sequence of whitespace-run and
+// non-whitespace-run segments (mirrors highlightSegments's tokenisation).
+// Unlike tokenizeFlags this is NOT quote-aware — the splice helpers below
+// accept that a quoted value's spacing may get normalized when re-spliced
+// (documented on spliceFlagValue/removeFlagFromText) in exchange for editing
+// the original string segment-wise so every OTHER token's spelling and
+// spacing survives untouched.
+function rawSegments(text) {
+  const s = String(text || "");
+  const segs = [];
+  const re = /(\s+)|(\S+)/g;
+  let m;
+  while ((m = re.exec(s)) !== null) {
+    if (m[1] != null) segs.push({ text: m[1], word: false });
+    else segs.push({ text: m[2], word: true });
+  }
+  return segs;
+}
+
+// Locate the { flag, value } pair in `segs` (as produced by rawSegments)
+// whose canonFlag(flag) === canon, returning the segment indices of the flag
+// token and its value token (null when the flag carries no value, i.e. the
+// next word is itself a flag or there is no next word). Returns null when no
+// pair matches.
+function findFlagPairSegIndices(segs, canon) {
+  const wordIdx = [];
+  segs.forEach((seg, i) => { if (seg.word) wordIdx.push(i); });
+  for (let k = 0; k < wordIdx.length; k += 1) {
+    const flagIdx = wordIdx[k];
+    const tok = segs[flagIdx].text;
+    if (!isFlagToken(tok) || canonFlag(tok) !== canon) continue;
+    const next = wordIdx[k + 1];
+    if (next != null && !isFlagToken(segs[next].text)) {
+      return { flagIdx, valueIdx: next };
+    }
+    return { flagIdx, valueIdx: null };
+  }
+  return null;
+}
+
+// Replace the value token of the pair whose canonFlag(flag) === canon with
+// `nextValue`, preserving the operator's original flag spelling, token order,
+// and every other token's surrounding whitespace verbatim. A no-op (returns
+// `text` unchanged) when no pair matches canon, or the matched flag carries no
+// value token to replace.
+export function spliceFlagValue(text, canon, nextValue) {
+  const s = String(text || "");
+  const segs = rawSegments(s);
+  const found = findFlagPairSegIndices(segs, canon);
+  if (!found || found.valueIdx == null) return s;
+  segs[found.valueIdx] = { text: String(nextValue), word: true };
+  return segs.map((seg) => seg.text).join("");
+}
+
+// Drop the flag token + its value token (or just the flag, for a boolean
+// flag) for the pair whose canonFlag(flag) === canon, collapsing the
+// resulting double space so the surrounding tokens read as if the pair had
+// never been there. A no-op when no pair matches canon.
+export function removeFlagFromText(text, canon) {
+  const s = String(text || "");
+  const segs = rawSegments(s);
+  const found = findFlagPairSegIndices(segs, canon);
+  if (!found) return s;
+  const { flagIdx, valueIdx } = found;
+  const endIdx = valueIdx != null ? valueIdx : flagIdx;
+  const drop = new Set();
+  for (let i = flagIdx; i <= endIdx; i += 1) drop.add(i);
+  if (flagIdx > 0 && !segs[flagIdx - 1].word) {
+    drop.add(flagIdx - 1);
+  } else if (endIdx + 1 < segs.length && !segs[endIdx + 1].word) {
+    drop.add(endIdx + 1);
+  }
+  return segs.filter((_, i) => !drop.has(i)).map((seg) => seg.text).join("");
+}
+
+// Append `flag` (and `value`, when given) to `text`, space-separated from
+// whatever's already there. A value containing whitespace is wrapped in
+// double quotes so it round-trips through tokenizeFlags as one token; a
+// null/undefined/empty value is omitted entirely (a boolean flag).
+export function addFlagToText(text, flag, value) {
+  const base = String(text || "");
+  let piece = flag;
+  if (value !== null && value !== undefined && value !== "") {
+    const v = String(value);
+    piece += /\s/.test(v) ? ` "${v}"` : ` ${v}`;
+  }
+  return base ? `${base} ${piece}` : piece;
 }

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -481,7 +481,8 @@ function SeedProfileButton({ options, onPick, disabled = false }) {
 // IS the confirm's message. Three parts:
 //   1. diff counts (changed/added/removed — each line omitted when its count
 //      is zero), naming the flags that move.
-//   2. the provenance line the pick commits to ("seeded from {name}").
+//   2. the provenance line the pick commits to (spec §5: `tune becomes
+//      "seeded from {name}" — divergence markers reset`).
 //   3. the restart consequence, from the slots that already load this model.
 //
 // Diff direction: `diffFlags(modelText, profileText)` describes going FROM
@@ -520,7 +521,7 @@ function SeedPreview({ targetName, targetFlags, currentFlags, slots }) {
 					{removed.length} removed: {removed.map((r) => r.flag).join(", ")}
 				</div>
 			)}
-			<div>seeded from {targetName}</div>
+			<div>tune becomes "seeded from {targetName}" — divergence markers reset</div>
 			<div>
 				{slots.length === 0
 					? "no slots currently load this model"

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -30,6 +30,8 @@ import { useModelSeedProfile } from "@/api/hooks/useModelSeedProfile";
 import { useChatTemplates } from "@/api/hooks/useChatTemplates";
 import { useProfiles } from "@/api/hooks/useProfiles";
 import { useMetaEnums } from "@/api/hooks/useMeta";
+import { useSlots } from "@/api/hooks/useSlots";
+import { slotsUsingModel } from "@/dash/model-usage.js";
 import {
 	canonicalCapabilities,
 	deviceById,
@@ -666,13 +668,19 @@ function deriveModelChanges(baseline, form) {
 }
 
 // ─── ModelDrawer ─────────────────────────────────────────────────────────────
-function ModelDrawer({ open, onClose, model }) {
+// `onOpenSlot` is optional (Task 3, facts-band used-by cell): when a host
+// passes it, each slot name in the used-by list is a jump button; absent, the
+// names render as plain text. jump wiring: models.jsx passes onOpenSlot — NOT
+// wired yet (the standalone Models page has no slot-drawer opener nearby to
+// reach trivially); tracked as a follow-up rather than faked here.
+export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 	const update = useModelUpdate();
 	const setDefault = useModelSetDefault();
 	const seedProfile = useModelSeedProfile();
 	const templates = useChatTemplates(open);
 	const profilesQuery = useProfiles();
 	const enums = useMetaEnums();
+	const slotsQuery = useSlots();
 
 	// Identity + typed fields (preserve the full RecipeEditor save surface).
 	const [name, setName] = useStateMD("");
@@ -699,6 +707,19 @@ function ModelDrawer({ open, onClose, model }) {
 	const [vision, setVision] = useStateMD("auto");
 	// Local UI state.
 	const [confirm, setConfirm] = useStateMD(null); // {title,message,confirmLabel,onConfirm}
+	// Inline title editor (Task 3): the ✎ button swaps the name span for an
+	// input seeded from the CURRENT draft (`name`), never from the live model
+	// prop, so a prior uncommitted edit survives reopening the editor. Escape
+	// must revert without ever calling setName — the 735b6291 bug class (a
+	// blur fired by the input's own removal from the DOM once landed a
+	// "cancelled" edit anyway). titleCancelRef is the synchronous guard: Escape
+	// flags it before closing, and the shared commit path checks the flag
+	// first, so even a stray blur from unmounting can't sneak the draft
+	// through. Enter and a real click-away both funnel through the same
+	// commit path — "blur commits like Enter".
+	const [editingTitle, setEditingTitle] = useStateMD(false);
+	const [titleDraft, setTitleDraft] = useStateMD("");
+	const titleCancelRef = useRefMD(false);
 	// Per-type default: the `model` prop is live-polled (see the seam note
 	// above), but the models-query invalidation this POST fires can land after
 	// the drawer has already read the row, so track the POST response as the
@@ -955,6 +976,33 @@ function ModelDrawer({ open, onClose, model }) {
 		}
 	};
 
+	// Inline title editor (Task 3, see the state comment above). One commit
+	// path for both Enter and a real click-away blur; Escape never reaches it
+	// with the cancel flag unset, so it can never carry the draft into `name`.
+	const openTitleEdit = () => {
+		titleCancelRef.current = false;
+		setTitleDraft(name);
+		setEditingTitle(true);
+	};
+	const commitTitle = () => {
+		if (titleCancelRef.current) {
+			titleCancelRef.current = false;
+			setEditingTitle(false);
+			return;
+		}
+		setName(titleDraft);
+		setEditingTitle(false);
+	};
+	const cancelTitleEdit = (e) => {
+		// Consumed here so the Drawer's document-level Escape→close listener
+		// never sees this press — Escape in the field cancels the rename, it
+		// must not also close the drawer (same reasoning as the slot rename
+		// field, slot-modals.jsx).
+		e.stopPropagation();
+		titleCancelRef.current = true;
+		setEditingTitle(false);
+	};
+
 	// THE comparison — derived once, against the FROZEN baseline, read by both
 	// the unsaved-changes guard and the save body. Nothing below re-derives a
 	// predicate and nothing touches the live `model` prop.
@@ -1067,12 +1115,51 @@ function ModelDrawer({ open, onClose, model }) {
 	// slot drawer's ceiling placeholder.
 	const modelContextLength = Number(model?.metadata?.context_length) || null;
 
-	// Title row: modality tag + default badge ride the header now (panel 07,
-	// callout K) — both are facts/actions, not field rows, so the old
-	// "Modality" and "Default for {type}" rows are gone below.
+	// Title row (Task 3): inline-editable name + modality tag + ONE default
+	// chip ride the header — facts/actions, not field rows, so the old
+	// "Modality" and "Default for {type}" rows stay gone below, and the old
+	// badge+ghost-chip+button trio collapses into the single toggle chip.
+	// Shows the live draft (`name`), never the frozen `model` prop, so a
+	// committed-but-unsaved edit sticks even if the editor is reopened.
+	const titleText = name.trim() || model.longName || model.id;
 	const titleNode = (
-		<span style={{ display: "inline-flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-			<span>{model.longName || model.name || model.id}</span>
+		<span style={{ display: "inline-flex", alignItems: "center", gap: 10, flexWrap: "wrap", minWidth: 0 }}>
+			{editingTitle ? (
+				<input
+					className="input mono"
+					data-testid="model-title-input"
+					autoFocus
+					placeholder={model.id}
+					value={titleDraft}
+					onChange={(e) => setTitleDraft(e.target.value)}
+					onBlur={commitTitle}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") {
+							e.preventDefault();
+							commitTitle();
+						} else if (e.key === "Escape") {
+							e.preventDefault();
+							cancelTitleEdit(e);
+						}
+					}}
+					style={{ fontSize: 14, minWidth: 140 }}
+				/>
+			) : (
+				<>
+					<span>{titleText}</span>
+					<button
+						type="button"
+						className="btn ghost sm"
+						data-testid="model-title-edit"
+						onClick={openTitleEdit}
+						aria-label="Edit name"
+						title="Edit name"
+						style={{ fontSize: 11, padding: "2px 7px", lineHeight: 1 }}
+					>
+						✎
+					</button>
+				</>
+			)}
 			<span
 				className="tag"
 				data-testid="model-modality"
@@ -1088,60 +1175,129 @@ function ModelDrawer({ open, onClose, model }) {
 			>
 				{modality}
 			</span>
-			{isTypeDefault ? (
-				<span
-					className="tag"
-					data-testid="model-default-badge"
-					style={{
-						color: "var(--ok)",
-						borderColor: "var(--ok)",
-						background: "var(--bg-2)",
-						fontFamily: "var(--jbm)",
-						fontSize: 9,
-						letterSpacing: ".05em",
-						textTransform: "uppercase",
-						padding: "2px 6px",
-						borderRadius: 3,
-						border: "1px solid var(--ok)",
-					}}
-				>
-					✓ {typeLabel} default
-				</span>
-			) : (
-				<span
-					className="tag"
-					data-testid="model-default-none"
-					style={{
-						color: "var(--fg-4)",
-						borderColor: "var(--line)",
-						background: "var(--bg-2)",
-						fontFamily: "var(--jbm)",
-						fontSize: 9,
-						letterSpacing: ".05em",
-						textTransform: "uppercase",
-						padding: "2px 6px",
-						borderRadius: 3,
-						border: "1px solid var(--line)",
-					}}
-				>
-					not the default
-				</span>
-			)}
 			<button
 				type="button"
 				className="btn ghost sm"
 				data-testid="model-default-toggle"
 				onClick={onToggleDefault}
 				disabled={setDefault.isPending}
-				style={{ fontSize: 10.5 }}
+				style={
+					isTypeDefault
+						? {
+								fontSize: 10.5,
+								color: "var(--ok)",
+								borderColor: "var(--ok)",
+								background: "var(--ok-soft)",
+							}
+						: { fontSize: 10.5 }
+				}
 			>
-				{setDefault.isPending
-					? "Saving…"
-					: isTypeDefault
-						? "Remove default"
-						: "Set as default"}
+				{isTypeDefault ? `✓ ${typeLabel} default` : `${typeLabel} default`}
 			</button>
 		</span>
+	);
+
+	// Facts band (Task 3): read-only quant/size/arch/context/sha256/used-by
+	// strip under the header. Each cell renders ONLY when its fact exists on
+	// the row — an absent fact is an absent cell, never a blank one.
+	const sizeGb =
+		Number(model.size_bytes) > 0
+			? (Number(model.size_bytes) / 1024 ** 3).toFixed(1)
+			: null;
+	const nativeContext = modelContextLength
+		? modelContextLength >= 1024
+			? `${Math.round(modelContextLength / 1024)}K`
+			: String(modelContextLength)
+		: null;
+	const modelSha256 =
+		typeof model?.metadata?.sha256 === "string" && model.metadata.sha256
+			? model.metadata.sha256
+			: null;
+	const usedBySlots = slotsUsingModel(slotsQuery.data, model.id);
+	const factCellStyle = { minWidth: 0 };
+	const factLabelStyle = {
+		fontSize: 9,
+		letterSpacing: ".05em",
+		textTransform: "uppercase",
+		color: "var(--fg-4)",
+		marginBottom: 2,
+	};
+	const factValueStyle = { fontSize: 12, color: "var(--fg-2)" };
+	const factsNode = (
+		<div
+			data-testid="model-facts"
+			style={{
+				display: "grid",
+				gridTemplateColumns: "repeat(auto-fit, minmax(110px, 1fr))",
+				gap: "10px 16px",
+				margin: "4px 0 16px",
+				padding: "11px 14px",
+				border: "1px solid var(--line)",
+				borderRadius: 8,
+				background: "var(--bg-2)",
+			}}
+		>
+			{model.quant && (
+				<div style={factCellStyle}>
+					<div style={factLabelStyle}>Quant</div>
+					<div className="mono" style={factValueStyle}>{model.quant}</div>
+				</div>
+			)}
+			{sizeGb && (
+				<div style={factCellStyle}>
+					<div style={factLabelStyle}>Size</div>
+					<div className="mono" style={factValueStyle}>{sizeGb} GB</div>
+				</div>
+			)}
+			{model.architecture && (
+				<div style={factCellStyle}>
+					<div style={factLabelStyle}>Architecture</div>
+					<div className="mono" style={factValueStyle}>{model.architecture}</div>
+				</div>
+			)}
+			{nativeContext && (
+				<div style={factCellStyle}>
+					<div style={factLabelStyle}>Native ctx</div>
+					<div className="mono" style={factValueStyle}>{nativeContext}</div>
+				</div>
+			)}
+			{modelSha256 && (
+				<div style={factCellStyle}>
+					<div style={factLabelStyle}>sha256</div>
+					<div className="mono" style={factValueStyle} title={modelSha256}>
+						{modelSha256.slice(0, 8)}
+					</div>
+				</div>
+			)}
+			<div style={factCellStyle} data-testid="model-facts-usedby">
+				<div style={factLabelStyle}>Used by</div>
+				<div className="mono" style={factValueStyle}>
+					{usedBySlots.length === 0 ? (
+						"0 slots"
+					) : (
+						<>
+							{usedBySlots.length} slot{usedBySlots.length === 1 ? "" : "s"} —{" "}
+							{usedBySlots.map((s, i) => (
+								<React.Fragment key={s.name}>
+									{i > 0 && " · "}
+									{onOpenSlot ? (
+										<button
+											type="button"
+											className="link"
+											onClick={() => onOpenSlot(s.name)}
+										>
+											{s.name}
+										</button>
+									) : (
+										s.name
+									)}
+								</React.Fragment>
+							))}
+						</>
+					)}
+				</div>
+			</div>
+		</div>
 	);
 
 	return (
@@ -1182,22 +1338,9 @@ function ModelDrawer({ open, onClose, model }) {
 					</>
 				}
 			>
-				{/* ── Identity ── */}
-				<div className="form-row">
-					<div className="form-lbl">
-						<span>Display name</span>
-						<FieldInfoIcon description="empty keeps the model id" />
-					</div>
-					<div className="form-ctl">
-						<input
-							className="input"
-							data-testid="model-name-input"
-							placeholder={model.id}
-							value={name}
-							onChange={(e) => setName(e.target.value)}
-						/>
-					</div>
-				</div>
+				{/* ── Facts band (Task 3) — name/default moved onto the header title;
+				    quant/size/arch/context/sha256/used-by ride here instead. ── */}
+				{factsNode}
 
 				{/* ── Launch-command hero: seed button + flags (1b / panel 12 Fix 2/3) ── */}
 				<div

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -31,6 +31,8 @@ import { useChatTemplates } from "@/api/hooks/useChatTemplates";
 import { useProfiles } from "@/api/hooks/useProfiles";
 import { useMetaEnums } from "@/api/hooks/useMeta";
 import { useSlots } from "@/api/hooks/useSlots";
+import { useModelsFeasibility } from "@/api/hooks/useModelsFeasibility";
+import { feasibilityHint } from "@/dash/feasibility-copy";
 import { slotsUsingModel } from "@/dash/model-usage.js";
 import { RichSelect } from "@/dash/rich-select.jsx";
 import {
@@ -84,6 +86,14 @@ function modalityLabel(caps, type) {
 	if (c.has("tts")) return "audio";
 	if (c.has("image")) return "image";
 	return type ? String(type) : "text";
+}
+
+// Native-context K-format, shared by the facts-band "Native ctx" cell (Task
+// 3) and the ctx row's native chip (Task 7) so the two "128K"-style displays
+// of the same metadata.context_length value can't drift apart.
+function contextLengthLabel(v) {
+	if (!v) return null;
+	return v >= 1024 ? `${Math.round(v / 1024)}K` : String(v);
 }
 
 // tri-state: absent (auto) | true (on) | false (off) — for mtp / jinja typed caps.
@@ -1319,6 +1329,28 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 	// in one place and forgotten in the other.
 	const saveBlocked = !!flagsError || !!mmprojError || !!ctxError;
 
+	// GTT feasibility probe (Task 7) — same 400ms-debounced pattern as the slot
+	// drawer's ceiling probe (slot-modals.jsx's ceilingFeasibility). Advisory
+	// only (warn-never-block, 993ea3b6): this NEVER feeds saveBlocked above,
+	// it only feeds the hint text rendered under the ctx row. Fires only while
+	// the drawer is open, and only for a non-empty ctx that already passes the
+	// same clean-integer check ctxError enforces — no probe for an empty or
+	// malformed field.
+	const ctxFeasibility = useModelsFeasibility();
+	const ctxFeasibilityTimer = useRefMD(null);
+	useEffectMD(() => {
+		if (ctxFeasibilityTimer.current) clearTimeout(ctxFeasibilityTimer.current);
+		const raw = ctx.trim();
+		if (!open || !model?.id || !raw || !/^\d+$/.test(raw)) return undefined;
+		const ctxNum = Number(raw);
+		if (!Number.isFinite(ctxNum) || ctxNum < 128) return undefined;
+		ctxFeasibilityTimer.current = setTimeout(() => {
+			ctxFeasibility.mutate({ models: [{ model_id: model.id, ctx: ctxNum }] });
+		}, 400);
+		return () => clearTimeout(ctxFeasibilityTimer.current);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [open, model?.id, ctx]);
+
 	// Return null when closed — matching the Modal contract the deleted
 	// RecipeEditorModal honoured (Modal returns null when !open). The <Drawer>
 	// primitive otherwise stays mounted, and `selected` is non-null even when the
@@ -1711,11 +1743,25 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 		Number(model.size_bytes) > 0
 			? (Number(model.size_bytes) / 1024 ** 3).toFixed(1)
 			: null;
-	const nativeContext = modelContextLength
-		? modelContextLength >= 1024
-			? `${Math.round(modelContextLength / 1024)}K`
-			: String(modelContextLength)
-		: null;
+	const nativeContext = contextLengthLabel(modelContextLength);
+	// Ctx row intelligence (Task 7). ctxError already guarantees a clean,
+	// ≥128 integer for any non-empty value, so `ctxNumValue` is only ever
+	// non-null for a valid ctx — an errored or empty field never flips the
+	// native chip to warn or shows the rope box.
+	const ctxNumValue =
+		!ctxError && ctx.trim() ? Number(ctx.trim()) : null;
+	const ropeWarn = !!(
+		ctxNumValue &&
+		modelContextLength &&
+		ctxNumValue > modelContextLength
+	);
+	// The bound model's row from the last successful feasibility probe (or
+	// none — `feasibilityHint`'s default branch, and the `unknown` verdict,
+	// both render no hint at all; see feasibility-copy.ts).
+	const ctxFeasibilityRow = (ctxFeasibility.data?.results || []).find(
+		(r) => r.model_id === model?.id,
+	);
+	const ctxHint = ctxFeasibilityRow ? feasibilityHint(ctxFeasibilityRow) : null;
 	const modelSha256 =
 		typeof model?.metadata?.sha256 === "string" && model.metadata.sha256
 			? model.metadata.sha256
@@ -2046,6 +2092,17 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 					<div className="form-lbl">
 						<span>Context size</span>
 						<FieldInfoIcon description="tokens · the model's own limit — a slot's Context ceiling is hardware · empty = launcher default · sets managed --ctx-size" />
+						{/* Native-context chip (Task 7) — hidden when the GGUF carries no
+						    metadata.context_length. Flips to warn the moment a valid ctx
+						    entry exceeds it (same condition as the rope warnbox below). */}
+						{nativeContext && (
+							<span
+								className={"chip" + (ropeWarn ? " warn" : "")}
+								data-testid="model-ctx-native-chip"
+							>
+								{ropeWarn ? `> native ${nativeContext}` : `native ${nativeContext}`}
+							</span>
+						)}
 					</div>
 					<div className="form-ctl">
 						<input
@@ -2063,6 +2120,57 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 								style={{ color: "var(--err)" }}
 							>
 								{ctxError}
+							</div>
+						)}
+						{/* Rope warnbox (Task 7) — warn-never-block: this never touches
+						    saveBlocked above, it only surfaces that a launcher may need to
+						    apply rope scaling past the GGUF's trained (native) length. */}
+						{ropeWarn && (
+							<div
+								className="hint"
+								data-testid="model-ctx-rope-warn"
+								style={{
+									marginTop: 6,
+									padding: "6px 10px",
+									borderRadius: "var(--rad-sm)",
+									color: "var(--warn)",
+									border: "1px solid var(--warn-line)",
+									background: "var(--warn-soft)",
+								}}
+							>
+								{`◐ above the GGUF's native ${nativeContext} — needs rope scaling the launcher may not apply; quality degrades past native. Saves anyway.`}
+							</div>
+						)}
+						{/* GTT feasibility line (Task 7) — host-truth, warn-never-block
+						    (993ea3b6): an absent/unknown verdict renders nothing at all,
+						    same idiom as the slot drawer's ctxHint (slot-modals.jsx). */}
+						{ctxHint?.tone && (
+							<div
+								className="hint"
+								data-testid="model-ctx-feasibility"
+								style={
+									ctxHint.tone === "warn"
+										? {
+												marginTop: 6,
+												padding: "6px 10px",
+												borderRadius: "var(--rad-sm)",
+												color: "var(--warn)",
+												border: "1px solid var(--warn-line)",
+												background: "var(--warn-soft)",
+											}
+										: ctxHint.tone === "err"
+											? {
+													marginTop: 6,
+													padding: "6px 10px",
+													borderRadius: "var(--rad-sm)",
+													color: "var(--err)",
+													border: "1px solid var(--err-line)",
+													background: "var(--err-soft)",
+												}
+											: { marginTop: 6 }
+								}
+							>
+								{ctxHint.text}
 							</div>
 						)}
 					</div>

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -1073,6 +1073,49 @@ function chatTemplateRichOptions(templates) {
 	return opts;
 }
 
+// Engine identity (Runner compatibility · Task 6). UI copy ONLY — the family
+// VOCABULARY always comes from enums.runtime_families (see engineRichOptions
+// below); this map never grows a family enums doesn't already list, and a
+// family enums adds before this map catches up still renders a plain row
+// with no description rather than being dropped.
+const ENGINE_BLURBS = {
+	"llama-server": "GGUF chat · vision · embeddings · the default engine",
+	flm: "FastLLM · NPU-lane models",
+	kokoro: "TTS voices",
+	qwen3tts: "TTS voices · Qwen",
+	moonshine: "streaming ASR",
+	comfyui: "image gen graphs — rows owned by the ComfyUI catalog",
+};
+
+function mutedChip(text) {
+	return <span className="chip">{text}</span>;
+}
+
+// Build the engine RichSelect's options. `providerEffective` is the row's
+// server-computed provider_effective (model_to_dict, Task 6 of the drawer
+// overhaul) — the Auto row's closed-control preview and blurb. Mock fixtures
+// predating that field won't carry it, so "llama-server" (the resolver's own
+// total default — hal0.model_meta.derive_model_provider never returns
+// anything else for an empty/unrecognised tag set) is the fallback, never a
+// blank chip.
+function engineRichOptions(runtimeFamilies, providerEffective) {
+	const families = Array.isArray(runtimeFamilies) ? runtimeFamilies : [];
+	const resolved = providerEffective || "llama-server";
+	return [
+		{
+			id: "",
+			row: "Auto",
+			right: mutedChip("→ " + resolved),
+			desc: "derived from the stored backend tags",
+		},
+		...families.map((rf) => ({
+			id: rf,
+			row: rf,
+			desc: ENGINE_BLURBS[rf],
+		})),
+	];
+}
+
 // ─── ModelDrawer ─────────────────────────────────────────────────────────────
 // `onOpenSlot` is optional (Task 3, facts-band used-by cell): when a host
 // passes it, each slot name in the used-by list is a jump button; absent, the
@@ -2038,19 +2081,13 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 						<FieldInfoIcon description="engine identity that serves this model's launch (llama-server · flm · kokoro · qwen3tts · moonshine · comfyui) · empty = derive from the stored backend tags" />
 					</div>
 					<div className="form-ctl">
-						<select
-							className="input mono"
+						<RichSelect
 							data-testid="model-provider-select"
+							aria-label="Engine"
 							value={provider}
-							onChange={(e) => setProvider(e.target.value)}
-						>
-							<option value="">Auto (derive from tags)</option>
-							{enums.runtime_families.map((rf) => (
-								<option key={rf} value={rf}>
-									{rf}
-								</option>
-							))}
-						</select>
+							options={engineRichOptions(enums.runtime_families, model.provider_effective)}
+							onChange={setProvider}
+						/>
 					</div>
 				</div>
 				<div className="form-row">

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -34,7 +34,7 @@ import { useMetaEnums } from "@/api/hooks/useMeta";
 import { useSlots } from "@/api/hooks/useSlots";
 import { useModelsFeasibility } from "@/api/hooks/useModelsFeasibility";
 import { feasibilityHint } from "@/dash/feasibility-copy";
-import { slotsUsingModel } from "@/dash/model-usage.js";
+import { slotsUsingModel, footSummary } from "@/dash/model-usage.js";
 import { RichSelect } from "@/dash/rich-select.jsx";
 import {
 	canonicalCapabilities,
@@ -2156,8 +2156,13 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 				title={titleNode}
 				foot={
 					<>
-						<span style={{ color: "var(--warn)" }}>
-							⟳ changes require the slot to restart
+						<span
+							style={{
+								color: dirty ? "var(--warn)" : "var(--muted)",
+							}}
+							data-testid="model-foot-summary"
+						>
+							{footSummary(changes, slotsUsingModel(slotsQuery.data, model.id))}
 						</span>
 						<span style={{ display: "inline-flex", gap: 8 }}>
 							<button className="btn ghost sm" onClick={onClose}>

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -640,33 +640,61 @@ function TunePills({ text, onChange, profileFlags }) {
 	const removedPairs = d
 		? d.removed.map((r) => ({ ...r, canon: canonFlag(r.flag) }))
 		: [];
+	// Repeating a flag is legitimate llama-server usage (-ot ffn=CPU -ot
+	// attn=GPU, --override-kv, --lora), so a canon alone does not identify a
+	// pill. Number each pill among its same-canon siblings and carry that index
+	// into every splice — otherwise ✕ on the second pill removes the first, and
+	// the value popover edits the wrong one. Counting per group is the same as
+	// counting over the whole text: a canon's category is a pure function of the
+	// canon, so all its pairs land in one group, in text order.
+	const numberByCanon = (list) => {
+		const seen = new Map();
+		return list.map((p) => {
+			const occurrence = seen.get(p.canon) || 0;
+			seen.set(p.canon, occurrence + 1);
+			return { ...p, occurrence };
+		});
+	};
 	const sections = CATEGORY_ORDER.map((c) => ({
 		id: c.id,
 		label: c.label,
-		pairs: (groups.find((g) => g.id === c.id) || { pairs: [] }).pairs,
-		ghosts: removedPairs.filter(
-			(r) => (FLAG_CATEGORIES[r.canon] || "template-misc") === c.id,
+		pairs: numberByCanon((groups.find((g) => g.id === c.id) || { pairs: [] }).pairs),
+		ghosts: numberByCanon(
+			removedPairs.filter(
+				(r) => (FLAG_CATEGORIES[r.canon] || "template-misc") === c.id,
+			),
 		),
 	})).filter((s) => s.pairs.length > 0 || s.ghosts.length > 0);
 
-	const revert = (canon) => {
+	// Testids stay stable for the first occurrence — the overwhelmingly common
+	// case, and the shape the specs already key on — and only a repeat earns a
+	// 1-based suffix, so ids remain unique without churning the existing ones.
+	const pillId = (canon, occurrence) =>
+		occurrence === 0 ? canon : `${canon}-${occurrence + 1}`;
+	// Popover identity is the pill, not the flag: keying on canon alone opened
+	// one input per duplicate pill (several nodes sharing model-tune-value-input).
+	const pillKey = (canon, occurrence) => `${canon}:${occurrence}`;
+
+	const revert = (canon, occurrence) => {
 		const c = changedFor(canon);
 		if (!c) return;
 		// A boolean⇄valued change has no value token to splice on one side
 		// (spliceFlagValue is a documented no-op there), so it falls back to a
 		// remove + re-add at the tail, keeping the operator's own spelling.
 		if (c.from == null || c.to == null) {
-			onChange(addFlagToText(removeFlagFromText(text, canon), c.flag, c.from));
+			onChange(
+				addFlagToText(removeFlagFromText(text, canon, occurrence), c.flag, c.from),
+			);
 			return;
 		}
-		onChange(spliceFlagValue(text, canon, c.from));
+		onChange(spliceFlagValue(text, canon, c.from, occurrence));
 	};
-	const openValue = (canon, value) => {
+	const openValue = (canon, occurrence, value) => {
 		setAdding(false);
 		setValueDraft(value == null ? "" : String(value));
-		setEditingValue(canon);
+		setEditingValue(pillKey(canon, occurrence));
 	};
-	const commitValue = (canon) => {
+	const commitValue = (canon, occurrence) => {
 		setEditingValue(null);
 		const v = valueDraft.trim();
 		// Emptying the box is not "make this a bare flag" — spliceFlagValue would
@@ -676,7 +704,9 @@ function TunePills({ text, onChange, profileFlags }) {
 		// spliceFlagValue inserts the replacement verbatim, so a multi-word value
 		// has to arrive quoted or it tokenizes as two tokens and corrupts
 		// everything after it. Same rule addFlagToText applies on the add path.
-		onChange(spliceFlagValue(text, canon, /\s/.test(v) ? `"${v}"` : v));
+		onChange(
+			spliceFlagValue(text, canon, /\s/.test(v) ? `"${v}"` : v, occurrence),
+		);
 	};
 	const commitAdd = () => {
 		const raw = addDraft.trim();
@@ -744,18 +774,21 @@ function TunePills({ text, onChange, profileFlags }) {
 						{s.label}
 					</div>
 					<div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-						{s.pairs.map((p, i) => {
+						{s.pairs.map((p) => {
 							const kind = divergenceFor(p.flag, p.canon);
 							const c = changedFor(p.canon);
+							const id = pillId(p.canon, p.occurrence);
 							return (
 								<span
-									key={`${p.canon}-${i}`}
+									key={pillKey(p.canon, p.occurrence)}
 									className={pillClass(kind)}
-									data-testid={`model-tune-pill-${p.canon}`}
+									data-testid={`model-tune-pill-${id}`}
 									data-divergence={kind}
 									title={
 										kind === "changed"
-											? `profile has ${p.flag} ${c ? c.from : ""}`
+											? c && c.from != null
+												? `profile has ${p.flag} ${c.from}`
+												: `profile has a bare ${p.flag}`
 											: kind === "denied"
 												? `${p.flag} is not settable on the model — see the error below`
 												: undefined
@@ -766,9 +799,9 @@ function TunePills({ text, onChange, profileFlags }) {
 										<span style={{ position: "relative" }}>
 											<button
 												type="button"
-												data-testid={`model-tune-pill-value-${p.canon}`}
+												data-testid={`model-tune-pill-value-${id}`}
 												aria-label={`Edit ${p.flag} value`}
-												onClick={() => openValue(p.canon, p.value)}
+												onClick={() => openValue(p.canon, p.occurrence, p.value)}
 												style={{
 													...iconBtnStyle,
 													color: "var(--fg)",
@@ -777,17 +810,18 @@ function TunePills({ text, onChange, profileFlags }) {
 											>
 												{p.value}
 											</button>
-											{editingValue === p.canon && (
+											{editingValue === pillKey(p.canon, p.occurrence) && (
 												<input
 													className="input mono"
 													data-testid="model-tune-value-input"
+													aria-label={`${p.flag} value`}
 													autoFocus
 													value={valueDraft}
 													onChange={(e) => setValueDraft(e.target.value)}
 													onKeyDown={(e) => {
 														if (e.key === "Enter") {
 															e.preventDefault();
-															commitValue(p.canon);
+															commitValue(p.canon, p.occurrence);
 														} else if (e.key === "Escape") {
 															// Consumed so the Drawer's document-level
 															// Escape→close never sees it: Escape here
@@ -806,10 +840,10 @@ function TunePills({ text, onChange, profileFlags }) {
 									{kind === "changed" && (
 										<button
 											type="button"
-											data-testid={`model-tune-pill-revert-${p.canon}`}
+											data-testid={`model-tune-pill-revert-${id}`}
 											aria-label={`Revert ${p.flag} to the profile value`}
-											title={`↺ back to ${c ? c.from : "the profile value"}`}
-											onClick={() => revert(p.canon)}
+											title={`↺ back to ${c && c.from != null ? c.from : "the profile value"}`}
+											onClick={() => revert(p.canon, p.occurrence)}
 											style={iconBtnStyle}
 										>
 											↺
@@ -817,9 +851,11 @@ function TunePills({ text, onChange, profileFlags }) {
 									)}
 									<button
 										type="button"
-										data-testid={`model-tune-pill-remove-${p.canon}`}
+										data-testid={`model-tune-pill-remove-${id}`}
 										aria-label={`Remove ${p.flag}`}
-										onClick={() => onChange(removeFlagFromText(text, p.canon))}
+										onClick={() =>
+											onChange(removeFlagFromText(text, p.canon, p.occurrence))
+										}
 										style={iconBtnStyle}
 									>
 										✕
@@ -827,29 +863,32 @@ function TunePills({ text, onChange, profileFlags }) {
 								</span>
 							);
 						})}
-						{s.ghosts.map((r, i) => (
-							<span
-								key={`ghost-${r.canon}-${i}`}
-								className="fpill fpill-tune fpill-rm"
-								data-testid={`model-tune-pill-ghost-${r.canon}`}
-								data-divergence="removed"
-								title={`in the profile, dropped here — restore ${r.flag}`}
-							>
-								<span>
-									{r.flag}
-									{r.value != null ? ` ${r.value}` : ""}
-								</span>
-								<button
-									type="button"
-									data-testid={`model-tune-pill-restore-${r.canon}`}
-									aria-label={`Restore ${r.flag} from the profile`}
-									onClick={() => onChange(addFlagToText(text, r.flag, r.value))}
-									style={iconBtnStyle}
+						{s.ghosts.map((r) => {
+							const id = pillId(r.canon, r.occurrence);
+							return (
+								<span
+									key={`ghost-${pillKey(r.canon, r.occurrence)}`}
+									className="fpill fpill-tune fpill-rm"
+									data-testid={`model-tune-pill-ghost-${id}`}
+									data-divergence="removed"
+									title={`in the profile, dropped here — restore ${r.flag}`}
 								>
-									+
-								</button>
-							</span>
-						))}
+									<span>
+										{r.flag}
+										{r.value != null ? ` ${r.value}` : ""}
+									</span>
+									<button
+										type="button"
+										data-testid={`model-tune-pill-restore-${id}`}
+										aria-label={`Restore ${r.flag} from the profile`}
+										onClick={() => onChange(addFlagToText(text, r.flag, r.value))}
+										style={iconBtnStyle}
+									>
+										+
+									</button>
+								</span>
+							);
+						})}
 					</div>
 				</div>
 			))}
@@ -876,6 +915,7 @@ function TunePills({ text, onChange, profileFlags }) {
 					<input
 						className="input mono"
 						data-testid="model-tune-add-input"
+						aria-label="Add a launch flag"
 						autoFocus
 						placeholder="--cache-type-k q8_0"
 						value={addDraft}

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -32,6 +32,7 @@ import { useProfiles } from "@/api/hooks/useProfiles";
 import { useMetaEnums } from "@/api/hooks/useMeta";
 import { useSlots } from "@/api/hooks/useSlots";
 import { slotsUsingModel } from "@/dash/model-usage.js";
+import { RichSelect } from "@/dash/rich-select.jsx";
 import {
 	canonicalCapabilities,
 	deviceById,
@@ -1043,6 +1044,35 @@ function deriveModelChanges(baseline, form) {
 	return c;
 }
 
+// Build the chat-template RichSelect's options from useChatTemplates rows
+// (`{id, label, valid, error}` — chat_templates.py's `_entry`). `auto` is
+// hand-rolled first with its own blurb (the catalog's own "Auto (GGUF
+// embedded)" label rides the chip instead of the row name, matching the
+// mockup); every other row chips a lint failure inline — `valid: false`
+// carries the render-check's error string — so a broken template dropped
+// into the store dir reads as a warning here, not only as a slot crash.
+function chatTemplateRichOptions(templates) {
+	const rows = Array.isArray(templates) ? templates : [];
+	const opts = [
+		{
+			id: "auto",
+			row: "Auto",
+			right: <span className="chip ok">GGUF embedded</span>,
+			desc: "use the template the model file ships — right for ~every GGUF",
+		},
+	];
+	for (const t of rows) {
+		if (t.id === "auto") continue;
+		opts.push({
+			id: t.id,
+			row: t.label,
+			right: t.valid === false ? <span className="chip warn">⚠ broken</span> : null,
+			desc: t.valid === false ? t.error : null,
+		});
+	}
+	return opts;
+}
+
 // ─── ModelDrawer ─────────────────────────────────────────────────────────────
 // `onOpenSlot` is optional (Task 3, facts-band used-by cell): when a host
 // passes it, each slot name in the used-by list is a jump button; absent, the
@@ -1917,21 +1947,13 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 						<FieldInfoIcon description="auto = use the template embedded in the GGUF" />
 					</div>
 					<div className="form-ctl">
-						<select
-							className="input mono chat-template-select"
+						<RichSelect
 							data-testid="model-chat-template"
+							aria-label="Chat template"
 							value={chatTemplate}
-							onChange={(e) => setChatTemplate(e.target.value)}
-						>
-							<option value="auto">Auto (GGUF embedded)</option>
-							{(Array.isArray(templates.data) ? templates.data : [])
-								.filter((t) => t.id !== "auto")
-								.map((t) => (
-									<option key={t.id} value={t.id}>
-										{t.label}
-									</option>
-								))}
-						</select>
+							options={chatTemplateRichOptions(templates.data)}
+							onChange={setChatTemplate}
+						/>
 					</div>
 				</div>
 				{/* Overrides ledger (panel 09 V1): Auto is invisible — only an

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -474,6 +474,63 @@ function SeedProfileButton({ options, onPick, disabled = false }) {
 	);
 }
 
+// ─── SeedPreview — the seed confirm's consequence preview (Task 8, #2205) ───
+// EVERY profile pick shows this now — the old wouldClobber shortcut that
+// skipped the confirm entirely for empty/matching flags is gone; this preview
+// IS the confirm's message. Three parts:
+//   1. diff counts (changed/added/removed — each line omitted when its count
+//      is zero), naming the flags that move.
+//   2. the provenance line the pick commits to ("seeded from {name}").
+//   3. the restart consequence, from the slots that already load this model.
+//
+// Diff direction: `diffFlags(modelText, profileText)` describes going FROM
+// profileText TO modelText (its own added/removed/changed read that way —
+// see flags-tune.js's jsdoc). The seed replaces the CURRENT flags with the
+// TARGET profile's, so `targetFlags` — not `currentFlags` — has to be the
+// first argument for "changed" to read current→target rather than backwards.
+function SeedPreview({ targetName, targetFlags, currentFlags, slots }) {
+	const diff = diffFlags(targetFlags, currentFlags || "");
+	const { added, removed, changed } = diff;
+	return (
+		<div
+			className="mono"
+			data-testid="model-seed-preview"
+			style={{ fontSize: 12, lineHeight: 1.7 }}
+		>
+			{changed.length > 0 && (
+				<div>
+					{changed.length} changed:{" "}
+					{changed.map((c) => `${c.flag} ${c.from}→${c.to}`).join(", ")}
+				</div>
+			)}
+			{added.length > 0 && (
+				<div>
+					{added.length} added:{" "}
+					{added
+						.map((a) => `${a.flag}${a.value != null ? ` ${a.value}` : ""}`)
+						.join(", ")}
+				</div>
+			)}
+			{removed.length > 0 && (
+				<div>
+					{/* #2195's honesty pattern: a flag that disappears is billed here
+					    too, not just additions/changes — the operator sees the whole
+					    consequence, not a partial one. */}
+					{removed.length} removed: {removed.map((r) => r.flag).join(", ")}
+				</div>
+			)}
+			<div>seeded from {targetName}</div>
+			<div>
+				{slots.length === 0
+					? "no slots currently load this model"
+					: `${slots.length} slot${slots.length === 1 ? "" : "s"} restart · ${slots
+							.map((s) => s.name)
+							.join(" · ")}`}
+			</div>
+		</div>
+	);
+}
+
 // ─── DivergenceDiff — client-side model-vs-profile diff (1c, inline) ─────────
 function DivergenceDiff({ diff, profileName, onReset }) {
 	return (
@@ -1230,11 +1287,22 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 
 	// Profiles that fit this model (same filter the old RecipeEditor used), so the
 	// template dropdown offers device-appropriate seeds.
+	//
+	// #2205: the filter used to stop at device/backend/type — a profile whose
+	// `runtime_family` names a different engine than the model's own provider
+	// still showed up (e.g. a rocm-tagged row that had its Engine explicitly
+	// set to kokoro kept offering llama-server profiles). `providerOk` keys off
+	// `model.provider_effective` — the same explicit-wins-over-derived
+	// precedence `_provider_for_backend` uses (catalog.py, since #2196) — with
+	// the same "llama-server" ultimate fallback engineRichOptions uses for a
+	// mock fixture that predates the field. A profile with no `runtime_family`
+	// carries no runtime opinion (flags-only tune) and always fits.
 	const fitProfiles = useMemoMD(() => {
 		const all = Array.isArray(profilesQuery.data) ? profilesQuery.data : [];
 		if (!model) return all;
 		const mClasses = modelDeviceClasses(model.backends, model.device, enums);
 		const mBackends = Array.isArray(model.backends) ? model.backends : [];
+		const modelProvider = model.provider_effective || "llama-server";
 		const fit = all.filter((p) => {
 			const pc = profileDeviceClass(p);
 			const classOk = !pc || mClasses.size === 0 || mClasses.has(pc);
@@ -1244,7 +1312,8 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 				!model.type ||
 				!Array.isArray(p.supported_slot_types) ||
 				p.supported_slot_types.includes(model.type);
-			return classOk && backendOk && typeOk;
+			const providerOk = !p.runtime_family || p.runtime_family === modelProvider;
+			return classOk && backendOk && typeOk && providerOk;
 		});
 		// Always keep the current provenance selectable even if it no longer fits.
 		const names = new Set(fit.map((p) => p.name));
@@ -1253,7 +1322,7 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 			if (cur) return [cur, ...fit];
 		}
 		return fit;
-	}, [profilesQuery.data, model?.id, profile, enums]);
+	}, [profilesQuery.data, model?.id, model?.provider_effective, profile, enums]);
 
 	const sourceProfile = useMemoMD(
 		() =>
@@ -1362,9 +1431,9 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 	// from the "⤵ Seed from profile…" menu POSTs /api/models/{id}/seed-profile
 	// (useModelSeedProfile, Task 7), which materialises the profile's flags
 	// into the model's `defaults` server-side and returns the updated row.
-	// Confirm first if the current flags would be clobbered (non-empty and not
-	// already the target text) — the write is immediate, there is no Cancel
-	// once it lands. On success, splice just the two fields the route owns
+	// EVERY pick previews its consequences first (Task 8) — the write is
+	// immediate, there is no Cancel once it lands. On success, splice just the
+	// two fields the route owns
 	// (profile provenance + extra_args) into the local form AND the frozen
 	// baseline, so the provenance/diverged chips read the new truth without
 	// the Save-model gate reporting a false "unsaved change" for a value the
@@ -1413,18 +1482,26 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 		if (!nextName || seedProfile.isPending) return; // double-click / double-POST guard
 		const target = (profilesQuery.data || []).find((p) => p.name === nextName);
 		const targetFlags = target ? target.flags || "" : "";
-		const wouldClobber = extra.trim() && diffFlags(extra, targetFlags).diverged;
-		if (wouldClobber) {
-			setConfirm({
-				kind: "seed",
-				title: "Replace launch flags?",
-				message: `Seed from ${nextName}? Unsaved edits to the current flags are lost — this writes immediately.`,
-				confirmLabel: "Seed from profile",
-				onConfirm: () => doSeed(nextName),
-			});
-		} else {
-			doSeed(nextName);
-		}
+		const usedBySlotsForSeed = slotsUsingModel(slotsQuery.data, model.id);
+		// EVERY pick routes through this confirm now — the old wouldClobber
+		// shortcut (skip confirm when the current flags were empty or already
+		// matched the target) is gone. The preview IS the confirm: it always
+		// tells the operator what will change and what restarts, even for a
+		// pick that looks like a no-op.
+		setConfirm({
+			kind: "seed",
+			title: `Stamp tune from ${nextName}?`,
+			message: (
+				<SeedPreview
+					targetName={nextName}
+					targetFlags={targetFlags}
+					currentFlags={extra}
+					slots={usedBySlotsForSeed}
+				/>
+			),
+			confirmLabel: "Stamp tune",
+			onConfirm: () => doSeed(nextName),
+		});
 	};
 
 	const resetToProfile = () => {

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -1205,12 +1205,23 @@ function engineRichOptions(runtimeFamilies, providerEffective) {
 //     does the discover scan (`model.mmproj = str(candidate.mmproj)`,
 //     src/hal0/registry/discover.py:404).
 //
-// So the picker lists repo FILENAMES but must write `<dir>/<filename>`, with
+// So the picker lists repo files but must write `<dir>/<basename>`, with
 // `<dir>` the directory the sidecar sits in beside the model — exactly what
 // the pull worker would have produced. `mmprojDirOf` prefers the stored
 // projector's own directory (a row whose sidecar lives elsewhere keeps it) and
 // falls back to the model file's directory. No derivable directory ⇒ no
 // picker: this drawer resolves a path, it never invents one.
+//
+// BASENAME, not the variant id: an inspect variant's `id` is the repo-RELATIVE
+// PATH (`"id": rel` from the recursive tree walk,
+// src/hal0/upstreams/huggingface.py:357), and repos really do nest projectors
+// and quants in subdirectories — the same file's own comment cites
+// `vision/Foo.mmproj` (huggingface.py:270-274), and `recursive=true` exists for
+// exactly that (registry/update_check.py:39-40, registry/fileset.py:208-210).
+// The pull worker flattens that away (`Path(mm_rec.hf_filename).name`,
+// pull.py:1071), so joining a variant id verbatim would write
+// `<dir>/UD-Q4_K_XL/mmproj-F16.gguf` — a path no pull ever produces, and one
+// that fails `screen_vision_mmproj`'s on-disk check on save.
 function mmprojDirOf(storedMmproj, modelPath) {
 	const src = String(storedMmproj || modelPath || "").trim();
 	const cut = src.lastIndexOf("/");
@@ -1238,13 +1249,19 @@ function sizeChipText(variant) {
 // stores (the resolved absolute path), so `onChange` is a plain `setMmproj`
 // and the control's `value` compares against the stored string directly —
 // there is no second place where a filename could be re-derived into a
-// different path than the one that was saved.
+// different path than the one that was saved. The ROW keeps the variant's full
+// repo-relative id, so two projectors that flatten onto the same filename are
+// still told apart by eye; `seen` keeps the first (smallest, the list arrives
+// size-sorted), which is the same one-file-per-directory outcome a pull of both
+// would leave behind.
 //
-// `current` (a projector stored on the row that this repo's listing doesn't
-// offer — a hand-placed sidecar, or a repo that has since dropped the file)
-// always gets its own row, verbatim. A value this picker cannot explain is
-// still a value the operator chose; it is never silently rewritten or dropped.
-function mmprojRichOptions(dir, variants, current) {
+// `extras` are values the row already carries — the stored projector and the
+// current draft — that this repo's listing doesn't offer (a hand-placed
+// sidecar, or a repo that has since dropped the file). Each gets its own row,
+// verbatim. A value this picker cannot explain is still a value the operator
+// chose: it is never silently rewritten, and never disappears out from under a
+// pick that could otherwise not be undone without closing the drawer.
+function mmprojRichOptions(dir, variants, extras) {
 	const opts = [
 		{
 			id: "",
@@ -1254,14 +1271,16 @@ function mmprojRichOptions(dir, variants, current) {
 	];
 	const seen = new Set([""]);
 	for (const v of variants) {
-		const id = joinMmprojPath(dir, v.id);
+		const id = joinMmprojPath(dir, basenameOf(v.id));
 		if (seen.has(id)) continue;
 		seen.add(id);
 		const chip = sizeChipText(v);
 		opts.push({ id, row: v.id, right: chip ? mutedChip(chip) : null });
 	}
-	const cur = String(current || "").trim();
-	if (cur && !seen.has(cur)) {
+	for (const extra of extras) {
+		const cur = String(extra || "").trim();
+		if (!cur || seen.has(cur)) continue;
+		seen.add(cur);
 		opts.push({
 			id: cur,
 			row: basenameOf(cur),
@@ -1275,33 +1294,51 @@ function mmprojRichOptions(dir, variants, current) {
 // One read-only path line for the Source disclosure's paths block: mono text
 // that wraps mid-token (#2210's overflow-wrap:anywhere pattern — a projector
 // path is long, unbreakable, and must not push the drawer sideways) plus the
-// house copy affordance (model-modals.jsx:391).
-function SourcePathLine({ label, value, testId, empty }) {
+// house copy affordance. The copy goes through the sturdier of the two house
+// idioms (command-palette.jsx's `cpCopy`, :35-42): a clipboard write can throw
+// (no permission, insecure origin, no API at all), and reporting "copied" for
+// a write that never happened is worse than saying nothing.
+//
+// `note` is for a line whose value is NOT on-disk truth — the projector line
+// shows the unsaved pick, and says so rather than implying the file is there.
+function SourcePathLine({ label, value, testId, empty, note }) {
 	const has = !!String(value || "").trim();
 	return (
-		<div style={{ display: "flex", gap: 8, alignItems: "baseline", marginTop: 4 }}>
-			<span className="hint" style={{ minWidth: 52, flex: "0 0 auto" }}>
-				{label}
-			</span>
-			<span
-				className="mono"
-				style={{ flex: 1, minWidth: 0, overflowWrap: "anywhere", fontSize: 12 }}
-			>
-				{has ? value : <span className="hint">{empty}</span>}
-			</span>
-			{has && (
-				<button
-					type="button"
-					className="btn ghost sm"
-					data-testid={testId}
-					onClick={() => {
-						navigator.clipboard?.writeText(String(value));
-						window.__hal0Toast &&
-							window.__hal0Toast(`${label} path copied to clipboard`, "ok");
-					}}
+		<div style={{ marginTop: 4 }}>
+			<div style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
+				<span className="hint" style={{ minWidth: 52, flex: "0 0 auto" }}>
+					{label}
+				</span>
+				<span
+					className="mono"
+					style={{ flex: 1, minWidth: 0, overflowWrap: "anywhere", fontSize: 12 }}
 				>
-					Copy
-				</button>
+					{has ? value : <span className="hint">{empty}</span>}
+				</span>
+				{has && (
+					<button
+						type="button"
+						className="btn ghost sm"
+						data-testid={testId}
+						onClick={() => {
+							try {
+								navigator.clipboard.writeText(String(value));
+								window.__hal0Toast &&
+									window.__hal0Toast(`${label} path copied to clipboard`, "ok");
+							} catch {
+								window.__hal0Toast &&
+									window.__hal0Toast("Copy failed — clipboard unavailable", "err");
+							}
+						}}
+					>
+						Copy
+					</button>
+				)}
+			</div>
+			{note && (
+				<div className="hint" style={{ marginLeft: 60, marginTop: 2 }}>
+					{note}
+				</div>
 			)}
 		</div>
 	);
@@ -1539,9 +1576,16 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 	// Each degrades to the free-text path input rather than to a dead control.
 	const mmprojPicker =
 		!!hfRepo.trim() && !inspect.isError && !!mmprojDir && mmprojVariants.length > 0;
+	// Both the STORED projector and the current draft ride as extra rows: a
+	// stored value the repo doesn't list must stay pickable after the operator
+	// tries "— none —", or the only way back to it is closing the drawer and
+	// losing every other unsaved edit.
 	const mmprojOptions = useMemoMD(
-		() => (mmprojPicker ? mmprojRichOptions(mmprojDir, mmprojVariants, mmproj) : []),
-		[mmprojPicker, mmprojDir, mmprojVariants, mmproj],
+		() =>
+			mmprojPicker
+				? mmprojRichOptions(mmprojDir, mmprojVariants, [baseline?.mmproj, mmproj])
+				: [],
+		[mmprojPicker, mmprojDir, mmprojVariants, baseline?.mmproj, mmproj],
 	);
 
 	// Context size validation (#1378). A lenient parseInt destroyed data twice
@@ -2585,7 +2629,7 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 						<div className="form-row">
 							<div className="form-lbl">
 								<span>Paths</span>
-								<FieldInfoIcon description="where these files sit on this host · read-only — the model file is registry-owned, and the projector is set by the control above" />
+								<FieldInfoIcon description="read-only · the model path is the registry's stored value; the mmproj line reads back whatever the control above currently has selected, saved or not" />
 							</div>
 							<div className="form-ctl" data-testid="model-source-paths">
 								<SourcePathLine
@@ -2596,12 +2640,18 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 								/>
 								{/* The DRAFT projector, not the stored one: this line is
                     where a pick made above reads back as the resolved
-                    absolute path it will save as. */}
+                    absolute path it WOULD save as — so an unsaved pick says
+                    so rather than passing itself off as a file on disk. */}
 								<SourcePathLine
 									label="mmproj"
 									value={mmproj}
 									testId="model-source-copy-mmproj"
 									empty="no projector paired"
+									note={
+										baseline && mmproj.trim() !== baseline.mmproj
+											? "unsaved selection — this is the path Save will write, not what is stored today"
+											: null
+									}
 								/>
 							</div>
 						</div>

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -45,6 +45,13 @@ import {
 	highlightSegments,
 	diffFlags,
 	tokenizeFlags,
+	canonFlag,
+	groupFlagPairs,
+	spliceFlagValue,
+	removeFlagFromText,
+	addFlagToText,
+	FLAG_CATEGORIES,
+	CATEGORY_ORDER,
 } from "@/dash/flags-tune.js";
 import {
 	CAP_DEFS,
@@ -562,6 +569,335 @@ function DivergenceDiff({ diff, profileName, onReset }) {
 	);
 }
 
+// ─── TunePills — the structured tune editor (grouped pills) ─────────────────
+//
+// The flags STRING stays the single source of truth. This is a pure render of
+// the `text` prop: there is no internal copy of it, and every affordance
+// splices the prop through one of the flags-tune helpers and hands the result
+// straight to `onChange`. What the pills show and what launches therefore
+// cannot drift — the only local state here is which popover is open.
+//
+// `profileFlags` is the seeding profile's current text, or null when the model
+// was never stamped. Null means there is nothing to diverge FROM: every pill
+// reads `data-divergence="none"`, no ghost pills render, and no revert
+// affordance appears — an unstamped model has no "profile value" to go back to.
+//
+// The parent owns the parse error: unparseable text renders FlagsEditor
+// instead of this, so groupFlagPairs is assumed to have succeeded here.
+function TunePills({ text, onChange, profileFlags }) {
+	// canon of the pill whose value popover is open (null = none), plus the
+	// in-flight draft. Only Enter commits; Escape and a click-away discard, so
+	// a half-typed value can never reach the flags string by accident.
+	const [editingValue, setEditingValue] = useStateMD(null);
+	const [valueDraft, setValueDraft] = useStateMD("");
+	const [adding, setAdding] = useStateMD(false);
+	const [addDraft, setAddDraft] = useStateMD("");
+	const wrapRef = useRefMD(null);
+	const popoverOpen = editingValue != null || adding;
+	const closePopovers = () => {
+		setEditingValue(null);
+		setAdding(false);
+		setAddDraft("");
+	};
+	// Same click-outside/Escape idiom as CapOverrideAdd above.
+	useEffectMD(() => {
+		if (!popoverOpen) return;
+		const onDown = (e) => {
+			if (wrapRef.current && !wrapRef.current.contains(e.target)) closePopovers();
+		};
+		const onKey = (e) => {
+			if (e.key === "Escape") closePopovers();
+		};
+		document.addEventListener("mousedown", onDown);
+		document.addEventListener("keydown", onKey);
+		return () => {
+			document.removeEventListener("mousedown", onDown);
+			document.removeEventListener("keydown", onKey);
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [popoverOpen]);
+
+	const { groups } = groupFlagPairs(text);
+	const d = profileFlags != null ? diffFlags(text, profileFlags) : null;
+	// Denial is judged per flag, not per string. The drawer's flagsError
+	// pipeline still owns the save gate and the rejection copy — unchanged; the
+	// pill only wears the styling, so the offending token is findable in a long
+	// tune without reading the message first.
+	const isDenied = (flag) =>
+		findManagedFlags(flag).length > 0 || findSlotHardwareFlags(flag).length > 0;
+	const changedFor = (canon) =>
+		d ? d.changed.find((c) => canonFlag(c.flag) === canon) || null : null;
+	const divergenceFor = (flag, canon) => {
+		if (isDenied(flag)) return "denied";
+		if (!d) return "none";
+		if (changedFor(canon)) return "changed";
+		if (d.added.some((a) => canonFlag(a.flag) === canon)) return "added";
+		return "unchanged";
+	};
+	// Ghosts: in the profile, absent from the text. Rendered dimmed in their own
+	// category so "what the profile had and this model dropped" is visible where
+	// the operator is already looking, instead of only in the raw-mode diff.
+	const removedPairs = d
+		? d.removed.map((r) => ({ ...r, canon: canonFlag(r.flag) }))
+		: [];
+	const sections = CATEGORY_ORDER.map((c) => ({
+		id: c.id,
+		label: c.label,
+		pairs: (groups.find((g) => g.id === c.id) || { pairs: [] }).pairs,
+		ghosts: removedPairs.filter(
+			(r) => (FLAG_CATEGORIES[r.canon] || "template-misc") === c.id,
+		),
+	})).filter((s) => s.pairs.length > 0 || s.ghosts.length > 0);
+
+	const revert = (canon) => {
+		const c = changedFor(canon);
+		if (!c) return;
+		// A boolean⇄valued change has no value token to splice on one side
+		// (spliceFlagValue is a documented no-op there), so it falls back to a
+		// remove + re-add at the tail, keeping the operator's own spelling.
+		if (c.from == null || c.to == null) {
+			onChange(addFlagToText(removeFlagFromText(text, canon), c.flag, c.from));
+			return;
+		}
+		onChange(spliceFlagValue(text, canon, c.from));
+	};
+	const openValue = (canon, value) => {
+		setAdding(false);
+		setValueDraft(value == null ? "" : String(value));
+		setEditingValue(canon);
+	};
+	const commitValue = (canon) => {
+		setEditingValue(null);
+		const v = valueDraft.trim();
+		// Emptying the box is not "make this a bare flag" — spliceFlagValue would
+		// leave the flag stranded with a blank token behind it. Removing a flag is
+		// the ✕'s job, so an empty commit just closes.
+		if (!v) return;
+		// spliceFlagValue inserts the replacement verbatim, so a multi-word value
+		// has to arrive quoted or it tokenizes as two tokens and corrupts
+		// everything after it. Same rule addFlagToText applies on the add path.
+		onChange(spliceFlagValue(text, canon, /\s/.test(v) ? `"${v}"` : v));
+	};
+	const commitAdd = () => {
+		const raw = addDraft.trim();
+		setAdding(false);
+		setAddDraft("");
+		if (!raw) return;
+		// "flag value…" — split on the FIRST space only, so a multi-word value
+		// (--chat-template-kwargs '{"enable_thinking":false}') stays one value.
+		const sp = raw.indexOf(" ");
+		const flag = sp === -1 ? raw : raw.slice(0, sp);
+		const value = sp === -1 ? null : raw.slice(sp + 1).trim();
+		// Hand addFlagToText the BARE value: it re-quotes whatever needs it, so
+		// passing an already-quoted string through would double the quotes.
+		const bare =
+			value && /^(["']).*\1$/.test(value) ? value.slice(1, -1) : value;
+		onChange(addFlagToText(text, flag, bare));
+	};
+
+	const pillClass = (kind) =>
+		`fpill fpill-tune${
+			kind === "changed"
+				? " fpill-chg"
+				: kind === "added"
+					? " fpill-add"
+					: kind === "denied"
+						? " fpill-deny"
+						: ""
+		}`;
+	const iconBtnStyle = {
+		background: "transparent",
+		border: "none",
+		color: "inherit",
+		font: "inherit",
+		cursor: "pointer",
+		padding: 0,
+		lineHeight: 1,
+	};
+	const popoverInputStyle = {
+		position: "absolute",
+		top: "calc(100% + 6px)",
+		left: 0,
+		zIndex: 60,
+		width: 150,
+		fontSize: 12,
+	};
+
+	return (
+		<div ref={wrapRef} data-testid="model-tune-pills">
+			{sections.map((s) => (
+				<div
+					key={s.id}
+					data-testid={`model-tune-group-${s.id}`}
+					style={{ marginBottom: 10 }}
+				>
+					<div
+						className="mono"
+						style={{
+							fontSize: 9,
+							letterSpacing: ".06em",
+							textTransform: "uppercase",
+							color: "var(--fg-4)",
+							marginBottom: 5,
+						}}
+					>
+						{s.label}
+					</div>
+					<div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+						{s.pairs.map((p, i) => {
+							const kind = divergenceFor(p.flag, p.canon);
+							const c = changedFor(p.canon);
+							return (
+								<span
+									key={`${p.canon}-${i}`}
+									className={pillClass(kind)}
+									data-testid={`model-tune-pill-${p.canon}`}
+									data-divergence={kind}
+									title={
+										kind === "changed"
+											? `profile has ${p.flag} ${c ? c.from : ""}`
+											: kind === "denied"
+												? `${p.flag} is not settable on the model — see the error below`
+												: undefined
+									}
+								>
+									<span>{p.flag}</span>
+									{p.value != null && (
+										<span style={{ position: "relative" }}>
+											<button
+												type="button"
+												data-testid={`model-tune-pill-value-${p.canon}`}
+												aria-label={`Edit ${p.flag} value`}
+												onClick={() => openValue(p.canon, p.value)}
+												style={{
+													...iconBtnStyle,
+													color: "var(--fg)",
+													borderBottom: "1px dotted var(--line-strong)",
+												}}
+											>
+												{p.value}
+											</button>
+											{editingValue === p.canon && (
+												<input
+													className="input mono"
+													data-testid="model-tune-value-input"
+													autoFocus
+													value={valueDraft}
+													onChange={(e) => setValueDraft(e.target.value)}
+													onKeyDown={(e) => {
+														if (e.key === "Enter") {
+															e.preventDefault();
+															commitValue(p.canon);
+														} else if (e.key === "Escape") {
+															// Consumed so the Drawer's document-level
+															// Escape→close never sees it: Escape here
+															// discards the draft, it must not also shut
+															// the drawer.
+															e.preventDefault();
+															e.stopPropagation();
+															closePopovers();
+														}
+													}}
+													style={popoverInputStyle}
+												/>
+											)}
+										</span>
+									)}
+									{kind === "changed" && (
+										<button
+											type="button"
+											data-testid={`model-tune-pill-revert-${p.canon}`}
+											aria-label={`Revert ${p.flag} to the profile value`}
+											title={`↺ back to ${c ? c.from : "the profile value"}`}
+											onClick={() => revert(p.canon)}
+											style={iconBtnStyle}
+										>
+											↺
+										</button>
+									)}
+									<button
+										type="button"
+										data-testid={`model-tune-pill-remove-${p.canon}`}
+										aria-label={`Remove ${p.flag}`}
+										onClick={() => onChange(removeFlagFromText(text, p.canon))}
+										style={iconBtnStyle}
+									>
+										✕
+									</button>
+								</span>
+							);
+						})}
+						{s.ghosts.map((r, i) => (
+							<span
+								key={`ghost-${r.canon}-${i}`}
+								className="fpill fpill-tune fpill-rm"
+								data-testid={`model-tune-pill-ghost-${r.canon}`}
+								data-divergence="removed"
+								title={`in the profile, dropped here — restore ${r.flag}`}
+							>
+								<span>
+									{r.flag}
+									{r.value != null ? ` ${r.value}` : ""}
+								</span>
+								<button
+									type="button"
+									data-testid={`model-tune-pill-restore-${r.canon}`}
+									aria-label={`Restore ${r.flag} from the profile`}
+									onClick={() => onChange(addFlagToText(text, r.flag, r.value))}
+									style={iconBtnStyle}
+								>
+									+
+								</button>
+							</span>
+						))}
+					</div>
+				</div>
+			))}
+			{sections.length === 0 && (
+				<div className="hint" style={{ marginBottom: 10 }}>
+					no tune flags — seed from a profile, or add one below
+				</div>
+			)}
+			<div style={{ position: "relative", display: "inline-block" }}>
+				<button
+					type="button"
+					className="btn ghost sm"
+					data-testid="model-tune-add-flag"
+					aria-expanded={adding}
+					onClick={() => {
+						setEditingValue(null);
+						setAddDraft("");
+						setAdding((o) => !o);
+					}}
+				>
+					+ Add flag…
+				</button>
+				{adding && (
+					<input
+						className="input mono"
+						data-testid="model-tune-add-input"
+						autoFocus
+						placeholder="--cache-type-k q8_0"
+						value={addDraft}
+						onChange={(e) => setAddDraft(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") {
+								e.preventDefault();
+								commitAdd();
+							} else if (e.key === "Escape") {
+								e.preventDefault();
+								e.stopPropagation();
+								closePopovers();
+							}
+						}}
+						style={{ ...popoverInputStyle, width: 240 }}
+					/>
+				)}
+			</div>
+		</div>
+	);
+}
+
 // ─── Drawer dirty-tracking seam (#1398) ──────────────────────────────────────
 //
 // Same seam the slot drawer got in #1447, for the same reason. This drawer
@@ -707,6 +1043,12 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 	const [vision, setVision] = useStateMD("auto");
 	// Local UI state.
 	const [confirm, setConfirm] = useStateMD(null); // {title,message,confirmLabel,onConfirm}
+	// Task 4: ONE mode flag for the tune editor. Pills are the resting view;
+	// this only records the operator's explicit "show me the text" toggle. The
+	// EFFECTIVE mode (`rawEditor` below) also goes raw whenever the text won't
+	// tokenize — there are no pills to render for a string nobody can parse,
+	// and the textarea is the only surface that can repair it.
+	const [rawMode, setRawMode] = useStateMD(false);
 	// Inline title editor (Task 3): the ✎ button swaps the name span for an
 	// input seeded from the CURRENT draft (`name`), never from the live model
 	// prop, so a prior uncommitted edit survives reopening the editor. Escape
@@ -759,6 +1101,7 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 		setJinja(b.jinja);
 		setVision(b.vision);
 		setDefaultOverride(null);
+		setRawMode(false);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [open, model?.id]);
 
@@ -801,6 +1144,9 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 		[extra, sourceProfile],
 	);
 	const diverged = !!(diff && diff.diverged);
+	const divergedCount = diff
+		? diff.added.length + diff.changed.length + diff.removed.length
+		: 0;
 
 	// Managed-arg + slot-hardware + shlex validation on the flags text (inline,
 	// blocks save). spec-hw-slot-ownership §5: the model is device-agnostic, so
@@ -811,6 +1157,9 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 	const managedOffenders = useMemoMD(() => findManagedFlags(extra), [extra]);
 	const hwOffenders = useMemoMD(() => findSlotHardwareFlags(extra), [extra]);
 	const shlexErr = useMemoMD(() => tokenizeFlags(extra).error, [extra]);
+	// Effective tune mode: the operator's toggle, OR forced raw because the text
+	// can't be tokenized into pills at all.
+	const rawEditor = rawMode || !!shlexErr;
 	const flagsError = shlexErr
 		? shlexErr
 		: hwOffenders.length
@@ -1197,6 +1546,51 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 		</span>
 	);
 
+	// Provenance + divergence chips (Task 4). They describe the flags, so they
+	// ride the tune card's own header row instead of a separate strip under it —
+	// "seeded from X" and "◆ N diverged" now read next to the thing they
+	// qualify, and the count answers "how much drifted?" without opening the
+	// raw-mode diff.
+	const tuneChipBase = {
+		fontFamily: "var(--jbm)",
+		fontSize: 9,
+		letterSpacing: ".05em",
+		textTransform: "uppercase",
+		padding: "2px 6px",
+		borderRadius: 3,
+	};
+	const tuneChips = (
+		<>
+			<span
+				className="tag"
+				data-testid="model-provenance-chip"
+				style={{
+					...tuneChipBase,
+					color: profile ? "var(--fg-3)" : "var(--fg-4)",
+					background: "var(--bg-2)",
+					border: "1px solid var(--line)",
+				}}
+			>
+				{profile ? `seeded from ${profile}` : "no template"}
+			</span>
+			{diverged && (
+				<span
+					className="tag"
+					data-testid="model-diverged-chip"
+					title={`Flags differ from ${profile}'s current text. The model owns these — the profile won't change them.`}
+					style={{
+						...tuneChipBase,
+						color: "var(--warn)",
+						background: "var(--warn-soft)",
+						border: "1px solid var(--warn-line)",
+					}}
+				>
+					◆ {divergedCount} diverged
+				</span>
+			)}
+		</>
+	);
+
 	// Facts band (Task 3): read-only quant/size/arch/context/sha256/used-by
 	// strip under the header. Each cell renders ONLY when its fact exists on
 	// the row — an absent fact is an absent cell, never a blank one.
@@ -1358,7 +1752,8 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 							borderBottom: "1px solid var(--line)",
 							display: "flex",
 							alignItems: "center",
-							gap: 10,
+							gap: 8,
+							flexWrap: "wrap",
 						}}
 					>
 						<span
@@ -1372,7 +1767,25 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 						>
 							launch flags · tune remainder · exactly what launches
 						</span>
+						{tuneChips}
 						<span style={{ flex: 1 }} />
+						<button
+							type="button"
+							className="btn ghost sm"
+							data-testid="model-tune-raw-toggle"
+							aria-pressed={rawEditor}
+							disabled={!!shlexErr}
+							title={
+								shlexErr
+									? "the text can't be parsed into pills — fix it here first"
+									: rawEditor
+										? "back to grouped pills"
+										: "edit the raw flags text"
+							}
+							onClick={() => setRawMode((r) => !r)}
+						>
+							{rawEditor ? "▦ pills" : "⌨ raw text"}
+						</button>
 						<SeedProfileButton
 							options={fitProfiles}
 							onPick={seedFromProfile}
@@ -1380,11 +1793,19 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 						/>
 					</div>
 					<div style={{ padding: 14, background: "var(--bg-sunken)" }}>
-						<FlagsEditor
-							value={extra}
-							onChange={setExtra}
-							invalid={!!flagsError}
-						/>
+						{rawEditor ? (
+							<FlagsEditor
+								value={extra}
+								onChange={setExtra}
+								invalid={!!flagsError}
+							/>
+						) : (
+							<TunePills
+								text={extra}
+								onChange={setExtra}
+								profileFlags={sourceProfile ? sourceProfile.flags || "" : null}
+							/>
+						)}
 						{flagsError && (
 							<div
 								className="err"
@@ -1437,80 +1858,8 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 							</span>
 						</div>
 					</div>
-					<div
-						style={{
-							padding: "9px 14px",
-							background: "var(--bg-2)",
-							borderTop: "1px solid var(--line)",
-							display: "flex",
-							alignItems: "center",
-							gap: 8,
-							flexWrap: "wrap",
-						}}
-					>
-						{profile ? (
-							<span
-								className="tag"
-								data-testid="model-provenance-chip"
-								style={{
-									color: "var(--fg-3)",
-									borderColor: "var(--line)",
-									background: "var(--bg-2)",
-									fontFamily: "var(--jbm)",
-									fontSize: 9,
-									letterSpacing: ".05em",
-									textTransform: "uppercase",
-									padding: "2px 6px",
-									borderRadius: 3,
-									border: "1px solid var(--line)",
-								}}
-							>
-								seeded from {profile}
-							</span>
-						) : (
-							<span
-								className="tag"
-								data-testid="model-provenance-chip"
-								style={{
-									color: "var(--fg-4)",
-									borderColor: "var(--line)",
-									background: "var(--bg-2)",
-									fontFamily: "var(--jbm)",
-									fontSize: 9,
-									letterSpacing: ".05em",
-									textTransform: "uppercase",
-									padding: "2px 6px",
-									borderRadius: 3,
-									border: "1px solid var(--line)",
-								}}
-							>
-								no template
-							</span>
-						)}
-						{diverged && (
-							<span
-								className="tag"
-								data-testid="model-diverged-chip"
-								title={`Flags differ from ${profile}'s current text. The model owns these — the profile won't change them.`}
-								style={{
-									color: "var(--warn)",
-									borderColor: "var(--warn-line)",
-									background: "var(--warn-soft)",
-									fontFamily: "var(--jbm)",
-									fontSize: 9,
-									letterSpacing: ".05em",
-									textTransform: "uppercase",
-									padding: "2px 6px",
-									borderRadius: 3,
-									border: "1px solid var(--warn-line)",
-								}}
-							>
-								◆ diverged from {profile}
-							</span>
-						)}
-					</div>
 				</div>
-				{diverged && diff && (
+				{rawEditor && diverged && diff && (
 					<DivergenceDiff
 						diff={diff}
 						profileName={profile}
@@ -1801,5 +2150,6 @@ function slotHardwareFlagMessage(offenders) {
 Object.assign(window, {
 	ModelDrawer,
 	FlagsEditor,
+	TunePills,
 	DivergenceDiff,
 });

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -25,6 +25,7 @@
 import {
 	useModelUpdate,
 	useModelSetDefault,
+	useModelInspect,
 } from "@/api/hooks/useModels";
 import { useModelSeedProfile } from "@/api/hooks/useModelSeedProfile";
 import { useChatTemplates } from "@/api/hooks/useChatTemplates";
@@ -1183,6 +1184,129 @@ function engineRichOptions(runtimeFamilies, providerEffective) {
 	];
 }
 
+// ── MMProj: the shape the registry actually stores (Task 9) ──────────────────
+//
+// `Model.mmproj` is an ABSOLUTE HOST PATH, never a bare filename. Three
+// independent places in the source say so:
+//
+//   · the field itself — "Absolute path to a multimodal projector (mmproj)
+//     GGUF sidecar … surfaced verbatim to the llama-server provider as
+//     --mmproj" (src/hal0/registry/model.py:249-256);
+//   · the write screen — `screen_vision_mmproj` rejects a projector that is
+//     not `Path(projector).is_file()` on this host, and its docstring names
+//     every registry-bound value "a caller-supplied host path"
+//     (src/hal0/services/models_service.py:1440-1475);
+//   · the pull worker — the `mmproj_filename` the Add-from-HF modal sends is
+//     an HF-side FILENAME and is resolved before it reaches the registry:
+//     `mmproj_final = final.parent / Path(mm_rec.hf_filename).name`
+//     (src/hal0/registry/pull.py:1071), persisted as `str(mmproj_final)`
+//     (pull.py:1095); the fileset branch does the same with the installed
+//     destination (`updates["mmproj"] = str(mmproj_dest)`, pull.py:1588), as
+//     does the discover scan (`model.mmproj = str(candidate.mmproj)`,
+//     src/hal0/registry/discover.py:404).
+//
+// So the picker lists repo FILENAMES but must write `<dir>/<filename>`, with
+// `<dir>` the directory the sidecar sits in beside the model — exactly what
+// the pull worker would have produced. `mmprojDirOf` prefers the stored
+// projector's own directory (a row whose sidecar lives elsewhere keeps it) and
+// falls back to the model file's directory. No derivable directory ⇒ no
+// picker: this drawer resolves a path, it never invents one.
+function mmprojDirOf(storedMmproj, modelPath) {
+	const src = String(storedMmproj || modelPath || "").trim();
+	const cut = src.lastIndexOf("/");
+	if (cut < 0) return null;
+	return cut === 0 ? "/" : src.slice(0, cut);
+}
+
+function joinMmprojPath(dir, filename) {
+	return dir === "/" ? `/${filename}` : `${dir}/${filename}`;
+}
+
+function basenameOf(p) {
+	const s = String(p || "");
+	const cut = s.lastIndexOf("/");
+	return cut < 0 ? s : s.slice(cut + 1);
+}
+
+function sizeChipText(variant) {
+	if (variant && variant.size) return String(variant.size);
+	const b = Number(variant && variant.size_bytes);
+	return b > 0 ? `${(b / 1024 ** 3).toFixed(2)} GB` : "";
+}
+
+// Build the MMProj RichSelect's options. Option ids are the VALUE the picker
+// stores (the resolved absolute path), so `onChange` is a plain `setMmproj`
+// and the control's `value` compares against the stored string directly —
+// there is no second place where a filename could be re-derived into a
+// different path than the one that was saved.
+//
+// `current` (a projector stored on the row that this repo's listing doesn't
+// offer — a hand-placed sidecar, or a repo that has since dropped the file)
+// always gets its own row, verbatim. A value this picker cannot explain is
+// still a value the operator chose; it is never silently rewritten or dropped.
+function mmprojRichOptions(dir, variants, current) {
+	const opts = [
+		{
+			id: "",
+			row: "— none —",
+			desc: "no projector paired — a row advertising vision cannot save without one",
+		},
+	];
+	const seen = new Set([""]);
+	for (const v of variants) {
+		const id = joinMmprojPath(dir, v.id);
+		if (seen.has(id)) continue;
+		seen.add(id);
+		const chip = sizeChipText(v);
+		opts.push({ id, row: v.id, right: chip ? mutedChip(chip) : null });
+	}
+	const cur = String(current || "").trim();
+	if (cur && !seen.has(cur)) {
+		opts.push({
+			id: cur,
+			row: basenameOf(cur),
+			right: mutedChip("stored"),
+			desc: "paired on this model · not among this repo's files",
+		});
+	}
+	return opts;
+}
+
+// One read-only path line for the Source disclosure's paths block: mono text
+// that wraps mid-token (#2210's overflow-wrap:anywhere pattern — a projector
+// path is long, unbreakable, and must not push the drawer sideways) plus the
+// house copy affordance (model-modals.jsx:391).
+function SourcePathLine({ label, value, testId, empty }) {
+	const has = !!String(value || "").trim();
+	return (
+		<div style={{ display: "flex", gap: 8, alignItems: "baseline", marginTop: 4 }}>
+			<span className="hint" style={{ minWidth: 52, flex: "0 0 auto" }}>
+				{label}
+			</span>
+			<span
+				className="mono"
+				style={{ flex: 1, minWidth: 0, overflowWrap: "anywhere", fontSize: 12 }}
+			>
+				{has ? value : <span className="hint">{empty}</span>}
+			</span>
+			{has && (
+				<button
+					type="button"
+					className="btn ghost sm"
+					data-testid={testId}
+					onClick={() => {
+						navigator.clipboard?.writeText(String(value));
+						window.__hal0Toast &&
+							window.__hal0Toast(`${label} path copied to clipboard`, "ok");
+					}}
+				>
+					Copy
+				</button>
+			)}
+		</div>
+	);
+}
+
 // ─── ModelDrawer ─────────────────────────────────────────────────────────────
 // `onOpenSlot` is optional (Task 3, facts-band used-by cell): when a host
 // passes it, each slot name in the used-by list is a jump button; absent, the
@@ -1197,6 +1321,9 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 	const profilesQuery = useProfiles();
 	const enums = useMetaEnums();
 	const slotsQuery = useSlots();
+	// Repo listing behind the Source disclosure's mmproj picker (Task 9) —
+	// POST /api/models/inspect, server-cached, fired lazily (see srcOpen below).
+	const inspect = useModelInspect();
 
 	// Identity + typed fields (preserve the full RecipeEditor save surface).
 	const [name, setName] = useStateMD("");
@@ -1229,6 +1356,15 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 	// tokenize — there are no pills to render for a string nobody can parse,
 	// and the textarea is the only surface that can repair it.
 	const [rawMode, setRawMode] = useStateMD(false);
+	// Task 9: the Source section is a disclosure ("▸ Source — repo · file ·
+	// mmproj · paths"), closed at rest. Re-pull coords and the projector are
+	// reference material for an operator who came looking; the drawer's resting
+	// height is spent on the launch tune instead.
+	const [srcOpen, setSrcOpen] = useStateMD(false);
+	// Which repo the mmproj picker's listing was fetched for. The probe is
+	// lazy — one POST on the disclosure's first open, never on drawer mount —
+	// and this guards the re-open from re-firing it for the same coord.
+	const inspectedRepo = useRefMD(null);
 	// Inline title editor (Task 3): the ✎ button swaps the name span for an
 	// input seeded from the CURRENT draft (`name`), never from the live model
 	// prop, so a prior uncommitted edit survives reopening the editor. Escape
@@ -1282,8 +1418,25 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 		setVision(b.vision);
 		setDefaultOverride(null);
 		setRawMode(false);
+		// A different row means a different repo listing — close the disclosure
+		// and forget the probe, so the next open fetches THIS model's projectors.
+		setSrcOpen(false);
+		inspectedRepo.current = null;
+		inspect.reset();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [open, model?.id]);
+
+	// The lazy repo probe (Task 9). Fires on the transition into `open` only,
+	// so editing the HF repo field while the disclosure is open doesn't fire a
+	// POST per keystroke; closing and re-opening picks the new coord up.
+	useEffectMD(() => {
+		if (!srcOpen) return;
+		const repo = hfRepo.trim();
+		if (!repo || inspectedRepo.current === repo) return;
+		inspectedRepo.current = repo;
+		inspect.mutate({ hf_repo: repo });
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [srcOpen]);
 
 	// Profiles that fit this model (same filter the old RecipeEditor used), so the
 	// template dropdown offers device-appropriate seeds.
@@ -1372,6 +1525,24 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
 		visionModel && !mmproj.trim()
 			? "this model advertises vision — an mmproj sidecar path is required"
 			: null;
+
+	// MMProj picker feed (Task 9). The directory comes off the BASELINE, not the
+	// live draft: picking "— none —" empties `mmproj`, and re-deriving from the
+	// draft would make the picker's own options disappear mid-interaction.
+	const mmprojDir = mmprojDirOf(baseline?.mmproj, model?.path);
+	const mmprojVariants = useMemoMD(() => {
+		const rows = Array.isArray(inspect.data?.variants) ? inspect.data.variants : [];
+		return rows.filter((v) => /mmproj/i.test(String(v?.id || "")));
+	}, [inspect.data]);
+	// Four ways to have nothing to pick FROM — no repo, a failed probe, a repo
+	// that ships no projector, or no directory to resolve a filename against.
+	// Each degrades to the free-text path input rather than to a dead control.
+	const mmprojPicker =
+		!!hfRepo.trim() && !inspect.isError && !!mmprojDir && mmprojVariants.length > 0;
+	const mmprojOptions = useMemoMD(
+		() => (mmprojPicker ? mmprojRichOptions(mmprojDir, mmprojVariants, mmproj) : []),
+		[mmprojPicker, mmprojDir, mmprojVariants, mmproj],
+	);
 
 	// Context size validation (#1378). A lenient parseInt destroyed data twice
 	// over: "32k" landed as 32 (a 1000x context collapse) and "abc" dropped the
@@ -2314,64 +2485,128 @@ export function ModelDrawer({ open, onClose, model, onOpenSlot = undefined }) {
             runner is chosen on the slot (BINARY → RUNNER_IMAGES); the Runtimes
             page (Settings → Runtimes) shows which slots resolve to each runner. */}
 
-				{/* ── Source · re-pull coords ── */}
-				<div className="form-section" style={{ marginTop: 16 }}>
-					Source · re-pull coords
+				{/* ── Source (disclosure) ── Where this row came from and where its
+            files sit: coords, projector, paths. Reference material, so it
+            rests closed — same controlled "▸"/"▾" idiom the slot drawer's
+            Advanced disclosure uses (slot-modals.jsx's slot-hw-advanced),
+            not a native <details>, so the glyph and label stay ours. */}
+				<div
+					className="form-section"
+					data-testid="model-source-disclosure"
+					role="button"
+					tabIndex={0}
+					aria-expanded={srcOpen}
+					style={{ marginTop: 16, cursor: "pointer", userSelect: "none" }}
+					onClick={() => setSrcOpen((o) => !o)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter" || e.key === " ") {
+							e.preventDefault();
+							setSrcOpen((o) => !o);
+						}
+					}}
+				>
+					<span className="mono" style={{ marginRight: 6, color: "var(--fg-4)" }}>
+						{srcOpen ? "▾" : "▸"}
+					</span>
+					Source — repo · file · mmproj · paths
 				</div>
-				<div className="form-row">
-					<div className="form-lbl">
-						<span>MMProj</span>
-						<FieldInfoIcon description="vision projector sidecar path" />
-					</div>
-					<div className="form-ctl">
-						<input
-							className="input mono"
-							data-testid="model-mmproj-input"
-							placeholder="/var/lib/hal0/models/…/mmproj-Q8.gguf"
-							value={mmproj}
-							onChange={(e) => setMmproj(e.target.value)}
-						/>
-						{mmprojError && (
-							<div
-								className="err"
-								data-testid="model-mmproj-error"
-								style={{ marginTop: 6 }}
-							>
-								{mmprojError}
+				{srcOpen && (
+					<>
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>MMProj</span>
+								<FieldInfoIcon
+									description={
+										mmprojPicker
+											? "vision projector sidecar · picked from the repo's own files and stored as the absolute path beside the model"
+											: "vision projector sidecar path — absolute, handed to the runner as --mmproj"
+									}
+								/>
 							</div>
-						)}
-					</div>
-				</div>
-				<div className="form-row">
-					<div className="form-lbl">
-						<span>HF repo</span>
-						<FieldInfoIcon description="HuggingFace repo · needed to re-pull" />
-					</div>
-					<div className="form-ctl">
-						<input
-							className="input mono"
-							data-testid="model-hfrepo-input"
-							placeholder="unsloth/Qwen3-8B-GGUF"
-							value={hfRepo}
-							onChange={(e) => setHfRepo(e.target.value)}
-						/>
-					</div>
-				</div>
-				<div className="form-row">
-					<div className="form-lbl">
-						<span>HF filename</span>
-						<FieldInfoIcon description="variant filename within the repo" />
-					</div>
-					<div className="form-ctl">
-						<input
-							className="input mono"
-							data-testid="model-hffile-input"
-							placeholder="qwen3-8b-q4_k_m.gguf"
-							value={hfFilename}
-							onChange={(e) => setHfFilename(e.target.value)}
-						/>
-					</div>
-				</div>
+							<div className="form-ctl">
+								{mmprojPicker ? (
+									<RichSelect
+										data-testid="model-mmproj-select"
+										aria-label="MMProj"
+										value={mmproj}
+										options={mmprojOptions}
+										onChange={setMmproj}
+									/>
+								) : (
+									<input
+										className="input mono"
+										data-testid="model-mmproj-input"
+										placeholder="/var/lib/hal0/models/…/mmproj-Q8.gguf"
+										value={mmproj}
+										onChange={(e) => setMmproj(e.target.value)}
+									/>
+								)}
+								{mmprojError && (
+									<div
+										className="err"
+										data-testid="model-mmproj-error"
+										style={{ marginTop: 6 }}
+									>
+										{mmprojError}
+									</div>
+								)}
+							</div>
+						</div>
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>HF repo</span>
+								<FieldInfoIcon description="HuggingFace repo · needed to re-pull · feeds the projector list above" />
+							</div>
+							<div className="form-ctl">
+								<input
+									className="input mono"
+									data-testid="model-hfrepo-input"
+									placeholder="unsloth/Qwen3-8B-GGUF"
+									value={hfRepo}
+									onChange={(e) => setHfRepo(e.target.value)}
+								/>
+							</div>
+						</div>
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>HF filename</span>
+								<FieldInfoIcon description="variant filename within the repo" />
+							</div>
+							<div className="form-ctl">
+								<input
+									className="input mono"
+									data-testid="model-hffile-input"
+									placeholder="qwen3-8b-q4_k_m.gguf"
+									value={hfFilename}
+									onChange={(e) => setHfFilename(e.target.value)}
+								/>
+							</div>
+						</div>
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>Paths</span>
+								<FieldInfoIcon description="where these files sit on this host · read-only — the model file is registry-owned, and the projector is set by the control above" />
+							</div>
+							<div className="form-ctl" data-testid="model-source-paths">
+								<SourcePathLine
+									label="model"
+									value={model.path}
+									testId="model-source-copy-path"
+									empty="not recorded on this row"
+								/>
+								{/* The DRAFT projector, not the stored one: this line is
+                    where a pick made above reads back as the resolved
+                    absolute path it will save as. */}
+								<SourcePathLine
+									label="mmproj"
+									value={mmproj}
+									testId="model-source-copy-mmproj"
+									empty="no projector paired"
+								/>
+							</div>
+						</div>
+					</>
+				)}
 
 				{update.isError && (
 					<div className="err">{update.error?.message || "Save failed"}</div>

--- a/ui/src/dash/model-usage.js
+++ b/ui/src/dash/model-usage.js
@@ -23,3 +23,73 @@ export function slotsUsingModel(slots, modelId) {
 
   return result
 }
+
+/**
+ * Build the footer summary text for staged model changes.
+ * Maps field changes to display names, dedupes, and formats with slot restart info.
+ * @param {Object} changes - Changes object from deriveModelChanges with boolean fields
+ * @param {Array<{name: string}>} usingSlots - Slots using this model
+ * @returns {string} Footer text: "no changes", or "N changes — {names} [⟳ restarts ...]"
+ */
+export function footSummary(changes, usingSlots) {
+  if (!changes || !changes.any) {
+    return 'no changes'
+  }
+
+  // Display name map per task brief
+  const fieldMap = {
+    name: 'name',
+    provider: 'engine',
+    mmproj: 'mmproj',
+    hfRepo: 'source',
+    hfFilename: 'source',
+    extra: 'flags',
+    profile: 'profile',
+    ctx: 'context',
+    chatTemplate: 'template',
+    mtp: 'overrides',
+    thinking: 'overrides',
+    jinja: 'overrides',
+    vision: 'overrides',
+  }
+
+  // Collect changed field display names, preserving order and deduping
+  const displayNamesSet = new Set()
+  const displayNames = []
+  const fieldOrder = [
+    'name',
+    'provider',
+    'mmproj',
+    'hfRepo',
+    'hfFilename',
+    'extra',
+    'profile',
+    'ctx',
+    'chatTemplate',
+    'mtp',
+    'thinking',
+    'jinja',
+    'vision',
+  ]
+
+  for (const field of fieldOrder) {
+    if (changes[field] && field in fieldMap) {
+      const displayName = fieldMap[field]
+      if (!displayNamesSet.has(displayName)) {
+        displayNamesSet.add(displayName)
+        displayNames.push(displayName)
+      }
+    }
+  }
+
+  const count = displayNames.length
+  let summary = `${count} changes — ${displayNames.join(' · ')}`
+
+  // Add restart clause if any slots are using this model
+  if (usingSlots && usingSlots.length > 0) {
+    const slotNames = usingSlots.map((s) => s.name).join(' · ')
+    summary += ` ⟳ restarts ${usingSlots.length} slots: ${slotNames}`
+  }
+
+  return summary
+}

--- a/ui/src/dash/model-usage.js
+++ b/ui/src/dash/model-usage.js
@@ -29,7 +29,7 @@ export function slotsUsingModel(slots, modelId) {
  * Maps field changes to display names, dedupes, and formats with slot restart info.
  * @param {Object} changes - Changes object from deriveModelChanges with boolean fields
  * @param {Array<{name: string}>} usingSlots - Slots using this model
- * @returns {string} Footer text: "no changes", or "N changes — {names} [⟳ restarts ...]"
+ * @returns {string} Footer text: "no changes", or "N change(s) — {names} [⟳ restarts N slot(s) ...]"
  */
 export function footSummary(changes, usingSlots) {
   if (!changes || !changes.any) {
@@ -83,12 +83,14 @@ export function footSummary(changes, usingSlots) {
   }
 
   const count = displayNames.length
-  let summary = `${count} changes — ${displayNames.join(' · ')}`
+  const changeNoun = count === 1 ? 'change' : 'changes'
+  let summary = `${count} ${changeNoun} — ${displayNames.join(' · ')}`
 
   // Add restart clause if any slots are using this model
   if (usingSlots && usingSlots.length > 0) {
     const slotNames = usingSlots.map((s) => s.name).join(' · ')
-    summary += ` ⟳ restarts ${usingSlots.length} slots: ${slotNames}`
+    const slotNoun = usingSlots.length === 1 ? 'slot' : 'slots'
+    summary += ` ⟳ restarts ${usingSlots.length} ${slotNoun}: ${slotNames}`
   }
 
   return summary

--- a/ui/src/dash/model-usage.js
+++ b/ui/src/dash/model-usage.js
@@ -1,0 +1,25 @@
+/**
+ * Filter slots by model ID, matching either default or live model.
+ * @param {Array | undefined} slots - Slots array from useSlots()
+ * @param {string} modelId - Model ID to match against
+ * @returns {Array<{name: string}>} Filtered and deduped slots, preserving input order
+ */
+export function slotsUsingModel(slots, modelId) {
+  if (!slots || !Array.isArray(slots)) {
+    return []
+  }
+
+  const seen = new Set()
+  const result = []
+
+  for (const slot of slots) {
+    if (slot.name && !seen.has(slot.name)) {
+      if (slot.model_default === modelId || slot.model === modelId) {
+        seen.add(slot.name)
+        result.push({ name: slot.name })
+      }
+    }
+  }
+
+  return result
+}

--- a/ui/src/dash/rich-select-core.ts
+++ b/ui/src/dash/rich-select-core.ts
@@ -113,6 +113,15 @@ export function handleKey(
     if (key === 'ArrowDown' || key === 'ArrowUp' || key === 'Enter' || key === ' ') {
       return { kind: 'state', state: openList(options, value) }
     }
+    // #2204: Home/End used to be inert while closed (wired only for the
+    // open branch below) — mirror Arrow's "opens the list" behaviour so a
+    // keyboard user gets the jump-to-first/last affordance before opening.
+    if (key === 'Home') {
+      return { kind: 'state', state: { open: true, activeId: firstEnabledId(options) } }
+    }
+    if (key === 'End') {
+      return { kind: 'state', state: { open: true, activeId: lastEnabledId(options) } }
+    }
     return { kind: 'none' }
   }
   switch (key) {

--- a/ui/src/dash/rich-select.jsx
+++ b/ui/src/dash/rich-select.jsx
@@ -48,27 +48,27 @@ export function RichSelect({
   'aria-label': ariaLabel,
   'data-testid': testId,
 }) {
-  const generatedId = useId()
-  const baseId = testId || generatedId
-  const rootRef = useRef(null)
-  const listRef = useRef(null)
-  const [state, setState] = useState(() => initialState(value ?? null))
+  const generatedId = useId();
+  const baseId = testId || generatedId;
+  const rootRef = useRef(null);
+  const listRef = useRef(null);
+  const [state, setState] = useState(() => initialState(value ?? null));
 
   // Optional open/close notification (Task 11d) — the Model select's caller
   // fires its one-shot batch feasibility probe here, on the transition into
   // `open`, rather than on every render while open. No consumer is required
   // to pass this; the effect is a no-op without it.
   useEffect(() => {
-    if (onOpenChange) onOpenChange(state.open)
+    if (onOpenChange) onOpenChange(state.open);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.open])
+  }, [state.open]);
 
   // A `value` change from outside while closed (e.g. a sibling control
   // driving this select, or the initial load resolving) re-seeds activeId
   // so the next open starts on the right row. While open, an in-flight
   // keyboard/mouse navigation owns activeId and is left alone.
   useEffect(() => {
-    setState((s) => (s.open ? s : closeList(value ?? null)))
+    setState((s) => (s.open ? s : closeList(value ?? null)));
   }, [value]);
 
   useEffect(() => {
@@ -132,7 +132,9 @@ export function RichSelect({
         role="combobox"
         aria-haspopup="listbox"
         aria-expanded={state.open}
-        aria-controls={`${baseId}-listbox`}
+        // #2204: only name the listbox once it actually exists — pointing
+        // aria-controls at a closed/unrendered id misdirects assistive tech.
+        aria-controls={state.open ? `${baseId}-listbox` : undefined}
         aria-activedescendant={activeDescendantId(baseId, state)}
         aria-label={ariaLabel}
         onClick={onTriggerClick}

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -3540,7 +3540,7 @@ select.npu-sel {
 .rsel-option:hover, .rsel-option[data-active="true"] { background: var(--bg-3); }
 .rsel-option[aria-selected="true"] { background: var(--accent-bg); }
 .rsel-option[aria-selected="true"] .rsel-option-row { color: var(--accent); }
-.rsel-option[aria-disabled="true"] { cursor: not-allowed; opacity: 0.4; }
+.rsel-option[aria-disabled="true"] { cursor: not-allowed; opacity: 0.4; pointer-events: none; }
 .rsel-option[aria-disabled="true"]:hover { background: transparent; }
 .rsel-empty { padding: 10px 12px; font-size: 11.5px; color: var(--fg-4); font-family: var(--jbm); }
 

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1333,6 +1333,11 @@ a { color: inherit; text-decoration: none; }
 }
 .input.mono { font-family: var(--jbm); font-size: 12.5px; }
 .input:focus { border-color: var(--accent-line); box-shadow: 0 0 0 3px var(--accent-soft); }
+/* Field-error state (#2207) — `.input-err` was applied throughout the drawers
+   (model-drawer.jsx, slot-modals.jsx) with no rule of its own; same error
+   token as `.rsel-trigger.rsel-err` below borrows today. */
+.input-err { border-color: var(--err-line); }
+.input-err:focus { box-shadow: 0 0 0 3px var(--err-soft); }
 
 /* ════════════════════════════════════════════════════════════════════
    Dashboard view
@@ -3500,9 +3505,9 @@ select.npu-sel {
 }
 .rsel-trigger[disabled] { opacity: 0.45; cursor: not-allowed; }
 /* Field-error state, passed via RichSelect's `className` prop (Task 11
-   review fix) — same error tokens the plain `.input-err` inputs elsewhere
-   in the drawer use (border/err color), since `.input-err` itself carries
-   no rule of its own to reuse here. */
+   review fix) — same error tokens `.input-err` carries (#2207). RichSelect
+   isn't an <input>, so it needs its own selector rather than `.input-err`
+   itself. */
 .rsel-trigger.rsel-err { border-color: var(--err-line); }
 .rsel-trigger.rsel-err:focus-visible { box-shadow: 0 0 0 3px var(--err-soft); }
 .rsel-trigger-row { flex: 1; min-width: 0; display: flex; align-items: center; gap: 8px; }

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -2321,6 +2321,27 @@ select.npu-sel {
 .mdl-chip:hover { color: var(--fg); border-color: var(--line-strong); }
 .mdl-chip.on { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
 
+/* Tune pills (model drawer, structured flags editor) — the .fpill idiom again,
+   with one modifier per divergence state so the colour IS the answer to "how
+   does this differ from the profile that seeded it?". Unchanged pills stay
+   plain .fpill; `none` (no seeding profile) is deliberately indistinguishable
+   from unchanged, because with nothing to diverge from there is nothing to
+   say. .fpill-rm is the ghost: in the profile, dropped here. */
+/* The pill body is a read-out, not a control — only the affordances inside it
+   (value, ↺, ✕, +) are clickable, so it must not borrow .fpill's pointer. */
+.fpill-tune { cursor: default; }
+.fpill-tune button { cursor: pointer; }
+.fpill-chg { color: var(--warn); border-color: var(--warn-line); background: var(--warn-soft); }
+.fpill-add { color: var(--ok); border-color: var(--ok-line); background: var(--ok-soft); }
+.fpill-deny { color: var(--err); border-color: var(--err-line); background: var(--err-soft); }
+.fpill-rm {
+  color: var(--fg-4);
+  border-style: dashed;
+  background: transparent;
+  text-decoration: line-through;
+}
+.fpill-rm button { text-decoration: none; }
+
 .mdl-list {
   background: var(--bg-1);
   border: 1px solid var(--line);

--- a/ui/tests/e2e/specs/drawer-save-errors-v3.spec.ts
+++ b/ui/tests/e2e/specs/drawer-save-errors-v3.spec.ts
@@ -215,6 +215,15 @@ test.describe('Model drawer — rejected writes', () => {
   async function openDrawer(page: Page) {
     await page.goto('/#models')
     await page.locator('button:has-text("Edit options")').first().click()
+    await expect(page.getByTestId('model-tune-raw-toggle')).toBeVisible()
+  }
+
+  /** model-drawer-2 Task 4: the tune editor rests on grouped pills, and the
+   *  flags TEXTAREA is the raw view behind the toggle. These cases are about
+   *  the flags string itself (managed-arg screening, an unbalanced quote), so
+   *  they reach it the way an operator would — through raw mode. */
+  async function showRawFlags(page: Page) {
+    await page.getByTestId('model-tune-raw-toggle').click()
     await expect(page.getByTestId('model-flags-input')).toBeVisible()
   }
 
@@ -274,6 +283,7 @@ test.describe('Model drawer — rejected writes', () => {
     })
 
     await openDrawer(page)
+    await showRawFlags(page)
     await page.getByTestId('model-flags-input').fill('--port 9999')
 
     await expect(page.getByTestId('model-save')).toBeDisabled()
@@ -297,6 +307,7 @@ test.describe('Model drawer — rejected writes', () => {
     })
 
     await openDrawer(page)
+    await showRawFlags(page)
     await page.getByTestId('model-flags-input').fill('--chat-template "broken')
 
     await expect(page.getByTestId('model-save')).toBeDisabled()

--- a/ui/tests/e2e/specs/drawer-save-errors-v3.spec.ts
+++ b/ui/tests/e2e/specs/drawer-save-errors-v3.spec.ts
@@ -238,7 +238,11 @@ test.describe('Model drawer — rejected writes', () => {
     })
 
     await openDrawer(page)
-    await page.getByTestId('model-name-input').fill('Renamed while failing')
+    // model-drawer-2 Task 3: name edits ride the inline title editor now
+    // (✎ → model-title-input, Enter commits), not a "Display name" form row.
+    await page.getByTestId('model-title-edit').click()
+    await page.getByTestId('model-title-input').fill('Renamed while failing')
+    await page.getByTestId('model-title-input').press('Enter')
     await page.getByTestId('model-ctx-input').fill('16384')
     await page.getByTestId('model-save').click()
 
@@ -249,7 +253,9 @@ test.describe('Model drawer — rejected writes', () => {
     )
     // …drawer stays open with BOTH edits still in the fields.
     await expect(page.locator('.drawer.open')).toHaveCount(1)
-    await expect(page.getByTestId('model-name-input')).toHaveValue('Renamed while failing')
+    await expect(
+      page.locator('.drawer.open h2 > span > span').first(),
+    ).toHaveText('Renamed while failing')
     await expect(page.getByTestId('model-ctx-input')).toHaveValue('16384')
   })
 

--- a/ui/tests/e2e/specs/model-drawer-default-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-default-v3.spec.ts
@@ -68,7 +68,7 @@ test.describe('Model drawer — per-type default', () => {
 
     await page.goto('/#models')
     await page.locator('button:has-text("Edit options")').first().click()
-    await expect(page.getByTestId('model-flags-input')).toBeVisible()
+    await expect(page.getByTestId('model-tune-raw-toggle')).toBeVisible()
 
     // Initially not the default.
     const toggle = page.getByTestId('model-default-toggle')

--- a/ui/tests/e2e/specs/model-drawer-default-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-default-v3.spec.ts
@@ -1,12 +1,17 @@
 /**
  * model-drawer-default-v3 — per-type default MODEL marker (Set / Remove).
  *
- * The model drawer surfaces whether the model is its dispatcher type's default
- * and a Set-as-default / Remove-default affordance that POSTs
- * /api/models/{id}/default. The server enforces the single-holder invariant;
- * the UI just fires the mutation and lets the models-query invalidation flip
- * the badge. Asserts the badge + button reflect the (stateful-mocked) flag both
- * ways round.
+ * The model drawer surfaces whether the model is its dispatcher type's
+ * default via a single toggle chip that POSTs /api/models/{id}/default. The
+ * server enforces the single-holder invariant; the UI just fires the
+ * mutation and lets the models-query invalidation flip the chip. Asserts the
+ * chip's text reflects the (stateful-mocked) flag both ways round.
+ *
+ * model-drawer-2 Task 3 collapsed the old badge (`model-default-badge` /
+ * `model-default-none`) + ghost chip + separate button trio into ONE
+ * `model-default-toggle` chip whose own text carries the state ("llm
+ * default" / "✓ llm default") — the testid is preserved, only the badge
+ * testids and the "Set as default" / "Remove default" text are gone.
  */
 import { test, expect } from '../fixtures/apiMock'
 import { MOCK_DATA } from '../fixtures/mock-data'
@@ -28,7 +33,7 @@ function mockChatTemplates(page: import('@playwright/test').Page) {
 }
 
 test.describe('Model drawer — per-type default', () => {
-  test('Set as default → badge flips → Remove default flips back', async ({ page }) => {
+  test('default chip toggles both ways', async ({ page }) => {
     await mockProfiles(page)
     await mockChatTemplates(page)
 
@@ -66,18 +71,15 @@ test.describe('Model drawer — per-type default', () => {
     await expect(page.getByTestId('model-flags-input')).toBeVisible()
 
     // Initially not the default.
-    await expect(page.getByTestId('model-default-none')).toBeVisible()
     const toggle = page.getByTestId('model-default-toggle')
-    await expect(toggle).toHaveText(/Set as default/)
+    await expect(toggle).toHaveText('llm default')
 
-    // Promote → badge appears, button flips to Remove.
+    // Promote → chip flips to the checked state.
     await toggle.click()
-    await expect(page.getByTestId('model-default-badge')).toBeVisible()
-    await expect(page.getByTestId('model-default-toggle')).toHaveText(/Remove default/)
+    await expect(page.getByTestId('model-default-toggle')).toHaveText('✓ llm default')
 
-    // Clear → badge gone, button back to Set.
+    // Clear → chip flips back.
     await page.getByTestId('model-default-toggle').click()
-    await expect(page.getByTestId('model-default-none')).toBeVisible()
-    await expect(page.getByTestId('model-default-toggle')).toHaveText(/Set as default/)
+    await expect(page.getByTestId('model-default-toggle')).toHaveText('llm default')
   })
 })

--- a/ui/tests/e2e/specs/model-drawer-dirty-baseline-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-dirty-baseline-v3.spec.ts
@@ -144,7 +144,7 @@ async function landConcurrentWrite(page: Page, patch: Record<string, unknown>) {
 async function openDrawer(page: Page) {
   await page.goto('/#models')
   await page.locator('button:has-text("Edit options")').first().click()
-  await expect(page.getByTestId('model-flags-input')).toBeVisible()
+  await expect(page.getByTestId('model-tune-raw-toggle')).toBeVisible()
 }
 
 const saveBtn = (page: Page) => page.getByTestId('model-save')

--- a/ui/tests/e2e/specs/model-drawer-dirty-baseline-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-dirty-baseline-v3.spec.ts
@@ -240,7 +240,10 @@ test.describe('Model drawer — frozen baseline + dirty-gated Save', () => {
     await openDrawer(page)
     await expect(saveBtn(page)).toBeDisabled()
 
-    await page.getByTestId('model-name-input').fill('Renamed model')
+    // model-drawer-2 Task 3: name edits ride the inline title editor now.
+    await page.getByTestId('model-title-edit').click()
+    await page.getByTestId('model-title-input').fill('Renamed model')
+    await page.getByTestId('model-title-input').press('Enter')
     await expect(saveBtn(page)).toBeEnabled()
     await saveBtn(page).click()
 

--- a/ui/tests/e2e/specs/model-drawer-reset-profile-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-reset-profile-v3.spec.ts
@@ -88,7 +88,14 @@ test.describe('Model drawer — reset to profile', () => {
 
     await page.goto('/#models')
     await page.locator('button:has-text("Edit options")').click()
-    await expect(page.getByTestId('model-flags-input')).toBeVisible()
+    await expect(page.getByTestId('model-tune-raw-toggle')).toBeVisible()
+
+    // model-drawer-2 Task 4: the tune editor rests on grouped pills and the
+    // flags textarea is the raw view behind the toggle — as is "↺ reset to
+    // profile", which lives on the raw-mode divergence panel (the pills carry
+    // per-flag revert inline instead). This spec is about the whole-text
+    // re-stamp, so it works in raw throughout, exactly as before.
+    await page.getByTestId('model-tune-raw-toggle').click()
 
     // Stamp (now a POST /api/models/{id}/seed-profile round-trip), then diverge.
     await stampFromProfile(page, 'rocm-moe')

--- a/ui/tests/e2e/specs/model-drawer-reset-profile-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-reset-profile-v3.spec.ts
@@ -78,6 +78,11 @@ async function mockSeedProfile(page: import('@playwright/test').Page) {
 async function stampFromProfile(page: import('@playwright/test').Page, name: string) {
   await page.getByTestId('model-seed-profile-open').click()
   await page.getByTestId(`model-seed-profile-option-${name}`).click()
+  // Task 8 (#2205): EVERY pick now opens the consequence-preview confirm —
+  // the old wouldClobber shortcut that skipped it for an empty/matching
+  // current flags text is gone. Same POST, same effects; one extra click.
+  await expect(page.getByTestId('model-seed-preview')).toBeVisible()
+  await page.getByRole('button', { name: 'Stamp tune', exact: true }).click()
 }
 
 test.describe('Model drawer — reset to profile', () => {

--- a/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
@@ -121,7 +121,7 @@ async function setCapOverride(
 async function openDrawer(page: import('@playwright/test').Page) {
   await page.goto('/#models')
   await page.locator('button:has-text("Edit options")').first().click()
-  await expect(page.getByTestId('model-flags-input')).toBeVisible()
+  await expect(page.getByTestId('model-tune-raw-toggle')).toBeVisible()
 }
 
 test.describe('Model drawer — complete save and compact field help', () => {
@@ -157,6 +157,10 @@ test.describe('Model drawer — complete save and compact field help', () => {
     await page.getByTestId('model-hffile-input').fill('saved-q4.gguf')
     // Stamp now round-trips through POST /api/models/{id}/seed-profile.
     await stampFromProfile(page, 'rocm-save')
+    // model-drawer-2 Task 4: the flags textarea is the raw view behind
+    // `model-tune-raw-toggle` — the stamped STRING is what this asserts, so it
+    // reads it there.
+    await page.getByTestId('model-tune-raw-toggle').click()
     await expect(page.getByTestId('model-flags-input')).toHaveValue(PROFILE_FLAGS)
     expect(seedRequests).toEqual([{ profile: 'rocm-save' }])
     await page.getByTestId('model-ctx-input').fill('16384')

--- a/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
@@ -21,6 +21,7 @@
  * despite both existing server-side too.
  */
 import { test, expect } from '../fixtures/apiMock'
+import { pickRichOption } from '../fixtures/richSelect'
 
 const MODEL_ID = 'qwen3.6-27b-mtp'
 const PROFILE_FLAGS = '--cache-type-k q8_0'
@@ -164,7 +165,7 @@ test.describe('Model drawer — complete save and compact field help', () => {
     await expect(page.getByTestId('model-flags-input')).toHaveValue(PROFILE_FLAGS)
     expect(seedRequests).toEqual([{ profile: 'rocm-save' }])
     await page.getByTestId('model-ctx-input').fill('16384')
-    await page.getByTestId('model-chat-template').selectOption('chatml')
+    await pickRichOption(page.getByTestId('model-chat-template'), 'chatml')
     // Overrides ledger replaces the four always-on TypedCapSeg rows.
     await setCapOverride(page, 'mtp', 'off')
     await setCapOverride(page, 'thinking', 'on')

--- a/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
@@ -130,6 +130,17 @@ async function openDrawer(page: import('@playwright/test').Page) {
   await expect(page.getByTestId('model-tune-raw-toggle')).toBeVisible()
 }
 
+/**
+ * model-drawer-2 Task 9: MMProj / HF repo / HF filename / Paths live behind a
+ * disclosure that rests closed. The apiMock catch-all answers the lazy
+ * POST /api/models/inspect with `{}` — no variants, so MMProj degrades to the
+ * free-text path input this spec's save contract fills.
+ */
+async function openSource(page: import('@playwright/test').Page) {
+  await page.getByTestId('model-source-disclosure').click()
+  await expect(page.getByTestId('model-source-paths')).toBeVisible()
+}
+
 test.describe('Model drawer — complete save and compact field help', () => {
   test('successful PUT carries every surfaced field, preserves unrelated defaults, and closes with feedback', async ({ page }) => {
     await seedProductionModel(page)
@@ -159,6 +170,7 @@ test.describe('Model drawer — complete save and compact field help', () => {
     // write path now; "Runs on" is derived/read-only and not editable here.
     // Task 6: the native <select> became a RichSelect (rich-select.jsx).
     await pickRichOption(page.getByTestId('model-provider-select'), 'flm')
+    await openSource(page)
     await page.getByTestId('model-mmproj-input').fill('/models/mmproj-saved.gguf')
     await page.getByTestId('model-hfrepo-input').fill('org/saved-repo')
     await page.getByTestId('model-hffile-input').fill('saved-q4.gguf')
@@ -230,6 +242,14 @@ test.describe('Model drawer — complete save and compact field help', () => {
 
     const drawer = page.locator('.drawer.open')
     const labels = drawer.locator('.form-lbl')
+    // model-drawer-2 Task 9: the three Source rows (MMProj / HF repo / HF
+    // filename) moved behind the Source disclosure and a read-only "Paths" row
+    // joined them there, so the RESTING drawer shows 9 − 3 = 6 rows and the
+    // opened disclosure adds 4 back for 10. Both counts are asserted, because
+    // the rule under test ("every described label carries the info icon, and
+    // nothing carries a .sub subtitle") has to hold on either side of it.
+    await expect(labels).toHaveCount(6)
+    await openSource(page)
     // 9 rows (was 13 pre-Task-8): Option A's header meta move relocated
     // "Default for {type}" off the row list entirely (−1) and folded the
     // "Modality" row into a renamed "Capabilities" row in place (±0 — the
@@ -238,10 +258,11 @@ test.describe('Model drawer — complete save and compact field help', () => {
     // "Overrides" ledger row (−4 +1 = −3); and the single editable "Backends"
     // row split into "Engine" + read-only "Runs on" (−1 +2 = +1).
     // 13 − 1 − 3 + 1 = 10, then model-drawer-2 Task 3 moved "Display name"
-    // off the row list onto the header's inline title editor (−1) = 9.
-    await expect(labels).toHaveCount(9)
+    // off the row list onto the header's inline title editor (−1) = 9, and
+    // Task 9 added the read-only "Paths" row inside the disclosure (+1) = 10.
+    await expect(labels).toHaveCount(10)
     await expect(drawer.locator('.form-lbl .sub')).toHaveCount(0)
-    await expect(drawer.locator('.form-lbl .field-info-btn')).toHaveCount(9)
+    await expect(drawer.locator('.form-lbl .field-info-btn')).toHaveCount(10)
 
     // Display name no longer has a form row (Task 3) — MMProj is a plain
     // text-input row with the same FieldInfoIcon shape, so it stands in for

--- a/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
@@ -152,7 +152,8 @@ test.describe('Model drawer — complete save and compact field help', () => {
     await page.getByTestId('model-title-input').press('Enter')
     // Backends is retired (spec-hw-slot-ownership §1/§8) — Engine is the
     // write path now; "Runs on" is derived/read-only and not editable here.
-    await page.getByTestId('model-provider-select').selectOption('flm')
+    // Task 6: the native <select> became a RichSelect (rich-select.jsx).
+    await pickRichOption(page.getByTestId('model-provider-select'), 'flm')
     await page.getByTestId('model-mmproj-input').fill('/models/mmproj-saved.gguf')
     await page.getByTestId('model-hfrepo-input').fill('org/saved-repo')
     await page.getByTestId('model-hffile-input').fill('saved-q4.gguf')

--- a/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
@@ -107,6 +107,11 @@ async function mockSeedProfile(page: import('@playwright/test').Page) {
 async function stampFromProfile(page: import('@playwright/test').Page, name: string) {
   await page.getByTestId('model-seed-profile-open').click()
   await page.getByTestId(`model-seed-profile-option-${name}`).click()
+  // Task 8 (#2205): EVERY pick now opens the consequence-preview confirm —
+  // the old wouldClobber shortcut that skipped it for an empty/matching
+  // current flags text is gone. Same POST, same effects; one extra click.
+  await expect(page.getByTestId('model-seed-preview')).toBeVisible()
+  await page.getByRole('button', { name: 'Stamp tune', exact: true }).click()
 }
 
 /** Set an override via the ledger's "+ Override…" menu (cap id + on/off). */

--- a/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
@@ -145,7 +145,10 @@ test.describe('Model drawer — complete save and compact field help', () => {
 
     await openDrawer(page)
 
-    await page.getByTestId('model-name-input').fill('Saved model name')
+    // model-drawer-2 Task 3: name edits ride the inline title editor now.
+    await page.getByTestId('model-title-edit').click()
+    await page.getByTestId('model-title-input').fill('Saved model name')
+    await page.getByTestId('model-title-input').press('Enter')
     // Backends is retired (spec-hw-slot-ownership §1/§8) — Engine is the
     // write path now; "Runs on" is derived/read-only and not editable here.
     await page.getByTestId('model-provider-select').selectOption('flm')
@@ -216,20 +219,24 @@ test.describe('Model drawer — complete save and compact field help', () => {
 
     const drawer = page.locator('.drawer.open')
     const labels = drawer.locator('.form-lbl')
-    // 10 rows (was 13 pre-Task-8): Option A's header meta move relocated
+    // 9 rows (was 13 pre-Task-8): Option A's header meta move relocated
     // "Default for {type}" off the row list entirely (−1) and folded the
     // "Modality" row into a renamed "Capabilities" row in place (±0 — the
     // modality tag left for the header, the readout chips stayed); the four
     // always-on tri-state rows (mtp/thinking/jinja/vision) collapsed into one
     // "Overrides" ledger row (−4 +1 = −3); and the single editable "Backends"
     // row split into "Engine" + read-only "Runs on" (−1 +2 = +1).
-    // 13 − 1 − 3 + 1 = 10.
-    await expect(labels).toHaveCount(10)
+    // 13 − 1 − 3 + 1 = 10, then model-drawer-2 Task 3 moved "Display name"
+    // off the row list onto the header's inline title editor (−1) = 9.
+    await expect(labels).toHaveCount(9)
     await expect(drawer.locator('.form-lbl .sub')).toHaveCount(0)
-    await expect(drawer.locator('.form-lbl .field-info-btn')).toHaveCount(10)
+    await expect(drawer.locator('.form-lbl .field-info-btn')).toHaveCount(9)
 
-    const displayNameLabel = labels.filter({ hasText: 'Display name' })
-    const info = displayNameLabel.getByRole('button', { name: 'Info' })
+    // Display name no longer has a form row (Task 3) — MMProj is a plain
+    // text-input row with the same FieldInfoIcon shape, so it stands in for
+    // the generic hover/focus-only info-help behaviour asserted below.
+    const mmprojLabel = labels.filter({ hasText: 'MMProj' })
+    const info = mmprojLabel.getByRole('button', { name: 'Info' })
     // #1683: the popup portals to document.body (so overflow:hidden panels
     // can't clip it), so it's no longer a DOM descendant of the label — find
     // it via the button's aria-describedby instead of a row-scoped locator.

--- a/ui/tests/e2e/specs/model-drawer-stamp-diverge-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-stamp-diverge-v3.spec.ts
@@ -81,6 +81,11 @@ async function mockSeedProfile(page: import('@playwright/test').Page) {
 async function stampFromProfile(page: import('@playwright/test').Page, name: string) {
   await page.getByTestId('model-seed-profile-open').click()
   await page.getByTestId(`model-seed-profile-option-${name}`).click()
+  // Task 8 (#2205): EVERY pick now opens the consequence-preview confirm —
+  // the old wouldClobber shortcut that skipped it for an empty/matching
+  // current flags text is gone. Same POST, same effects; one extra click.
+  await expect(page.getByTestId('model-seed-preview')).toBeVisible()
+  await page.getByRole('button', { name: 'Stamp tune', exact: true }).click()
 }
 
 async function openDrawer(page: import('@playwright/test').Page) {

--- a/ui/tests/e2e/specs/model-drawer-stamp-diverge-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-stamp-diverge-v3.spec.ts
@@ -86,6 +86,15 @@ async function stampFromProfile(page: import('@playwright/test').Page, name: str
 async function openDrawer(page: import('@playwright/test').Page) {
   await page.goto('/#models')
   await page.locator('button:has-text("Edit options")').click()
+  await expect(page.getByTestId('model-tune-raw-toggle')).toBeVisible()
+}
+
+/** model-drawer-2 Task 4: the tune editor rests on grouped pills; the flags
+ *  TEXTAREA is the raw view behind `model-tune-raw-toggle`. Every assertion
+ *  below is about the flags STRING, so it reads that string the way an
+ *  operator would — by flipping to raw. */
+async function showRawFlags(page: import('@playwright/test').Page) {
+  await page.getByTestId('model-tune-raw-toggle').click()
   await expect(page.getByTestId('model-flags-input')).toBeVisible()
 }
 
@@ -98,6 +107,17 @@ test.describe('Model drawer — stamp & diverge', () => {
 
     await stampFromProfile(page, 'rocm-moe')
 
+    // The stamp lands as pills first (the resting view): every flag the
+    // profile carries gets one, and the hardware flag it smuggles in wears the
+    // deny styling before anyone reads the error text.
+    await expect(page.getByTestId('model-tune-pill---flash-attn')).toBeVisible()
+    await expect(page.getByTestId('model-tune-pill---batch-size')).toBeVisible()
+    await expect(page.getByTestId('model-tune-pill---threads')).toHaveAttribute(
+      'data-divergence',
+      'denied',
+    )
+
+    await showRawFlags(page)
     await expect(page.getByTestId('model-flags-input')).toHaveValue(PROFILE_FLAGS)
     await expect(page.getByTestId('model-provenance-chip')).toHaveText(/seeded from rocm-moe/i)
     // Freshly stamped text equals the profile — no divergence yet.
@@ -123,14 +143,26 @@ test.describe('Model drawer — stamp & diverge', () => {
     await openDrawer(page)
 
     await stampFromProfile(page, 'rocm-moe')
+    await showRawFlags(page)
     await expect(page.getByTestId('model-flags-input')).toHaveValue(PROFILE_FLAGS)
     // Add a flag the profile doesn't carry → diverged (added token).
     await page.getByTestId('model-flags-input').fill(`${PROFILE_FLAGS} --cache-type-k q8_0`)
 
-    await expect(page.getByTestId('model-diverged-chip')).toBeVisible()
+    // The chip now counts the drift; the inline diff is the raw-mode view of it.
+    await expect(page.getByTestId('model-diverged-chip')).toHaveText('◆ 1 diverged')
     const diff = page.getByTestId('model-divergence-diff')
     await expect(diff).toBeVisible()
     await expect(diff).toContainText('--cache-type-k')
+
+    // Back on the pills, the same fact reads inline — the added flag is marked
+    // added, and the diff panel is not duplicated there.
+    await page.getByTestId('model-tune-raw-toggle').click()
+    await expect(page.getByTestId('model-tune-pill---cache-type-k')).toHaveAttribute(
+      'data-divergence',
+      'added',
+    )
+    await expect(page.getByTestId('model-divergence-diff')).toHaveCount(0)
+    await expect(page.getByTestId('model-diverged-chip')).toHaveText('◆ 1 diverged')
   })
 
   test('a managed flag in the tune text blocks Save with an inline error, no PUT', async ({ page }) => {
@@ -145,6 +177,7 @@ test.describe('Model drawer — stamp & diverge', () => {
     await mockProfiles(page)
     await mockChatTemplates(page)
     await openDrawer(page)
+    await showRawFlags(page)
 
     await page.getByTestId('model-flags-input').fill('-fa on --port 9000')
 

--- a/ui/tests/e2e/specs/model-drawer-validation-gates.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-validation-gates.spec.ts
@@ -68,7 +68,7 @@ async function capturePut(page: import('@playwright/test').Page) {
 async function openDrawer(page: import('@playwright/test').Page) {
   await page.goto('/#models')
   await page.locator('button:has-text("Edit options")').first().click()
-  await expect(page.getByTestId('model-flags-input')).toBeVisible()
+  await expect(page.getByTestId('model-tune-raw-toggle')).toBeVisible()
 }
 
 test.describe('Model drawer — inline errors gate the save (#1380, #1381)', () => {

--- a/ui/tests/e2e/specs/model-drawer-validation-gates.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-validation-gates.spec.ts
@@ -124,9 +124,13 @@ test.describe('Model drawer — inline errors gate the save (#1380, #1381)', () 
     const puts = await capturePut(page)
     await openDrawer(page)
 
-    const nameInput = page.getByTestId('model-name-input')
+    // model-drawer-2 Task 3: name edits ride the inline title editor now
+    // (✎ → model-title-input, Enter commits), not a "Display name" form row.
+    await page.getByTestId('model-title-edit').click()
+    const nameInput = page.getByTestId('model-title-input')
     await expect(nameInput).toHaveValue('Original name')
     await nameInput.fill('')
+    await nameInput.press('Enter')
     await page.getByTestId('model-save').click()
 
     await expect.poll(() => puts.length).toBe(1)
@@ -148,8 +152,11 @@ test.describe('Model drawer — inline errors gate the save (#1380, #1381)', () 
     // rather than asserting the whole heading's text.
     await expect(page.locator('.drawer.open h2')).toContainText(MODEL_ID)
     // titleNode's structure: h2 > span (title row) > span (the name, first
-    // child) + modality tag + default badge/toggle.
+    // child) + modality tag + default toggle chip.
     await expect(page.locator('.drawer.open h2 > span > span').first()).toHaveText(MODEL_ID)
-    await expect(page.getByTestId('model-name-input')).toHaveValue('')
+    // model-drawer-2 Task 3: the empty draft still seeds the inline editor —
+    // opening it shows the stored empty string, not a fabricated value.
+    await page.getByTestId('model-title-edit').click()
+    await expect(page.getByTestId('model-title-input')).toHaveValue('')
   })
 })

--- a/ui/tests/e2e/specs/model-drawer-validation-gates.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-validation-gates.spec.ts
@@ -14,6 +14,7 @@
  *        back to `model.id` for display, so an explicit empty is a valid write.
  */
 import { test, expect } from '../fixtures/apiMock'
+import { pickRichOption } from '../fixtures/richSelect'
 
 const MODEL_ID = 'qwen3.6-27b-mtp'
 
@@ -71,12 +72,39 @@ async function openDrawer(page: import('@playwright/test').Page) {
   await expect(page.getByTestId('model-tune-raw-toggle')).toBeVisible()
 }
 
+/**
+ * model-drawer-2 Task 9: the Source rows (MMProj / HF repo / HF filename /
+ * Paths) live behind a disclosure that rests closed, so every spec touching
+ * them opens it first. Opening also fires the ONE lazy POST /api/models/inspect
+ * that feeds the mmproj picker.
+ */
+async function openSource(page: import('@playwright/test').Page) {
+  await page.getByTestId('model-source-disclosure').click()
+  await expect(page.getByTestId('model-source-paths')).toBeVisible()
+}
+
+/** Stub the repo listing behind the mmproj picker (default: no projectors). */
+async function mockInspect(page: import('@playwright/test').Page, variants: any[] = []) {
+  await page.route('**/api/models/inspect', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ repo: 'org/original-repo', cached: true, variants, tags: [] }),
+    }),
+  )
+}
+
 test.describe('Model drawer — inline errors gate the save (#1380, #1381)', () => {
   test('clearing mmproj on a vision model blocks the PUT until a path is restored', async ({ page }) => {
     await seedModel(page)
+    // No projector in the repo listing → the picker degrades to the free-text
+    // path input this test has always driven (Task 9's fallback).
+    await mockInspect(page)
     const puts = await capturePut(page)
     await openDrawer(page)
+    await openSource(page)
 
+    await expect(page.getByTestId('model-mmproj-select')).toHaveCount(0)
     await expect(page.getByTestId('model-mmproj-error')).toHaveCount(0)
     await page.getByTestId('model-mmproj-input').fill('')
 
@@ -98,6 +126,43 @@ test.describe('Model drawer — inline errors gate the save (#1380, #1381)', () 
     // save" — a different gate, not this one.)
     await page.getByTestId('model-mmproj-input').fill('/models/mmproj-Q8.gguf')
     await expect(page.getByTestId('model-mmproj-error')).toHaveCount(0)
+  })
+
+  test('the repo-fed picker gates the same way, and stores an absolute path', async ({ page }) => {
+    await seedModel(page)
+    // The repo ships a projector, so MMProj is a RichSelect (Task 9). Its
+    // option ids are the VALUE stored on the row — `Model.mmproj` is an
+    // absolute host path (registry/model.py:249, pull.py:1071), so the
+    // filename the repo lists resolves against the stored sidecar's own
+    // directory (`/models` here) before it is offered.
+    await mockInspect(page, [
+      { id: 'mmproj-F16.gguf', size_bytes: 644245094, size: '0.6 GB', info: 'mmproj · 0.6 GB' },
+      { id: 'model-q8.gguf', size_bytes: 9771050700, size: '9.1 GB', info: 'weights' },
+    ])
+    const puts = await capturePut(page)
+    await openDrawer(page)
+    await openSource(page)
+
+    const picker = page.getByTestId('model-mmproj-select')
+    await expect(picker).toBeVisible()
+    // The editable absolute-path input is gone while the picker is up.
+    await expect(page.getByTestId('model-mmproj-input')).toHaveCount(0)
+    // The stored projector isn't in the repo listing — it keeps its own row.
+    await expect(picker).toContainText('mmproj-Q8.gguf')
+
+    // "— none —" clears the pairing and re-arms the vision gate.
+    await pickRichOption(picker, '')
+    await expect(page.getByTestId('model-mmproj-error')).toBeVisible()
+    await expect(page.getByTestId('model-save')).toBeDisabled()
+
+    // Picking the repo's projector writes `<dir>/<filename>`, and that exact
+    // string is what the PUT carries — never the bare filename.
+    await pickRichOption(picker, '/models/mmproj-F16.gguf')
+    await expect(page.getByTestId('model-mmproj-error')).toHaveCount(0)
+    await expect(page.getByTestId('model-source-paths')).toContainText('/models/mmproj-F16.gguf')
+    await page.getByTestId('model-save').click()
+    await expect.poll(() => puts.length).toBe(1)
+    expect(puts[0].mmproj).toBe('/models/mmproj-F16.gguf')
   })
 
   test('capability chips are no longer editable in the drawer', async ({ page }) => {

--- a/ui/tests/e2e/specs/model-edit-identity-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-edit-identity-v3.spec.ts
@@ -1,6 +1,11 @@
 /**
- * model-edit-identity-v3 — display name editing in the model "Edit options"
- * pane (RecipeEditorModal).
+ * model-edit-identity-v3 — display name editing in the model drawer header.
+ *
+ * model-drawer-2 Task 3 moved the name field off a "Display name" form row
+ * and onto the drawer title itself: a ✎ button (`model-title-edit`) swaps the
+ * name span for an inline input (`model-title-input`), committed on
+ * Enter/blur. These tests were written against the old form-row field
+ * (`model-name-input`) — retargeted to the inline editor, same contract.
  *
  * The curated "type" toggle row (mtp/moe/tool-calling/reasoning/coder/vision)
  * is RETIRED: behaviour is owned by typed fields (defaults.mtp,
@@ -27,12 +32,13 @@ function mockChatTemplates(page: import('@playwright/test').Page) {
 }
 
 test.describe('Model edit — display name, type toggles retired', () => {
-  test('name input renders; no curated type toggles', async ({ page }) => {
+  test('title editor opens on the ✎ button; no curated type toggles', async ({ page }) => {
     await mockChatTemplates(page)
     await page.goto('/#models')
     await page.locator('button:has-text("Edit options")').click()
 
-    const nameInput = page.getByTestId('model-name-input')
+    await page.getByTestId('model-title-edit').click()
+    const nameInput = page.getByTestId('model-title-input')
     await expect(nameInput).toBeVisible()
     // Placeholder falls back to the model id so the field is self-describing
     // even when no display name is set.
@@ -64,7 +70,9 @@ test.describe('Model edit — display name, type toggles retired', () => {
     await page.goto('/#models')
     await page.locator('button:has-text("Edit options")').click()
 
-    await page.getByTestId('model-name-input').fill('My Renamed Qwen')
+    await page.getByTestId('model-title-edit').click()
+    await page.getByTestId('model-title-input').fill('My Renamed Qwen')
+    await page.getByTestId('model-title-input').press('Enter')
     await page.getByTestId('model-save').click()
 
     await expect.poll(() => putBody?.name).toBe('My Renamed Qwen')

--- a/ui/tests/e2e/specs/model-recipe-template-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-recipe-template-v3.spec.ts
@@ -10,6 +10,7 @@
  * mirroring the existing "Recipe editor opens" test in models-v3.spec.ts.
  */
 import { test, expect } from '../fixtures/apiMock'
+import { openRichSelect, pickRichOption } from '../fixtures/richSelect'
 
 test.describe('Recipe editor — chat-template field', () => {
   test('select is populated from /api/chat-templates and Save writes defaults.chat_template', async ({
@@ -49,17 +50,18 @@ test.describe('Recipe editor — chat-template field', () => {
     await page.goto('/#models')
     await page.locator('button:has-text("Edit options")').click()
 
-    // ── 4. Chat-template select is visible ───────────────────────
-    const tmplSelect = page.locator('select.chat-template-select')
+    // ── 4. Chat-template RichSelect is visible ────────────────────
+    const tmplSelect = page.getByTestId('model-chat-template')
     await expect(tmplSelect).toBeVisible()
 
     // ── 5. Options are populated from the mock ───────────────────
-    await expect(tmplSelect.locator('option[value="auto"]')).toHaveCount(1)
-    await expect(tmplSelect.locator('option[value="chatml"]')).toHaveCount(1)
-    await expect(tmplSelect.locator('option[value="llama3"]')).toHaveCount(1)
+    const listbox = await openRichSelect(tmplSelect)
+    await expect(listbox.locator('[data-option-id="auto"]')).toHaveCount(1)
+    await expect(listbox.locator('[data-option-id="chatml"]')).toHaveCount(1)
+    await expect(listbox.locator('[data-option-id="llama3"]')).toHaveCount(1)
 
     // ── 6. Select chatml and save ─────────────────────────────────
-    await tmplSelect.selectOption('chatml')
+    await pickRichOption(tmplSelect, 'chatml')
     await page.getByTestId('model-save').click()
 
     // ── 7. PUT body includes defaults.chat_template === 'chatml' ─
@@ -81,9 +83,11 @@ test.describe('Recipe editor — chat-template field', () => {
     await page.goto('/#models')
     await page.locator('button:has-text("Edit options")').click()
 
-    const tmplSelect = page.locator('select.chat-template-select')
+    const tmplSelect = page.getByTestId('model-chat-template')
     await expect(tmplSelect).toBeVisible()
-    // Default value should be "auto"
-    await expect(tmplSelect).toHaveValue('auto')
+    // Default value should be "auto" — the closed trigger renders the
+    // selected option's row + chip directly (rich-select.jsx).
+    await expect(tmplSelect).toContainText('Auto')
+    await expect(tmplSelect).toContainText('GGUF embedded')
   })
 })

--- a/ui/tests/e2e/specs/models-row-menu-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-row-menu-v3.spec.ts
@@ -52,7 +52,7 @@ test.describe('Models row menu (kebab)', () => {
     // directly rather than guessing at uncovered page coordinates.
     await page.locator('.mdl-row-menu-backdrop').click({ position: { x: 5, y: 5 } })
     await expect(page.locator('.hal0-menu')).toHaveCount(0)
-    await expect(page.getByTestId('model-flags-input')).toHaveCount(0)
+    await expect(page.getByTestId('model-tune-raw-toggle')).toHaveCount(0)
   })
 
   test('"Edit model settings" opens the ModelDrawer directly for a non-selected row — no prior row-select needed', async ({ page }) => {
@@ -64,7 +64,7 @@ test.describe('Models row menu (kebab)', () => {
     await page.locator('.hal0-menu-item', { hasText: 'Edit model settings' }).click()
 
     // Drawer opened, targeted at the kebab'd row (not the auto-selected one).
-    await expect(page.getByTestId('model-flags-input')).toBeVisible()
+    await expect(page.getByTestId('model-tune-raw-toggle')).toBeVisible()
     // Option A drawer (Task 8, PR-3): the title row now also carries the
     // modality tag + default badge/toggle (relocated here from their own
     // field-rows), so the h2 is no longer JUST the name.

--- a/ui/tests/e2e/specs/slot-drawer-model-stack-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-model-stack-v3.spec.ts
@@ -153,6 +153,10 @@ test.describe('Slot drawer — stacked model editor', () => {
     // NGL lives behind the slot drawer's Advanced disclosure (Task 11a).
     await page.getByTestId('slot-hw-advanced').click()
     const ngl = page.getByTestId('slot-hw-ngl')
+    // model-drawer-2 Task 4: the model drawer's tune editor rests on grouped
+    // pills; the flags textarea — the free-text control this case needs, to
+    // prove both drawers accept typing at once — is behind the raw toggle.
+    await modelDrawer(page).getByTestId('model-tune-raw-toggle').click()
     const flags = modelDrawer(page).getByTestId('model-flags-input')
     await expect(ngl).toBeVisible()
     await expect(flags).toBeVisible()
@@ -248,6 +252,6 @@ test.describe('Slot drawer — stacked model editor', () => {
     expect(modelBox.x).toBeGreaterThanOrEqual(0)
     expect(Math.round(modelBox.x + modelBox.width)).toBe(1024)
     // Still fully usable at the narrow size.
-    await expect(modelDrawer(page).getByTestId('model-flags-input')).toBeVisible()
+    await expect(modelDrawer(page).getByTestId('model-tune-raw-toggle')).toBeVisible()
   })
 })

--- a/ui/tests/e2e/specs/slot-drawer-model-stack-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-model-stack-v3.spec.ts
@@ -118,7 +118,10 @@ test.describe('Slot drawer — stacked model editor', () => {
     await expect(
       modelDrawer(page).locator('.drawer-h h2 > span > span').first(),
     ).toHaveText('Qwen3.6-27B-MTP')
-    await expect(modelDrawer(page).getByTestId('model-name-input')).toHaveAttribute(
+    // model-drawer-2 Task 3: the id-fallback placeholder lives on the inline
+    // title input now, not a "Display name" form row.
+    await modelDrawer(page).getByTestId('model-title-edit').click()
+    await expect(modelDrawer(page).getByTestId('model-title-input')).toHaveAttribute(
       'placeholder',
       'qwen3.6-27b-mtp',
     )


### PR DESCRIPTION
Second-pass overhaul of the model edit drawer to the slot-drawer bar. Spec + mockups operator-approved 2026-09-02 (all recommended options).

## What's in
- **Structured tune editor** (flagship): launch flags render as pills grouped Sampling / Cache·KV / Memory·batch / Template·misc, with per-flag divergence vs the seeding profile (changed ↺ revert · added ✕ · removed ghost ↩), value-edit popover, add-flag with managed-denylist guard, and a `{ } raw` toggle back to the token-highlighted textarea. Pills are a pure view over `defaults.extra_args` — save path unchanged. Occurrence-indexed splices handle repeated flags (`-ot a=1 -ot b=2`); quote-aware segmentation keeps `--chat-template-kwargs '{...}'` intact.
- **Header & facts band**: inline-editable title (Escape reverts), default badge is now the toggle (chip+button pair removed), display-only facts band (quant · size · arch · native context · sha256 · used-by-N-slots from the slots list).
- **RichSelect adoption**: chat template (render-lint chips from the catalog's valid/error) and Engine (Auto row previews the derived engine via new read-only `provider_effective`).
- **Context intelligence**: native-context chip, over-native rope warning (saves anyway), debounced GTT feasibility line via `POST /api/models/feasibility` — warn-never-block throughout.
- **Seed consequence preview**: every stamp shows changed/added/removed flags (removed billed — the #2195 honesty pattern applied to this surface), provenance reset, and which slots restart; profile list is provider-aware.
- **Source & files**: section demotes to a disclosure; mmproj picked from the repo listing (`POST /api/models/inspect`), variant ids basenamed onto the model directory (matches the pull worker's flattening); paths render read-only + copyable.
- **Live footer**: staged-change summary ("2 changes — flags · context ⟳ restarts 2 slots: agent · brain") from the existing changes aggregate.

## Server touches (only two)
- `provider_effective` on serialized model rows — derived, read-only.
- Explicit `provider: null` in POST/PUT now converges onto the derive path.

## Closes
Closes #2199
Closes #2204
Closes #2205
Closes #2207

## Filed en route (deferred)
- #2211 diffFlags canon-mismatch + repeat-collapse (shared surface, out of wave)
- #2212 verify-files / re-pull affordance (no stat endpoint exists yet)
- #2214 house clipboard idiom only catches synchronous throws

## Notes for reviewers
- Title precedence changed to `name.trim() || longName || id` (editable title must show the thing being edited); rows with a distinct `longName` now show the name once edited.
- `onOpenSlot` jump from the used-by facts cell is stubbed (optional prop, renders plain text) — models.jsx has no slot-drawer opener to reach; follow-up if wanted.
- New curated UI const `FLAG_CATEGORIES`; unknown flags land in Template·misc (drift degrades to "less grouped", never hidden). A python drift-guard test pins the JS `FLAG_ALIASES` mirror against `hal0.slots.argv`.

## Test evidence
vitest 348/348 · playwright chromium 689 passed / 13 skipped · python models+ui_contracts 339 passed · ruff check+format clean · zero scar words / LAN hosts in the diff. Whole-branch final review + per-task adversarial reviews all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bUrn3nhQKXBBygeerxsnv