### PR TITLE
fix(scripts): never null a ghcr digest pin on an auth/transport failure

### DIFF
--- a/scripts/update-toolbox-digests.sh
+++ b/scripts/update-toolbox-digests.sh
@@ -25,15 +25,22 @@
 #   3. patches manifest.json in place via python3 so JSON formatting stays
 #      stable.
 #
-# A ghcr.io image that fails resolution leaves its digest null and emits a
-# warning — matching the runtime contract (null digest => pull-by-tag +
-# warn); that image really is unpublished/unreachable. A NON-ghcr image that
-# fails resolution (no authoritative path here beyond the two above) instead
-# KEEPS whatever digest is already recorded and warns — a transient/offline
-# lookup must never regress a previously-valid pin to null, which used to
-# fail release.yml's null-digest gate on the very manifest this script
-# prepares (#1676). The script never hard-fails on a single unresolved
-# image; it exits non-zero only on a usage / environment error.
+# A digest is set to null ONLY when the registry answers a definitive
+# 404/NAME_UNKNOWN for the manifest — the image really is unpublished, and
+# null matches the runtime contract (null digest => pull-by-tag + warn).
+# Every other resolution failure — the token endpoint issues no anonymous
+# pull token, 401/403/DENIED, a curl/network error, docker buildx
+# unavailable — proves nothing about the published state, so the script
+# KEEPS whatever digest is already recorded and warns that the pin could
+# not be re-verified. The same rule covers non-ghcr images (which have no
+# authoritative lookup path beyond the digest-pinned-ref shortcut and the
+# buildx fallback): a transient/offline/auth lookup must never regress a
+# previously-valid pin to null, which used to fail release.yml's
+# null-digest gate on the very manifest this script prepares (#1676,
+# #2218 — ghcr.io/hal0ai/hal0-strix-vulkan serves no anonymous token, and
+# the old ghcr path read that DENIED as an unpublish). The script never
+# hard-fails on a single unresolved image; it exits non-zero only on a
+# usage / environment error.
 #
 # Usage:
 #   scripts/update-toolbox-digests.sh [path/to/manifest.json]
@@ -75,10 +82,19 @@ PY
 }
 
 # Resolve a ghcr.io content digest for "<registry>/<repo>:<reference>"
-# anonymously. Prints the sha256 digest on stdout, or nothing on failure.
+# anonymously. Prints the sha256 digest on stdout and returns 0 on success.
+# On failure the return code tells the caller which of two very different
+# situations it is in:
+#   2 — DEFINITIVE: the registry issued a pull token and then answered 404
+#       (NAME_UNKNOWN/MANIFEST_UNKNOWN) for the manifest — the image really
+#       is unpublished;
+#   1 — UNVERIFIED: an auth-shaped or transport failure (token endpoint
+#       returned no token, 401/403/DENIED, curl/network error, docker buildx
+#       unavailable) — nothing was proven about the published state.
 resolve_digest() {
     local image_ref="$1"
-    local registry repo_ref repo reference token digest
+    local registry repo_ref repo reference token digest headers status
+    local unpublished=0
 
     # A digest-pinned ref ("registry/repo@sha256:...") is authoritative by
     # construction — the digest IS the reference, no registry round-trip
@@ -115,18 +131,28 @@ resolve_digest() {
         2>/dev/null || true)"
 
     if [[ -n "${token}" ]]; then
-        # HEAD the manifest and read the Docker-Content-Digest response header.
-        digest="$(curl -fsSI -X GET \
+        # HEAD the manifest and read the Docker-Content-Digest response
+        # header. No -f: a 4xx status is signal, not noise — we need to see
+        # WHICH failure the registry chose.
+        headers="$(curl -sSI -X GET \
             -H "Authorization: Bearer ${token}" \
             -H "Accept: ${ACCEPT_HEADER}" \
             "https://${registry}/v2/${repo}/manifests/${reference}" \
-            2>/dev/null \
-            | tr -d '\r' \
+            2>/dev/null | tr -d '\r' || true)"
+        digest="$(printf '%s\n' "${headers}" \
             | awk -F': ' 'tolower($1)=="docker-content-digest"{print $2}' \
-            | tail -n1 || true)"
+            | tail -n1)"
         if [[ "${digest}" == sha256:* ]]; then
             printf '%s\n' "${digest}"
             return 0
+        fi
+        status="$(printf '%s\n' "${headers}" \
+            | awk 'toupper($1) ~ /^HTTP\//{code=$2} END{print code}')"
+        if [[ "${status}" == "404" ]]; then
+            # Token granted, manifest definitively absent. Still give the
+            # buildx fallback a chance below — operator docker credentials
+            # may see what anonymous auth cannot.
+            unpublished=1
         fi
     fi
 
@@ -141,6 +167,9 @@ resolve_digest() {
         fi
     fi
 
+    if [[ "${unpublished}" -eq 1 ]]; then
+        return 2
+    fi
     return 1
 }
 
@@ -214,25 +243,30 @@ while IFS=$'\t' read -r name tag; do
     fi
 
     echo "  ${name}: resolving ${tag}"
-    if digest="$(resolve_digest "${tag}")" && [[ -n "${digest}" ]]; then
+    digest=""
+    resolve_rc=0
+    digest="$(resolve_digest "${tag}")" || resolve_rc=$?
+    if [[ ${resolve_rc} -eq 0 && -n "${digest}" ]]; then
         patch_digest "${name}" "${digest}"
         echo "    -> ${digest}"
         updated=$((updated + 1))
     else
-        # Never regress a valid pin to null. A ghcr.io image that fails
-        # resolution really is unpublished/unreachable — null is correct,
-        # the runtime falls back to pull-by-tag. A non-ghcr registry (no
-        # authoritative resolution path here beyond the digest-pinned-ref
-        # shortcut and the docker buildx fallback above) that fails is far
-        # more likely a transient/offline lookup than an actual unpublish —
-        # keep whatever digest is already recorded and warn instead (#1676).
-        registry="${tag%%/*}"
+        # Never regress a valid pin to null (#1676, #2218). Only a
+        # DEFINITIVE 404 from the registry (resolve_digest rc 2) proves an
+        # image is unpublished — null is then correct, the runtime falls
+        # back to pull-by-tag. Every other failure — no anonymous pull
+        # token, 401/403/DENIED, network error, buildx missing — proves
+        # nothing about the published state, so keep whatever digest is
+        # already recorded and warn that the pin could not be re-verified.
         existing="$(current_digest "${name}")"
-        if [[ "${registry}" != "ghcr.io" && -n "${existing}" ]]; then
-            echo "warn: ${name}: ${tag} could not be resolved on ${registry} — keeping existing digest ${existing} (never regress a valid pin to null)" >&2
+        if [[ ${resolve_rc} -eq 2 ]]; then
+            echo "warn: ${name}: ${tag} is unpublished (registry answered 404 for the manifest) — leaving digest null (runtime pulls by tag)" >&2
+            patch_digest "${name}" ""
+        elif [[ -n "${existing}" ]]; then
+            echo "warn: ${name}: ${tag} could not be re-verified (auth/transport failure, not proof of an unpublish) — keeping existing digest ${existing} (never regress a valid pin to null)" >&2
             patch_digest "${name}" "${existing}"
         else
-            echo "warn: ${name}: ${tag} is unpublished or unreachable — leaving digest null (runtime pulls by tag)" >&2
+            echo "warn: ${name}: ${tag} could not be resolved and no digest is recorded — leaving digest null (runtime pulls by tag)" >&2
             patch_digest "${name}" ""
         fi
         warned=$((warned + 1))

--- a/tests/scripts/test_update_toolbox_digests.py
+++ b/tests/scripts/test_update_toolbox_digests.py
@@ -11,12 +11,17 @@ the non-ghcr paths any more — the #1676 coverage lives entirely in the
 synthetic docker.io fixtures below.
 
 These tests drive the REAL script against throwaway fixture manifests,
-under a hermetic PATH where ``curl`` and ``docker`` are stubbed to always
-fail (simulating an offline / token-less run) so the tests are deterministic
-regardless of the sandbox's real network access. A digest-pinned ref must
-resolve without ever touching either stub; a non-ghcr tag-only ref that
-cannot be resolved must keep its previously-recorded digest instead of going
-null; a ghcr ref that cannot be resolved keeps the documented null contract.
+under a hermetic PATH where ``curl`` and ``docker`` are stubbed (offline /
+token-less by default, or scripted registry answers) so the tests are
+deterministic regardless of the sandbox's real network access. A
+digest-pinned ref must resolve without ever touching either stub; ANY
+tag-only ref that cannot be resolved — ghcr or not — must keep its
+previously-recorded digest instead of going null (#2218 extended the #1676
+rule to the ghcr path: ghcr.io/hal0ai/hal0-strix-vulkan serves no anonymous
+pull token, and the old ghcr path read that DENIED as an unpublish). Only a
+DEFINITIVE unpublish — a pull token granted and then a 404 for the
+manifest — nulls a digest, as does a failure with no recorded digest to
+keep.
 """
 
 from __future__ import annotations
@@ -114,12 +119,15 @@ def test_unresolvable_non_ghcr_tag_keeps_its_existing_digest(
     assert "keeping existing digest" in proc.stderr
 
 
-def test_unresolvable_ghcr_tag_still_nulls_per_the_documented_contract(
+def test_unverified_ghcr_failure_keeps_its_existing_digest(
     tmp_path: Path, offline_path: str
 ) -> None:
-    # Regression guard the other way: ghcr.io failures must still null out
-    # (the runtime's documented pull-by-tag + warn contract), not silently
-    # keep a possibly-stale digest.
+    # The #2218 fix: an auth-shaped/transport failure on the ghcr path (here
+    # the token endpoint itself is unreachable — same bucket as "no token
+    # issued" / DENIED / 401 / 403) proves nothing about the published
+    # state, so the recorded pin must survive, exactly like the non-ghcr
+    # branch. Nulling here regressed the valid strix pin during the v1.2.0
+    # cut, which release.yml's null-digest gate then rejects.
     existing = "sha256:" + "b" * 64
     manifest = _fixture_manifest(
         tmp_path, {"vulkan": {"tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1", "digest": existing}}
@@ -128,8 +136,86 @@ def test_unresolvable_ghcr_tag_still_nulls_per_the_documented_contract(
     proc = _run(manifest, offline_path)
 
     assert proc.returncode == 0, proc.stderr
+    assert _load(manifest)["toolbox_images"]["vulkan"]["digest"] == existing
+    assert "could not be re-verified" in proc.stderr
+    assert "keeping existing digest" in proc.stderr
+
+
+def test_unverified_ghcr_failure_with_no_recorded_digest_stays_null(
+    tmp_path: Path, offline_path: str
+) -> None:
+    # Nothing to keep: an unverifiable ghcr ref whose entry has no recorded
+    # digest stays null (the runtime's pull-by-tag contract).
+    manifest = _fixture_manifest(
+        tmp_path, {"vulkan": {"tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1", "digest": None}}
+    )
+
+    proc = _run(manifest, offline_path)
+
+    assert proc.returncode == 0, proc.stderr
     assert _load(manifest)["toolbox_images"]["vulkan"]["digest"] is None
-    assert "unpublished or unreachable" in proc.stderr
+    assert "no digest is recorded" in proc.stderr
+
+
+def _write_ghcr_stub(path: Path, manifest_status: str) -> None:
+    """A curl stub that grants a pull token, then answers ``manifest_status``
+    (e.g. "404 Not Found") for the manifest GET — the two-request shape of
+    the script's anonymous ghcr flow."""
+    path.write_text(
+        "#!/usr/bin/env bash\n"
+        'for arg in "$@"; do\n'
+        '  case "${arg}" in\n'
+        '    *"/token?"*) printf \'{"token":"stub-token"}\\n\'; exit 0 ;;\n'
+        '    *"/v2/"*"/manifests/"*)\n'
+        f"      printf 'HTTP/2 {manifest_status}\\r\\n'\n"
+        "      printf 'content-type: application/json\\r\\n'\n"
+        "      printf '\\r\\n'\n"
+        "      exit 0 ;;\n"
+        "  esac\n"
+        "done\n"
+        "exit 22\n",
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _ghcr_stub_path(tmp_path: Path, manifest_status: str) -> str:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_ghcr_stub(bin_dir / "curl", manifest_status)
+    _write_always_failing(bin_dir / "docker")
+    return f"{bin_dir}:{os.environ['PATH']}"
+
+
+def test_definitive_ghcr_404_nulls_even_a_recorded_digest(tmp_path: Path) -> None:
+    # The one case that legitimately nulls a pin: the registry granted a
+    # pull token and then answered 404 for the manifest — the image really
+    # is unpublished, and a stale pin must not survive that.
+    existing = "sha256:" + "d" * 64
+    manifest = _fixture_manifest(
+        tmp_path, {"vulkan": {"tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1", "digest": existing}}
+    )
+
+    proc = _run(manifest, _ghcr_stub_path(tmp_path, "404 Not Found"))
+
+    assert proc.returncode == 0, proc.stderr
+    assert _load(manifest)["toolbox_images"]["vulkan"]["digest"] is None
+    assert "unpublished (registry answered 404" in proc.stderr
+
+
+def test_ghcr_403_after_token_grant_keeps_its_existing_digest(tmp_path: Path) -> None:
+    # A non-404 registry refusal AFTER a token was granted is still only an
+    # auth-shaped failure — keep the pin.
+    existing = "sha256:" + "e" * 64
+    manifest = _fixture_manifest(
+        tmp_path, {"vulkan": {"tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1", "digest": existing}}
+    )
+
+    proc = _run(manifest, _ghcr_stub_path(tmp_path, "403 Forbidden"))
+
+    assert proc.returncode == 0, proc.stderr
+    assert _load(manifest)["toolbox_images"]["vulkan"]["digest"] == existing
+    assert "keeping existing digest" in proc.stderr
 
 
 def test_missing_tag_still_nulls(tmp_path: Path, offline_path: str) -> None:


### PR DESCRIPTION
Fixes #2218

`scripts/update-toolbox-digests.sh` treated every ghcr resolution failure as proof the image is unpublished and nulled the recorded digest — the exact #1676 failure mode the non-ghcr branch already guards against. Trigger: `ghcr.io/hal0ai/hal0-strix-vulkan` serves no anonymous pull token (the package's ghcr visibility is **`internal`**, confirmed via `gh api /orgs/Hal0ai/packages/container/hal0-strix-vulkan` — issue half 2; not changed here), so during the v1.2.0 cut the script nulled the valid strix pin and `release.yml`'s null-digest gate would have rejected the manifest.

`resolve_digest` now distinguishes outcomes by return code — `0` resolved, `2` definitive 404/NAME_UNKNOWN after a token WAS granted (really unpublished), `1` auth-shaped or transport failure (no token, 401/403/DENIED, curl/network error, buildx unavailable) — and only a definitive 404 nulls a digest. Output format, exit codes, and the `Done:` summary line are unchanged; the header comment documents the rule.

## Before / after

| Resolution outcome | Before | After |
|---|---|---|
| Resolved (token + manifest GET, or buildx) | update digest | update digest (unchanged) |
| Digest-pinned ref (`@sha256:...`) | authoritative, no round-trip | unchanged |
| Token granted, manifest GET → 404 | null | null (unchanged — really unpublished) |
| Token endpoint returns no token / DENIED | **null (regressed valid pin)** | **keep recorded digest + warn** |
| 401/403, curl/network failure, buildx unavailable | **null** | **keep recorded digest + warn** |
| Failure with no digest recorded | null | null (nothing to keep) |
| Non-ghcr failure with recorded digest | keep + warn (#1676) | keep + warn (unchanged) |

## Live test (this branch, real registry)

```
  promptforge: resolving ghcr.io/hal0ai/hal0-promptforge:v2.3-qwen38
    -> sha256:370af6e9717e8c96742198a4b920888e6a248d447e21e3432de4d2c913703aea
  strix: resolving ghcr.io/hal0ai/hal0-strix-vulkan:0831
warn: strix: ghcr.io/hal0ai/hal0-strix-vulkan:0831 could not be re-verified (auth/transport failure, not proof of an unpublish) — keeping existing digest sha256:b50a73487d05bcae146aa54170cec981c7c6a158cc5cd1fa45a6096dfc5fe107 (never regress a valid pin to null)
Done: 9 digest(s) updated, 1 left null.
```

All 9 anonymously-pullable images resolved and updated; strix kept its recorded pin. Return-code paths exercised directly against ghcr:

```
404-case rc=2 digest=[] (expect rc=2, empty)        # public repo, nonexistent tag → still nulls
denied-case rc=1 digest=[] (expect rc=1, empty)     # strix, no anonymous token → keeps pin
ok-case rc=0 digest=[sha256:eab70d03...]            # public repo, real tag
pinned-case rc=0 digest=[sha256:deadbeef]           # @sha256 ref, authoritative
```

Manifest churn from the test run was discarded — this PR touches only the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181rff5wtNoioAHumZsYCD4