### PR TITLE
fix(tests): stop patching the global os.path.exists in provider GPU tests

### DIFF
--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -103,6 +103,17 @@ from hal0.system.seam import SystemCtlSeam, is_hal0_service_user
 # callers/tests still import the old name from this module.
 ContainerSpec = RuntimeLaunchPlan
 
+#: Existence probe for GPU device nodes (/dev/kfd, /dev/dri/renderD*), used by
+#: the AMD passthrough filter in :meth:`ContainerProvider.container_spec`.
+#: A dedicated seam so tests can force device nodes "present" on hosts without
+#: a GPU by patching ``hal0.providers.container._dev_node_exists`` — patching
+#: ``hal0.providers.container.os.path.exists`` instead mutates the ONE shared
+#: ``os`` module for the whole process, and on Python >= 3.14
+#: ``pathlib.Path.exists()`` delegates to ``os.path.exists``, so a
+#: ``return_value=True`` patch made every absent-file guard in the config
+#: loaders take the read path and raise ConfigNotFound (#2166).
+_dev_node_exists = os.path.exists
+
 
 class UnknownRuntimeFamilyError(Hal0Error):
     """A slot profile resolved to a runtime family with no dispatch branch.
@@ -2444,7 +2455,7 @@ class ContainerProvider(Provider):
                 devices = nvidia_cdi_devices(scalars["gpu_index"])
                 group_ids = []
             else:
-                devices = [p for p in resolve_gpu_device_paths() if os.path.exists(p)]
+                devices = [p for p in resolve_gpu_device_paths() if _dev_node_exists(p)]
                 group_ids = [str(g) for g in resolve_gpu_group_ids()]
         else:
             devices = []

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -694,7 +694,7 @@ class TestContainerSpec:
             ),
             # GPU device nodes are existence-filtered at the container_spec call
             # site; force present so the CI host (no /dev/kfd) still keeps them.
-            patch("hal0.providers.container.os.path.exists", return_value=True),
+            patch("hal0.providers.container._dev_node_exists", return_value=True),
         ):
             spec = self._build_spec()
         assert spec.devices == ["/dev/kfd", "/dev/dri/renderD128"]
@@ -1146,7 +1146,7 @@ class TestGpuPassthroughGate:
             ),
             # Existence-filtered at the call site; force present so a CI host
             # with no /dev/kfd still exercises the gate rather than the filter.
-            patch("hal0.providers.container.os.path.exists", return_value=True),
+            patch("hal0.providers.container._dev_node_exists", return_value=True),
             patch("hal0.providers.container.resolve_gpu_group_ids", return_value=[993, 44]),
         ):
             return provider.container_spec(cfg, _model_info())
@@ -2031,7 +2031,7 @@ class TestFPXQuantRunnerGuard:
                 "hal0.providers.container.resolve_gpu_device_paths",
                 return_value=list(self._GPU_NODES),
             ),
-            patch("hal0.providers.container.os.path.exists", return_value=True),
+            patch("hal0.providers.container._dev_node_exists", return_value=True),
             patch("hal0.providers.container.resolve_gpu_group_ids", return_value=[993, 44]),
         ):
             return provider.container_spec(cfg, model_info)

--- a/tests/providers/test_container_assembler.py
+++ b/tests/providers/test_container_assembler.py
@@ -239,7 +239,7 @@ def test_cpu_profile_gets_no_gpu_plumbing() -> None:
             return_value=["/dev/kfd", "/dev/dri/renderD128"],
         ),
         patch("hal0.providers.container.resolve_gpu_group_ids", return_value=[993, 44]),
-        patch("hal0.providers.container.os.path.exists", return_value=True),
+        patch("hal0.providers.container._dev_node_exists", return_value=True),
     ):
         spec = ContainerProvider().container_spec(
             cfg, {"_model_key": "m", "path": "/mnt/ai-models/m.gguf"}
@@ -267,7 +267,7 @@ def test_gpu_profile_existence_filters_devices() -> None:
             return_value=["/dev/kfd", "/dev/dri/renderD128"],
         ),
         patch("hal0.providers.container.resolve_gpu_group_ids", return_value=[993]),
-        patch("hal0.providers.container.os.path.exists", side_effect=_exists),
+        patch("hal0.providers.container._dev_node_exists", side_effect=_exists),
     ):
         spec = ContainerProvider().container_spec(
             cfg, {"_model_key": "m", "path": "/mnt/ai-models/m.gguf"}

--- a/tests/providers/test_container_npu.py
+++ b/tests/providers/test_container_npu.py
@@ -231,7 +231,7 @@ class TestLoadSyncNpuBranch:
             ),
             # GPU device nodes are existence-filtered at the container_spec call
             # site; force present so the CI host (no /dev/kfd) still renders them.
-            patch("hal0.providers.container.os.path.exists", return_value=True),
+            patch("hal0.providers.container._dev_node_exists", return_value=True),
             patch.object(provider, "_run", side_effect=fake_run),
             patch.object(provider, "_unit_path", return_value=unit_file),
         ):

--- a/tests/providers/test_container_spec_dispatch.py
+++ b/tests/providers/test_container_spec_dispatch.py
@@ -265,7 +265,7 @@ def test_gpu_slot_unaffected_still_takes_llama_path(tmp_path: Any) -> None:
         ),
         # GPU device nodes are existence-filtered at the container_spec call
         # site; force them "present" so the CI host (no /dev/kfd) still renders.
-        patch("hal0.providers.container.os.path.exists", return_value=True),
+        patch("hal0.providers.container._dev_node_exists", return_value=True),
         patch.object(provider, "_run", side_effect=fake_run),
         patch.object(provider, "_unit_path", return_value=unit_file),
     ):


### PR DESCRIPTION
Fixes #2166

## Root cause

Six provider tests forced the GPU device-node existence filter with

```python
patch("hal0.providers.container.os.path.exists", return_value=True)
```

(plus one `side_effect` variant). `hal0.providers.container.os` is the **one shared `os` module**, so for the duration of each `with` block this rewrites `os.path.exists` for the entire process — not just for `container.py`.

On **Python >= 3.14**, `pathlib.Path.exists()` delegates to `os.path.exists`:

```python
# CPython 3.14.7 pathlib
def exists(self, *, follow_symlinks=True):
    if follow_symlinks:
        return os.path.exists(self)
```

3.13 and earlier call `self.stat()` instead, which is why only the 3.14 leg ever hit this. With the patch active, every config loader's absent-file guard — `if not Path(target).exists(): return <defaults>` (`load_profiles_config` loader.py:781, `load_hal0_config` loader.py:211) — was told the file exists, took the read path, and `_read_toml` raised `ConfigNotFound` for `profiles.toml` / `hal0.toml` that legitimately don't exist in the test's fresh `HAL0_HOME`.

**The "ordering-dependent" look:** whether a failing run reached a config loader *inside* a patch window is state-dependent (e.g. the profile-template gate in `_resolve_llama_scalars` only calls `profile_fits_slot` → `load_profiles_config` under specific resolved-profile conditions), so identical 3.14.7 runs could pass or fail. It was never actually ordering between tests.

**Per-leg verification:** the non-3.14 "hits" in #2166 were a different flake. Run 33412063158 attempt 1's `python (3.12)` job and run 33367222284 attempt 1's `python (3.13)` job each failed **only** `tests/slots/test_fail_watcher_warming.py` (the already-tracked #2002 warming race) — zero `profiles.toml` failures. The profiles cluster appears exclusively on 3.14 (both 3.14 attempts ran CPython 3.14.7; one passed, one failed — see the state-dependent gate above).

## Fix

Fix at the seam, not in 30 tests: `container.py` routes the AMD passthrough filter through a module-level alias

```python
_dev_node_exists = os.path.exists  # patchable per-test without touching the shared os module
...
devices = [p for p in resolve_gpu_device_paths() if _dev_node_exists(p)]
```

and the seven test patch sites target `hal0.providers.container._dev_node_exists` instead. Scoped to the module under test, invisible to pathlib and every other module, identical behavior in production.

## Minimal repro + evidence

On main @ 49516479, CPython 3.14.7, the headline test fails **run entirely alone** — no ordering needed:

```
$ uv run -p 3.14 pytest "tests/providers/test_container.py::TestContainerSpec::test_devices_present" -q
hal0.config.loader.ConfigNotFound: config file not found: .../test_devices_present0/etc/hal0/hal0.toml
1 failed in 0.19s
```

The exact 16-test cluster from CI run 33412063158's 3.14 leg, before/after this change (same machine, 3.14.7):

```
=== BEFORE (main @ HEAD, py3.14) ===
16 failed in 1.14s
=== AFTER (fix, py3.14) ===
................                                                         [100%]
16 passed in 0.13s
```

Broader runs with the fix:

- `tests/providers tests/slots tests/config` on **3.14.7**: `2623 passed, 9 skipped` (the only failures are the two `test_moonshine_server.py` ffmpeg tests, which fail identically on unmodified main on this ffmpeg-less Mac)
- same selection on **3.13.15**: `2623 passed, 9 skipped`
- `ruff check` / `ruff format --check` clean

## Notes

- No CHANGELOG entry: test-infrastructure only, no product behavior change.
- Same hazard class exists in `tests/api/test_comfyui_phase4.py:309,321` (`patch("hal0.api.routes.comfyui.os.path.isfile")` — `Path.is_file()` delegates to `os.path.isfile` on 3.14 too). Those two have never flaked, so they're left alone here; happy to file a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181rff5wtNoioAHumZsYCD4
