### PR TITLE
fix(ui): async-safe clipboard copies + diffFlags keyed on the full alias table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ applying. Add those subsections to a version's section to surface them; see
   again — not an added pill plus a struck ghost — and no longer inflates the
   `◆ N diverged` count. Rendered spellings still come from the operator's
   own text; only the matching canonicalises. (#2211)
+- Copy-to-clipboard buttons across the dashboard (command palette, model
+  drawer source paths, model detail path, benchmark commands, slot logs,
+  connections) now report the real outcome: the success toast waits for the
+  async clipboard write to resolve, and a rejected write — permission denial,
+  non-secure origin — shows a failure toast instead of a false success. All
+  call sites share one helper (`@/lib/clipboard`) that keeps the legacy
+  `execCommand("copy")` fallback for plain-http LAN dashboards. (#2214)
 
 ## [1.2.0] — 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Fixed
+
+- The model drawer's flags divergence (`diffFlags` — the raw-mode diff, tune
+  pills, profile apply preview and seed consequence preview all consume it) now
+  matches pairs through the full llama-server alias table (`FLAG_ALIASES`)
+  instead of only the managed subset. A model tune carrying `-b 2048` diffed
+  against a profile carrying `--batch-size 1024` reads as one changed pair
+  again — not an added pill plus a struck ghost — and no longer inflates the
+  `◆ N diverged` count. Rendered spellings still come from the operator's
+  own text; only the matching canonicalises. (#2211)
+
 ## [1.2.0] — 2026-09-03
 
 ### Highlights

--- a/ui/src/dash/Benchmarks.tsx
+++ b/ui/src/dash/Benchmarks.tsx
@@ -16,6 +16,7 @@
  *       POST /control {action,exclusive} · DELETE /api/benchmarks/queue/{id}
  */
 
+import { copyTextToClipboard } from '@/lib/clipboard';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { apiDelete, apiGet, apiPost } from '../api/client';
 import { useUpdateState } from '../api/hooks/useUpdates';
@@ -1407,8 +1408,12 @@ function CopyButton({ text }: { text: string }) {
     <button
       className="btn ghost sm"
       style={{ fontSize: 10, padding: '2px 8px' }}
-      onClick={() => {
-        navigator.clipboard?.writeText(text);
+      onClick={async () => {
+        const ok = await copyTextToClipboard(text);
+        if (!ok) {
+          toast('Copy failed — clipboard unavailable', 'err');
+          return;
+        }
         setCopied(true);
         setTimeout(() => setCopied(false), 1400);
       }}

--- a/ui/src/dash/__tests__/flags-tune.test.ts
+++ b/ui/src/dash/__tests__/flags-tune.test.ts
@@ -257,6 +257,23 @@ describe('diffFlags', () => {
     expect(d.diverged).toBe(false)
     expect(d.unchanged).toBe(1)
   })
+  it('folds the FULL alias table, not just the managed subset (#2211)', () => {
+    // -b is an unmanaged llama-server alias for --batch-size. Same value spelled
+    // two ways must be no-change, not added+removed.
+    const d = diffFlags('-b 2048', '--batch-size 2048')
+    expect(d.diverged).toBe(false)
+    expect(d.added).toEqual([])
+    expect(d.removed).toEqual([])
+    expect(d.unchanged).toBe(1)
+  })
+  it('cross-spelling value divergence is ONE changed pair, in the operator spelling (#2211)', () => {
+    const d = diffFlags('-b 2048', '--batch-size 1024')
+    expect(d.diverged).toBe(true)
+    expect(d.added).toEqual([])
+    expect(d.removed).toEqual([])
+    // `flag` carries the model side's own spelling; only the matching canonicalises.
+    expect(d.changed).toEqual([{ flag: '-b', from: '1024', to: '2048' }])
+  })
 })
 
 describe('flagsEquivalent', () => {

--- a/ui/src/dash/__tests__/model-drawer.test.tsx
+++ b/ui/src/dash/__tests__/model-drawer.test.tsx
@@ -1355,7 +1355,7 @@ describe('ModelDrawer source disclosure (Task 9)', () => {
     act(() => root.unmount())
   })
 
-  it('a clipboard that throws reports the failure instead of a false success', () => {
+  it('a clipboard that throws reports the failure instead of a false success', async () => {
     const toasts: [string, string][] = []
     ;(globalThis as unknown as { __hal0Toast: unknown }).__hal0Toast = (m: string, k: string) =>
       toasts.push([m, k])
@@ -1367,11 +1367,38 @@ describe('ModelDrawer source disclosure (Task 9)', () => {
       },
       configurable: true,
     })
+    // The legacy execCommand fallback is unavailable too — full copy failure.
+    Object.defineProperty(globalThis.document, 'execCommand', {
+      value: () => false,
+      configurable: true,
+    })
     const { host, root } = mount(
       React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: SOURCE_MODEL }),
     )
     openSource(host)
-    act(() => q<HTMLButtonElement>(host, 'model-source-copy-path').click())
+    await act(async () => q<HTMLButtonElement>(host, 'model-source-copy-path').click())
+    expect(toasts).toEqual([['Copy failed — clipboard unavailable', 'err']])
+    delete (globalThis as unknown as { __hal0Toast?: unknown }).__hal0Toast
+    act(() => root.unmount())
+  })
+
+  it('an ASYNC clipboard rejection reports the failure too (#2214)', async () => {
+    const toasts: [string, string][] = []
+    ;(globalThis as unknown as { __hal0Toast: unknown }).__hal0Toast = (m: string, k: string) =>
+      toasts.push([m, k])
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      value: { writeText: () => Promise.reject(new Error('NotAllowedError')) },
+      configurable: true,
+    })
+    Object.defineProperty(globalThis.document, 'execCommand', {
+      value: () => false,
+      configurable: true,
+    })
+    const { host, root } = mount(
+      React.createElement(ModelDrawer, { open: true, onClose: () => {}, model: SOURCE_MODEL }),
+    )
+    openSource(host)
+    await act(async () => q<HTMLButtonElement>(host, 'model-source-copy-path').click())
     expect(toasts).toEqual([['Copy failed — clipboard unavailable', 'err']])
     delete (globalThis as unknown as { __hal0Toast?: unknown }).__hal0Toast
     act(() => root.unmount())

--- a/ui/src/dash/command-palette.jsx
+++ b/ui/src/dash/command-palette.jsx
@@ -13,6 +13,7 @@
 // clear-downloads, replay-tour) were removed — every item now does what
 // it says.
 
+import { copyTextToClipboard } from '@/lib/clipboard'
 import { useSlots, useSlotRestart, useSlotLoad, useSlotUnload } from '@/api/hooks/useSlots'
 import { useModels, fmtBytes } from '@/api/hooks/useModels'
 import { useConfigUrls } from '@/api/hooks/useConfigUrls'
@@ -33,12 +34,10 @@ if (typeof window !== "undefined") {
 }
 
 const cpCopy = (text, label) => {
-  try {
-    navigator.clipboard.writeText(text);
-    window.__hal0Toast && window.__hal0Toast(label, "ok");
-  } catch {
-    window.__hal0Toast && window.__hal0Toast("Copy failed — clipboard unavailable", "err");
-  }
+  copyTextToClipboard(text).then((ok) => {
+    if (ok) window.__hal0Toast && window.__hal0Toast(label, "ok");
+    else window.__hal0Toast && window.__hal0Toast("Copy failed — clipboard unavailable", "err");
+  });
 };
 
 const cpCurlFor = (slotName) =>

--- a/ui/src/dash/connections.jsx
+++ b/ui/src/dash/connections.jsx
@@ -23,6 +23,7 @@
 // doesn't 401 (#1467). Tool detail comes from GET /api/mcp/servers
 // (`tool_details`).
 
+import { copyTextToClipboard } from '@/lib/clipboard'
 import { useAuthStatus } from '@/api/hooks/useAuthStatus'
 import { useSlots } from '@/api/hooks/useSlots'
 import { slotIndicatorFromPhase } from './slot-status.js'
@@ -105,28 +106,9 @@ function CIcon({ name, size = 14 }) {
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────
-function copyText(t) {
-  try {
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(t)
-      return
-    }
-  } catch (e) {
-    /* fall through */
-  }
-  try {
-    const ta = document.createElement('textarea')
-    ta.value = t
-    ta.style.position = 'fixed'
-    ta.style.opacity = '0'
-    document.body.appendChild(ta)
-    ta.select()
-    document.execCommand('copy')
-    document.body.removeChild(ta)
-  } catch (e) {
-    /* no-op */
-  }
-}
+// Shared async-safe copy (@/lib/clipboard) — resolves the REAL outcome, with
+// the legacy execCommand fallback this file used to carry inline (#2214).
+const copyText = (t) => copyTextToClipboard(t)
 function toast(msg, kind) {
   if (typeof window !== 'undefined' && window.__hal0Toast) window.__hal0Toast(msg, kind)
 }
@@ -423,10 +405,15 @@ function CopyIcon({ text, title }) {
       title={title || 'Copy'}
       onClick={(e) => {
         e.stopPropagation()
-        copyText(text)
-        setDone(true)
-        toast((title || 'copied') + ' · clipboard')
-        setTimeout(() => setDone(false), 1200)
+        copyText(text).then((ok) => {
+          if (!ok) {
+            toast('Copy failed — clipboard unavailable', 'err')
+            return
+          }
+          setDone(true)
+          toast((title || 'copied') + ' · clipboard')
+          setTimeout(() => setDone(false), 1200)
+        })
       }}
     >
       <CIcon name={done ? 'check' : 'copy'} size={13} />
@@ -440,10 +427,15 @@ function CopyBtn({ text, label, icon, cls }) {
       className={(cls || 'cbtn') + (done ? ' ok-flash' : '')}
       onClick={(e) => {
         e.stopPropagation()
-        copyText(text)
-        setDone(true)
-        toast(label + ' copied · clipboard')
-        setTimeout(() => setDone(false), 1300)
+        copyText(text).then((ok) => {
+          if (!ok) {
+            toast('Copy failed — clipboard unavailable', 'err')
+            return
+          }
+          setDone(true)
+          toast(label + ' copied · clipboard')
+          setTimeout(() => setDone(false), 1300)
+        })
       }}
     >
       <CIcon name={done ? 'check' : icon || 'copy'} size={13} />
@@ -717,8 +709,10 @@ function AddTo({ client, servers }) {
       className="clientchip"
       onClick={(e) => {
         e.stopPropagation()
-        copyText(buildClientConfig(client, servers))
-        toast(meta.label + ' config copied · paste into ' + meta.file)
+        copyText(buildClientConfig(client, servers)).then((ok) => {
+          if (ok) toast(meta.label + ' config copied · paste into ' + meta.file)
+          else toast('Copy failed — clipboard unavailable', 'err')
+        })
       }}
     >
       <span className="ic">

--- a/ui/src/dash/flags-tune.js
+++ b/ui/src/dash/flags-tune.js
@@ -268,7 +268,12 @@ export function highlightSegments(text) {
 
 // Client-side divergence: diff the model's tune text against the profile text
 // that seeded it. Keyed by canonical flag so a reordered `-b 2048` isn't a
-// spurious change. Returns { added, removed, changed, unchanged, diverged }.
+// spurious change. Matching folds through canonFlag (the full FLAG_ALIASES
+// mirror, not just the managed subset) so a model `-b 2048` against a profile
+// `--batch-size 1024` reads as ONE changed pair, not added+removed (#2211) —
+// the same canonicalisation groupFlagPairs and the tune pills use. Reported
+// `flag` spellings stay the operator's own text; only the matching
+// canonicalises. Returns { added, removed, changed, unchanged, diverged }.
 //   added:     [{ flag, value }]  present in model, not in profile
 //   removed:   [{ flag, value }]  present in profile, not in model
 //   changed:   [{ flag, from, to }] same flag, different value
@@ -276,7 +281,7 @@ export function highlightSegments(text) {
 export function diffFlags(modelText, profileText) {
   const mp = flagPairs(tokenizeFlags(modelText).tokens);
   const pp = flagPairs(tokenizeFlags(profileText).tokens);
-  const key = (p) => p.canon;
+  const key = (p) => canonFlag(p.flag);
   const pByFlag = new Map();
   for (const p of pp) pByFlag.set(key(p), p);
   const mByFlag = new Map();

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -22,6 +22,7 @@
 // is flat-merged wholesale, so we start from the stored defaults and override
 // only the keys we surface (emptying an input deletes just that key).
 
+import { copyTextToClipboard } from "@/lib/clipboard";
 import {
 	useModelUpdate,
 	useModelSetDefault,
@@ -1321,15 +1322,14 @@ function SourcePathLine({ label, value, testId, empty, note }) {
 						type="button"
 						className="btn ghost sm"
 						data-testid={testId}
-						onClick={() => {
-							try {
-								navigator.clipboard.writeText(String(value));
+						onClick={async () => {
+							const ok = await copyTextToClipboard(String(value));
+							if (ok)
 								window.__hal0Toast &&
 									window.__hal0Toast(`${label} path copied to clipboard`, "ok");
-							} catch {
+							else
 								window.__hal0Toast &&
 									window.__hal0Toast("Copy failed — clipboard unavailable", "err");
-							}
 						}}
 					>
 						Copy

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -14,6 +14,7 @@
 // affected_slots straight from the backend. The old HAL0_DATA fallbacks
 // live on only as cosmetic fixtures (host RAM, /var disk hint).
 
+import { copyTextToClipboard } from "@/lib/clipboard";
 import { useModels, useModelInspect, useModelDelete, usePullJob, useScanPreview, useAddModelFromPath, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
 import { useSlots } from '@/api/hooks/useSlots'
 import { useSettings } from '@/api/hooks/useSettings'
@@ -387,9 +388,10 @@ function OnDiskPanel({ model }) {
         <span className="v">{model.ns || "—"}</span>
       </div>
       <div style={{display: "flex", gap: 6, marginTop: 8}}>
-        <button className="btn ghost sm" onClick={() => {
-          navigator.clipboard?.writeText(path);
-          window.__hal0Toast && window.__hal0Toast("Path copied to clipboard", "ok");
+        <button className="btn ghost sm" onClick={async () => {
+          const ok = await copyTextToClipboard(path);
+          if (ok) window.__hal0Toast && window.__hal0Toast("Path copied to clipboard", "ok");
+          else window.__hal0Toast && window.__hal0Toast("Copy failed — clipboard unavailable", "err");
         }}>Copy path</button>
       </div>
     </div>

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -4,6 +4,7 @@
 // window globals. All persistence + lifecycle calls go through the typed
 // `useSlots` mutation hooks — no toast-only stubs survive in this file.
 
+import { copyTextToClipboard } from "@/lib/clipboard";
 import {
 	useSlotEdit,
 	useSlotDefaults,
@@ -3341,13 +3342,13 @@ function SlotLogsDrawer({ open, slot, onClose }) {
 
 	const copyAll = async () => {
 		if (!text) return;
-		try {
-			await navigator.clipboard.writeText(text);
-			setCopied(true);
-			setTimeout(() => setCopied(false), 1500);
-		} catch {
+		const ok = await copyTextToClipboard(text);
+		if (!ok) {
 			window.__hal0Toast && window.__hal0Toast("Clipboard unavailable", "warn");
+			return;
 		}
+		setCopied(true);
+		setTimeout(() => setCopied(false), 1500);
 	};
 
 	if (!slot) return null;

--- a/ui/src/lib/clipboard.test.ts
+++ b/ui/src/lib/clipboard.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+//
+// copyTextToClipboard (#2214) — the async-safe copy idiom. The old house
+// pattern try/caught around navigator.clipboard.writeText, which only catches
+// a synchronous throw; a rejected write (permission denial, insecure origin)
+// still toasted success. The helper must answer the REAL outcome: true only
+// after the promise resolves (or the legacy fallback succeeds), false on
+// rejection/sync-throw when the fallback can't copy either.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { copyTextToClipboard } from './clipboard'
+
+const setClipboard = (value: unknown) => {
+  Object.defineProperty(globalThis.navigator, 'clipboard', {
+    value,
+    configurable: true,
+  })
+}
+
+const setExecCommand = (fn: ((cmd: string) => boolean) | undefined) => {
+  Object.defineProperty(globalThis.document, 'execCommand', {
+    value: fn,
+    configurable: true,
+  })
+}
+
+afterEach(() => {
+  setClipboard(undefined)
+  setExecCommand(undefined)
+})
+
+describe('copyTextToClipboard', () => {
+  it('resolves true when the async write resolves', async () => {
+    const copied: string[] = []
+    setClipboard({ writeText: (t: string) => { copied.push(t); return Promise.resolve() } })
+    await expect(copyTextToClipboard('hello')).resolves.toBe(true)
+    expect(copied).toEqual(['hello'])
+  })
+
+  it('an ASYNC rejection is a failure, not a false success (the #2214 bug)', async () => {
+    setClipboard({ writeText: () => Promise.reject(new Error('NotAllowedError')) })
+    setExecCommand(() => false)
+    await expect(copyTextToClipboard('x')).resolves.toBe(false)
+  })
+
+  it('a synchronous throw is a failure too', async () => {
+    setClipboard({ writeText: () => { throw new Error('NotAllowedError') } })
+    setExecCommand(() => false)
+    await expect(copyTextToClipboard('x')).resolves.toBe(false)
+  })
+
+  it('no async clipboard at all (insecure LAN origin) → legacy execCommand fallback', async () => {
+    setClipboard(undefined)
+    const exec = vi.fn(() => true)
+    setExecCommand(exec)
+    await expect(copyTextToClipboard('fallback me')).resolves.toBe(true)
+    expect(exec).toHaveBeenCalledWith('copy')
+  })
+
+  it('rejection + working legacy fallback still copies (resolves true)', async () => {
+    setClipboard({ writeText: () => Promise.reject(new Error('denied')) })
+    setExecCommand(() => true)
+    await expect(copyTextToClipboard('x')).resolves.toBe(true)
+  })
+
+  it('nothing available anywhere resolves false (never throws)', async () => {
+    setClipboard(undefined)
+    setExecCommand(undefined)
+    await expect(copyTextToClipboard('x')).resolves.toBe(false)
+  })
+})

--- a/ui/src/lib/clipboard.ts
+++ b/ui/src/lib/clipboard.ts
@@ -1,0 +1,37 @@
+// Copy-to-clipboard with a REAL outcome (#2214).
+//
+// navigator.clipboard.writeText returns a Promise; the old house idiom
+// try/caught around the call, which only catches a synchronous throw. A real
+// browser failure — permission denied, or a non-secure LAN origin where
+// navigator.clipboard is absent entirely — surfaced as an async rejection (or
+// a sync TypeError), so the success toast fired anyway and the rejection went
+// unhandled. This helper awaits the write and answers what actually happened;
+// callers toast off the boolean.
+//
+// On failure (or where the async API is missing — hal0 dashboards are often
+// served over plain http on a LAN) it falls back to the legacy hidden-textarea
+// execCommand("copy") path that connections.jsx already carried.
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  const s = String(text);
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(s);
+      return true;
+    }
+  } catch {
+    // fall through to the legacy path
+  }
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = s;
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok === true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Fixes #2214. Fixes #2211.

Two small UI fixes deferred out of the model-drawer-2 wave. One commit per issue.

## #2214 — clipboard copy awaits the async write

`navigator.clipboard.writeText` returns a Promise; the house idiom try/caught around the call, which only catches a synchronous throw. Permission denial or a non-secure LAN origin surfaced as an async rejection (or a sync `TypeError` where `navigator.clipboard` is absent) — the success toast fired anyway.

New shared helper `ui/src/lib/clipboard.ts` (`copyTextToClipboard`): awaits the write, resolves the **real** outcome as a boolean, and keeps the legacy hidden-textarea `execCommand("copy")` fallback that `connections.jsx` used to carry inline — hal0 dashboards are routinely served over plain http on a LAN, where the async API does not exist at all.

Every `writeText` call site in `ui/src` now routes through it and toasts off the boolean:

| Call site | Surface |
|---|---|
| `ui/src/dash/command-palette.jsx` (`cpCopy`) | API base URL, curl snippets |
| `ui/src/dash/model-modals.jsx` | "Copy path" |
| `ui/src/dash/model-drawer.jsx` (`SourcePathLine`) | source/mmproj path copy |
| `ui/src/dash/Benchmarks.tsx` (`CopyButton`) | benchmark command copy |
| `ui/src/dash/slot-modals.jsx` (`copyAll`) | slot logs "Copy all" |
| `ui/src/dash/connections.jsx` (`CopyIcon`/`CopyBtn`/`AddTo`) | endpoint URLs, client configs |

The only remaining `writeText` reference in production code is inside the helper itself.

Coverage: `ui/src/lib/clipboard.test.ts` pins resolve / async-reject / sync-throw / fallback / nothing-available outcomes; the existing model-drawer clipboard-failure test now exercises the async path and gains an async-rejection case.

## #2211 — diffFlags keys on the full alias table

`diffFlags` (ui/src/dash/flags-tune.js) keyed pairs on `canonManaged` (only `-ngl`/`-c`), while the tune-pill layer (`groupFlagPairs`) folds through `canonFlag` — the full `FLAG_ALIASES` mirror.

**Before:** model `-b 2048` vs profile `--batch-size 1024` → one *added* + one *removed* pair; the editor rendered a green added pill **plus** a struck ghost for the same flag, and the `◆ N diverged` count was inflated by one.

**After:** both sides key on `canonFlag(p.flag)` → one *changed* pair (`{ flag: '-b', from: '1024', to: '2048' }`); same value in two spellings is no-change. Reported `flag` spellings still come from the operator's own text — only the matching canonicalises — so `DivergenceDiff`, the slot drawer's profile apply preview, and the seed consequence preview render identically for same-spelling input. This is exactly the fold the pill layer already applies (`canonFlag(c.flag)` in `divergenceFor`/`changedFor`), so the two layers now agree.

Coverage: two new `diffFlags` unit tests (`-b` vs `--batch-size` no-change; cross-spelling value divergence = one changed pair in the operator spelling).

## Verification

- `npm run test:unit` — 41 files, 472 tests, all pass
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — clean (vite production build)

CHANGELOG: one bullet per fix under Unreleased → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181rff5wtNoioAHumZsYCD4
