### PR TITLE
release: v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,37 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+## [1.2.0] — 2026-09-03
+
+### Highlights
+
+- **Profiles carry a runtime, and the dashboard shows it everywhere a profile
+  appears.** A profile can pin a `runner`; profile cards carry a runtime badge,
+  the import preview shows the envelope's runtime before commit, and the slot
+  Edit drawer's apply preview enumerates the runtime, lane, flags and restart a
+  profile change would actually cause before you save it.
+- **The seed profile catalog is pruned from 18 to a 10-profile minimal core**,
+  and the eight demoted tunes ship as portable `.hal0profile.json` addon
+  envelopes under `community/addons/` that Profiles → Import installs from a
+  paste or an upload.
+- **The model and slot drawers were reworked end to end** — task-grouped slot
+  fields, rich selects, GTT hints, inline model pull, tune pills, a facts band,
+  and an overrides ledger naming every field that diverges from the stamped
+  profile.
+- **Host-truth GTT feasibility.** `GET /api/hardware` carries live
+  `gtt_used_mb`/`gtt_free_mb` from the amdgpu sysfs counters, and the slot load
+  path emits an advisory `slot.gtt_feasibility` warning — never a block — when a
+  model's weights exceed the free GTT pool.
+- **Arch-aware model↔runner fit-check.** GGUF `general.architecture` is detected
+  and persisted at registration, and binding a model whose arch the runner
+  denylists now WARNS at assignment, naming the catalogued image that can serve
+  it, instead of leaving the operator at a silent crash-loop.
+- **The dashboard surfaces the decisive crash line** when a slot container dies
+  during model load, stamped on slot state and carried by the crash-breaker
+  chip's tooltip.
+- **The Proxmox VE quick-start script builds a privileged GPU-passthrough LXC by
+  default**, so a fresh container reaches the GPU without a manual pass.
+
 ### Fixed
 
 - Editing a profile whose stored runtime key has left this box's runner
@@ -146,6 +177,18 @@ applying. Add those subsections to a version's section to surface them; see
   the kyuz0 layout by construction, so existing img slots need no
   reconfiguration; `--purge` uninstall still removes the old kyuz0 image on
   upgraded boxes (#2171).
+- The model and slot drawers were reworked end to end. The slot drawer
+  regroups its fields by task, uses rich selects for model/profile/runtime,
+  carries GTT hints and an inline pull for a model it does not have yet, and
+  shows one Advanced image row (a single ref with a live-state chip) instead
+  of the previous overflow. The model drawer gains header meta, a
+  seed-from-profile button, tune pills, a facts band, an explicit engine
+  field, and an overrides ledger that names every field diverging from the
+  stamped profile (#2206, #2208, #2210, #2215).
+- Dashboard: the model Capabilities/Labels editors are retired (#2193). Capabilities
+  display read-only in the model drawer; the Add-from-HF flow now offers a repo's
+  mmproj projector directly and derives the vision label from that choice; the
+  add-by-path flow always auto-detects labels. `/api/models` contracts are unchanged.
 
 ### Migrations
 
@@ -162,13 +205,6 @@ applying. Add those subsections to a version's section to surface them; see
   Back up `/etc/hal0/profiles.toml` before upgrading if you may downgrade;
   restoring that copy (or deleting the two keys) makes the file readable by
   1.1.0 again.
-
-### Changed
-
-- Dashboard: the model Capabilities/Labels editors are retired (#2193). Capabilities
-  display read-only in the model drawer; the Add-from-HF flow now offers a repo's
-  mmproj projector directly and derives the vision label from that choice; the
-  add-by-path flow always auto-detects labels. `/api/models` contracts are unchanged.
 
 ## [1.1.0] — 2026-08-31
 
@@ -864,7 +900,6 @@ serving again quickly, not as an undo.
   bound its blast radius. `/mcp/admin` and any future `/mcp/*` mount
   remain ADMIN. Docs that still claimed "no built-in network auth"
   (pre-KB-1) are corrected everywhere.
-
 
 ## [1.0.0-rc.12] — 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ process to babysit.
 curl -fsSL https://hal0.dev/install.sh | sudo bash
 ```
 
-> **v1.1.0 is the GA release.** It is what the `stable` channel has been
+> **v1.2.0 is the GA release.** It is what the `stable` channel has been
 > waiting for since 0.9.8 shipped on 2026-07-13: the 1.0 line ran rc.1
 > through rc.12 on `preview`, each candidate validated on a real-hardware
 > fleet. From v1.0.0 the project follows semver proper. If you are upgrading

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, cpu, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release — the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md §12 and §17 (maintainer-local).",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "channel": "stable",
   "toolbox_images": {
     "vulkan": {
@@ -43,7 +43,7 @@
     },
     "qwen3tts": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1",
-      "digest": "sha256:748774babc8bd9b83da4c437d09311bbcbd279f0328d1a9f5b419e70ca2a036c",
+      "digest": "sha256:b412d26fe3af480d47c57d79f770a0a7a4e66eaa394409e48fc3d9aee8c48f60",
       "_notes": "Qwen3-TTS-12Hz-1.7B-CustomVoice multilingual GPU TTS (ROCm); OpenAI-compat /v1/audio/speech. Digest pinned from the CI push via .github/workflows/toolbox.yml; refresh with scripts/update-toolbox-digests.sh."
     },
     "promptforge": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "1.1.0"
+version = "1.2.0"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hal0/api/routes/dashboard_layout.py
+++ b/src/hal0/api/routes/dashboard_layout.py
@@ -29,7 +29,7 @@ so a v2 file already on disk keeps round-tripping under the v2 rules. The
 client's own ``reconcile()`` fail-softs an unrecognised payload to its default
 layout, so an operator holding a pre-#1061 file sees defaults, not an error.
 
-HAL0-SUNSET: v1.2 — drop the v2 branch once no cached pre-#1061 UI bundle can
+HAL0-SUNSET: v1.3.0 — drop the v2 branch once no cached pre-#1061 UI bundle can
 still be in a browser. v3 is then the only accepted body.
 
 Unknown CardIds in ``enabled`` or ``order`` are rejected with 422; so is any
@@ -115,7 +115,7 @@ class DashLayoutV3(BaseModel):
 class DashLayout(BaseModel):
     """Validated dashboard layout body (v2 — superseded, still tolerated).
 
-    HAL0-SUNSET: v1.2 — see the module docstring.
+    HAL0-SUNSET: v1.3.0 — see the module docstring.
     """
 
     v: int

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -230,7 +230,7 @@ def status() -> None:
     console.print(table)
 
 
-# HAL0-SUNSET: v1.2.0 — alias for `hal0 config hardware --refresh`; drop the alias.
+# HAL0-SUNSET: v2.0.0 — alias for `hal0 config hardware --refresh`; drop the alias.
 @app.command(hidden=True)
 def probe() -> None:
     """[DEPRECATED] alias for `hal0 config hardware --refresh`; use that instead."""

--- a/src/hal0/cli/model_commands.py
+++ b/src/hal0/cli/model_commands.py
@@ -263,7 +263,7 @@ def model_update(
     _poll_pull_progress(ref, done_verb="Updated")
 
 
-# HAL0-SUNSET: v1.2.0 — alias for `model add`; drop the alias.
+# HAL0-SUNSET: v2.0.0 — alias for `model add`; drop the alias.
 @app.command("register", hidden=True)
 def model_register(
     model_id: str = typer.Argument(..., help="Model id, e.g. 'qwen3-4b-q4_k_m'"),
@@ -326,7 +326,7 @@ def model_show(
     console.print(table)
 
 
-# HAL0-SUNSET: v1.2.0 — alias for `slot edit --model`; drop the alias.
+# HAL0-SUNSET: v2.0.0 — alias for `slot edit --model`; drop the alias.
 @app.command("assign", hidden=True)
 def model_assign(
     ref: str = typer.Argument(..., help="Model ref to assign"),

--- a/src/hal0/cli/registry_commands.py
+++ b/src/hal0/cli/registry_commands.py
@@ -283,7 +283,7 @@ def _do_import_backup(path: Path, force: bool, dest: Path) -> None:
     )
 
 
-# HAL0-SUNSET: v1.2.0 — alias for `hal0 model import-backup`; drop the alias.
+# HAL0-SUNSET: v2.0.0 — alias for `hal0 model import-backup`; drop the alias.
 @app.command("import", hidden=True)
 def import_backup(
     path: Path = typer.Argument(

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -497,7 +497,7 @@ def slot_create(
         ),
         case_sensitive=False,
     ),
-    # HAL0-SUNSET: v1.2.0 — --backend renamed to --provider in v0.2; use --provider.
+    # HAL0-SUNSET: v2.0.0 — --backend renamed to --provider in v0.2; use --provider.
     backend: str | None = typer.Option(
         None,
         "--backend",
@@ -622,7 +622,7 @@ def slot_edit(
             "created before the profile was inferred (#1830)."
         ),
     ),
-    # HAL0-SUNSET: v1.2.0 — --backend renamed to --provider in v0.2; use --provider.
+    # HAL0-SUNSET: v2.0.0 — --backend renamed to --provider in v0.2; use --provider.
     backend: str | None = typer.Option(
         None,
         "--backend",
@@ -730,7 +730,7 @@ def slot_delete(
     console.print(f"Deleted slot [bold]{name}[/bold].")
 
 
-# HAL0-SUNSET: v1.2.0 — alias for `slot create`; drop the alias.
+# HAL0-SUNSET: v2.0.0 — alias for `slot create`; drop the alias.
 @app.command("add", hidden=True)
 def slot_add(
     name: str = typer.Argument(..., help="Slot name (e.g. primary, embed, stt)"),
@@ -762,7 +762,7 @@ def slot_add(
     )
 
 
-# HAL0-SUNSET: v1.2.0 — alias for `slot delete`; drop the alias.
+# HAL0-SUNSET: v2.0.0 — alias for `slot delete`; drop the alias.
 @app.command("remove", hidden=True)
 def slot_remove(
     name: str = typer.Argument(..., help="Slot name to delete"),

--- a/src/hal0/cli/upstream_commands.py
+++ b/src/hal0/cli/upstream_commands.py
@@ -537,7 +537,7 @@ def credentials_set(
     _do_set_credentials(name, key, env_var)
 
 
-# HAL0-SUNSET: v1.2.0 — alias for `upstream credentials set`; drop the alias.
+# HAL0-SUNSET: v2.0.0 — alias for `upstream credentials set`; drop the alias.
 @app.command("set-credentials", hidden=True)
 def set_credentials(
     name: str = typer.Argument(..., help="Provider name."),

--- a/src/hal0/config/paths.py
+++ b/src/hal0/config/paths.py
@@ -438,7 +438,7 @@ def first_run_lock() -> Path:
     return var_lib() / ".first-run.lock"
 
 
-# HAL0-SUNSET: v1.2.0 — picker deferred; marker unwired.
+# HAL0-SUNSET: v1.3.0 — picker deferred; marker unwired.
 def bundle_chosen_marker() -> Path:
     """Return the bundle-picker completion marker path.
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -168,7 +168,7 @@ class ModelConfig(BaseModel):
             "hal0.providers.container._resolve_context_size."
         ),
     )
-    # HAL0-SUNSET: v1.2.0 — flags own by models (spec-flags-ownership §2/§4).
+    # HAL0-SUNSET: v2.0.0 — flags own by models (spec-flags-ownership §2/§4).
     # This slot [model].n_gpu_layers no longer reaches the launch argv; the
     # migrator folds a slot's effective -ngl into its model's
     # ``defaults.n_gpu_layers`` (trusted, managed-flag) field. Field stays for
@@ -281,7 +281,7 @@ class ServerConfig(BaseModel):
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
-    # HAL0-SUNSET: v1.2.0 — flags own by models (spec-flags-ownership §2/§4).
+    # HAL0-SUNSET: v2.0.0 — flags own by models (spec-flags-ownership §2/§4).
     # This slot [server].extra_args no longer reaches the launch argv chain;
     # the migrator folds a slot's effective tune into its model's
     # ``defaults.extra_args`` (the screened ``model_extra_args`` segment). Kept
@@ -467,7 +467,7 @@ class SlotConfig(BaseModel):
     # already required a model id. Stale ``enabled`` keys from older installs
     # round-trip harmlessly via ``extra="allow"`` until
     # ``hal0.config.migrations.slot_enabled_removal`` sweeps them off disk.
-    # HAL0-SUNSET: v1.2.0 — runtime is Literal["container"] only; field is ceremony, drop it.
+    # HAL0-SUNSET: v2.0.0 — runtime is Literal["container"] only; field is ceremony, drop it.
     runtime: Literal["container"] = Field(
         default="container",
         description=(
@@ -496,7 +496,7 @@ class SlotConfig(BaseModel):
     # pre-migration TOML still carrying the keys loads without error; the
     # one-shot migrator (hal0.config.migrations.model_owned_caps) folds any
     # such value into the bound model's defaults and drops the slot key.
-    # HAL0-SUNSET: v1.2.0 — flags own by models (spec-flags-ownership §2/§4).
+    # HAL0-SUNSET: v2.0.0 — flags own by models (spec-flags-ownership §2/§4).
     # This slot-level parallelism knob no longer reaches the launch argv; the
     # migrator folds an effective ``--parallel N`` (plus ``--kv-unified`` when
     # N>1) into the bound model's ``defaults.extra_args``. Kept for round-trip
@@ -512,7 +512,7 @@ class SlotConfig(BaseModel):
             "Retained for TOML round-trip."
         ),
     )
-    # HAL0-SUNSET: v1.2.0 — chat_template is model-intrinsic and folds into the
+    # HAL0-SUNSET: v2.0.0 — chat_template is model-intrinsic and folds into the
     # model (spec-flags-ownership §7 slot-purity). INERT at launch: the slot
     # tier was removed from resolve_chat_template, so model.defaults.chat_template
     # is the single source. The one-shot migrator folds each slot's effective
@@ -575,7 +575,7 @@ class SlotConfig(BaseModel):
     # keys, not [server] keys, into the validated SlotConfig).  The new
     # nested ``server`` model below holds fields that are authored under
     # [server] in TOML — keep additions there.
-    # HAL0-SUNSET: v1.2.0 — workers is inert; a non-default value only logs a warning.
+    # HAL0-SUNSET: v2.0.0 — workers is inert; a non-default value only logs a warning.
     workers: int = Field(
         default=1,
         ge=1,
@@ -3036,7 +3036,7 @@ class MemoryConfig(BaseModel):
             "(private:<agent> / project:<id> banks + fan-out recall)."
         ),
     )
-    # HAL0-SUNSET: v1.2.0 — 'cognee' engine literal retired here. It is no
+    # HAL0-SUNSET: v2.0.0 — 'cognee' engine literal retired here. It is no
     # longer an accepted config value (was previously a back-compat alias
     # that resolved to hindsight at runtime). provider_from_config's runtime
     # resolution still treats any *unrecognized* engine as Hindsight as a

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1109,7 +1109,7 @@ def _llama_argv_segments(
     ignored (kept for call-site compat until the sunset ratchet drops the
     plumbing).
     """
-    # HAL0-SUNSET: v1.2.0 — profile flags + slot parallel/extra_args lost their
+    # HAL0-SUNSET: v2.0.0 — profile flags + slot parallel/extra_args lost their
     # launch surface (spec-flags-ownership §2/§4). These params are inert; drop
     # them (and the callers threading them) once the sunset ratchet lands.
     del profile_flags, slot_parallel, extra_args

--- a/src/hal0/registry/runner_pull.py
+++ b/src/hal0/registry/runner_pull.py
@@ -250,7 +250,7 @@ def persisted_job_files(image_id: str) -> list[Path]:
     if not jobs_dir.is_dir():
         return []
     stem = _sanitise_id(image_id)
-    # HAL0-SUNSET: v1.2 — the bare <id>.json lookup reads snapshots written
+    # HAL0-SUNSET: v1.3.0 — the bare <id>.json lookup reads snapshots written
     # before per-tag files (#2048); drop it once those have aged out of the
     # 14-day sweep_pull_jobs window.
     out = [p for p in (_contained_jobs_path(f"{stem}.json"),) if p.is_file()]

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hal0-ui",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hal0-ui",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal0-ui",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "hal0ai"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Cuts the 1.2.0 stable release.

## What's in it

- `set-version.py 1.2.0` across the six version artifacts (pyproject, ui/package.json, ui/package-lock.json, manifest.json, uv.lock, README status line).
- CHANGELOG `[Unreleased]` cut to `[1.2.0] — 2026-09-03`, with a new `### Highlights` section. Extractor-validated by `scripts/gen_release_notes.py --tag v1.2.0`: 7 highlights, 0 breaking, 1 migration.
- The model/slot drawer wave (#2206, #2208, #2210, #2215) landed with no CHANGELOG entries — added as one `### Changed` bullet. The trailing duplicate `### Changed` block is folded into the section above it.
- `manifest.json` toolbox digests refreshed against ghcr.io (`qwen3tts` moves to the current published digest).
- The v1.2.0 sunset backlog is re-stamped by semver class rather than slid one more minor — see below.

## Sunset backlog (#2168)

The v1.1.0 cut deferred 19 markers to v1.2.0 because deleting deprecated compat surface hours before a stable tag was riskier than carrying it. Bumping to 1.2.0 makes them overdue and turns the `sunset` gate red, so this decides where they can actually land.

CHANGELOG's semver contract is explicit: from v1.0.0, breaking changes land only in a major release. Most of the backlog is breaking to remove — the hidden CLI aliases (`model add`, `slot create`, `slot delete`, `slot edit --model`, `model import-backup`, `upstream credentials set`, `config hardware --refresh`), the `--backend` flag renamed to `--provider` in v0.2, and the config-schema fields an existing `hal0.toml` still parses against. Those move to **v2.0.0**.

Three markers are internal and break nothing on removal, so they move to **v1.3.0**: the dashboard-layout v2 branch, the `runner_pull` bare `<id>.json` snapshot read, and the unwired picker marker in `config/paths.py`.

Comment-only; no behavior moves. #2168 stays open as the ledger.

## strix digest, by hand

`scripts/update-toolbox-digests.sh` regressed `toolbox_images.strix.digest` from its recorded pin to `null`. `ghcr.io/hal0ai/hal0-strix-vulkan` does not serve an anonymous pull token (`DENIED: invalid token`), so the script's ghcr path cannot resolve it and falls through to the null branch — which `release.yml`'s null-digest gate would then reject. The recorded pin (the exact image the 2026-08-31 §3-C gate validated) is restored by hand in this PR. Filed separately, along with the fact that an anonymous-pull-only installer cannot fetch that image either.

## Not covered here

`scripts/release-check.sh` gate 5 (tier-γ release-gate report) cannot pass: the checked-in report is 5 fail / 2 pass and stale, which is #2050 — the γ rows still speak the retired v0.1 CLI contract. v1.1.0 was tagged in the same state.