### PR TITLE
fix(slots): treat a clean SIGTERM stop as offline, not error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,19 @@ applying. Add those subsections to a version's section to surface them; see
   - `hal0.config.paths.bundle_chosen_marker()` (the `.bundle-chosen`
     bundle-picker marker path) is deleted — the picker stayed deferred and
     nothing ever wired the marker.
+- A deliberate stop of a slot no longer reads as a red `error` in
+  `hal0 slot list` (#2130). `systemctl stop` sends SIGTERM and podman
+  propagates the container's graceful shutdown as exit code 143, which the
+  generated unit — having no `SuccessExitStatus` — recorded as
+  `Failed with result 'exit-code'`; the state probe then painted every slot
+  the documented `migrate-flags --apply --stop-services` path stopped as an
+  error on a healthy mid-upgrade box. The rendered unit now declares
+  `SuccessExitStatus=143`, the systemd probe recognises the plain
+  SIGTERM-stop signature on units that predate the directive, and a cached
+  `error` converges back to `offline` once the unit's own properties show it
+  was stopped on purpose (a clean stop or `systemctl reset-failed`) — while a
+  genuinely crashed or crash-looping unit keeps its error verdict, breaker
+  bookkeeping, and `last_crash_line` evidence untouched.
 
 ## [1.2.0] — 2026-09-03
 

--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -281,8 +281,8 @@ validate_dropin_body() {  # arg: kind (gateway|hindsight); body on stdin
 #               HealthCmd= HealthStartPeriod= HealthInterval= HealthRetries=
 #               HealthTimeout= Exec=
 #   [Service]   Restart= RestartSec= RestartSteps= RestartMaxDelaySec=
-#               RestartPreventExitStatus= SyslogIdentifier= StandardOutput=
-#               StandardError=
+#               RestartPreventExitStatus= SuccessExitStatus=
+#               SyslogIdentifier= StandardOutput= StandardError=
 #   [Install]   WantedBy=hal0.target        (omitted when autoload = false)
 #
 # Sections may appear at most once and only in that order; [Container] is
@@ -439,17 +439,19 @@ validate_quadlet_directive() {  # args: section, "Key=Value" line
 
     # ── [Service] ───────────────────────────────────────────────────────
     # Copied VERBATIM into the generated system unit by podman's quadlet
-    # generator — i.e. host-side root. Exactly the eight the renderer emits;
+    # generator — i.e. host-side root. Exactly the nine the renderer emits;
     # every Exec*=, User=, Group=, WorkingDirectory=, … lands in the default
     # arm below and dies. RestartPreventExitStatus= (#2037, widened by #2126)
-    # is pinned to a bounded space-separated list of bare exit statuses — the
-    # renderer emits `64 132`; the signal NAMES and ranges systemd would also
-    # accept are still refused here.
+    # and SuccessExitStatus= (#2130 — the renderer emits `143` so a requested
+    # SIGTERM stop is not recorded as a unit failure) are pinned to a bounded
+    # space-separated list of bare exit statuses; the signal NAMES and ranges
+    # systemd would also accept are still refused here.
     'Service|Restart')           [[ "$value" =~ $_QRE_RESTART ]] || _quadlet_die "bad Restart: $value" ;;
     'Service|RestartSec')        [[ "$value" =~ $_QRE_UINT ]]    || _quadlet_die "bad RestartSec: $value" ;;
     'Service|RestartSteps')      [[ "$value" =~ $_QRE_UINT ]]    || _quadlet_die "bad RestartSteps: $value" ;;
     'Service|RestartMaxDelaySec') [[ "$value" =~ $_QRE_UINT ]]   || _quadlet_die "bad RestartMaxDelaySec: $value" ;;
     'Service|RestartPreventExitStatus') [[ "$value" =~ $_QRE_EXITSTATUS_LIST ]] || _quadlet_die "bad RestartPreventExitStatus: $value" ;;
+    'Service|SuccessExitStatus') [[ "$value" =~ $_QRE_EXITSTATUS_LIST ]]        || _quadlet_die "bad SuccessExitStatus: $value" ;;
     'Service|SyslogIdentifier')  [[ "$value" =~ $_QRE_CTRNAME ]] || _quadlet_die "bad SyslogIdentifier: $value" ;;
     'Service|StandardOutput')    [[ "$value" == "journal" ]]     || _quadlet_die "bad StandardOutput: $value" ;;
     'Service|StandardError')     [[ "$value" == "journal" ]]     || _quadlet_die "bad StandardError: $value" ;;

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -725,6 +725,28 @@ _SIGILL_HINT = (
 )
 
 
+def _is_sigterm_stop(props: Mapping[str, str]) -> bool:
+    """True when a ``failed`` unit's death is a plain SIGTERM exit (#2130).
+
+    podman propagates a container's graceful SIGTERM shutdown as its own exit
+    CODE 143 (128+15), so on a unit rendered before ``SuccessExitStatus=143``
+    a deliberate ``systemctl stop`` reads ``Result=exit-code`` /
+    ``ExecMainStatus=143`` — indistinguishable, to systemd, from a crash. It
+    is distinguishable here: a self-inflicted 143 under ``Restart=always``
+    would have been restarted rather than parked in ``failed``, so a unit
+    that IS parked with this signature was told to stop. This is the
+    version-skew-proof half of the fix — deployed units keep their old text
+    until the next load rerenders them.
+
+    Deliberately narrow: only ``exit-code`` + 143. ``start-limit-hit`` (the
+    crash-loop verdict), the terminal statuses (64/132), and every other exit
+    code stay failures.
+    """
+    if props.get("Result", "") != "exit-code":
+        return False
+    return str(props.get("ExecMainStatus", "")).strip() == "143"
+
+
 def _fault_diagnosis(props: Mapping[str, str]) -> str:
     """Name the deterministic fault behind a failed unit, or ``""`` (#2126).
 
@@ -998,6 +1020,19 @@ def _render_quadlet_from_plan(
             # "before /health ever answered" makes them deterministic, in
             # packaging/runner/rocmfpx/entrypoint.sh.
             "RestartPreventExitStatus=64 132",
+            # #2130: a requested stop is not a failure. `systemctl stop` sends
+            # SIGTERM; podman propagates the container's graceful SIGTERM exit
+            # as its own exit CODE 143 (128+15), not a signal death — so
+            # without this, systemd records `status=143 … Failed with result
+            # 'exit-code'` and parks every deliberately-stopped slot in
+            # `failed`, which the slot-state probe then paints as a red ERROR
+            # (the v1.0.0 migrate-flags --stop-services shape). Declaring 143 a
+            # success makes a stop end `inactive`/`Result=success`. Restart
+            # semantics are untouched: Restart=always restarts on success and
+            # failure alike (never during a requested stop job), and the
+            # terminal statuses above are exit codes systemd already treats as
+            # distinct.
+            "SuccessExitStatus=143",
             f"SyslogIdentifier={container_name}",
             "StandardOutput=journal",
             "StandardError=journal",
@@ -3003,6 +3038,14 @@ class ContainerProvider(Provider):
         restarts = props.get("NRestarts", "") or "0"
         fault = _fault_diagnosis(props)
         if active_state == "failed":
+            if _is_sigterm_stop(props):
+                # #2130: a deliberate `systemctl stop` on a unit that predates
+                # `SuccessExitStatus=143` parks it in `failed` with a plain
+                # SIGTERM exit. The service was ASKED to die and did so
+                # cleanly — reporting it as a failure painted every slot
+                # stopped by `migrate-flags --stop-services` (or a bare
+                # systemctl stop) as a red ERROR on a healthy box.
+                return ""
             if result == "start-limit-hit":
                 base = (
                     f"{unit} is crash-looping: systemd stopped retrying after "
@@ -3020,6 +3063,43 @@ class ContainerProvider(Provider):
                 f"was loading. `hal0 slot load {token}` recreates it"
             )
         return ""
+
+    def unit_stopped_cleanly(self, slot: Mapping[str, Any] | str) -> bool:
+        """POSITIVE evidence that the slot's unit was stopped on purpose (#2130).
+
+        The inverse question to :meth:`unit_failure_reason`, and deliberately
+        not its negation: that probe's ``""`` means "no terminal evidence",
+        which callers must never read as proof of health. This one answers
+        ``True`` only when the unit's own properties show a deliberate,
+        non-crash end:
+
+          * ``ActiveState=inactive`` with ``Result=success`` — a clean stop on
+            a unit carrying ``SuccessExitStatus=143``, a unit reset via
+            ``systemctl reset-failed``, or one not started since boot;
+          * ``ActiveState=failed`` with the plain-SIGTERM signature
+            (``Result=exit-code`` / ``ExecMainStatus=143``) — a deliberate
+            stop on a unit rendered before ``SuccessExitStatus=143`` existed.
+
+        Everything else — crash-loop (``start-limit-hit``), any other exit
+        code, a unit mid-restart (``activating``), a removed unit
+        (``LoadState=not-found``, the output-sanity teardown shape), or a
+        probe error — is ``False``. Callers use ``True`` to retire a cached
+        ERROR, so absence of evidence must never manufacture an OFFLINE.
+        """
+        try:
+            props = self.unit_status(slot)
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning(
+                "container.unit_status_failed",
+                extra={"slot": _artefact_token(slot), "error": str(exc)},
+            )
+            return False
+        if props.get("LoadState", "") != "loaded":
+            return False
+        active_state = props.get("ActiveState", "")
+        if active_state == "inactive":
+            return props.get("Result", "") in ("success", "")
+        return active_state == "failed" and _is_sigterm_stop(props)
 
     def reset_failed(self, slot: Mapping[str, Any] | str) -> None:
         """Clear a unit's ``failed`` sub-state and its start-limit counter.

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1513,6 +1513,38 @@ class SlotManager:
         # facing message. Only a real ``str`` is evidence.
         return reason if isinstance(reason, str) else ""
 
+    async def _unit_stopped_cleanly(self, slot_name: str) -> bool:
+        """POSITIVE evidence the slot's unit was stopped on purpose (#2130).
+
+        Thin async wrapper over
+        :meth:`hal0.providers.container.ContainerProvider.unit_stopped_cleanly`
+        (a blocking ``systemctl show``, so it runs in the executor). The same
+        strictness rules as :meth:`unit_failure_reason`, inverted: callers use
+        ``True`` as proof a cached ERROR may be retired, so everything
+        inconclusive — no config, an NPU trio shadow, a provider double
+        without the probe, a probe that raises, a non-bool answer (a bare
+        ``MagicMock`` auto-creates the attribute) — must answer ``False``.
+        Absence of evidence never clears an ERROR.
+        """
+        cfg = await self._maybe_load_config(slot_name)
+        if cfg is None or is_npu_trio_shadow(cfg):
+            return False
+
+        from hal0.providers.container import container_provider
+
+        probe = getattr(container_provider(), "unit_stopped_cleanly", None)
+        if probe is None:
+            return False
+        try:
+            verdict = await asyncio.get_event_loop().run_in_executor(None, probe, _cfg_to_dict(cfg))
+        except Exception as exc:
+            log.warning(
+                "slot.unit_stopped_cleanly_probe_failed",
+                extra={"slot": slot_name, "error": str(exc)},
+            )
+            return False
+        return verdict is True
+
     async def _read_last_crash_line(self, slot_name: str, cfg: Any) -> str | None:
         """Decisive crash line from the slot unit's journal, or ``None``.
 
@@ -2157,6 +2189,10 @@ class SlotManager:
             unit is active → adopt the running slot into READY. Covers
             the case where another process started the unit
             out-of-band.
+          - state.json says ERROR but the unit's own properties show it
+            was deliberately stopped (clean SIGTERM stop, ``systemctl
+            reset-failed``) → converge to OFFLINE (#2130). Positive
+            evidence only — a crashed/crash-looping unit keeps the ERROR.
         """
         slot_name = self._resolve_alias(slot_name)
         self._ensure_known(slot_name)
@@ -2238,6 +2274,28 @@ class SlotManager:
             # message (#1791). Re-read the record so ``hal0 status`` and
             # ``/api/slots`` actually carry it.
             rec = self._states.get(self._key(slot_name)) or rec
+        elif observed == SlotState.ERROR and not active:
+            # #2130 second half: a cached ERROR must converge once the unit's
+            # own properties show a deliberate, non-crash end — a clean
+            # SIGTERM stop (`migrate-flags --stop-services`, a bare
+            # `systemctl stop`) or an operator's `systemctl reset-failed`.
+            # Without this the display stayed red until a full `slot load`,
+            # telling an operator mid-upgrade that the obvious systemd
+            # remediation had not worked. Gated on POSITIVE evidence only
+            # (see the provider probe): a crash-looping unit (`activating` /
+            # `failed`/start-limit-hit), a usage-exit (64), a removed unit
+            # (the output-sanity teardown), or an inconclusive probe all keep
+            # the ERROR — so genuine crash verdicts, the breaker bookkeeping,
+            # and `last_crash_line` evidence are never retired by drift.
+            if await self._unit_stopped_cleanly(slot_name):
+                await self._transition(
+                    slot_name,
+                    SlotState.OFFLINE,
+                    message="container stopped (auto-reloads on next request)",
+                    force=True,
+                )
+                observed = SlotState.OFFLINE
+                rec = self._states.get(self._key(slot_name)) or rec
         elif observed in (SlotState.OFFLINE, SlotState.ERROR) and active:
             # Inverse drift — state.json says we're not running, but
             # the unit is active. Adoption picks the slot up.

--- a/tests/installer/test_systemctl_quadlet_validation.py
+++ b/tests/installer/test_systemctl_quadlet_validation.py
@@ -250,6 +250,16 @@ def test_restart_prevent_exit_status_list_is_accepted() -> None:
     _accepts(body, "chat")
 
 
+def test_success_exit_status_is_accepted() -> None:
+    """#2130: the renderer emits ``SuccessExitStatus=143`` so a requested
+    SIGTERM stop ends ``Result=success`` instead of parking the unit in
+    ``failed`` (which the state probe painted as a red ERROR). The root-side
+    allow-list must accept it, or every slot load on a provisioned box dies
+    at write-quadlet."""
+    body = f"{_HEAD}\n[Service]\nSuccessExitStatus=143\n"
+    _accepts(body, "chat")
+
+
 def test_live_container_provider_render_is_accepted() -> None:
     """End-to-end through the production path: ``ContainerProvider.container_spec``
     → ``_render_quadlet_from_plan``, not a hand-built plan."""
@@ -367,6 +377,11 @@ ESCALATIONS = {
     "service-restartpreventexitstatus-trailing-space": (
         f"{_HEAD}\n[Service]\nRestartPreventExitStatus=64 \n"
     ),
+    # #2130: SuccessExitStatus= is pinned exactly like RestartPreventExitStatus=
+    # (the renderer emits `143`); signal names and ranges are refused.
+    "service-successexitstatus-signal": f"{_HEAD}\n[Service]\nSuccessExitStatus=SIGTERM\n",
+    "service-successexitstatus-range": f"{_HEAD}\n[Service]\nSuccessExitStatus=0-255\n",
+    "service-successexitstatus-too-wide": f"{_HEAD}\n[Service]\nSuccessExitStatus=1430\n",
     "service-workingdirectory": f"{_HEAD}\n[Service]\nWorkingDirectory=/root\n",
     "service-environmentfile": f"{_HEAD}\n[Service]\nEnvironmentFile=/tmp/evil.env\n",
     "service-permissionsstartonly": f"{_HEAD}\n[Service]\nPermissionsStartOnly=true\n",

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -589,6 +589,20 @@ class TestRenderUnit:
         service_section = unit.partition("[Service]")[2].partition("[Install]")[0]
         assert "RestartPreventExitStatus=64 132" in service_section
 
+    def test_sigterm_stop_is_a_success_exit_status(self) -> None:
+        """#2130: `systemctl stop` sends SIGTERM and podman propagates the
+        container's graceful shutdown as exit CODE 143 — without
+        ``SuccessExitStatus=143`` systemd records ``Failed with result
+        'exit-code'`` and every deliberately-stopped slot (the documented
+        ``migrate-flags --stop-services`` path included) parks in ``failed``,
+        which `hal0 slot list` painted as a red ERROR on a healthy box.
+        """
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_llama("test-slot", _TEST_IMAGE, 8095, "/mnt/ai-models/model.gguf", flags)
+        service_section = unit.partition("[Service]")[2].partition("[Install]")[0]
+        assert "SuccessExitStatus=143" in service_section.splitlines()
+
     def test_sigill_is_terminal_host_side(self) -> None:
         """#2126: exit 64 only exists inside images that SHIP the runner
         entrypoint. The `cpu` runner resolves to a foreign GPU toolbox, which

--- a/tests/providers/test_container_unit_failure.py
+++ b/tests/providers/test_container_unit_failure.py
@@ -406,3 +406,104 @@ def test_a_failed_restart_is_typed_even_when_the_probe_has_no_reason(
     assert "journalctl" in err.message
     assert "sudo" not in err.message
     assert "hal0-systemctl" not in err.message
+
+
+# ── #2130: a deliberate SIGTERM stop is not a failure ───────────────────────
+
+
+def test_sigterm_stop_on_a_presuccessexitstatus_unit_is_not_a_failure(
+    provider: ContainerProvider, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#2130's exact shape: `systemctl stop` on a unit rendered before
+    ``SuccessExitStatus=143`` existed. podman propagates the container's
+    graceful SIGTERM shutdown as exit CODE 143 (128+15), so systemd records
+    ``status=143 … Failed with result 'exit-code'`` and parks the unit in
+    ``failed`` — but the service was ASKED to die and did so cleanly. The
+    probe must stay silent: a non-empty reason stamps a red ERROR on every
+    slot the documented ``migrate-flags --stop-services`` path stopped.
+    """
+    _stub_run(
+        monkeypatch,
+        provider,
+        "LoadState=loaded\nActiveState=failed\nResult=exit-code\nNRestarts=0\nExecMainStatus=143\n",
+    )
+
+    assert provider.unit_failure_reason("chat") == ""
+
+
+def test_a_crash_loop_of_sigterm_exits_is_still_a_failure(
+    provider: ContainerProvider, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Narrowness guard: 143 only reads "deliberate stop" on a plain
+    ``exit-code`` result. A unit that burned its whole restart ramp dying
+    143 lands in ``start-limit-hit``, which stays a crash-loop verdict —
+    only a requested stop parks a unit in ``failed`` with a bare 143 under
+    ``Restart=always`` (systemd would otherwise have restarted it)."""
+    _stub_run(
+        monkeypatch,
+        provider,
+        "LoadState=loaded\nActiveState=failed\nResult=start-limit-hit\n"
+        "NRestarts=5\nExecMainStatus=143\n",
+    )
+
+    reason = provider.unit_failure_reason("chat")
+
+    assert "crash-looping" in reason
+    assert "start-limit-hit" in reason
+
+
+# ── #2130: unit_stopped_cleanly — positive evidence a stop was deliberate ──
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        # Clean stop on a SuccessExitStatus=143 unit, or reset-failed, or
+        # not started since boot.
+        "LoadState=loaded\nActiveState=inactive\nSubState=dead\nResult=success\n",
+        # Result unreported (older systemd / property elided) but inactive.
+        "LoadState=loaded\nActiveState=inactive\nSubState=dead\n",
+        # SIGTERM stop on a unit predating SuccessExitStatus=143.
+        "LoadState=loaded\nActiveState=failed\nResult=exit-code\nExecMainStatus=143\n",
+    ],
+)
+def test_unit_stopped_cleanly_recognises_deliberate_stops(
+    provider: ContainerProvider, monkeypatch: pytest.MonkeyPatch, stdout: str
+) -> None:
+    _stub_run(monkeypatch, provider, stdout)
+
+    assert provider.unit_stopped_cleanly("chat") is True
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        # Crash loop: systemd gave up.
+        "LoadState=loaded\nActiveState=failed\nResult=start-limit-hit\nNRestarts=5\n",
+        # Usage-exit death (#2221's shape) — a real failure.
+        "LoadState=loaded\nActiveState=failed\nResult=exit-code\nExecMainStatus=64\n",
+        # SIGILL — terminal fault (#2126).
+        "LoadState=loaded\nActiveState=failed\nResult=exit-code\nExecMainStatus=132\n",
+        # Plain non-zero exit.
+        "LoadState=loaded\nActiveState=failed\nResult=exit-code\nExecMainStatus=1\n",
+        # Mid-restart between crashes: not evidence of a stop.
+        "LoadState=loaded\nActiveState=activating\nResult=success\n",
+        # Still running.
+        "LoadState=loaded\nActiveState=active\nSubState=running\nResult=success\n",
+        # Removed unit (the output-sanity teardown shape) — the record's
+        # verdict must survive, so a gone unit is NOT a clean stop.
+        "LoadState=not-found\nActiveState=inactive\n",
+        # Inactive but the last run genuinely failed (Restart=no style).
+        "LoadState=loaded\nActiveState=inactive\nResult=exit-code\n",
+        # Unreadable probe output.
+        "",
+    ],
+)
+def test_unit_stopped_cleanly_never_manufactures_an_offline(
+    provider: ContainerProvider, monkeypatch: pytest.MonkeyPatch, stdout: str
+) -> None:
+    """Callers use ``True`` to retire a cached ERROR, so absence of evidence
+    (or evidence of an actual crash) must answer ``False``."""
+    _stub_run(monkeypatch, provider, stdout)
+
+    assert provider.unit_stopped_cleanly("chat") is False

--- a/tests/slots/conftest.py
+++ b/tests/slots/conftest.py
@@ -80,6 +80,11 @@ class FakeContainerProvider:
         # test keeps the old "nothing is wrong with the unit" behaviour.
         self.unit_failure_by_slot: dict[str, str] = {}
         self.reset_failed_calls: list[str] = []
+        # #2130 — slots whose unit reads "deliberately stopped" to systemd
+        # (clean SIGTERM stop / reset-failed). Empty by default: the probe
+        # answers True only on POSITIVE evidence, so existing tests keep the
+        # "no evidence, nothing converges" behaviour.
+        self.stopped_cleanly: set[str] = set()
         # #1922 — the fake slot server's completion output. "Paris" is the
         # right answer to the gate's prompt, so the default double models a
         # box whose model actually works, exactly as ``healthy = True`` models
@@ -118,6 +123,10 @@ class FakeContainerProvider:
     def reset_failed(self, slot: Any) -> None:
         """Mirror ``ContainerProvider.reset_failed`` (#1424/#1791)."""
         self.reset_failed_calls.append(probe_slot_name(slot))
+
+    def unit_stopped_cleanly(self, slot: Any) -> bool:
+        """Mirror ``ContainerProvider.unit_stopped_cleanly`` (#2130)."""
+        return probe_slot_name(slot) in self.stopped_cleanly
 
     async def health(self, port: int, slot_cfg: dict[str, Any] | None = None) -> dict[str, Any]:
         # Mirrors ContainerProvider.health's (port, slot_cfg) signature —

--- a/tests/slots/test_clean_stop_reconcile.py
+++ b/tests/slots/test_clean_stop_reconcile.py
@@ -1,0 +1,141 @@
+"""#2130 — a deliberate stop must read OFFLINE, never ERROR.
+
+The v1.0.0 shape: the documented ``hal0 slot migrate-flags --apply
+--stop-services`` path runs a bare ``systemctl stop`` on every active slot
+unit. The stop is graceful (SIGTERM, application shutdown logged) but podman
+propagates it as exit code 143, the pre-#2130 unit had no
+``SuccessExitStatus=143``, systemd parked the unit in ``failed``, and the next
+``hal0 slot list`` painted every slot on a healthy mid-upgrade box as a red
+``error``. Worse, the verdict was sticky: ``systemctl reset-failed`` fixed
+systemd's view but hal0 kept its cached ERROR until a full ``slot load``.
+
+Pinned here, against the manager's ``status()`` reconciler:
+
+  * deliberate stop → OFFLINE, with no crash-line stamped and no crash-loop
+    breaker bookkeeping — a clean stop is not a failure;
+  * real crash (systemd's terminal verdict) → still ERROR;
+  * cached ERROR + positive "deliberately stopped" evidence from the unit →
+    converges to OFFLINE (the ``reset-failed`` remediation works);
+  * cached ERROR + inconclusive probe → stays ERROR (absence of evidence
+    never manufactures an OFFLINE).
+
+The provider-side halves (``SuccessExitStatus=143`` in the rendered unit, the
+SIGTERM-stop mapping in ``unit_failure_reason`` / ``unit_stopped_cleanly``)
+are pinned in ``tests/providers/test_container.py`` and
+``tests/providers/test_container_unit_failure.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hal0.slots.manager import SlotManager
+from hal0.slots.state import SlotState
+from tests.slots.conftest import FakeContainerProvider
+
+_CRASH_REASON = (
+    "hal0-slot@chat.service failed (result=exit-code, restarts=1) — "
+    "see `journalctl -u hal0-slot@chat.service`"
+)
+
+
+async def _load_ready(sm: SlotManager) -> None:
+    slot = await sm.load("chat")
+    assert slot.state == SlotState.READY
+
+
+async def test_deliberate_stop_reads_offline_not_error(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """The unit stopped on purpose; the probe reads nothing terminal (#2130:
+    a SIGTERM-stop no longer produces a failure reason) → grey OFFLINE."""
+    sm = SlotManager()
+    await _load_ready(sm)
+
+    # Out-of-band `systemctl stop`: the unit goes inactive; the failure
+    # probe stays silent (the post-#2130 mapper answer for a SIGTERM stop).
+    container_stub.active.discard("chat")
+
+    slot = await sm.status("chat")
+
+    assert slot.state == SlotState.OFFLINE
+    # A clean stop is not a crash: no crash-line evidence may be stamped and
+    # the crash-loop breaker must not have counted anything.
+    assert "last_crash_line" not in slot.metadata
+    assert "load_failures" not in slot.metadata
+    assert slot.metadata.get("breaker") is None
+    assert sm._load_failures == {}
+
+
+async def test_real_crash_still_reads_error(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """systemd's terminal verdict (a genuinely failed unit) keeps the red
+    ERROR — #2130 must not blunt the #1791/#2126 crash reporting."""
+    sm = SlotManager()
+    await _load_ready(sm)
+
+    container_stub.active.discard("chat")
+    container_stub.unit_failure_by_slot["chat"] = _CRASH_REASON
+
+    slot = await sm.status("chat")
+
+    assert slot.state == SlotState.ERROR
+    assert slot.metadata.get("message") == _CRASH_REASON
+
+
+async def test_cached_error_converges_once_unit_reads_deliberately_stopped(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """#2130 second half: the ERROR was sticky. An operator who ran
+    ``systemctl reset-failed`` (or whose unit shows the plain SIGTERM-stop
+    signature) and re-checked was told the problem was still there — the
+    cached state never re-derived from the unit. With positive
+    "deliberately stopped" evidence the display must converge to OFFLINE."""
+    sm = SlotManager()
+    await _load_ready(sm)
+
+    # First: the pre-fix failure shape stamps a cached ERROR.
+    container_stub.active.discard("chat")
+    container_stub.unit_failure_by_slot["chat"] = _CRASH_REASON
+    slot = await sm.status("chat")
+    assert slot.state == SlotState.ERROR
+
+    # The operator's remediation: `systemctl reset-failed` → the unit now
+    # reads inactive/Result=success, i.e. deliberately stopped.
+    container_stub.unit_failure_by_slot.pop("chat")
+    container_stub.stopped_cleanly.add("chat")
+
+    slot = await sm.status("chat")
+
+    assert slot.state == SlotState.OFFLINE
+    # Durable too — the persisted record converged, not just the snapshot.
+    assert sm._current_state("chat") == SlotState.OFFLINE
+
+
+async def test_cached_error_stays_without_positive_evidence(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """An inconclusive probe (no failure reason, but no clean-stop evidence
+    either — e.g. a unit mid-restart between crashes, or a removed unit)
+    must never retire a cached ERROR: absence of evidence is not OFFLINE."""
+    sm = SlotManager()
+    await _load_ready(sm)
+
+    container_stub.active.discard("chat")
+    container_stub.unit_failure_by_slot["chat"] = _CRASH_REASON
+    slot = await sm.status("chat")
+    assert slot.state == SlotState.ERROR
+
+    # Probe goes silent, but nothing positively says "stopped on purpose".
+    container_stub.unit_failure_by_slot.pop("chat")
+
+    slot = await sm.status("chat")
+
+    assert slot.state == SlotState.ERROR
+    # The crash verdict (operator-facing message) survives untouched.
+    assert slot.metadata.get("message") == _CRASH_REASON


### PR DESCRIPTION
Fixes #2130

## Root cause

Two halves, both confirmed in the source:

1. **The generated Quadlet unit never told systemd that SIGTERM is a normal way to end.** The renderer emits `Restart=always` + `RestartPreventExitStatus=64 132` but no `SuccessExitStatus` (`src/hal0/providers/container.py`, the `[Service]` block). `systemctl stop` sends SIGTERM; podman propagates the container's graceful shutdown as its own exit **code** 143 (128+15), not a signal death, so systemd records `status=143 … Failed with result 'exit-code'` and parks the unit in `failed`. `SlotManager.status()`'s drift reconciler then asks `unit_failure_reason()`, reads the terminal `ActiveState=failed`, and stamps a red ERROR — on every slot the documented `migrate-flags --apply --stop-services` path stopped (that path runs a bare `systemctl stop`, `src/hal0/cli/slot_commands.py:1131`, never the manager's teardown, which does `reset-failed` for exactly this reason).

2. **The stamped ERROR was sticky.** `systemctl reset-failed` fixed systemd's view, but no `status()` branch ever re-derived a cached ERROR from an inactive unit — only a full `hal0 slot load` cleared the display.

## Fix — why these layers

- **Unit file** (`SuccessExitStatus=143`): the issue's suggested fix and the correct root-cause layer — a requested stop now ends `inactive`/`Result=success`. Restart semantics are untouched: `Restart=always` restarts on success and failure alike (and never during a requested stop job), and 64/132 stay terminal via `RestartPreventExitStatus`.
- **Root-side seam** (`installer/wrappers/hal0-systemctl`): the write-quadlet validator's `[Service]` key set is CLOSED (#1740) — without allow-listing `SuccessExitStatus=` every rendered unit would be rejected on a provisioned box and no slot could load. Pinned to the same bounded bare-exit-status list as `RestartPreventExitStatus=` (signal names/ranges refused), same commit-together precedent as #2126's widening.
- **State mapper** (`unit_failure_reason` recognises `failed` + `Result=exit-code` + `ExecMainStatus=143` as a deliberate stop): version-skew-proof half — deployed boxes keep their old unit text until the next load rerenders it. Narrow by design: a unit that burned its restart ramp dying 143 lands in `Result=start-limit-hit` and is still reported as crash-looping; 64 (usage), 132 (SIGILL), and every other exit code stay failures.
- **Convergence** (new `ContainerProvider.unit_stopped_cleanly` probe + a `status()` branch for `ERROR` + inactive): a cached ERROR is retired to OFFLINE only on **positive** evidence of a deliberate end (`inactive`/`Result=success` — a clean stop or `reset-failed` — or the pre-directive SIGTERM signature). Absence of evidence never clears an ERROR, so a crash-looping unit (`activating` between restarts), a usage-exit, a removed unit (the #1922 output-sanity teardown shape, `LoadState=not-found`), or an unprobeable double all keep the ERROR, the crash-loop breaker bookkeeping, and the `last_crash_line` evidence intact. A clean stop never bumps `load_failures`, never trips the breaker, never stamps a crash line (pinned by test). #2221's usage-exit crash-line gap is untouched (exit 64 stays a failure with its existing reporting).

An intent-flag approach (record "stopping on purpose" before the stop) was rejected: the reported repro is an *external* stop (`systemctl stop` by the operator or migrate-flags), which no manager-side flag can see — the unit's own properties are the only truth both paths share.

## Test evidence

New pins:
- `tests/slots/test_clean_stop_reconcile.py` — deliberate stop → OFFLINE with no crash bookkeeping; real crash → still ERROR; cached ERROR converges once the unit reads deliberately stopped; cached ERROR stays without positive evidence.
- `tests/providers/test_container_unit_failure.py` — SIGTERM-stop signature is silent; a 143 crash-loop (`start-limit-hit`) still reports; `unit_stopped_cleanly` recognise/refuse matrices (9 negative shapes incl. exit 64/132, `activating`, `not-found`, empty probe).
- `tests/providers/test_container.py` — `SuccessExitStatus=143` renders in `[Service]`.
- `tests/installer/test_systemctl_quadlet_validation.py` — `SuccessExitStatus=143` accepted; `SIGTERM` / `0-255` / `1430` refused.

```
uv run pytest tests/slots tests/providers/test_container.py tests/providers/test_container_unit_failure.py -q
1163 passed
uv run pytest tests/slots tests/providers -q
1847 passed, 2 failed — the 2 failures are tests/providers/test_moonshine_server.py 415-payload cases,
which fail identically on clean main on this host (no ffmpeg); unrelated.
Full unit tier (pytest -m "not integration"): 12465 passed, 231 failed — the 231 fail identically on the
parent main commit on this macOS host (bash 3.2 lacks `mapfile` for the wrapper suites, no ffmpeg, no
cosign); spot-verified per-file counts match main exactly.
```

The wrapper suite cannot run on this macOS host, so the seam change was verified through the **real** wrapper under bash 5.3: `_render_quadlet_from_plan` output (carrying `SuccessExitStatus=143`) → `check-quadlet` → rc 0 with byte-identical reconstruction; `SuccessExitStatus=SIGTERM`/`0-255`/`1430` → rc 64. Linux CI runs the suite proper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181rff5wtNoioAHumZsYCD4