### PR TITLE
fix(capabilities): gate the rocm backend tag on available_backends() (#2029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Fixed
 
+- The capability catalog no longer advertises a `gpu-rocm` backend for
+  registry models on hosts that cannot run it. The `rocm` tag branch in
+  `_backend_variants` appended `gpu-rocm` unconditionally — no
+  `available_backends()` intersection, unlike its vulkan/llama-server and
+  provider-runtime siblings — so every `hal0 model add`-registered GGUF
+  (which carries `rocm` in its default backend tags) surfaced an unrunnable
+  `gpu-rocm` entry at `fit_status: allowed` on kfd-less hosts. The branch now
+  applies the same host intersection: no compute-capable AMD GPU, no
+  advertised ROCm lane. The deliberate `qwen3-tts` voice.tts engine row is
+  injected separately and is unaffected. (#2029)
 - The model drawer's flags divergence (`diffFlags` — the raw-mode diff, tune
   pills, profile apply preview and seed consequence preview all consume it) now
   matches pairs through the full llama-server alias table (`FLAG_ALIASES`)

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -495,7 +495,17 @@ def _backend_variants(entry: Any) -> list[str]:
                 if candidate in host_backends and candidate not in out:
                     out.append(candidate)
         elif low in {"rocm", "gpu-rocm"}:
-            if "gpu-rocm" not in out:
+            # Same host-presence intersection as the llamacpp fan-out and
+            # ``_RUNTIME_TO_HOST_BACKENDS`` branches (#2029): on a kfd-less
+            # host ``available_backends()`` omits gpu-rocm ("GPU/ROCm only
+            # when the GPU is compute_capable"), so a raw "rocm" tag —
+            # every ``hal0 model add`` GGUF carries one via
+            # ``_GGUF_BACKENDS`` — must not advertise a lane the host
+            # cannot run. (The voice.tts qwen3-tts row is unaffected: it
+            # is injected by ``_tts_rows_for_capability``, not this
+            # fan-out.)
+            host_backends = {b["id"] for b in available_backends()}
+            if "gpu-rocm" in host_backends and "gpu-rocm" not in out:
                 out.append("gpu-rocm")
         elif low in {"cpu"}:
             if "cpu" not in out:

--- a/tests/capabilities/test_provider_field.py
+++ b/tests/capabilities/test_provider_field.py
@@ -183,6 +183,66 @@ def test_runs_on_for_model_non_empty_for_empty_backends_llama_row(
     assert model_to_dict(m)["runs_on"] == ["gpu-vulkan", "cpu"]
 
 
+# ── rocm tag host gate (#2029) ────────────────────────────────────────────────
+#
+# The ``elif low in {"rocm", "gpu-rocm"}`` tag branch used to append gpu-rocm
+# unconditionally, with no ``available_backends()`` intersection. Every
+# ``hal0 model add`` GGUF gets ``backends=["vulkan","rocm","cuda","cpu"]``
+# (``registry.detect._GGUF_BACKENDS``), so on a kfd-less host each user-added
+# model advertised a gpu-rocm lane at fit_status: allowed that
+# require_kfd_for_gpu_slot then refused at load time. The rocm branch must go
+# through the same host intersection as its llamacpp / runtime-map siblings.
+
+
+def test_backend_variants_rocm_tag_gated_off_kfdless_host(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Host with no compute_capable GPU: available_backends() omits gpu-rocm.
+    # A registry GGUF's default tag list must not leak a gpu-rocm lane.
+    monkeypatch.setattr(catalog, "available_backends", lambda: _hosts("gpu-vulkan", "cpu"))
+    monkeypatch.setattr(catalog, "host_is_amd_gpu", lambda: True)
+    m = Model(
+        id="added-a",
+        path=str(tmp_path / "added-a.gguf"),
+        backends=["vulkan", "rocm", "cuda", "cpu"],
+    )
+    variants = catalog._backend_variants(m)
+    assert "gpu-rocm" not in variants, f"kfd-less host must not advertise gpu-rocm: {variants!r}"
+    assert variants == ["gpu-vulkan", "cpu"]
+
+
+def test_backend_variants_bare_rocm_tag_gated_off_kfdless_host(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A rocm-only tag on a host without gpu-rocm yields no lanes at all —
+    # consistent with how a vulkan-only tag behaves on a GPU-less host.
+    monkeypatch.setattr(catalog, "available_backends", lambda: _hosts("cpu"))
+    monkeypatch.setattr(catalog, "host_is_amd_gpu", lambda: False)
+    m = Model(id="rocm-only", path=str(tmp_path / "rocm-only.gguf"), backends=["rocm"])
+    assert catalog._backend_variants(m) == []
+
+
+def test_backend_variants_rocm_tag_kept_on_kfd_host(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # kfd-present AMD host: behaviour unchanged — gpu-rocm first (via the
+    # llamacpp fan-out's AMD ordering), vulkan and cpu beside it.
+    monkeypatch.setattr(
+        catalog, "available_backends", lambda: _hosts("gpu-rocm", "gpu-vulkan", "cpu")
+    )
+    monkeypatch.setattr(catalog, "host_is_amd_gpu", lambda: True)
+    m = Model(
+        id="added-b",
+        path=str(tmp_path / "added-b.gguf"),
+        backends=["vulkan", "rocm", "cuda", "cpu"],
+    )
+    assert catalog._backend_variants(m) == ["gpu-rocm", "gpu-vulkan", "cpu"]
+
+    # And a bare rocm tag still advertises the lane when the host has it.
+    bare = Model(id="rocm-bare", path=str(tmp_path / "rocm-bare.gguf"), backends=["rocm"])
+    assert catalog._backend_variants(bare) == ["gpu-rocm"]
+
+
 def test_backend_variants_qwen3tts_yields_gpu_rocm(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/capabilities/test_vision_mmproj_autosurface.py
+++ b/tests/capabilities/test_vision_mmproj_autosurface.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from hal0.capabilities import catalog
 from hal0.capabilities.catalog import _model_capabilities, models_for_capability
 from hal0.registry.model import Model
 from hal0.registry.store import ModelRegistry
@@ -36,7 +39,14 @@ def test_mmproj_model_advertises_vision_keeping_chat(tmp_path: Path) -> None:
     assert "vision" in caps, f"vision must be auto-surfaced from the sidecar: {caps}"
 
 
-def test_mmproj_model_listed_under_vision_capability(tmp_path: Path) -> None:
+def test_mmproj_model_listed_under_vision_capability(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Pin the host backends: this fixture's gpu-rocm tag only produces a
+    # row when the host advertises gpu-rocm (#2029 gated the rocm tag on
+    # available_backends()), and this test is about mmproj→vision
+    # surfacing, not host hardware.
+    monkeypatch.setattr(catalog, "available_backends", lambda: [{"id": "gpu-rocm"}, {"id": "cpu"}])
     reg = _reg(tmp_path)
     reg.add(
         Model(


### PR DESCRIPTION
Fixes #2029

## Root cause

`src/hal0/capabilities/catalog.py::_backend_variants`'s `elif low in {"rocm", "gpu-rocm"}` tag branch appended `gpu-rocm` unconditionally — no `available_backends()` intersection — while its siblings (the vulkan/llama-server fan-out and the `_RUNTIME_TO_HOST_BACKENDS` provider-runtime branch) both gate on host truth. Since `registry/detect.py::_GGUF_BACKENDS` tags every `hal0 model add` GGUF with `["vulkan", "rocm", "cuda", "cpu"]`, 100% of user-added GGUFs advertised a `gpu-rocm` backend at `fit_status: allowed` on hosts whose `available_backends()` correctly omits it (no compute-capable AMD GPU / no `/dev/kfd`). Selecting the entry then failed loudly at load in `require_kfd_for_gpu_slot`.

## Before / after

Kfd-less host, `hal0 model add`-registered GGUF (`backends=["vulkan","rocm","cuda","cpu"]`):

- Before: `_backend_variants` → `["gpu-vulkan", "cpu", "gpu-rocm"]` — trailing unrunnable entry, surfaced in `/api/capabilities` at `fit_status: allowed`.
- After: `["gpu-vulkan", "cpu"]` — matches `available_backends()` exactly, per the issue's Expected.

Kfd-present AMD host: unchanged — the llamacpp fan-out already emits `gpu-rocm` first there (ROCm-first ordering from #1948 is untouched), and the tag branch remains a dedupe no-op.

Deliberately out of scope, verified unaffected: the `voice.tts` `qwen3-tts` two-engine row is injected by `_tts_rows_for_capability` / `_TTS_ENGINES`, not this fan-out (known-issue `tts-catalog-lists-qwen3-on-gpu-rocm-regardless-of-host` stays by-design). The arch-aware fit check and GTT feasibility path (`evaluate_model_fit`) are untouched.

One test needed adjusting: `tests/capabilities/test_vision_mmproj_autosurface.py::test_mmproj_model_listed_under_vision_capability` used a `backends=["gpu-rocm"]` fixture that silently relied on the ungated append (and was host-dependent as a result); it now pins `available_backends` explicitly — its subject is mmproj→vision surfacing, not backend gating.

## Test evidence

New tests in `tests/capabilities/test_provider_field.py`:

- `test_backend_variants_rocm_tag_gated_off_kfdless_host` — full `_GGUF_BACKENDS` tag list on a host without `gpu-rocm` → `["gpu-vulkan", "cpu"]`, no `gpu-rocm`.
- `test_backend_variants_bare_rocm_tag_gated_off_kfdless_host` — rocm-only tag on a CPU-only host → `[]` (consistent with vulkan-only on a GPU-less host).
- `test_backend_variants_rocm_tag_kept_on_kfd_host` — kfd-present AMD host → `["gpu-rocm", "gpu-vulkan", "cpu"]` unchanged; bare rocm tag still yields `["gpu-rocm"]`.

Runs (all green):

- `uv run pytest tests/capabilities -q` — 103 passed
- `uv run pytest tests/registry tests/api -k "catalog or backend or fit" -q` — 84 passed, 2415 deselected
- `uv run pytest tests/cli/test_capabilities_commands.py tests/dispatcher/test_router.py tests/slots/test_manager_npu_container.py tests/mcp/test_memory.py -q` — 86 passed
- `uv run ruff check` / `ruff format --check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181rff5wtNoioAHumZsYCD4