### PR TITLE
feat(ui): slot-card model + profile dropdowns to the RichSelect bar

### DIFF
--- a/ui/src/dash/__tests__/inference-pane-pickers.test.tsx
+++ b/ui/src/dash/__tests__/inference-pane-pickers.test.tsx
@@ -4,10 +4,12 @@
 //   Task 1 — the card model picker (ModelPicker) migrated from a native
 //   <select> to RichSelect: multi-line rows (quant tag, modality tag, size +
 //   used-by + engine desc line) and a lazy GTT fit-chip batch on first open.
-//   Task 2 — the card profile pill (DevCell) migrated to RichSelect: rich
-//   profile rows filtered to the slot type, an "✎ Edit slot…" row keeping the
-//   old open-the-editor gesture, and a consequence confirm that owns the only
-//   write.
+//   Task 2 — the card profile pill migrated to RichSelect: rich profile rows
+//   filtered to the slot type, an "✎ Edit slot…" row keeping the old
+//   open-the-editor gesture, and a consequence confirm that owns the only
+//   write. Driven through SlotCards, since the confirm is mounted by the card
+//   LIST (it must not sit inside a `.scard`) — so these tests exercise the
+//   real card→pane wiring, not a card in isolation.
 //
 // inference-pane.jsx is a window-globals dash module (bare `React.Fragment`/
 // `React.cloneElement` identifiers resolve off `window` under vitest's
@@ -19,10 +21,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 ;(globalThis as unknown as { window: typeof globalThis }).window = globalThis
 ;(globalThis as unknown as { React: typeof React }).React = React
-// slot-modals.jsx rides in on inference-pane's `profileApplyPreview` import
-// and reads `Icons` at render time; the module graph only needs the global to
-// exist. (Same shim slot-profile-preview.test.ts installs.)
+// primitives.jsx's Modal (the apply confirm's shell) reads `Icons` for its
+// close glyph at render time.
 ;(globalThis as unknown as { Icons: unknown }).Icons = new Proxy({}, { get: () => null })
+// React's act() contract — without it every act() call warns that the
+// environment is unconfigured.
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
 // GTT feasibility probe — a real useState-backed mutation stand-in so calling
 // `mutate()` from ModelPicker's onOpenChange handler genuinely re-renders the
@@ -98,7 +102,7 @@ vi.mock('@/api/hooks/useSlots', () => ({
   }),
 }))
 
-const { ModelPicker, DevCell } = await import('../inference-pane.jsx')
+const { ModelPicker, SlotCards } = await import('../inference-pane.jsx')
 
 function mount(el: React.ReactElement) {
   const host = document.createElement('div')
@@ -218,12 +222,62 @@ const P_TTS = {
   intent: 'kokoro synth tune',
   supported_slot_types: ['tts'],
 }
+// A serving slot (container running + healthy → slotCtrlPhase "running") and
+// a stopped one, so the confirm's lifecycle line has both branches to take.
 const PROFILE_SLOT = {
   name: 'primary',
   type: 'llm',
   device: 'gpu-vulkan',
   profile: 'rocm',
   binary: '',
+  container_status: 'running',
+  container_health: true,
+}
+const OFF_SLOT = {
+  name: 'spare',
+  type: 'llm',
+  device: 'gpu-vulkan',
+  profile: 'rocm',
+  binary: '',
+  container_status: 'exited',
+  container_health: false,
+}
+
+// The profile picker lives on the CARD but its apply confirm is owned by the
+// card LIST (it is a fixed overlay and `.scard` both clips and, on hover,
+// becomes its containing block), so every profile test drives the real
+// SlotCards wiring rather than a card in isolation.
+function mountCards(slots: Record<string, unknown>[]) {
+  const handlers = {
+    onSwap: () => {},
+    onStart: () => {},
+    onStop: () => {},
+    onRestart: () => {},
+    onLogs: () => {},
+    onEdit: vi.fn(),
+    onSetDefault: () => {},
+  }
+  const el = () => (
+    <SlotCards
+      rows={slots.map((s) => ({ s, ind: { cls: 'offline', tooltip: '' } }))}
+      full={false}
+      models={MODELS}
+      allSlots={slots}
+      busyName={null}
+      handlers={handlers}
+      loading={false}
+      modelRows={() => ({ id: 'm1', longName: 'Qwen3.6-8B', defaults: { extra_args: '' } })}
+    />
+  )
+  const mounted = mount(el())
+  // Re-render — how a landing /api/profiles poll reaches an already-open
+  // confirm. A FRESH element each time: React bails out of reconciling a
+  // referentially identical one, which would silently no-op the re-render.
+  const rerender = () =>
+    act(() => {
+      mounted.root.render(el())
+    })
+  return { ...mounted, handlers, rerender }
 }
 
 function profileTrigger(host: HTMLElement, name: string) {
@@ -236,9 +290,18 @@ function openProfileMenu(host: HTMLElement, name: string) {
   })
 }
 
-function pickOption(host: HTMLElement, id: string) {
+// The open listbox is the one hanging off the trigger we just clicked — with
+// more than one card mounted, `data-option-id` is not unique across the page.
+function openListbox(host: HTMLElement, name: string) {
+  const id = profileTrigger(host, name).getAttribute('aria-controls')!
+  return host.querySelector(`[id="${id}"]`) as HTMLElement
+}
+
+function pickProfile(host: HTMLElement, name: string, id: string) {
   act(() => {
-    optionById(host, id)!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    openListbox(host, name)
+      .querySelector(`[data-option-id="${id}"]`)!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }))
   })
 }
 
@@ -355,47 +418,54 @@ describe('ModelPicker (card-dropdowns Task 1)', () => {
   })
 })
 
-describe('DevCell profile picker (card-dropdowns Task 2)', () => {
+describe('card profile picker + apply confirm (card-dropdowns Task 2)', () => {
   it("profile pill opens rich rows filtered to the slot's type, current ticked", () => {
-    const { host } = mount(<DevCell s={PROFILE_SLOT} onProfile={() => {}} modelFlags="" />)
+    const { host } = mountCards([PROFILE_SLOT])
     // the pill still surfaces the slot's profile name (the e2e claim)
     expect(profileTrigger(host, 'primary').textContent).toContain('rocm')
     openProfileMenu(host, 'primary')
+    const listbox = openListbox(host, 'primary')
     // the tts-only profile is fenced out by supported_slot_types.
-    expect(optionById(host, 'voice')).toBeNull()
-    expect(optionById(host, 'rocm')).not.toBeNull()
-    expect(optionById(host, 'brainy')).not.toBeNull()
+    expect(listbox.querySelector('[data-option-id="voice"]')).toBeNull()
+    expect(listbox.querySelector('[data-option-id="rocm"]')).not.toBeNull()
+    expect(listbox.querySelector('[data-option-id="brainy"]')).not.toBeNull()
     // current is the ticked row — RichSelect's own selected affordance.
-    expect(optionById(host, 'rocm')!.getAttribute('aria-selected')).toBe('true')
-    expect(optionById(host, 'brainy')!.getAttribute('aria-selected')).toBe('false')
+    expect(
+      listbox.querySelector('[data-option-id="rocm"]')!.getAttribute('aria-selected'),
+    ).toBe('true')
+    expect(
+      listbox.querySelector('[data-option-id="brainy"]')!.getAttribute('aria-selected'),
+    ).toBe('false')
   })
 
   it('rows show runtime chip + blurb; Edit slot row present and calls onProfile', () => {
-    const onProfile = vi.fn()
-    const { host } = mount(<DevCell s={PROFILE_SLOT} onProfile={onProfile} modelFlags="" />)
+    const { host, handlers } = mountCards([PROFILE_SLOT])
     openProfileMenu(host, 'primary')
-    const pf = optionById(host, 'brainy')!
+    const listbox = openListbox(host, 'primary')
+    const pf = listbox.querySelector('[data-option-id="brainy"]') as HTMLElement
     // one solid chip per lane (runtimeChips), and the profile's intent line.
     expect(Array.from(pf.querySelectorAll('.pf-be')).map((c) => c.textContent)).toEqual(['ROCm'])
     expect(pf.querySelector('.rsel-option-desc')!.textContent).toBe('low-temp reasoning tune')
     // an unpinned profile chips AUTO rather than claiming a lane.
     expect(
-      Array.from(optionById(host, 'rocm')!.querySelectorAll('.pf-be')).map((c) => c.textContent),
+      Array.from(
+        listbox.querySelector('[data-option-id="rocm"]')!.querySelectorAll('.pf-be'),
+      ).map((c) => c.textContent),
     ).toEqual(['AUTO'])
     // the last row keeps today's gesture: the pill opened the slot editor.
-    const edit = optionById(host, '__edit_slot__')!
+    const edit = listbox.querySelector('[data-option-id="__edit_slot__"]') as HTMLElement
     expect(edit.textContent).toContain('Edit slot')
-    pickOption(host, '__edit_slot__')
-    expect(onProfile).toHaveBeenCalledTimes(1)
+    pickProfile(host, 'primary', '__edit_slot__')
+    expect(handlers.onEdit).toHaveBeenCalledTimes(1)
     // …and it is NOT a profile pick: no confirm, no write.
     expect(q(host, 'infer-profile-preview')).toBeNull()
     expect(editCalls).toEqual([])
   })
 
   it('pick opens the consequence confirm with flag/runtime/restart lines', () => {
-    const { host } = mount(<DevCell s={PROFILE_SLOT} onProfile={() => {}} modelFlags="" />)
+    const { host } = mountCards([PROFILE_SLOT])
     openProfileMenu(host, 'primary')
-    pickOption(host, 'brainy')
+    pickProfile(host, 'primary', 'brainy')
     const box = q(host, 'infer-profile-preview')!
     expect(box).not.toBeNull()
     const text = box.textContent || ''
@@ -407,17 +477,62 @@ describe('DevCell profile picker (card-dropdowns Task 2)', () => {
     // flags → the 3 pairs in brainy's tune the slot does not already launch
     // with (its current tune is rocm's `-fa auto`).
     expect(text).toContain('replaces 3 flags')
-    // …and the restart line the apply actually performs.
+    // …and the lifecycle line for a RUNNING slot.
     expect(text).toContain('restarts')
     // nothing has been written yet.
     expect(editCalls).toEqual([])
     expect(restartCalls).toEqual([])
   })
 
-  it('cancel writes nothing', () => {
-    const { host } = mount(<DevCell s={PROFILE_SLOT} onProfile={() => {}} modelFlags="" />)
+  it('the confirm is mounted by the card LIST — one dialog for N cards', () => {
+    const { host } = mountCards([PROFILE_SLOT, OFF_SLOT])
+    expect(host.querySelectorAll('.scard').length).toBe(2)
+    expect(host.querySelectorAll('.rsel-trigger.profile-pill').length).toBe(2)
     openProfileMenu(host, 'primary')
-    pickOption(host, 'brainy')
+    pickProfile(host, 'primary', 'brainy')
+    // exactly ONE confirm in the tree…
+    expect(host.querySelectorAll('[data-testid="infer-profile-preview"]').length).toBe(1)
+    // …and it is a sibling of the card grid, NOT inside a `.scard` (which
+    // clips with overflow:hidden and becomes the containing block for fixed
+    // descendants on hover).
+    const box = q(host, 'infer-profile-preview')!
+    expect(box.closest('.scard')).toBeNull()
+    expect(box.closest('.scards')).toBeNull()
+    // it names the slot the pick came from.
+    expect(box.textContent).toContain('primary')
+  })
+
+  it('a stopped slot is told it will START and load the model, not restart', () => {
+    const { host } = mountCards([OFF_SLOT])
+    openProfileMenu(host, 'spare')
+    pickProfile(host, 'spare', 'brainy')
+    const text = q(host, 'infer-profile-preview')!.textContent || ''
+    // SlotManager.restart is unload+load, so an off slot STARTS.
+    expect(text).toContain('starts')
+    expect(text).toContain('loads the model')
+    expect(text).not.toContain('restarts')
+  })
+
+  it('the lifecycle line renders even when the picked profile no longer resolves', () => {
+    const { host, rerender } = mountCards([PROFILE_SLOT])
+    openProfileMenu(host, 'primary')
+    pickProfile(host, 'primary', 'brainy')
+    // the catalogue drops the profile out from under the OPEN confirm (a 5s
+    // /api/profiles poll landing mid-decision).
+    profilesBox.current = [P_CUR, P_TTS]
+    rerender()
+    const box = q(host, 'infer-profile-preview')!
+    expect(box).not.toBeNull()
+    // no derived lines (nothing true left to say)…
+    expect(box.textContent).not.toContain('runtime →')
+    // …but the consequence of pressing Apply is still stated.
+    expect(box.textContent).toContain('restarts')
+  })
+
+  it('cancel writes nothing', () => {
+    const { host } = mountCards([PROFILE_SLOT])
+    openProfileMenu(host, 'primary')
+    pickProfile(host, 'primary', 'brainy')
     act(() => {
       footButton('Cancel')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
@@ -430,14 +545,14 @@ describe('DevCell profile picker (card-dropdowns Task 2)', () => {
   })
 
   it('apply follows the verified path: PUT /config {profile} then a background restart', () => {
-    const { host } = mount(<DevCell s={PROFILE_SLOT} onProfile={() => {}} modelFlags="" />)
+    const { host } = mountCards([PROFILE_SLOT])
     openProfileMenu(host, 'primary')
-    pickOption(host, 'brainy')
+    pickProfile(host, 'primary', 'brainy')
     act(() => {
       footButton('Apply profile')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
-    // Branch (a) of the plan's riddle, verified from slot-modals.jsx:1120/1130
-    // + :1143 — the drawer's own two-call save, reachable as one gesture.
+    // Branch (a) of the plan's riddle, verified from slot-modals.jsx:1013/1023
+    // + :1036 — the drawer's own two-call save, reachable as one gesture.
     expect(editCalls).toEqual([{ name: 'primary', body: { profile: 'brainy' } }])
     expect(restartCalls).toEqual(['primary'])
     // the confirm closes on apply; the slots poll re-renders the pill.
@@ -446,9 +561,11 @@ describe('DevCell profile picker (card-dropdowns Task 2)', () => {
 
   it('a slot with no profile keeps the "default" word as a listed row', () => {
     const bare = { ...PROFILE_SLOT, profile: '' }
-    const { host } = mount(<DevCell s={bare} onProfile={() => {}} modelFlags="" />)
+    const { host } = mountCards([bare])
     expect(profileTrigger(host, 'primary').textContent).toContain('default')
     openProfileMenu(host, 'primary')
-    expect(optionById(host, '')!.getAttribute('aria-selected')).toBe('true')
+    expect(
+      openListbox(host, 'primary').querySelector('[data-option-id=""]')!.getAttribute('aria-selected'),
+    ).toBe('true')
   })
 })

--- a/ui/src/dash/__tests__/inference-pane-pickers.test.tsx
+++ b/ui/src/dash/__tests__/inference-pane-pickers.test.tsx
@@ -1,9 +1,13 @@
 // @vitest-environment happy-dom
 //
-// Inference pane slot-card pickers (card-dropdowns Task 1):
-//   the card model picker (ModelPicker) migrated from a native <select> to
-//   RichSelect — multi-line rows (quant tag, modality tag, size + used-by +
-//   engine desc line) and a lazy GTT fit-chip batch on first open.
+// Inference pane slot-card pickers (card-dropdowns Tasks 1 + 2):
+//   Task 1 — the card model picker (ModelPicker) migrated from a native
+//   <select> to RichSelect: multi-line rows (quant tag, modality tag, size +
+//   used-by + engine desc line) and a lazy GTT fit-chip batch on first open.
+//   Task 2 — the card profile pill (DevCell) migrated to RichSelect: rich
+//   profile rows filtered to the slot type, an "✎ Edit slot…" row keeping the
+//   old open-the-editor gesture, and a consequence confirm that owns the only
+//   write.
 //
 // inference-pane.jsx is a window-globals dash module (bare `React.Fragment`/
 // `React.cloneElement` identifiers resolve off `window` under vitest's
@@ -15,6 +19,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 ;(globalThis as unknown as { window: typeof globalThis }).window = globalThis
 ;(globalThis as unknown as { React: typeof React }).React = React
+// slot-modals.jsx rides in on inference-pane's `profileApplyPreview` import
+// and reads `Icons` at render time; the module graph only needs the global to
+// exist. (Same shim slot-profile-preview.test.ts installs.)
+;(globalThis as unknown as { Icons: unknown }).Icons = new Proxy({}, { get: () => null })
 
 // GTT feasibility probe — a real useState-backed mutation stand-in so calling
 // `mutate()` from ModelPicker's onOpenChange handler genuinely re-renders the
@@ -43,7 +51,54 @@ vi.mock('@/api/hooks/useModelsFeasibility', () => ({
   },
 }))
 
-const { ModelPicker } = await import('../inference-pane.jsx')
+// Profile-picker seams (Task 2). `useProfiles`/`useSystemInfo` are read boxes;
+// `useSlotEdit`/`useSlotRestart` are the TWO mutations the verified apply path
+// fires, recorded so a test can assert that Cancel fires neither and Apply
+// fires both, in order.
+const { profilesBox, systemInfoBox, editCalls, restartCalls } = vi.hoisted(() => ({
+  profilesBox: { current: undefined as unknown[] | undefined },
+  systemInfoBox: { current: undefined as unknown },
+  editCalls: [] as { name: string; body: Record<string, unknown> }[],
+  restartCalls: [] as string[],
+}))
+
+vi.mock('@/api/hooks/useProfiles', () => ({
+  useProfiles: () => ({ data: profilesBox.current }),
+}))
+
+// Only `useSystemInfo` is stubbed — `deviceBackend` stays the real one, since
+// profileApplyPreview's lane lines are derived through it.
+vi.mock('@/api/hooks/useRuntimes', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useSystemInfo: () => ({ data: systemInfoBox.current }),
+}))
+
+vi.mock('@/api/hooks/useSlots', () => ({
+  useSlots: () => ({ data: undefined, isLoading: false }),
+  useSlotLoad: () => ({ mutate: () => {} }),
+  useSlotUnload: () => ({ mutate: () => {} }),
+  useSlotSwap: () => ({ mutate: () => {} }),
+  useSlotRestart: () => ({
+    mutate: (name: string) => {
+      restartCalls.push(name)
+    },
+  }),
+  useSlotEdit: () => ({
+    isPending: false,
+    mutate: (
+      args: { name: string; body: Record<string, unknown> },
+      opts?: { onSuccess?: () => void },
+    ) => {
+      editCalls.push(args)
+      opts?.onSuccess?.()
+    },
+    mutateAsync: async (args: { name: string; body: Record<string, unknown> }) => {
+      editCalls.push(args)
+    },
+  }),
+}))
+
+const { ModelPicker, DevCell } = await import('../inference-pane.jsx')
 
 function mount(el: React.ReactElement) {
   const host = document.createElement('div')
@@ -118,9 +173,88 @@ const ALL_SLOTS = [
   { name: 'other', model: 'm1' },
 ]
 
+// ── profile-picker fixtures (Task 2) ────────────────────────────────────────
+// One dual-lane default runtime and one single-lane ROCm runtime, so a pick
+// can move the slot's lane (Vulkan → ROCm) and the preview has a real lane
+// line to render.
+const BACKENDS = {
+  rocmfpx: {
+    title: 'Standard',
+    blurb: 'Runs everything.',
+    is_default: true,
+    supported_backends: ['rocm', 'vulkan'],
+    device_class: 'gpu',
+    runtime_family: 'llama-server',
+    state: 'installed',
+  },
+  promptforge: {
+    title: 'PromptForge',
+    blurb: 'Accelerated PF.',
+    is_default: false,
+    supported_backends: ['rocm'],
+    device_class: 'gpu',
+    runtime_family: 'llama-server',
+    state: 'installed',
+  },
+}
+// P_CUR is the slot's persisted profile (no runner → AUTO chip); P_PF pins a
+// single-lane ROCm runtime; P_TTS is type-fenced away from an llm slot.
+const P_CUR = {
+  name: 'rocm',
+  flags: '-fa auto',
+  intent: 'general chat tune',
+  supported_slot_types: ['llm'],
+}
+const P_PF = {
+  name: 'brainy',
+  flags: '--temp 0.2 --top-p 0.9 --jinja',
+  runner: 'promptforge',
+  intent: 'low-temp reasoning tune',
+  supported_slot_types: ['llm'],
+}
+const P_TTS = {
+  name: 'voice',
+  flags: '',
+  intent: 'kokoro synth tune',
+  supported_slot_types: ['tts'],
+}
+const PROFILE_SLOT = {
+  name: 'primary',
+  type: 'llm',
+  device: 'gpu-vulkan',
+  profile: 'rocm',
+  binary: '',
+}
+
+function profileTrigger(host: HTMLElement, name: string) {
+  return q(host, `infer-profile-${name}`)!
+}
+
+function openProfileMenu(host: HTMLElement, name: string) {
+  act(() => {
+    profileTrigger(host, name).dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+function pickOption(host: HTMLElement, id: string) {
+  act(() => {
+    optionById(host, id)!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+function footButton(label: string) {
+  return Array.from(document.querySelectorAll('.modal-foot button')).find(
+    (b) => (b.textContent || '').trim() === label,
+  ) as HTMLElement | undefined
+}
+
 beforeEach(() => {
   feasibilityCalls.length = 0
   feasibilityHandler.current = undefined
+  profilesBox.current = [P_CUR, P_PF, P_TTS]
+  systemInfoBox.current = { backends: BACKENDS }
+  editCalls.length = 0
+  restartCalls.length = 0
 })
 
 afterEach(() => {
@@ -218,5 +352,103 @@ describe('ModelPicker (card-dropdowns Task 1)', () => {
     expect(host.querySelector('.smodel')!.textContent).toBe('bge-m3')
     expect(q(host, 'infer-model-embed')).toBeNull()
     expect(feasibilityCalls.length).toBe(0)
+  })
+})
+
+describe('DevCell profile picker (card-dropdowns Task 2)', () => {
+  it("profile pill opens rich rows filtered to the slot's type, current ticked", () => {
+    const { host } = mount(<DevCell s={PROFILE_SLOT} onProfile={() => {}} modelFlags="" />)
+    // the pill still surfaces the slot's profile name (the e2e claim)
+    expect(profileTrigger(host, 'primary').textContent).toContain('rocm')
+    openProfileMenu(host, 'primary')
+    // the tts-only profile is fenced out by supported_slot_types.
+    expect(optionById(host, 'voice')).toBeNull()
+    expect(optionById(host, 'rocm')).not.toBeNull()
+    expect(optionById(host, 'brainy')).not.toBeNull()
+    // current is the ticked row — RichSelect's own selected affordance.
+    expect(optionById(host, 'rocm')!.getAttribute('aria-selected')).toBe('true')
+    expect(optionById(host, 'brainy')!.getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('rows show runtime chip + blurb; Edit slot row present and calls onProfile', () => {
+    const onProfile = vi.fn()
+    const { host } = mount(<DevCell s={PROFILE_SLOT} onProfile={onProfile} modelFlags="" />)
+    openProfileMenu(host, 'primary')
+    const pf = optionById(host, 'brainy')!
+    // one solid chip per lane (runtimeChips), and the profile's intent line.
+    expect(Array.from(pf.querySelectorAll('.pf-be')).map((c) => c.textContent)).toEqual(['ROCm'])
+    expect(pf.querySelector('.rsel-option-desc')!.textContent).toBe('low-temp reasoning tune')
+    // an unpinned profile chips AUTO rather than claiming a lane.
+    expect(
+      Array.from(optionById(host, 'rocm')!.querySelectorAll('.pf-be')).map((c) => c.textContent),
+    ).toEqual(['AUTO'])
+    // the last row keeps today's gesture: the pill opened the slot editor.
+    const edit = optionById(host, '__edit_slot__')!
+    expect(edit.textContent).toContain('Edit slot')
+    pickOption(host, '__edit_slot__')
+    expect(onProfile).toHaveBeenCalledTimes(1)
+    // …and it is NOT a profile pick: no confirm, no write.
+    expect(q(host, 'infer-profile-preview')).toBeNull()
+    expect(editCalls).toEqual([])
+  })
+
+  it('pick opens the consequence confirm with flag/runtime/restart lines', () => {
+    const { host } = mount(<DevCell s={PROFILE_SLOT} onProfile={() => {}} modelFlags="" />)
+    openProfileMenu(host, 'primary')
+    pickOption(host, 'brainy')
+    const box = q(host, 'infer-profile-preview')!
+    expect(box).not.toBeNull()
+    const text = box.textContent || ''
+    // runtime → the runner the profile pins, named by the system-info catalog.
+    expect(text).toContain('PromptForge')
+    // lane → a single-lane ROCm runtime moves this Vulkan slot's lane.
+    expect(text).toContain('Vulkan')
+    expect(text).toContain('ROCm')
+    // flags → the 3 pairs in brainy's tune the slot does not already launch
+    // with (its current tune is rocm's `-fa auto`).
+    expect(text).toContain('replaces 3 flags')
+    // …and the restart line the apply actually performs.
+    expect(text).toContain('restarts')
+    // nothing has been written yet.
+    expect(editCalls).toEqual([])
+    expect(restartCalls).toEqual([])
+  })
+
+  it('cancel writes nothing', () => {
+    const { host } = mount(<DevCell s={PROFILE_SLOT} onProfile={() => {}} modelFlags="" />)
+    openProfileMenu(host, 'primary')
+    pickOption(host, 'brainy')
+    act(() => {
+      footButton('Cancel')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(q(host, 'infer-profile-preview')).toBeNull()
+    expect(editCalls).toEqual([])
+    expect(restartCalls).toEqual([])
+    // the pill still reads the PERSISTED profile — a cancelled pick leaves no
+    // staged state behind either.
+    expect(profileTrigger(host, 'primary').textContent).toContain('rocm')
+  })
+
+  it('apply follows the verified path: PUT /config {profile} then a background restart', () => {
+    const { host } = mount(<DevCell s={PROFILE_SLOT} onProfile={() => {}} modelFlags="" />)
+    openProfileMenu(host, 'primary')
+    pickOption(host, 'brainy')
+    act(() => {
+      footButton('Apply profile')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // Branch (a) of the plan's riddle, verified from slot-modals.jsx:1120/1130
+    // + :1143 — the drawer's own two-call save, reachable as one gesture.
+    expect(editCalls).toEqual([{ name: 'primary', body: { profile: 'brainy' } }])
+    expect(restartCalls).toEqual(['primary'])
+    // the confirm closes on apply; the slots poll re-renders the pill.
+    expect(q(host, 'infer-profile-preview')).toBeNull()
+  })
+
+  it('a slot with no profile keeps the "default" word as a listed row', () => {
+    const bare = { ...PROFILE_SLOT, profile: '' }
+    const { host } = mount(<DevCell s={bare} onProfile={() => {}} modelFlags="" />)
+    expect(profileTrigger(host, 'primary').textContent).toContain('default')
+    openProfileMenu(host, 'primary')
+    expect(optionById(host, '')!.getAttribute('aria-selected')).toBe('true')
   })
 })

--- a/ui/src/dash/__tests__/inference-pane-pickers.test.tsx
+++ b/ui/src/dash/__tests__/inference-pane-pickers.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment happy-dom
+//
+// Inference pane slot-card pickers (card-dropdowns Task 1):
+//   the card model picker (ModelPicker) migrated from a native <select> to
+//   RichSelect — multi-line rows (quant tag, modality tag, size + used-by +
+//   engine desc line) and a lazy GTT fit-chip batch on first open.
+//
+// inference-pane.jsx is a window-globals dash module (bare `React.Fragment`/
+// `React.cloneElement` identifiers resolve off `window` under vitest's
+// classic-JSX esbuild config) — same pattern as model-drawer.test.tsx.
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+;(globalThis as unknown as { window: typeof globalThis }).window = globalThis
+;(globalThis as unknown as { React: typeof React }).React = React
+
+// GTT feasibility probe — a real useState-backed mutation stand-in so calling
+// `mutate()` from ModelPicker's onOpenChange handler genuinely re-renders the
+// component, the same way react-query's own mutation state does (idiom lifted
+// from model-drawer.test.tsx's feasibility mock).
+const { feasibilityCalls, feasibilityHandler } = vi.hoisted(() => ({
+  feasibilityCalls: [] as unknown[],
+  feasibilityHandler: {
+    current: undefined as
+      | ((body: { models: { model_id: string; ctx?: number }[] }) => { results: unknown[] } | undefined)
+      | undefined,
+  },
+}))
+
+vi.mock('@/api/hooks/useModelsFeasibility', () => ({
+  useModelsFeasibility: () => {
+    const [data, setData] = React.useState<{ results: unknown[] } | undefined>(undefined)
+    return {
+      data,
+      mutate: (body: { models: { model_id: string; ctx?: number }[] }) => {
+        feasibilityCalls.push(body)
+        const resp = feasibilityHandler.current?.(body)
+        if (resp) setData(resp)
+      },
+    }
+  },
+}))
+
+const { ModelPicker } = await import('../inference-pane.jsx')
+
+function mount(el: React.ReactElement) {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  act(() => {
+    root.render(el)
+  })
+  return { host, root }
+}
+
+const q = (host: HTMLElement, testid: string) =>
+  host.querySelector(`[data-testid="${testid}"]`) as HTMLElement | null
+
+function trigger(host: HTMLElement, name: string) {
+  return q(host, `infer-model-${name}`)!
+}
+
+function openMenu(host: HTMLElement, name: string) {
+  act(() => {
+    trigger(host, name).dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+function optionEls(host: HTMLElement) {
+  return Array.from(host.querySelectorAll('.rsel-listbox [role="option"]')) as HTMLElement[]
+}
+
+function optionById(host: HTMLElement, id: string) {
+  return host.querySelector(`[data-option-id="${id}"]`) as HTMLElement | null
+}
+
+// m1: current model of NO slot in the base fixture set (used-by = "other")
+// so its used-by text reads as a plain count, matching the brief's literal
+// "used by 1 slot" example rather than the "used by this slot" branch.
+const M1 = {
+  id: 'm1',
+  longName: 'Qwen3.6-8B',
+  quant: 'Q8_0',
+  size_bytes: 2_791_728_742, // (2_791_728_742 / 1024**3).toFixed(1) === "2.6"
+  type: 'llm',
+  capabilities: ['chat'],
+  installed: true,
+  provider_effective: 'llama-server',
+}
+const M2 = {
+  id: 'm2',
+  longName: 'Ornith-Vision',
+  quant: 'Q4_K',
+  size_bytes: 9_223_372_036, // ~8.6 GB
+  type: 'llm',
+  capabilities: ['chat', 'vision'],
+  installed: true,
+  provider_effective: 'vllm',
+}
+// upstream-advertised, not locally installed — excluded from `opts` by the
+// same rule slot-modals' compatibleModels() applies.
+const M3_UPSTREAM = {
+  id: 'm3',
+  longName: 'Upstream-Only',
+  type: 'llm',
+  origin: 'upstream',
+  installed: false,
+}
+const MODELS = [M1, M2, M3_UPSTREAM]
+
+const SLOT = { name: 'chat', type: 'llm', model_id: '', ctx_max: 32768 }
+// slotsUsingModel (model-usage.js) matches on `model`/`model_default`, not
+// `model_id` — the slot roster shape it was written against.
+const ALL_SLOTS = [
+  { name: 'chat', model: '' },
+  { name: 'other', model: 'm1' },
+]
+
+beforeEach(() => {
+  feasibilityCalls.length = 0
+  feasibilityHandler.current = undefined
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('ModelPicker (card-dropdowns Task 1)', () => {
+  it('renders rich rows: quant tag, size desc, used-by', () => {
+    const { host } = mount(
+      <ModelPicker s={SLOT} models={MODELS} allSlots={ALL_SLOTS} disabled={false} onSwap={() => {}} />,
+    )
+    openMenu(host, 'chat')
+    const row = optionById(host, 'm1')!
+    expect(row.textContent).toContain('Q8_0')
+    expect(row.querySelector('.rsel-option-desc')!.textContent).toContain('2.6 GB')
+    expect(row.querySelector('.rsel-option-desc')!.textContent).toContain('used by 1 slot')
+    expect(row.querySelector('.rsel-option-desc')!.textContent).toContain('other')
+    // upstream-only row never appears at all.
+    expect(optionById(host, 'm3')).toBeNull()
+  })
+
+  it('fires one lazy feasibility batch on first open with slot ctx, not on render', () => {
+    const { host } = mount(
+      <ModelPicker s={SLOT} models={MODELS} allSlots={ALL_SLOTS} disabled={false} onSwap={() => {}} />,
+    )
+    expect(feasibilityCalls.length).toBe(0)
+    openMenu(host, 'chat')
+    expect(feasibilityCalls.length).toBe(1)
+    expect(feasibilityCalls[0]).toEqual({
+      models: [
+        { model_id: 'm1', ctx: 32768 },
+        { model_id: 'm2', ctx: 32768 },
+      ],
+    })
+    // Closing and reopening does not re-fire — first open only.
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    })
+    openMenu(host, 'chat')
+    expect(feasibilityCalls.length).toBe(1)
+  })
+
+  it('verdict chips render per feasibilityHint tone; unknown renders no chip', () => {
+    feasibilityHandler.current = () => ({
+      results: [
+        { model_id: 'm1', verdict: 'fits', needed_mb: 2662, gtt_free_mb: 8192, gtt_total_mb: 16384 },
+        // m2 has no result row at all → unknown → no chip.
+      ],
+    })
+    const { host } = mount(
+      <ModelPicker s={SLOT} models={MODELS} allSlots={ALL_SLOTS} disabled={false} onSwap={() => {}} />,
+    )
+    openMenu(host, 'chat')
+    const row1 = optionById(host, 'm1')!
+    expect(row1.querySelector('.rsel-option-right')!.textContent).toContain('fits')
+    const row2 = optionById(host, 'm2')!
+    expect(row2.querySelector('.rsel-option-right')).toBeNull()
+  })
+
+  it('pick calls onSwap(id); picking current is a no-op', () => {
+    const onSwap = vi.fn()
+    const cur = { ...SLOT, model_id: 'm1' }
+    const { host } = mount(
+      <ModelPicker s={cur} models={MODELS} allSlots={ALL_SLOTS} disabled={false} onSwap={onSwap} />,
+    )
+    openMenu(host, 'chat')
+    act(() => {
+      optionById(host, 'm1')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(onSwap).not.toHaveBeenCalled()
+    openMenu(host, 'chat')
+    act(() => {
+      optionById(host, 'm2')!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(onSwap).toHaveBeenCalledWith('m2')
+  })
+
+  it('current out-of-vocab model renders as its own row', () => {
+    const cur = { ...SLOT, model_id: 'ghost-7b', model: 'ghost-7b' }
+    const { host } = mount(
+      <ModelPicker s={cur} models={MODELS} allSlots={ALL_SLOTS} disabled={false} onSwap={() => {}} />,
+    )
+    openMenu(host, 'chat')
+    const row = optionById(host, 'ghost-7b')
+    expect(row).not.toBeNull()
+    expect(row!.textContent).toContain('ghost-7b')
+    expect(optionEls(host).length).toBe(3) // ghost-7b + m1 + m2
+  })
+
+  it('non-llm slot keeps the static line', () => {
+    const util = { name: 'embed', type: 'embedding', model: 'bge-m3' }
+    const { host } = mount(
+      <ModelPicker s={util} models={MODELS} allSlots={ALL_SLOTS} disabled={false} onSwap={() => {}} />,
+    )
+    expect(host.querySelector('.smodel')!.textContent).toBe('bge-m3')
+    expect(q(host, 'infer-model-embed')).toBeNull()
+    expect(feasibilityCalls.length).toBe(0)
+  })
+})

--- a/ui/src/dash/__tests__/slot-profile-preview.test.ts
+++ b/ui/src/dash/__tests__/slot-profile-preview.test.ts
@@ -1,27 +1,21 @@
-// profileApplyPreview (slot-modals.jsx) — the slot drawer's profile apply
-// preview, the `slot-profile-preview` box (mockup panel 12).
+// profileApplyPreview (profile-apply-preview.js) — the profile apply preview
+// BOTH profile surfaces speak: the slot drawer's `slot-profile-preview` box
+// (mockup panel 12) and the slot card's `infer-profile-preview` apply confirm
+// (panel 02).
 //
-// Every consequence of "profile wins" enumerated in one place, BEFORE Save:
-// which runtime the profile pins, which lane the slot lands on, how many
-// flags the profile's tune replaces, and that the slot restarts. The box is
+// Every consequence of "profile wins" enumerated in one place, BEFORE the
+// write: which runtime the profile pins, which lane the slot lands on, how
+// many flags the profile's tune replaces, and that the slot restarts. It is
 // the operator's only chance to see the server-side reconcile (Task 5) before
 // it happens, so the lines must be derived from the SAME hw-cascade the
 // Hardware group drives (runnerOptions/applyRunnerChoice) rather than
 // re-guessed — and a line with nothing true to say is OMITTED, never faked.
 //
-// slot-modals.jsx is a window-globals dash module (`const {...} = React` at
-// module top, `Object.assign(window, {...})` at the bottom), so the globals
-// must be installed before the dynamic import — same pattern as
-// host-hw-flags.test.ts / runner-images-view.test.tsx.
-import React from 'react'
+// The function is pure and lives in its own module, so this file needs no
+// window/React globals shim.
 import { describe, expect, it } from 'vitest'
 import { runnerOptions } from '../hw-cascade.js'
-
-;(globalThis as unknown as { window: typeof globalThis }).window = globalThis
-;(globalThis as unknown as { React: typeof React }).React = React
-;(globalThis as unknown as { Icons: unknown }).Icons = new Proxy({}, { get: () => null })
-
-const { profileApplyPreview } = await import('../slot-modals.jsx')
+import { profileApplyPreview } from '../profile-apply-preview.js'
 
 // system-info `backends` rows (Task 2 shape) — a dual-lane default, a
 // single-lane ROCm runtime and a single-lane Vulkan one, so both the

--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -1241,6 +1241,9 @@
   white-space: nowrap;
   min-width: 0;
 }
+:is(.infer-pane, .npu-pane) .scard-profile-row .prov .rsel {
+  min-width: 0;
+}
 
 /* expanded-body status line — right-aligned mono */
 :is(.infer-pane, .npu-pane) .body-status {
@@ -1328,10 +1331,20 @@
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
-:is(.infer-pane, .npu-pane) .profile-pill {
+/* The profile side of the joined [ device | PROFILE ] tag. It is a RichSelect
+   trigger (card-dropdowns Task 2), so `.rsel` — which is `width: 100%` for the
+   full-width drawer fields it was written for — is pulled back to the pill's
+   own content width and the popover is released from the trigger's narrow
+   `left: 0; right: 0` box, which would otherwise force every profile row to
+   wrap inside ~90px. */
+:is(.infer-pane, .npu-pane) .prov .rsel {
+  width: auto;
+}
+:is(.infer-pane, .npu-pane) .rsel-trigger.profile-pill {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  width: auto;
   padding: 2px 7px;
   border: 1px solid var(--line);
   border-left: none;
@@ -1344,12 +1357,38 @@
   letter-spacing: 0.04em;
   cursor: pointer;
 }
-:is(.infer-pane, .npu-pane) .profile-pill:hover {
+:is(.infer-pane, .npu-pane) .rsel-trigger.profile-pill:hover {
   color: var(--comfy);
   border-color: var(--comfy-line);
 }
-:is(.infer-pane, .npu-pane) .profile-pill svg {
+:is(.infer-pane, .npu-pane) .rsel-trigger.profile-pill .rsel-trigger-caret {
+  font-size: 8px;
   color: var(--fg-4);
+}
+/* The closed pill stays a chip: the runtime lane chips a row carries belong to
+   the open menu, where there is room for them. */
+:is(.infer-pane, .npu-pane) .rsel-trigger.profile-pill .pf-be-row {
+  display: none;
+}
+:is(.infer-pane, .npu-pane) .prov .rsel-listbox {
+  right: auto;
+  min-width: 260px;
+  max-width: 340px;
+}
+/* Profile row layout — name + lane chips. Applies in the open menu AND in the
+   closed trigger (which renders the selected option's row), so a long custom
+   profile name ellipsises inside the pill instead of stretching the card. */
+:is(.infer-pane, .npu-pane) .prov .rsel-trigger-row-main,
+:is(.infer-pane, .npu-pane) .prov .prof-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+:is(.infer-pane, .npu-pane) .prov .prof-row-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* per-slot control icons */

--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -1178,49 +1178,45 @@
   background: var(--bg-1);
 }
 
-/* model picker (full cards) — a real <select> styled as the design's
-   full-width bordered control */
-:is(.infer-pane, .npu-pane) .model-picker {
-  appearance: none;
-  -webkit-appearance: none;
+/* model picker (full cards) — RichSelect's trigger button (card-dropdowns
+   Task 1: migrated off the native <select> this block used to style
+   directly). RichSelect renders its own caret glyph and truncates each row's
+   content itself (rich-select.jsx / modelPickerOptions' row markup), so the
+   select-only appearance-reset + background-image chevron hack is gone with
+   it — these overrides just pull the shared `.rsel-trigger` chrome (Task 10,
+   dashboard.css) back to the card's tighter mono identity. */
+:is(.infer-pane, .npu-pane) .rsel-trigger.model-picker {
   width: 100%;
   min-width: 0;
-  padding: 7px 28px 7px 10px;
+  padding: 7px 10px;
   border: 1px solid var(--line-strong);
   border-radius: var(--rad-sm);
-  background-color: var(--bg-1);
+  background: var(--bg-1);
   color: var(--fg);
   font-family: var(--jbm);
   font-size: 11.5px;
-  cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
-  background-repeat: no-repeat;
-  background-position: right 9px center;
-  background-size: 11px;
   transition: border-color var(--dur-fast) var(--ease);
 }
-:is(.infer-pane, .npu-pane) .model-picker:hover {
+:is(.infer-pane, .npu-pane) .rsel-trigger.model-picker:hover {
   border-color: var(--comfy-line);
 }
-:is(.infer-pane, .npu-pane) .model-picker:disabled {
+:is(.infer-pane, .npu-pane) .rsel-trigger.model-picker[disabled] {
   opacity: 0.6;
   cursor: default;
 }
 
 /* model row + inline model-edit pencil (slot card).
    The pencil is a SIBLING of the model control, never nested inside it: the
-   LLM row is a <select> whose own click gesture must stay uncontested. The
-   picker keeps flexing to fill; the button is a fixed square. */
+   LLM row is a RichSelect (`.model-picker-cell` wrapping `.rsel`) whose own
+   click gesture must stay uncontested. The picker keeps flexing to fill; the
+   button is a fixed square. */
 :is(.infer-pane, .npu-pane) .smodel-row {
   display: flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
 }
-:is(.infer-pane, .npu-pane) .smodel-row > .model-picker,
+:is(.infer-pane, .npu-pane) .smodel-row > .model-picker-cell,
 :is(.infer-pane, .npu-pane) .smodel-row > .smodel {
   flex: 1;
   min-width: 0;

--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -948,6 +948,34 @@
   overflow: hidden;
   transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
 }
+/* Open-dropdown escape hatch (card-dropdowns). Two card properties fight the
+   two RichSelects a full card carries (model picker, profile pill), whose
+   `.rsel-listbox` is an absolutely-positioned popover that must overflow the
+   card:
+     · `overflow: hidden` above decapitates it — on a card near the bottom of
+       the grid only the first row or two survived. The clip is not
+       incidental: `.scard-foot` is a full-bleed bar and `.scard::before` a
+       full-height accent stripe, and both need the radius to cut them, so
+       `overflow: visible` outright is wrong — it would leak those on every
+       card all the time. Release it only while a listbox is open.
+     · `.scard:hover`'s `transform` (and `.scard.dim`'s `opacity`) makes the
+       card a stacking context, which traps the listbox's `z-index: 30` inside
+       the card's own layer — and since the card sits in DOM order before the
+       utility grid below, the escaped menu painted UNDERNEATH the next row of
+       cards. Lifting the card itself while its menu is open puts that whole
+       layer on top.
+     · `.scard.dim`'s `opacity: 0.55` (an off slot) composites the menu at 55%
+       too, so a dropdown opened on a stopped slot was legibly see-through —
+       the cards behind it read straight through the rows. A card the operator
+       is actively choosing on is not passive furniture: full opacity while
+       its menu is open.
+   All three are keyed on the open state, so a closed card is byte-for-byte
+   what it was. */
+:is(.infer-pane, .npu-pane) .scard:has(.rsel-trigger[aria-expanded='true']) {
+  overflow: visible;
+  z-index: 20;
+  opacity: 1;
+}
 /* left accent — colour per state, matching the profile-card .pf-accent treatment */
 :is(.infer-pane, .npu-pane) .scard::before {
   content: '';
@@ -1374,6 +1402,18 @@
   right: auto;
   min-width: 260px;
   max-width: 340px;
+}
+/* The "✎ Edit slot…" row is a different KIND of thing from the profiles above
+   it — it opens the editor rather than picking a profile — so it is ruled off
+   and set in the muted secondary colour instead of reading as one more
+   profile. */
+:is(.infer-pane, .npu-pane) .prov .rsel-option[data-option-id='__edit_slot__'] {
+  border-top: 1px solid var(--line-strong);
+  margin-top: 4px;
+  color: var(--fg-3);
+}
+:is(.infer-pane, .npu-pane) .prov .rsel-option[data-option-id='__edit_slot__'] .rsel-option-row {
+  color: var(--fg-3);
 }
 /* Profile row layout — name + lane chips. Applies in the open menu AND in the
    closed trigger (which renders the selected option's row), so a long custom

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -40,7 +40,7 @@ import { useModelsFeasibility } from '@/api/hooks/useModelsFeasibility'
 import { useProfiles } from '@/api/hooks/useProfiles'
 import { useSystemInfo } from '@/api/hooks/useRuntimes'
 import { hostHwFlags, runnerOptions } from './hw-cascade.js'
-import { profileApplyPreview } from './slot-modals.jsx'
+import { profileApplyPreview } from './profile-apply-preview.js'
 import { runtimeChips } from './profiles.jsx'
 import { ConfirmDialog } from './primitives.jsx'
 import { isUpstreamModel } from '@/lib/normalizeApiModel'
@@ -216,7 +216,7 @@ const PROFILE_EDIT_ROW = '__edit_slot__'
 // differently here) + the profile's intent line.
 //
 // Filtered exactly like the drawer's picker: `supported_slot_types` first
-// (slot-modals.jsx:1496-1500, mirroring the backend's profile_fits_slot —
+// (slot-modals.jsx:1389-1393, mirroring the backend's profile_fits_slot —
 // model_fit.py:80). The drawer additionally splits device_class/backend
 // matches into `fit` vs a cross-device group; the card lists the type-fitting
 // set flat and lets the apply preview below announce a lane move, per
@@ -264,40 +264,12 @@ function profileCardOptions({ s, profiles, backends }) {
 }
 
 // provider tag — a joined [ device | PROFILE ] control. The device chip is
-// static; the profile side is a real picker over /api/profiles, and a pick
-// routes through a consequence confirm (the drawer's own `profileApplyPreview`
-// lines) before anything is written. Cancel writes nothing.
-//
-// ── THE APPLY PATH, VERIFIED FROM SOURCE (mockup callout F) ────────────────
-// The slot drawer persists a profile pick as exactly TWO plain mutations,
-// with no drawer-only state between them:
-//   1. PUT /api/slots/{name}/config {profile: name|null} — assembled at
-//      slot-modals.jsx:1120 and fired at :1130 through useSlotEdit
-//      (api/hooks/useSlots.ts:617). The route is a PURE config write with no
-//      lifecycle side effect (api/routes/slots.py:1386, note at :1441), and
-//      the server re-derives the slot's `device` from the new profile itself
-//      (slots/config_write.py:444 → _reconcile_device_profile(merged,
-//      {"profile"}) at :91) — the drawer sends no device of its own.
-//   2. POST /api/slots/{name}/restart, fired in the BACKGROUND (never
-//      awaited) because `changes.profile` is part of `hwChanged`
-//      (slot-modals.jsx:1097-1103, restart at :1143) via useSlotRestart.
-// Both are reachable from any component, so this is branch (a) of the plan's
-// riddle: Apply performs the write here, one gesture, no half-applied state.
-// The drawer's extra Save-time gates guard fields this control cannot touch —
-// a device+profile pair edited together (slot-modals.jsx:1075) and a bound
-// model stranded by a device switch the operator drove (:1242) — and the one
-// consequence that does reach a card pick, a lane move, is announced by the
-// preview's `lane` line instead of blocking (§4 warn-never-block).
-export function DevCell({ s, onProfile, modelFlags }) {
+// static; the profile side is a real picker over /api/profiles. Picking a row
+// WRITES NOTHING: it hands the pick up to the pane (`onPickProfile`), which
+// owns the consequence confirm. This component holds no data hooks and no
+// mutations — the card is a leaf.
+function DevCell({ s, onProfile, profiles, backends, onPickProfile }) {
   const kind = devKind(s.device)
-  const profilesQuery = useProfiles()
-  const systemInfoQuery = useSystemInfo()
-  const editMut = useSlotEdit()
-  const restartMut = useSlotRestart()
-  // The picked-but-not-yet-applied profile name; null = no confirm open.
-  // Nothing is written while this holds a value — it IS the "before the
-  // confirm" state.
-  const [pending, setPending] = useStateI(null)
   const dchip =
     kind === 'npu' ? (
       <span className="flm-chip">FLM · npu</span>
@@ -308,143 +280,214 @@ export function DevCell({ s, onProfile, modelFlags }) {
       </span>
     )
   const cur = s.profile || ''
-  const profiles = Array.isArray(profilesQuery.data) ? profilesQuery.data : []
-  const backends = systemInfoQuery.data?.backends ?? {}
-  const pendingRow = pending ? profiles.find((p) => p.name === pending) || null : null
-  // Same cascade the drawer's preview reads (slot-modals.jsx:1466-1472), fed
+  return (
+    <span className="prov">
+      {dchip}
+      <RichSelect
+        className="profile-pill"
+        value={cur}
+        options={profileCardOptions({ s, profiles, backends })}
+        aria-label={`Runtime profile for ${s.name}`}
+        data-testid={`infer-profile-${s.name}`}
+        onChange={(id) => {
+          if (id === PROFILE_EDIT_ROW) {
+            onProfile()
+            return
+          }
+          if (id !== cur) onPickProfile(id)
+        }}
+      />
+    </span>
+  )
+}
+
+// The consequence confirm for a card profile pick — mounted ONCE by the card
+// list, never inside a card.
+//
+// It must live outside `.scard`: that card carries `overflow: hidden`
+// (engine-panes.css `.scard`) and grows a `transform` on hover
+// (`.scard:hover`), and a transformed ancestor becomes the containing block
+// for `position: fixed` descendants. A dialog rendered inside the card would
+// therefore be laid out against the ~250px card box and clipped by it, and
+// would jump between card-box and viewport as the pointer crossed the card.
+// (Neither happy-dom nor Playwright's rect-based visibility notices that —
+// only the eye does.) One dialog for N cards also matches the truth that the
+// confirm is modal: there is only ever one pending pick.
+//
+// ── THE APPLY PATH, VERIFIED FROM SOURCE (mockup callout F) ────────────────
+// The slot drawer persists a profile pick as exactly TWO plain mutations,
+// with no drawer-only state between them:
+//   1. PUT /api/slots/{name}/config {profile} — assembled at
+//      slot-modals.jsx:1013 and fired at :1023 through useSlotEdit
+//      (api/hooks/useSlots.ts:617). The route is a PURE config write with no
+//      lifecycle side effect (api/routes/slots.py:1386, note at :1441), and
+//      the server re-derives the slot's `device` from the new profile itself
+//      (slots/config_write.py:444 → _reconcile_device_profile(merged,
+//      {"profile"}) at :91) — the drawer sends no device of its own.
+//   2. POST /api/slots/{name}/restart, fired in the BACKGROUND (never
+//      awaited) because `changes.profile` is part of `hwChanged`
+//      (slot-modals.jsx:990-996, restart at :1036) via useSlotRestart.
+// Both are reachable from any component, so this is branch (a) of the plan's
+// riddle: Apply performs the write here, one gesture, no half-applied state.
+// The drawer's extra Save-time gates guard fields this control cannot touch —
+// a device+profile pair edited together (slot-modals.jsx:968) and a bound
+// model stranded by a device switch the operator drove (:1135) — and the one
+// consequence that does reach a card pick, a lane move, is announced by the
+// preview's `lane` line instead of blocking (§4 warn-never-block).
+//
+// `pending` is `{ s, profile, modelFlags }` or null; null renders nothing.
+function ProfileApplyConfirm({ pending, profiles, backends, hardware, onClose }) {
+  const editMut = useSlotEdit()
+  const restartMut = useSlotRestart()
+  const s = pending?.s || null
+  const name = pending?.profile ?? null
+  const row = name ? (profiles || []).find((p) => p.name === name) || null : null
+  // Same cascade the drawer's preview reads (slot-modals.jsx:1359-1365), fed
   // the slot's PERSISTED device — the card has no pending-device state of its
   // own, so there is nothing to preview but the write it is about to make.
-  const preview = pendingRow
-    ? profileApplyPreview({
-        profile: pendingRow,
-        backends,
-        options: runnerOptions({
+  const preview =
+    row && s
+      ? profileApplyPreview({
+          profile: row,
           backends,
-          device: s.device || '',
-          slotType: s.type,
-          hw: hostHwFlags(systemInfoQuery.data?.hardware),
-        }).options,
-        baselineRunner: s.binary || '',
-        currentDevice: s.device || '',
-        modelFlags: modelFlags || '',
-        currentProfileFlags: profiles.find((p) => p.name === cur)?.flags || '',
-      })
-    : null
+          options: runnerOptions({
+            backends,
+            device: s.device || '',
+            slotType: s.type,
+            hw: hostHwFlags(hardware),
+          }).options,
+          baselineRunner: s.binary || '',
+          currentDevice: s.device || '',
+          modelFlags: pending?.modelFlags || '',
+          currentProfileFlags:
+            (profiles || []).find((p) => p.name === (s.profile || ''))?.flags || '',
+        })
+      : null
+  // A stopped slot does not "restart": SlotManager.restart is unload-then-load
+  // (src/hal0/slots/manager.py:2002 → `await self.unload(...)` +
+  // `return await self.load(...)` at :2028-2029), so applying to an off slot
+  // STARTS it and loads its model — minutes of GPU work the operator did not
+  // ask for if the confirm only said "restarts". Name the lifecycle that will
+  // actually run.
+  const starts = s ? slotCtrlPhase(s) === 'off' : false
   const onApply = () => {
-    const next = pending
-    if (next == null) return
-    setPending(null)
+    if (!s || name == null) return
+    onClose()
     editMut.mutate(
-      { name: s.name, body: { profile: next || null } },
+      // `profile` is always a real name here: the only ''-id row is the
+      // "default" one, and it is offered ONLY when the slot already has no
+      // profile — so picking it is a no-op, not a change. Clearing a profile
+      // is deliberately not a card gesture; "✎ Edit slot…" is where a slot
+      // gets un-profiled.
+      { name: s.name, body: { profile: name } },
       {
         onError: (err) =>
           toast(`${s.name}: profile apply failed — ${err?.message || 'see logs'}`, 'warn'),
         onSuccess: () => {
           restartMut.mutate(s.name, {
             onError: (err) =>
-              toast(`${s.name}: restart failed — ${err?.message || 'see logs'}`, 'warn'),
+              toast(
+                `${s.name}: ${starts ? 'start' : 'restart'} failed — ${err?.message || 'see logs'}`,
+                'warn',
+              ),
           })
-          toast(`${s.name} → profile "${next}" — restarting in the background`, 'info')
+          toast(
+            `${s.name} → profile "${name}" — ${starts ? 'starting' : 'restarting'} in the background`,
+            'info',
+          )
         },
       },
     )
   }
   return (
-    <React.Fragment>
-      <span className="prov" onClick={(e) => e.stopPropagation()}>
-        {dchip}
-        <RichSelect
-          className="profile-pill"
-          value={cur}
-          options={profileCardOptions({ s, profiles, backends })}
-          aria-label={`Runtime profile for ${s.name}`}
-          data-testid={`infer-profile-${s.name}`}
-          onChange={(id) => {
-            if (id === PROFILE_EDIT_ROW) {
-              onProfile()
-              return
-            }
-            if (id !== cur) setPending(id)
-          }}
-        />
-      </span>
-      <ConfirmDialog
-        open={pending != null}
-        title={`Apply profile "${pending}"`}
-        confirmLabel="Apply profile"
-        cancelLabel="Cancel"
-        footerNote="Nothing is written until you apply."
-        onCancel={() => setPending(null)}
-        onConfirm={onApply}
-        message={
-          <div className="hint sl-apply" data-testid="infer-profile-preview">
-            <div>
-              Applying <b>{pending}</b> to this slot:
-            </div>
-            {preview && (
-              <React.Fragment>
-                <div className="sl-apply-line">
-                  · runtime →{' '}
-                  {preview.runtime.unchanged ? (
-                    <React.Fragment>
-                      <b>unchanged</b>
-                      {preview.runtime.title ? (
-                        <React.Fragment>
-                          {' '}
-                          — already on <b>{preview.runtime.title}</b>
-                        </React.Fragment>
-                      ) : (
-                        ' — this profile pins none'
-                      )}
-                    </React.Fragment>
-                  ) : (
-                    <b>{preview.runtime.title}</b>
-                  )}
-                  <span className="pf-be-row">
-                    {runtimeChips(pendingRow, backends).map((c) => (
-                      <span
-                        key={c.key}
-                        className="pf-be mono"
-                        style={c.hue ? { '--bk': c.hue } : null}
-                      >
-                        {c.label}
-                      </span>
-                    ))}
-                  </span>
-                </div>
-                {preview.lane && (
-                  <div className="sl-apply-line">
-                    · lane →{' '}
-                    {preview.lane.unchanged ? (
+    <ConfirmDialog
+      open={pending != null}
+      title={`Apply profile "${name}"`}
+      confirmLabel="Apply profile"
+      cancelLabel="Cancel"
+      footerNote="Nothing is written until you apply."
+      onCancel={onClose}
+      onConfirm={onApply}
+      message={
+        <div className="hint sl-apply" data-testid="infer-profile-preview">
+          <div>
+            Applying <b>{name}</b> to {s ? <b>{s.name}</b> : 'this slot'}:
+          </div>
+          {preview && (
+            <React.Fragment>
+              <div className="sl-apply-line">
+                · runtime →{' '}
+                {preview.runtime.unchanged ? (
+                  <React.Fragment>
+                    <b>unchanged</b>
+                    {preview.runtime.title ? (
                       <React.Fragment>
-                        <b>unchanged</b> ({preview.lane.from})
+                        {' '}
+                        — already on <b>{preview.runtime.title}</b>
                       </React.Fragment>
                     ) : (
-                      <React.Fragment>
-                        {preview.lane.from} → <b>{preview.lane.to}</b>, this slot leaves the{' '}
-                        {preview.lane.from} lane
-                      </React.Fragment>
+                      ' — this profile pins none'
                     )}
-                  </div>
+                  </React.Fragment>
+                ) : (
+                  <b>{preview.runtime.title}</b>
                 )}
-                {preview.flags > 0 && (
-                  <div className="sl-apply-line">
-                    · flags → profile tune{' '}
-                    <b>
-                      replaces {preview.flags} flag{preview.flags === 1 ? '' : 's'}
-                    </b>{' '}
-                    on this slot
-                  </div>
-                )}
+                <span className="pf-be-row">
+                  {runtimeChips(row, backends).map((c) => (
+                    <span
+                      key={c.key}
+                      className="pf-be mono"
+                      style={c.hue ? { '--bk': c.hue } : null}
+                    >
+                      {c.label}
+                    </span>
+                  ))}
+                </span>
+              </div>
+              {preview.lane && (
                 <div className="sl-apply-line">
-                  · slot <b>restarts</b> to apply
+                  · lane →{' '}
+                  {preview.lane.unchanged ? (
+                    <React.Fragment>
+                      <b>unchanged</b> ({preview.lane.from})
+                    </React.Fragment>
+                  ) : (
+                    <React.Fragment>
+                      {preview.lane.from} → <b>{preview.lane.to}</b>, this slot leaves the{' '}
+                      {preview.lane.from} lane
+                    </React.Fragment>
+                  )}
                 </div>
+              )}
+              {preview.flags > 0 && (
+                <div className="sl-apply-line">
+                  · flags → profile tune{' '}
+                  <b>
+                    replaces {preview.flags} flag{preview.flags === 1 ? '' : 's'}
+                  </b>{' '}
+                  on this slot
+                </div>
+              )}
+            </React.Fragment>
+          )}
+          {/* OUTSIDE the `preview` guard: this line states what Apply itself
+              does, which is true whether or not the picked profile still
+              resolves to a catalogue row. A confirm that writes must never
+              render without it. */}
+          <div className="sl-apply-line">
+            {starts ? (
+              <React.Fragment>
+                · slot <b>starts</b> to apply — this loads the model
+              </React.Fragment>
+            ) : (
+              <React.Fragment>
+                · slot <b>restarts</b> to apply
               </React.Fragment>
             )}
           </div>
-        }
-      />
-    </React.Fragment>
+        </div>
+      }
+    />
   )
 }
 
@@ -740,15 +783,18 @@ export function slotCtrlPhase(slot) {
 //               from their modality toggle, not the slot's own state).
 //   onEditModel / modelName — inline model-edit affordance. Omit both and the
 //               model row renders exactly as before (the NPU stack does).
-//   modelFlags — the bound model's stamped tune (registry row
-//               `defaults.extra_args`), read only by the profile picker's apply
-//               preview to count the flags a profile's tune would replace.
-//               Absent = the preview counts against an empty base tune.
+//   profiles / backends — the /api/profiles rows and the system-info runtime
+//               catalog, for the profile pill's rows. Passed down (not hooked
+//               per card) so N cards share one query subscription.
+//   onPickProfile — called with the picked profile name. The card writes
+//               NOTHING itself: the caller owns the apply confirm, which has to
+//               live outside `.scard` (see ProfileApplyConfirm).
 //   grip / dragging / dropProps — drag-to-reorder wiring (see slots/card-order).
 //               Omit `grip` and the card carries no handle at all, which is how
 //               every non-reorderable caller renders it.
 export function SlotScard({
-  s, ind, full, modelNode, controls, phase, onEdit, onEditModel, modelName, modelFlags,
+  s, ind, full, modelNode, controls, phase, onEdit, onEditModel, modelName,
+  profiles, backends, onPickProfile,
   grip, dragging, dropProps,
 }) {
   const dot = dotCls(ind)
@@ -833,7 +879,13 @@ export function SlotScard({
             its own means .scard-foot only ever holds short, fixed-width
             chips + controls, so the controls stop competing for space. */}
         <div className="scard-profile-row">
-          <DevCell s={s} onProfile={onEdit} modelFlags={modelFlags} />
+          <DevCell
+            s={s}
+            onProfile={onEdit}
+            profiles={profiles}
+            backends={backends}
+            onPickProfile={onPickProfile}
+          />
         </div>
         {full && (
           <div className="scard-meta">
@@ -872,10 +924,22 @@ export function SlotScard({
   )
 }
 
-function SlotCards({ rows, full, models, allSlots, busyName, handlers, loading, modelRows }) {
+// The headline (full/compact) card grid. Exported for the picker tests, which
+// drive the real card→pane wiring (the profile confirm lives HERE, one per
+// list) rather than a card in isolation.
+export function SlotCards({ rows, full, models, allSlots, busyName, handlers, loading, modelRows }) {
   // Operator-arranged order + drag wiring. Called before the early returns so
   // the hook order is stable across the loading/empty/populated renders.
   const reorder = useCardReorder('inference.chat', rows)
+  // Profile picker data, fetched ONCE for the whole card list rather than per
+  // card — react-query would dedupe the requests, but not the subscriptions.
+  const profilesQuery = useProfiles()
+  const systemInfoQuery = useSystemInfo()
+  // The picked-but-unwritten profile: `{ s, profile, modelFlags }` or null.
+  // It lives here, not in the card, because the confirm it drives has to be
+  // rendered outside `.scard` (overflow-clipped, and a hover-transform
+  // containing block) — see ProfileApplyConfirm.
+  const [pendingProfile, setPendingProfile] = useStateI(null)
   if (!rows.length) {
     if (loading)
       return (
@@ -887,7 +951,10 @@ function SlotCards({ rows, full, models, allSlots, busyName, handlers, loading, 
       )
     return <div className="scards-empty">no inference slots — create one to start</div>
   }
+  const profiles = Array.isArray(profilesQuery.data) ? profilesQuery.data : []
+  const backends = systemInfoQuery.data?.backends ?? {}
   return (
+    <React.Fragment>
     <div className={'scards ' + (full ? 'full' : 'compact')}>
       {reorder.rows.map(({ s, ind }) => {
         const busy = busyName === s.name
@@ -936,7 +1003,18 @@ function SlotCards({ rows, full, models, allSlots, busyName, handlers, loading, 
               handlers.onEditModel ? () => handlers.onEditModel(s) : undefined
             }
             modelName={modelRow ? modelRow.longName || modelRow.name || modelRow.id : ''}
-            modelFlags={modelRow?.defaults?.extra_args || ''}
+            profiles={profiles}
+            backends={backends}
+            onPickProfile={(profile) =>
+              setPendingProfile({
+                s,
+                profile,
+                // The base tune the preview's flag count diffs against —
+                // captured with the pick so the confirm reads the model that
+                // was bound when the operator chose.
+                modelFlags: modelRow?.defaults?.extra_args || '',
+              })
+            }
             grip={<CardGrip name={s.name} grip={reorder.gripProps(s.name)} />}
             dragging={reorder.dragName === s.name}
             dropProps={reorder.dropProps(s.name)}
@@ -944,6 +1022,16 @@ function SlotCards({ rows, full, models, allSlots, busyName, handlers, loading, 
         )
       })}
     </div>
+    {/* Sibling of the grid, not a child of any card — the confirm is a fixed
+        overlay and must not sit inside `.scard`'s overflow/transform box. */}
+    <ProfileApplyConfirm
+      pending={pendingProfile}
+      profiles={profiles}
+      backends={backends}
+      hardware={systemInfoQuery.data?.hardware}
+      onClose={() => setPendingProfile(null)}
+    />
+    </React.Fragment>
   )
 }
 

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -36,18 +36,22 @@ import {
   useSlotEdit,
 } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
+import { useModelsFeasibility } from '@/api/hooks/useModelsFeasibility'
 import { isUpstreamModel } from '@/lib/normalizeApiModel'
 import { useMemoryMapModel } from './memory-map'
 import { slotIndicatorFromPhase, isSlotLive, imageStatusChip } from './slot-status.js'
 import { SlotBreakerChip } from './breaker-chip.jsx'
 import { slotModelRow } from './slots/slot-shared.js'
 import { useCardReorder } from './slots/card-order.js'
+import { RichSelect } from './rich-select.jsx'
+import { feasibilityHint } from './feasibility-copy'
+import { slotsUsingModel } from './model-usage.js'
 // devKind — one shared, meta-aware helper (src/lib/deviceMeta.ts); replaces
 // the copy this file used to carry (and the verbatim clones in slot-list.jsx
 // and npu-pane.jsx).
 import { devKind } from '@/lib/deviceMeta'
 
-const { useState: useStateI } = React
+const { useState: useStateI, useRef: useRefI } = React
 
 // Last live serving metrics per slot+model, so a paused/stopped slot keeps
 // showing its most recent real reading instead of collapsing to an em-dash.
@@ -287,9 +291,101 @@ function BackendMismatch({ s, onEdit }) {
   )
 }
 
-// full cards get a real model picker (a styled <select> wired to useModels);
-// non-LLM slots keep their static model line.
-export function ModelPicker({ s, models, disabled, onSwap }) {
+// ── card model picker rich rows (card-dropdowns Task 1) ────────────────────
+// The one non-"chat" capability worth calling out as a modality tag on the
+// row's name line (mockup panel 01 callout C) — plain chat/tool-calling/coding
+// models get no modality tag. "asr" is the display label for either
+// capability spelling the backend may send (transcription | asr).
+const MODEL_MODALITY_CAPS = ['vision', 'embed', 'rerank', 'asr', 'tts', 'image']
+function modelModalityTag(m) {
+  const caps = Array.isArray(m?.capabilities) ? m.capabilities : []
+  if (caps.includes('transcription') || caps.includes('asr')) return 'asr'
+  return MODEL_MODALITY_CAPS.find((c) => c !== 'asr' && caps.includes(c)) || null
+}
+
+// Size in whole-tenth GB from `size_bytes`, matching model-drawer's facts-band
+// rounding (Number(size_bytes) / 1024**3, one decimal) — one authority for
+// "how big is this model" so the two surfaces can't disagree. null when the
+// row carries no size at all (never fabricate a 0.0 GB).
+function modelSizeGb(m) {
+  const b = Number(m?.size_bytes)
+  return b > 0 ? (b / 1024 ** 3).toFixed(1) : null
+}
+
+// Right-aligned GTT fit chip for a `/api/models/feasibility` result row — tone
+// comes from the shared `feasibilityHint` mapper (one source of truth for
+// verdict→tone), so this can't drift from the drawer's own hint copy. An
+// absent row (never probed, or a verdict of "unknown") renders no chip at
+// all — warn-never-block means a missing signal must not read as an error.
+function modelFitChip(row) {
+  if (!row) return null
+  const hint = feasibilityHint(row)
+  if (!hint.tone) return null
+  const gb = Math.round((row.needed_mb ?? 0) / 1024)
+  if (hint.tone === 'ok') return <span className="chip ok">● fits · ~{gb} GB</span>
+  if (hint.tone === 'warn') return <span className="chip warn">◐ tight · ~{gb} GB</span>
+  return <span className="chip err">○ won't fit · ~{gb} GB</span>
+}
+
+// Build the card model picker's RichSelect options from the already-filtered
+// llm/local candidate list. `usedBy` excludes THIS slot from its count/names —
+// binding count is only interesting for OTHER slots — but marks the row
+// sensibly when it IS this slot's current model ("used by this slot" rather
+// than "used by 0 slots", which would misreport a real binding as unbound).
+function modelPickerOptions({ s, opts, cur, has, allSlots, verdictFor }) {
+  const list = []
+  if (cur && !has) {
+    list.push({ id: cur, row: s.model || cur })
+  }
+  if (!cur) {
+    list.push({ id: '', row: '—' })
+  }
+  for (const m of opts) {
+    const quant = m.quant || null
+    const modTag = modelModalityTag(m)
+    const usedBy = slotsUsingModel(allSlots, m.id).filter((u) => u.name !== s.name)
+    const isCurrent = m.id === cur
+    const names = usedBy.map((u) => u.name).join(', ')
+    const usedByText = isCurrent
+      ? usedBy.length > 0
+        ? `used by this slot + ${usedBy.length} other${usedBy.length === 1 ? '' : 's'} (${names})`
+        : 'used by this slot'
+      : usedBy.length > 0
+        ? `used by ${usedBy.length} slot${usedBy.length === 1 ? '' : 's'} (${names})`
+        : 'used by 0 slots'
+    const sizeGb = modelSizeGb(m)
+    const descBits = []
+    if (sizeGb) descBits.push(`${sizeGb} GB`)
+    descBits.push(usedByText)
+    if (m.provider_effective && m.provider_effective !== 'llama-server') {
+      descBits.push(m.provider_effective)
+    }
+    list.push({
+      id: m.id,
+      row: (
+        <span style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {m.longName || m.id}
+          </span>
+          {quant && <span className="chip amber">{quant}</span>}
+          {modTag && <span className="chip info">{modTag}</span>}
+        </span>
+      ),
+      right: verdictFor ? verdictFor(m.id) : null,
+      desc: descBits.join(' · '),
+    })
+  }
+  return list
+}
+
+// full cards get a real model picker (RichSelect, wired to useModels + the
+// GTT feasibility probe); non-LLM slots keep their static model line.
+export function ModelPicker({ s, models, allSlots, disabled, onSwap }) {
+  const feasibility = useModelsFeasibility()
+  // Fires the batch probe on the FIRST dropdown open only (mockup callout A)
+  // — the slot's ctx_max is fixed for the life of this card, so a second open
+  // has nothing new to learn and would just re-ask the same question.
+  const firedRef = useRefI(false)
   if (s.type !== 'llm')
     return (
       <div className="smodel" title={s.model || ''}>
@@ -303,26 +399,35 @@ export function ModelPicker({ s, models, disabled, onSwap }) {
   )
   const cur = s.model_id || s.model || ''
   const has = opts.some((m) => m.id === cur)
+  const ctx = typeof s.ctx_max === 'number' && s.ctx_max > 0 ? s.ctx_max : undefined
+  const verdictFor = (id) => {
+    const row = (feasibility.data?.results || []).find((r) => r.model_id === id)
+    return modelFitChip(row)
+  }
+  const options = modelPickerOptions({ s, opts, cur, has, allSlots, verdictFor })
   return (
-    <select
-      className="model-picker mono"
-      value={cur}
-      disabled={disabled}
-      onClick={(e) => e.stopPropagation()}
-      onChange={(e) => {
-        const id = e.target.value
-        if (id && id !== cur) onSwap(id)
-      }}
-      aria-label={`Model for ${s.name}`}
-    >
-      {cur && !has && <option value={cur}>{s.model || cur}</option>}
-      {!cur && <option value="">—</option>}
-      {opts.map((m) => (
-        <option key={m.id} value={m.id}>
-          {m.longName || m.id}
-        </option>
-      ))}
-    </select>
+    <span className="model-picker-cell" onClick={(e) => e.stopPropagation()}>
+      <RichSelect
+        className="model-picker"
+        value={cur}
+        options={options}
+        disabled={disabled}
+        aria-label={`Model for ${s.name}`}
+        data-testid={`infer-model-${s.name}`}
+        onOpenChange={(open) => {
+          if (!open || firedRef.current) return
+          const ids = opts.map((m) => m.id)
+          if (ids.length === 0) return
+          firedRef.current = true
+          feasibility.mutate({
+            models: ids.map((id) => ({ model_id: id, ...(ctx ? { ctx } : {}) })),
+          })
+        }}
+        onChange={(id) => {
+          if (id && id !== cur) onSwap(id)
+        }}
+      />
+    </span>
   )
 }
 
@@ -545,7 +650,7 @@ export function SlotScard({
   )
 }
 
-function SlotCards({ rows, full, models, busyName, handlers, loading, modelRows }) {
+function SlotCards({ rows, full, models, allSlots, busyName, handlers, loading, modelRows }) {
   // Operator-arranged order + drag wiring. Called before the early returns so
   // the hook order is stable across the loading/empty/populated renders.
   const reorder = useCardReorder('inference.chat', rows)
@@ -568,6 +673,7 @@ function SlotCards({ rows, full, models, busyName, handlers, loading, modelRows 
           <ModelPicker
             s={s}
             models={models}
+            allSlots={allSlots}
             disabled={busy}
             onSwap={(id) => handlers.onSwap(s, id)}
           />
@@ -877,6 +983,7 @@ export function InferencePane() {
                 full
                 loading={loading}
                 models={modelsQuery.data}
+                allSlots={allSlots}
                 modelRows={modelRowFor}
                 busyName={busyName}
                 handlers={handlers}

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -37,6 +37,12 @@ import {
 } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
 import { useModelsFeasibility } from '@/api/hooks/useModelsFeasibility'
+import { useProfiles } from '@/api/hooks/useProfiles'
+import { useSystemInfo } from '@/api/hooks/useRuntimes'
+import { hostHwFlags, runnerOptions } from './hw-cascade.js'
+import { profileApplyPreview } from './slot-modals.jsx'
+import { runtimeChips } from './profiles.jsx'
+import { ConfirmDialog } from './primitives.jsx'
 import { isUpstreamModel } from '@/lib/normalizeApiModel'
 import { useMemoryMapModel } from './memory-map'
 import { slotIndicatorFromPhase, isSlotLive, imageStatusChip } from './slot-status.js'
@@ -90,7 +96,6 @@ const IIcons = {
     </II>
   ),
   activity: <II d="M2 8h3l2-4 2 8 2-4h3" />,
-  chev: <II d="M4 6l4 4 4-4" />,
   plus: <II d="M8 3v10M3 8h10" />,
   logs: <II d="M3 3h10M3 6h10M3 9h7M3 12h5" />,
   refresh: (
@@ -200,11 +205,99 @@ function CardGrip({ name, grip }) {
 }
 
 // ── slot cards ──────────────────────────────────────────────────────────
-// provider tag — a joined [ device | PROFILE ] control. The profile pill
-// surfaces the slot's runtime profile (slot.profile, resolved from
-// /etc/hal0/profiles.toml by the backend) and opens the slot editor.
-function DevCell({ s, onProfile }) {
+// The synthetic option id for the picker's last row. Not a profile name —
+// profile names match ^[a-z0-9][a-z0-9_-]{0,31}$ (primitives.jsx NAME_RE), so
+// the double underscores can never collide with a real one.
+const PROFILE_EDIT_ROW = '__edit_slot__'
+
+// Rows for the card's profile picker: name + one solid chip per runtime lane
+// (profiles.jsx's runtimeChips — the SAME renderer the Profiles view, the slot
+// drawer's Profile select and the apply preview use, so a lane can't read
+// differently here) + the profile's intent line.
+//
+// Filtered exactly like the drawer's picker: `supported_slot_types` first
+// (slot-modals.jsx:1496-1500, mirroring the backend's profile_fits_slot —
+// model_fit.py:80). The drawer additionally splits device_class/backend
+// matches into `fit` vs a cross-device group; the card lists the type-fitting
+// set flat and lets the apply preview below announce a lane move, per
+// warn-never-block.
+function profileCardOptions({ s, profiles, backends }) {
+  const cur = s.profile || ''
+  const fit = (profiles || []).filter(
+    (p) => !Array.isArray(p.supported_slot_types) || p.supported_slot_types.includes(s.type),
+  )
+  const opts = []
+  // A slot with no profile keeps today's pill word as its own row, so the
+  // trigger has something to render and "no profile" stays a listed state
+  // rather than a placeholder. (Drawer twin: `none: !slot.profile`.)
+  if (!cur) opts.push({ id: '', row: 'default', desc: 'no profile — the slot launches on its device default' })
+  // A persisted profile that no longer resolves (deleted/renamed, or filtered
+  // out by type) stays listed as its own plain row — provenance is never
+  // dropped just because the catalogue moved on.
+  if (cur && !fit.some((p) => p.name === cur)) opts.push({ id: cur, row: cur })
+  for (const p of fit) {
+    opts.push({
+      id: p.name,
+      row: (
+        <span className="prof-row">
+          <span className="prof-row-name">{p.name}</span>
+          <span className="pf-be-row">
+            {runtimeChips(p, backends).map((c) => (
+              <span key={c.key} className="pf-be mono" style={c.hue ? { '--bk': c.hue } : null}>
+                {c.label}
+              </span>
+            ))}
+          </span>
+        </span>
+      ),
+      desc: p.intent || undefined,
+    })
+  }
+  // Today's pill gesture — "the pill opens the slot editor" — stays reachable
+  // as the last row rather than being replaced by the dropdown.
+  opts.push({
+    id: PROFILE_EDIT_ROW,
+    row: '✎ Edit slot…',
+    desc: 'full editor — flags, runtime, lifecycle',
+  })
+  return opts
+}
+
+// provider tag — a joined [ device | PROFILE ] control. The device chip is
+// static; the profile side is a real picker over /api/profiles, and a pick
+// routes through a consequence confirm (the drawer's own `profileApplyPreview`
+// lines) before anything is written. Cancel writes nothing.
+//
+// ── THE APPLY PATH, VERIFIED FROM SOURCE (mockup callout F) ────────────────
+// The slot drawer persists a profile pick as exactly TWO plain mutations,
+// with no drawer-only state between them:
+//   1. PUT /api/slots/{name}/config {profile: name|null} — assembled at
+//      slot-modals.jsx:1120 and fired at :1130 through useSlotEdit
+//      (api/hooks/useSlots.ts:617). The route is a PURE config write with no
+//      lifecycle side effect (api/routes/slots.py:1386, note at :1441), and
+//      the server re-derives the slot's `device` from the new profile itself
+//      (slots/config_write.py:444 → _reconcile_device_profile(merged,
+//      {"profile"}) at :91) — the drawer sends no device of its own.
+//   2. POST /api/slots/{name}/restart, fired in the BACKGROUND (never
+//      awaited) because `changes.profile` is part of `hwChanged`
+//      (slot-modals.jsx:1097-1103, restart at :1143) via useSlotRestart.
+// Both are reachable from any component, so this is branch (a) of the plan's
+// riddle: Apply performs the write here, one gesture, no half-applied state.
+// The drawer's extra Save-time gates guard fields this control cannot touch —
+// a device+profile pair edited together (slot-modals.jsx:1075) and a bound
+// model stranded by a device switch the operator drove (:1242) — and the one
+// consequence that does reach a card pick, a lane move, is announced by the
+// preview's `lane` line instead of blocking (§4 warn-never-block).
+export function DevCell({ s, onProfile, modelFlags }) {
   const kind = devKind(s.device)
+  const profilesQuery = useProfiles()
+  const systemInfoQuery = useSystemInfo()
+  const editMut = useSlotEdit()
+  const restartMut = useSlotRestart()
+  // The picked-but-not-yet-applied profile name; null = no confirm open.
+  // Nothing is written while this holds a value — it IS the "before the
+  // confirm" state.
+  const [pending, setPending] = useStateI(null)
   const dchip =
     kind === 'npu' ? (
       <span className="flm-chip">FLM · npu</span>
@@ -214,19 +307,144 @@ function DevCell({ s, onProfile }) {
         {kind}
       </span>
     )
+  const cur = s.profile || ''
+  const profiles = Array.isArray(profilesQuery.data) ? profilesQuery.data : []
+  const backends = systemInfoQuery.data?.backends ?? {}
+  const pendingRow = pending ? profiles.find((p) => p.name === pending) || null : null
+  // Same cascade the drawer's preview reads (slot-modals.jsx:1466-1472), fed
+  // the slot's PERSISTED device — the card has no pending-device state of its
+  // own, so there is nothing to preview but the write it is about to make.
+  const preview = pendingRow
+    ? profileApplyPreview({
+        profile: pendingRow,
+        backends,
+        options: runnerOptions({
+          backends,
+          device: s.device || '',
+          slotType: s.type,
+          hw: hostHwFlags(systemInfoQuery.data?.hardware),
+        }).options,
+        baselineRunner: s.binary || '',
+        currentDevice: s.device || '',
+        modelFlags: modelFlags || '',
+        currentProfileFlags: profiles.find((p) => p.name === cur)?.flags || '',
+      })
+    : null
+  const onApply = () => {
+    const next = pending
+    if (next == null) return
+    setPending(null)
+    editMut.mutate(
+      { name: s.name, body: { profile: next || null } },
+      {
+        onError: (err) =>
+          toast(`${s.name}: profile apply failed — ${err?.message || 'see logs'}`, 'warn'),
+        onSuccess: () => {
+          restartMut.mutate(s.name, {
+            onError: (err) =>
+              toast(`${s.name}: restart failed — ${err?.message || 'see logs'}`, 'warn'),
+          })
+          toast(`${s.name} → profile "${next}" — restarting in the background`, 'info')
+        },
+      },
+    )
+  }
   return (
-    <span className="prov">
-      {dchip}
-      <button
-        className="profile-pill"
-        title="Runtime profile — edit slot"
-        onClick={onProfile}
-        data-testid={`infer-profile-${s.name}`}
-      >
-        {s.profile || 'default'}
-        <Ic name="chev" size={10} />
-      </button>
-    </span>
+    <React.Fragment>
+      <span className="prov" onClick={(e) => e.stopPropagation()}>
+        {dchip}
+        <RichSelect
+          className="profile-pill"
+          value={cur}
+          options={profileCardOptions({ s, profiles, backends })}
+          aria-label={`Runtime profile for ${s.name}`}
+          data-testid={`infer-profile-${s.name}`}
+          onChange={(id) => {
+            if (id === PROFILE_EDIT_ROW) {
+              onProfile()
+              return
+            }
+            if (id !== cur) setPending(id)
+          }}
+        />
+      </span>
+      <ConfirmDialog
+        open={pending != null}
+        title={`Apply profile "${pending}"`}
+        confirmLabel="Apply profile"
+        cancelLabel="Cancel"
+        footerNote="Nothing is written until you apply."
+        onCancel={() => setPending(null)}
+        onConfirm={onApply}
+        message={
+          <div className="hint sl-apply" data-testid="infer-profile-preview">
+            <div>
+              Applying <b>{pending}</b> to this slot:
+            </div>
+            {preview && (
+              <React.Fragment>
+                <div className="sl-apply-line">
+                  · runtime →{' '}
+                  {preview.runtime.unchanged ? (
+                    <React.Fragment>
+                      <b>unchanged</b>
+                      {preview.runtime.title ? (
+                        <React.Fragment>
+                          {' '}
+                          — already on <b>{preview.runtime.title}</b>
+                        </React.Fragment>
+                      ) : (
+                        ' — this profile pins none'
+                      )}
+                    </React.Fragment>
+                  ) : (
+                    <b>{preview.runtime.title}</b>
+                  )}
+                  <span className="pf-be-row">
+                    {runtimeChips(pendingRow, backends).map((c) => (
+                      <span
+                        key={c.key}
+                        className="pf-be mono"
+                        style={c.hue ? { '--bk': c.hue } : null}
+                      >
+                        {c.label}
+                      </span>
+                    ))}
+                  </span>
+                </div>
+                {preview.lane && (
+                  <div className="sl-apply-line">
+                    · lane →{' '}
+                    {preview.lane.unchanged ? (
+                      <React.Fragment>
+                        <b>unchanged</b> ({preview.lane.from})
+                      </React.Fragment>
+                    ) : (
+                      <React.Fragment>
+                        {preview.lane.from} → <b>{preview.lane.to}</b>, this slot leaves the{' '}
+                        {preview.lane.from} lane
+                      </React.Fragment>
+                    )}
+                  </div>
+                )}
+                {preview.flags > 0 && (
+                  <div className="sl-apply-line">
+                    · flags → profile tune{' '}
+                    <b>
+                      replaces {preview.flags} flag{preview.flags === 1 ? '' : 's'}
+                    </b>{' '}
+                    on this slot
+                  </div>
+                )}
+                <div className="sl-apply-line">
+                  · slot <b>restarts</b> to apply
+                </div>
+              </React.Fragment>
+            )}
+          </div>
+        }
+      />
+    </React.Fragment>
   )
 }
 
@@ -522,11 +740,15 @@ export function slotCtrlPhase(slot) {
 //               from their modality toggle, not the slot's own state).
 //   onEditModel / modelName — inline model-edit affordance. Omit both and the
 //               model row renders exactly as before (the NPU stack does).
+//   modelFlags — the bound model's stamped tune (registry row
+//               `defaults.extra_args`), read only by the profile picker's apply
+//               preview to count the flags a profile's tune would replace.
+//               Absent = the preview counts against an empty base tune.
 //   grip / dragging / dropProps — drag-to-reorder wiring (see slots/card-order).
 //               Omit `grip` and the card carries no handle at all, which is how
 //               every non-reorderable caller renders it.
 export function SlotScard({
-  s, ind, full, modelNode, controls, phase, onEdit, onEditModel, modelName,
+  s, ind, full, modelNode, controls, phase, onEdit, onEditModel, modelName, modelFlags,
   grip, dragging, dropProps,
 }) {
   const dot = dotCls(ind)
@@ -611,7 +833,7 @@ export function SlotScard({
             its own means .scard-foot only ever holds short, fixed-width
             chips + controls, so the controls stop competing for space. */}
         <div className="scard-profile-row">
-          <DevCell s={s} onProfile={onEdit} />
+          <DevCell s={s} onProfile={onEdit} modelFlags={modelFlags} />
         </div>
         {full && (
           <div className="scard-meta">
@@ -714,6 +936,7 @@ function SlotCards({ rows, full, models, allSlots, busyName, handlers, loading, 
               handlers.onEditModel ? () => handlers.onEditModel(s) : undefined
             }
             modelName={modelRow ? modelRow.longName || modelRow.name || modelRow.id : ''}
+            modelFlags={modelRow?.defaults?.extra_args || ''}
             grip={<CardGrip name={s.name} grip={reorder.gripProps(s.name)} />}
             dragging={reorder.dragName === s.name}
             dropProps={reorder.dropProps(s.name)}

--- a/ui/src/dash/profile-apply-preview.js
+++ b/ui/src/dash/profile-apply-preview.js
@@ -1,0 +1,136 @@
+// profile-apply-preview.js — "what does applying this profile actually do?",
+// as one pure structure.
+//
+// Extracted from slot-modals.jsx (where it grew alongside the slot drawer's
+// Profile row) so the two surfaces that ask the question — the drawer's
+// `slot-profile-preview` box and the slot card's `infer-profile-preview`
+// confirm — import ONE definition. A view module is the wrong home for it:
+// the card pane would have had to import the drawer god-module to reach it,
+// inverting the layering (and dragging the whole modal graph into the pane's
+// bundle). It sits beside flags-tune.js / hw-cascade.js, the other pure
+// derivations it is built out of.
+//
+// No React, no hooks, no window globals — everything here is a function of
+// its arguments.
+
+import { applyRunnerChoice } from "./hw-cascade.js";
+import { deviceBackend } from "@/api/hooks/useRuntimes";
+import { diffFlags } from "./flags-tune.js";
+
+// Lane token → display title (hw-cascade.js's runnerOptions/laneValues deal
+// only in the raw backend tokens — rocm/vulkan/cuda/cpu — so the display copy
+// lives here). Exported because the slot drawer names lanes in its own prose
+// with the same table.
+export const LANE_TITLE = {
+	rocm: "ROCm",
+	vulkan: "Vulkan",
+	cuda: "CUDA",
+	cpu: "CPU",
+};
+export function laneTitle(lane) {
+	return LANE_TITLE[lane] || lane;
+}
+
+// Concatenate a flag base with an overlay the way the launcher does: the
+// profile's tune is appended AFTER the model tune, and diffFlags' pair map is
+// last-wins, so the joined text reads as the effective launch tune.
+function joinFlags(base, overlay) {
+	return [base, overlay]
+		.map((s) => String(s || "").trim())
+		.filter(Boolean)
+		.join(" ");
+}
+
+/**
+ * Apply preview for a profile pick — every consequence of "profile wins" in
+ * one structure, computed BEFORE anything is written (mockup panel 12 for the
+ * drawer's Save; panel 02 for the slot card's apply confirm).
+ *
+ * The lines are DERIVED, never re-guessed: the runtime and lane come out of
+ * the same hw-cascade.js `applyRunnerChoice` the Hardware group's Runtime
+ * select drives (and that the server's profile-wins reconcile mirrors, Task
+ * 5), and the flag count comes out of flags-tune.js's shlex-lite `diffFlags`
+ * — the same tokenizer the model drawer's divergence hint uses.
+ *
+ * A line with nothing true to say is OMITTED rather than faked (`lane: null`,
+ * `flags: 0`), with ONE exception the mockup calls out: a profile pinning no
+ * runtime (Auto) reports runtime/lane as `unchanged` instead of dropping
+ * them, so "this profile has no runtime opinion" can't be misread as "the
+ * preview failed to load".
+ *
+ * @param profile             the SELECTED profile row (null → no preview)
+ * @param backends            system-info `backends` catalog (key → row)
+ * @param options             runnerOptions() rows for this slot
+ * @param baselineRunner      the slot's FROZEN persisted binary ('' = auto)
+ * @param currentDevice       the slot's pending device enum, e.g. "gpu-rocm"
+ * @param modelFlags          the bound model's stamped tune (defaults.extra_args)
+ * @param currentProfileFlags the OUTGOING profile's tune ('' = none)
+ *
+ * Returns `{ runtime: { unchanged, title, lanes }, lane, flags, restart }`
+ * or null.
+ */
+export function profileApplyPreview({
+	profile,
+	backends,
+	options,
+	baselineRunner,
+	currentDevice,
+	modelFlags,
+	currentProfileFlags,
+}) {
+	if (!profile) return null;
+	const key = profile.runner || "";
+	const cat = (backends || {})[key] || null;
+	const hit = (options || []).find((o) => o.key === key) || null;
+	// Lanes from the cascade row first, the raw catalog row second; an
+	// out-of-catalog key claims NO lane rather than borrowing one.
+	const lanes = key
+		? hit?.lanes ||
+			(Array.isArray(cat?.supported_backends) ? cat.supported_backends : [])
+		: [];
+	const runtime = {
+		unchanged: !key || key === (baselineRunner || ""),
+		title: key ? hit?.title || cat?.title || key : null,
+		lanes,
+	};
+
+	// Post-save device truth. applyRunnerChoice moves the device only for a
+	// single-lane runner inside the same device class, and returns the current
+	// device untouched for an unknown key — so an invented lane move is
+	// unrepresentable here.
+	const nextDevice = key
+		? applyRunnerChoice({ options, key, currentDevice }).device
+		: currentDevice;
+	const curLane = deviceBackend(currentDevice);
+	const nextLane = deviceBackend(nextDevice);
+	let lane = null;
+	if (nextLane !== curLane) {
+		lane = {
+			unchanged: false,
+			from: laneTitle(curLane),
+			to: laneTitle(nextLane),
+		};
+	} else if (curLane && (!key || lanes.length !== 1)) {
+		// Auto, a multi-lane runtime (the lane stays a live choice) or an
+		// unknown key: say the lane holds. A single-lane runtime already
+		// sitting on its one lane — or a slot with no lane to name at all —
+		// has nothing to report, and an empty "lane → unchanged ()" is
+		// exactly the faked line the panel forbids.
+		lane = { unchanged: true, from: laneTitle(curLane), to: laneTitle(curLane) };
+	}
+
+	// "replaces N flags": the pairs in THIS profile's tune that the slot does
+	// not already launch with — diffed against the effective current tune
+	// (model stamp + the outgoing profile's overlay), so switching between two
+	// profiles that agree on a flag doesn't bill it as a change.
+	const d = diffFlags(
+		profile.flags || "",
+		joinFlags(modelFlags, currentProfileFlags),
+	);
+	return {
+		runtime,
+		lane,
+		flags: d.added.length + d.changed.length,
+		restart: true,
+	};
+}

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -46,8 +46,11 @@ import { formatProvenanceShort } from "./runner-images.jsx";
 // hook that could resolve a pull target differently.
 import { runtimeChips, useRunnerPull } from "./profiles.jsx";
 import { RichSelect } from "./rich-select.jsx";
-// shlex-lite flag diff — the apply preview's "replaces N flags" count.
-import { diffFlags } from "./flags-tune.js";
+// The profile apply preview + its lane-title table. Pure derivations, so they
+// live in their own module (profile-apply-preview.js) rather than in this view
+// file — the slot CARD's apply confirm asks the same question and must get the
+// same answer from the same code, without importing this drawer.
+import { laneTitle, profileApplyPreview } from "./profile-apply-preview.js";
 import { useSlotLogsStream } from "@/api/hooks/useLogs";
 import { ENDPOINTS } from "@/api/endpoints";
 import { normalizeApiModel, isUpstreamModel } from "@/lib/normalizeApiModel";
@@ -174,13 +177,6 @@ function crossDeviceTarget(profile, devBackend) {
 // less than wiring a new export across that boundary.
 const SLOT_NAME_RE = /^[a-z][a-z0-9-]{0,30}$/;
 
-// Lane token → display title, for the Runtime select's option suffix and the
-// Lane pills (hw-cascade.js's runnerOptions/laneValues deal only in the raw
-// backend tokens — rocm/vulkan/cuda/cpu — so the JSX owns the display copy).
-const LANE_TITLE = { rocm: "ROCm", vulkan: "Vulkan", cuda: "CUDA", cpu: "CPU" };
-function laneTitle(lane) {
-	return LANE_TITLE[lane] || lane;
-}
 
 // ── Runtime RichSelect rows (Task 11c) ────────────────────────────────────
 // (laneLabel(), the old plain-text " · ROCm + Vulkan" suffix helper, is gone
@@ -383,109 +379,6 @@ function profileRichOptions({ none, outOfVocab, fit, crossFit, backends, BACKEND
 		for (const p of crossFit) opts.push(rowFor(p, deviceMap[p.backend]));
 	}
 	return opts;
-}
-
-// Concatenate a flag base with an overlay the way the launcher does: the
-// profile's tune is appended AFTER the model tune, and diffFlags' pair map is
-// last-wins, so the joined text reads as the effective launch tune.
-function joinFlags(base, overlay) {
-	return [base, overlay]
-		.map((s) => String(s || "").trim())
-		.filter(Boolean)
-		.join(" ");
-}
-
-/**
- * Apply preview for the drawer's profile row — every consequence of
- * "profile wins" in one structure, computed BEFORE Save (mockup panel 12).
- *
- * The lines are DERIVED, never re-guessed: the runtime and lane come out of
- * the same hw-cascade.js `applyRunnerChoice` the Hardware group's Runtime
- * select drives (and that the server's profile-wins reconcile mirrors, Task
- * 5), and the flag count comes out of flags-tune.js's shlex-lite `diffFlags`
- * — the same tokenizer the model drawer's divergence hint uses.
- *
- * A line with nothing true to say is OMITTED rather than faked (`lane: null`,
- * `flags: 0`), with ONE exception the mockup calls out: a profile pinning no
- * runtime (Auto) reports runtime/lane as `unchanged` instead of dropping
- * them, so "this profile has no runtime opinion" can't be misread as "the
- * preview failed to load".
- *
- * @param profile             the SELECTED profile row (null → no preview)
- * @param backends            system-info `backends` catalog (key → row)
- * @param options             runnerOptions() rows for this slot
- * @param baselineRunner      the slot's FROZEN persisted binary ('' = auto)
- * @param currentDevice       the slot's pending device enum, e.g. "gpu-rocm"
- * @param modelFlags          the bound model's stamped tune (defaults.extra_args)
- * @param currentProfileFlags the OUTGOING profile's tune ('' = none)
- *
- * Returns `{ runtime: { unchanged, title, lanes }, lane, flags, restart }`
- * or null.
- */
-export function profileApplyPreview({
-	profile,
-	backends,
-	options,
-	baselineRunner,
-	currentDevice,
-	modelFlags,
-	currentProfileFlags,
-}) {
-	if (!profile) return null;
-	const key = profile.runner || "";
-	const cat = (backends || {})[key] || null;
-	const hit = (options || []).find((o) => o.key === key) || null;
-	// Lanes from the cascade row first, the raw catalog row second; an
-	// out-of-catalog key claims NO lane rather than borrowing one.
-	const lanes = key
-		? hit?.lanes ||
-			(Array.isArray(cat?.supported_backends) ? cat.supported_backends : [])
-		: [];
-	const runtime = {
-		unchanged: !key || key === (baselineRunner || ""),
-		title: key ? hit?.title || cat?.title || key : null,
-		lanes,
-	};
-
-	// Post-save device truth. applyRunnerChoice moves the device only for a
-	// single-lane runner inside the same device class, and returns the current
-	// device untouched for an unknown key — so an invented lane move is
-	// unrepresentable here.
-	const nextDevice = key
-		? applyRunnerChoice({ options, key, currentDevice }).device
-		: currentDevice;
-	const curLane = deviceBackend(currentDevice);
-	const nextLane = deviceBackend(nextDevice);
-	let lane = null;
-	if (nextLane !== curLane) {
-		lane = {
-			unchanged: false,
-			from: laneTitle(curLane),
-			to: laneTitle(nextLane),
-		};
-	} else if (curLane && (!key || lanes.length !== 1)) {
-		// Auto, a multi-lane runtime (the lane stays a live choice) or an
-		// unknown key: say the lane holds. A single-lane runtime already
-		// sitting on its one lane — or a slot with no lane to name at all —
-		// has nothing to report, and an empty "lane → unchanged ()" is
-		// exactly the faked line the panel forbids.
-		lane = { unchanged: true, from: laneTitle(curLane), to: laneTitle(curLane) };
-	}
-
-	// "replaces N flags": the pairs in THIS profile's tune that the slot does
-	// not already launch with — diffed against the effective current tune
-	// (model stamp + the outgoing profile's overlay), so switching between two
-	// profiles that agree on a flag doesn't bill it as a change.
-	const d = diffFlags(
-		profile.flags || "",
-		joinFlags(modelFlags, currentProfileFlags),
-	);
-	return {
-		runtime,
-		lane,
-		flags: d.added.length + d.changed.length,
-		restart: true,
-	};
 }
 
 // ─── Create-slot modal ──────────────────────────────────────────

--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -109,7 +109,14 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
     // Consequence BEFORE commit: the apply preview box, and NOTHING written.
     const preview = page.getByTestId('infer-profile-preview')
     await expect(preview).toBeVisible()
+    // `primary` is serving, so the lifecycle line is the restart one.
     await expect(preview).toContainText('restarts')
+    // The confirm is mounted by the card LIST, never inside a card: `.scard`
+    // clips (overflow:hidden) and becomes the containing block for fixed
+    // descendants once it carries a hover transform, which would lay the
+    // dialog out inside the ~250px card box.
+    await expect(page.locator('.scard .modal-shell')).toHaveCount(0)
+    await expect(page.locator('.modal-shell')).toHaveCount(1)
     expect(configPuts).toEqual([])
     // Cancel writes nothing at all.
     await page.locator('.modal-foot button', { hasText: 'Cancel' }).click()
@@ -121,6 +128,19 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
     await page.locator('.modal-foot button', { hasText: 'Apply profile' }).click()
     await expect.poll(() => configPuts).toEqual([{ profile: 'vulkan' }])
     await expect.poll(() => restarts.length).toBeGreaterThan(0)
+  })
+
+  test('a stopped slot is told the apply will START it, not restart it', async ({ page }) => {
+    await page.goto('/#slots')
+    // `legacy` is the off seed slot. POST /restart is unload+load, so applying
+    // to it starts the slot and loads its model — minutes of GPU work, which
+    // the confirm must not hide behind the word "restart".
+    const pill = body(page).getByTestId('infer-profile-legacy')
+    await pickRichOption(pill, 'rocm-mtp')
+    const preview = page.getByTestId('infer-profile-preview')
+    await expect(preview).toContainText('starts')
+    await expect(preview).toContainText('loads the model')
+    await expect(preview).not.toContainText('restarts')
   })
 
   test('device/profile pill has its own row, out of the bottom action bar (#squished-controls fix)', async ({ page }) => {

--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -10,7 +10,9 @@
  *     green loaded epill collapsed into it) + ALL slots as full cards, always
  *     visible (the old collapse/expand accordion + qcaret were removed)
  *   - the serving card's status pill shows live tok/s (no fabricated numbers)
- *   - the profile pill surfaces the slot's runtime profile name (slot.profile)
+ *   - the profile pill surfaces the slot's runtime profile name (slot.profile),
+ *     opens a real profile picker, and applies a pick only through its
+ *     consequence confirm (PUT /config + POST /restart)
  *   - NPU/FLM slots are cordoned off — absent from the inference pane, present
  *     in the NPU · FLM stack pane below
  *   - a lifecycle control fires the real mutation (Stop → POST /unload)
@@ -66,10 +68,59 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
   test('profile pill surfaces the runtime profile name (slot.profile)', async ({ page }) => {
     await page.goto('/#slots')
     // primary carries profile "rocm" in the seed; the [ device | PROFILE ]
-    // provider tag renders it on the full card.
+    // provider tag renders it on the full card. The pill is now a RichSelect
+    // trigger (card-dropdowns Task 2) — a closed trigger renders its selected
+    // option's row, so the claim is unchanged.
     const pill = body(page).getByTestId('infer-profile-primary')
     await expect(pill).toBeVisible()
     await expect(pill).toContainText('rocm')
+  })
+
+  test('profile picker lists profiles + an "Edit slot" row that opens the editor', async ({ page }) => {
+    await page.goto('/#slots')
+    const pill = body(page).getByTestId('infer-profile-primary')
+    const listbox = await openRichSelect(pill)
+    // seed profiles are listed as rich rows, current one selected.
+    await expect(listbox.locator('[data-option-id="rocm"]')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(listbox.locator('[data-option-id="vulkan"]')).toBeVisible()
+    // The pill's OLD gesture — "opens the slot editor" — lives on as the last
+    // row, so it stays reachable from the card.
+    await pickRichOption(pill, '__edit_slot__')
+    await expect.poll(() => page.url()).toContain('#slots/primary')
+  })
+
+  test('picking a profile confirms first, then PUTs /config + POSTs /restart', async ({ page }) => {
+    const configPuts: unknown[] = []
+    const restarts: string[] = []
+    await page.route('**/api/slots/primary/config', async (route) => {
+      configPuts.push(route.request().postDataJSON())
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.route('**/api/slots/primary/restart', async (route) => {
+      restarts.push(route.request().url())
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.goto('/#slots')
+    const pill = body(page).getByTestId('infer-profile-primary')
+    await pickRichOption(pill, 'vulkan')
+    // Consequence BEFORE commit: the apply preview box, and NOTHING written.
+    const preview = page.getByTestId('infer-profile-preview')
+    await expect(preview).toBeVisible()
+    await expect(preview).toContainText('restarts')
+    expect(configPuts).toEqual([])
+    // Cancel writes nothing at all.
+    await page.locator('.modal-foot button', { hasText: 'Cancel' }).click()
+    await expect(preview).toHaveCount(0)
+    expect(configPuts).toEqual([])
+    expect(restarts).toEqual([])
+    // Apply performs the drawer's own two-call save in one gesture.
+    await pickRichOption(pill, 'vulkan')
+    await page.locator('.modal-foot button', { hasText: 'Apply profile' }).click()
+    await expect.poll(() => configPuts).toEqual([{ profile: 'vulkan' }])
+    await expect.poll(() => restarts.length).toBeGreaterThan(0)
   })
 
   test('device/profile pill has its own row, out of the bottom action bar (#squished-controls fix)', async ({ page }) => {

--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -14,7 +14,7 @@
  *   - NPU/FLM slots are cordoned off — absent from the inference pane, present
  *     in the NPU · FLM stack pane below
  *   - a lifecycle control fires the real mutation (Stop → POST /unload)
- *   - the full card exposes a real model-picker <select> (useModels)
+ *   - the full card exposes a real model-picker RichSelect (useModels)
  *   - the NPU/FLM pane renders its own engine shell + trio
  *   - the Inference tab carries the yellow `infer` accent class
  *
@@ -27,6 +27,7 @@
  * stay valid either way.
  */
 import { test, expect, type Page } from '../fixtures/apiMock'
+import { openRichSelect, pickRichOption } from '../fixtures/richSelect'
 
 const pane = (page: Page) => page.locator('.infer-pane:not(.infer-hero-top)').first()
 const engine = (page: Page) => pane(page).locator('.engine').first()
@@ -207,25 +208,28 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
     })
     await page.goto('/#slots')
-    const picker = body(page).getByTestId('infer-slot-primary').locator('select.model-picker')
-    const opts = await picker.locator('option').evaluateAll((els) =>
-      els.map((e) => (e as HTMLOptionElement).value).filter(Boolean),
+    const trigger = page.getByTestId('infer-model-primary')
+    const listbox = await openRichSelect(trigger)
+    const ids = await listbox.locator('[data-option-id]').evaluateAll((els) =>
+      els.map((e) => e.getAttribute('data-option-id') || '').filter(Boolean),
     )
-    const cur = await picker.inputValue()
-    const next = opts.find((v) => v !== cur)
+    const curEl = listbox.locator('[aria-selected="true"]')
+    const cur = (await curEl.count()) > 0 ? await curEl.first().getAttribute('data-option-id') : null
+    const next = ids.find((id) => id !== cur)
     test.skip(!next, 'need ≥2 llm models in the catalog to swap')
-    await picker.selectOption(next!)
+    await pickRichOption(trigger, next!)
     await expect.poll(() => swaps.length).toBeGreaterThan(0)
     expect(typeof swaps[0].model_id).toBe('string')
   })
 
-  test('full card exposes a real model-picker <select> (useModels)', async ({ page }) => {
+  test('full card exposes a real model-picker RichSelect (useModels)', async ({ page }) => {
     await page.goto('/#slots')
     // The full-card model picker is always rendered in the engine body now.
-    const picker = body(page).getByTestId('infer-slot-primary').locator('select.model-picker')
-    await expect(picker).toHaveCount(1)
+    const trigger = body(page).getByTestId('infer-slot-primary').getByTestId('infer-model-primary')
+    await expect(trigger).toHaveCount(1)
     // the picker is populated (at minimum the current model is an option).
-    await expect.poll(async () => picker.locator('option').count()).toBeGreaterThan(0)
+    const listbox = await openRichSelect(trigger)
+    await expect.poll(async () => listbox.locator('[role="option"]').count()).toBeGreaterThan(0)
   })
 
   test('utility-type slots route to the support footer regardless of group', async ({ page }) => {

--- a/ui/tests/e2e/specs/slot-card-model-edit-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-card-model-edit-v3.spec.ts
@@ -69,9 +69,15 @@ test.describe('Slot card — inline model edit', () => {
     await page.goto('/#slots')
     await expect(card(page, 'primary')).toBeVisible()
 
-    // Sibling of the picker inside the model row, not nested inside it.
+    // Sibling of the picker inside the model row, not nested inside it. The
+    // model picker is a RichSelect now — `.model-picker-cell` is its own hit
+    // area (the click-stopPropagation guard the native <select> used to carry
+    // directly), wrapping the `.rsel` trigger+listbox. Neither lives inside
+    // the other, so the pencil's "only direct-child button" assertion below
+    // still holds unchanged.
     const row = card(page, 'primary').locator('.smodel-row')
-    await expect(row.locator('> select.model-picker')).toHaveCount(1)
+    await expect(row.locator('> .model-picker-cell')).toHaveCount(1)
+    await expect(row.locator('> .model-picker-cell .rsel')).toHaveCount(1)
     await expect(row.locator('> button')).toHaveCount(1)
     await expect(pencil(page, 'primary')).toBeEnabled()
     await expect(pencil(page, 'primary').locator('svg')).toHaveCount(1)
@@ -99,8 +105,8 @@ test.describe('Slot card — inline model edit', () => {
     await seedSlots(page, [PRIMARY])
     await page.goto('/#slots')
 
-    const select = card(page, 'primary').locator('select.model-picker')
-    await expect(select).toHaveValue('qwen3.6-27b-mtp')
+    const trigger = page.getByTestId('infer-model-primary')
+    await expect(trigger).toContainText('Qwen3.6-27B-MTP')
 
     await pencil(page, 'primary').click()
     await expect(drawer(page)).toBeVisible()
@@ -109,7 +115,7 @@ test.describe('Slot card — inline model edit', () => {
     // container here, so an accidental swap would also cold-restart it.
     await page.waitForTimeout(250)
     expect(swaps).toEqual([])
-    await expect(select).toHaveValue('qwen3.6-27b-mtp')
+    await expect(trigger).toContainText('Qwen3.6-27B-MTP')
   })
 
   test('K3 — the pencil does not open the slot edit drawer', async ({ page }) => {


### PR DESCRIPTION
Brings the inference-pane slot-card quick controls to the drawer bar (operator-directed, mockups: docs/.devdocs/2026-09-03-card-dropdowns-mockups.html — gitignored/local, artifact copy shared).

## What's in
- **Card model picker** → RichSelect with the approved V1 two-line rows: quant/modality tags, lazy GTT fit chips (one batch `POST /api/models/feasibility` on first open, ctx = the slot's `ctx_max`; unknown verdict renders nothing), desc line with size · used-by (via `slotsUsingModel`) · engine when non-default. Behavior unchanged: pick still fires `POST /swap`, rows always pickable (warn-never-block), non-LLM slots keep the static line.
- **Card profile pill** → real RichSelect: profile rows (runtime chip + blurb, filtered to the slot's type) plus a separated "✎ Edit slot…" escape row preserving the old open-editor semantic. A pick opens a consequence confirm (flags/runtime/lifecycle lines from `profileApplyPreview`; a stopped slot honestly says it will **start** and load the model) — nothing writes before Apply; Apply issues exactly the drawer's sequence: `PUT /api/slots/{name}/config {profile}` then restart on success only.
- **Structural**: `profileApplyPreview` (+`laneTitle`/`joinFlags`) extracted to pure `ui/src/dash/profile-apply-preview.js` (both call sites import it — removes a pane→modal-module layering inversion); the apply confirm renders once at the SlotCards level (a card-mounted dialog was trapped by the card's hover transform + `overflow:hidden` — caught in review, fixed with measured verification); card menus escape the clip via a scoped `:has([aria-expanded='true'])` rule covering both pickers.

## Notes for reviewers
- Stale one-line comment survives at the old "is a `<select>`" claim in SlotScard — fold into the next touch.
- Follow-up candidate: consolidate profiles.jsx's private `LANE_TITLE` onto the new export.
- Applying the just-applied profile again before the slots poll lands offers a second idempotent apply — harmless, confirm-gated.

## Test evidence
vitest 363/363 · playwright chromium 697 passed (full suite) · tsc exit 0 · eslint clean · zero scar words / LAN hosts in the diff. Per-task adversarial reviews (one Critical found + fixed + re-verified) and a whole-branch final review: ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bUrn3nhQKXBBygeerxsnv