### PR TITLE
fix(capabilities): reject enabled apply of undownloaded weights with typed 409

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,19 @@ applying. Add those subsections to a version's section to surface them; see
   mental-model refresh-schedule picker, which silently discarded whatever the
   operator picked (`useMentalModelCreate` sends only `{name, source_query}`),
   was removed rather than left inert. (#2107)
-
+- A capability apply naming a model whose weights are not on disk
+  (`downloaded: false` in the picker catalog, e.g. a pullable-but-never-pulled
+  row, or a registry entry whose file vanished) is now rejected up front with a
+  typed 409 `capability.model_not_downloaded` naming the
+  `POST /api/models/{id}/pull` remediation — before anything is persisted and
+  before any container is spawned. Previously the orchestrator went straight to
+  `SlotManager.load`, launched llama-server with the bare model id as
+  `--model` (instant `failed to open GGUF file` crash loop), blocked the apply
+  for the full ~3 min health-wait, and then returned HTTP 200 `"warming"`.
+  Disabling a selection whose weights vanished still always succeeds, and
+  picking a model while the child is disabled remains legal staging — the gate
+  arms on enable. NPU-trio selections are exempt (they toggle the FLM anchor,
+  never spawn a bare-id process). (#2026)
 - The model drawer's flags divergence (`diffFlags` — the raw-mode diff, tune
   pills, profile apply preview and seed consequence preview all consume it) now
   matches pairs through the full llama-server alias table (`FLAG_ALIASES`)

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -50,7 +50,7 @@ from hal0.config import paths
 from hal0.config.loader import load_slot_config, write_toml_atomic
 from hal0.config.locking import file_lock
 from hal0.dispatcher._npu_common import is_container_npu_cfg
-from hal0.errors import BadRequest, Hal0Error, NotFound
+from hal0.errors import BadRequest, Conflict, Hal0Error, NotFound
 from hal0.model_fit import evaluate_model_fit
 from hal0.model_meta import canonical_device
 from hal0.profiles import ProfileCatalog, ResolvedProfile
@@ -477,9 +477,19 @@ class CapabilityOrchestrator:
 
         # Validate the model against the catalog when one is set + the
         # caller didn't explicitly clear it. We don't fail when the model
-        # is empty — that's the "unset" state.
+        # is empty — that's the "unset" state. The downloaded gate only
+        # arms when the selection is (or stays) enabled: disabling a
+        # selection whose weights vanished must always succeed, and
+        # picking a model while the child is off is legal staging — the
+        # gate fires when the operator flips it on (#2026).
         if merged.model:
-            self._validate_model_in_catalog(slot, child, merged.model, merged.device)
+            self._validate_model_in_catalog(
+                slot,
+                child,
+                merged.model,
+                merged.device,
+                require_downloaded=merged.enabled,
+            )
 
         # ── reconcile + persist (issue #697) ──────────────────────────────
         # The SlotConfigStore computes the post-state of BOTH
@@ -605,6 +615,8 @@ class CapabilityOrchestrator:
         child: str,
         model_id: str,
         backend_id: str,
+        *,
+        require_downloaded: bool = False,
     ) -> None:
         # NOTE: ``backend_id`` is named for back-compat with v0.1.x call
         # sites; in v0.2 it carries a ``device`` value (gpu-rocm etc).
@@ -612,7 +624,7 @@ class CapabilityOrchestrator:
         # source-only.
         """Reject the merged selection if it's illegal against the catalog.
 
-        Two distinct failure modes:
+        Three distinct failure modes:
 
           1. ``model_id`` isn't advertised at all for this capability →
              :class:`NotFound` ``capability.unknown_model``. Likely a
@@ -628,6 +640,23 @@ class CapabilityOrchestrator:
              prevent (e.g. picking ``backend=npu`` with a llama.cpp GGUF
              which then crashes FLM at start-up with "Model not found").
 
+          3. ``require_downloaded`` is set (the merged selection is
+             enabled → the lifecycle below WILL load/swap the slot) and
+             the picked (model, backend) row advertises
+             ``downloaded: false`` → :class:`Conflict`
+             ``capability.model_not_downloaded``, raised BEFORE anything
+             is persisted or spawned. Without this gate the slot was
+             launched with the bare model id as ``--model``, llama-server
+             died with "failed to open GGUF file", and the apply blocked
+             for the full crash-loop dwell before answering 200
+             "warming" (#2026). The details name the ``POST
+             /api/models/{id}/pull`` remediation when the row is
+             pullable. ``backend_id == "npu"`` is exempt: NPU-trio
+             selections never spawn a standalone process (they toggle
+             the FLM anchor and return ``pending_reload``), and FLM
+             weights are pulled through ``flm pull``, not the registry
+             pull path.
+
         Empty ``backend_id`` skips the pair check — backend is allowed
         to be unset transiently while the user is still mid-selection;
         the slot lifecycle won't start until a backend lands anyway.
@@ -639,6 +668,8 @@ class CapabilityOrchestrator:
         match = next((row for row in rows if row["id"] == model_id), None)
         if match is None:
             if self._registry is not None and self._registry.has(model_id):
+                if require_downloaded and backend_id != "npu":
+                    self._require_registry_weights_present(slot, child, model_id, backend_id)
                 return
             raise NotFound(
                 f"model {model_id!r} not advertised for {slot}.{child}",
@@ -660,6 +691,19 @@ class CapabilityOrchestrator:
                     "legal_backends": legal_backends,
                 },
             )
+        if require_downloaded and backend_id != "npu":
+            backend_row = next(
+                (b for b in match.get("backends", []) if b.get("id") == backend_id),
+                None,
+            )
+            if backend_row is not None and backend_row.get("downloaded", True) is False:
+                self._raise_model_not_downloaded(
+                    slot,
+                    child,
+                    model_id,
+                    backend_id,
+                    pullable=bool(backend_row.get("pullable")),
+                )
         slot_type = _CAPABILITY_TO_SLOT_TYPE.get(capability)
         if slot_type is None:
             return
@@ -697,6 +741,79 @@ class CapabilityOrchestrator:
                 code="capability.illegal_model_fit",
                 details=details,
             )
+
+    def _require_registry_weights_present(
+        self,
+        slot: str,
+        child: str,
+        model_id: str,
+        backend_id: str,
+    ) -> None:
+        """Downloaded gate for the permissive registry-only fallback (#2026).
+
+        A model the curated catalog doesn't advertise is accepted when the
+        registry knows it — but an enabled selection must still not launch
+        a slot whose weights aren't on disk. Stays permissive on any
+        registry read error: this path exists precisely because the
+        catalog isn't authoritative for user-added models.
+        """
+        if self._registry is None:  # defensive; caller checked has()
+            return
+        try:
+            entry = self._registry.get(model_id)
+        except Exception:
+            return
+        path = getattr(entry, "path", None)
+        if isinstance(path, str) and path:
+            try:
+                if Path(path).exists():
+                    return
+            except OSError:
+                pass
+        pullable = bool(
+            (getattr(entry, "hf_repo", "") or "").strip()
+            and (getattr(entry, "hf_filename", "") or "").strip()
+        )
+        self._raise_model_not_downloaded(slot, child, model_id, backend_id, pullable=pullable)
+
+    def _raise_model_not_downloaded(
+        self,
+        slot: str,
+        child: str,
+        model_id: str,
+        backend_id: str,
+        *,
+        pullable: bool,
+    ) -> None:
+        """Raise the typed 409 for an enabled selection with absent weights.
+
+        Named after the rc-validate register key
+        ``capability-apply-skips-model-pull`` (#2026): apply must reject
+        before any container is spawned, naming the pull remediation,
+        instead of launching llama-server with the bare model id and
+        blocking through the crash-loop dwell.
+        """
+        remediation = (
+            f"POST /api/models/{model_id}/pull, then re-apply once the pull completes"
+            if pullable
+            else "stage the weights on disk and register them, then re-apply"
+        )
+        details: dict[str, Any] = {
+            "slot": slot,
+            "child": child,
+            "model": model_id,
+            "backend": backend_id,
+            "downloaded": False,
+            "pullable": pullable,
+            "remediation": remediation,
+        }
+        if pullable:
+            details["pull_endpoint"] = f"/api/models/{model_id}/pull"
+        raise Conflict(
+            f"weights for model {model_id!r} are not downloaded — {remediation}",
+            code="capability.model_not_downloaded",
+            details=details,
+        )
 
     def _profile_for_fit(self, capability: str, device: str) -> ResolvedProfile | None:
         """Infer the runtime profile implied by a capability selection.

--- a/tests/capabilities/test_apply_model_not_downloaded.py
+++ b/tests/capabilities/test_apply_model_not_downloaded.py
@@ -1,0 +1,298 @@
+"""Downloaded gate for capability apply (#2026).
+
+rc-validate register key ``capability-apply-skips-model-pull``: a
+capability apply naming a catalog row whose weights are NOT on disk
+(``downloaded: false``) used to go straight to ``SlotManager.load`` —
+llama-server was spawned with the bare model id as ``--model``, died
+with "failed to open GGUF file", the apply blocked for the full
+~180 s crash-loop dwell, and then answered HTTP 200 ``"warming"``.
+
+These tests pin the fixed contract:
+
+  - enabled selection + undownloaded catalog row → typed 409
+    ``capability.model_not_downloaded`` naming the
+    ``POST /api/models/{id}/pull`` remediation, raised BEFORE anything
+    is persisted or any lifecycle call fires;
+  - unknown model name → 404 ``capability.unknown_model`` (pre-existing,
+    pinned here against regressions), never a slot launch;
+  - downloaded row → the happy path is unchanged (slot loads);
+  - disabling / staging-while-disabled never trips the gate — you can
+    always turn a broken selection off, and picking a model before
+    enabling is legal (the gate fires on the enable).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.capabilities.orchestrator import CapabilityOrchestrator
+from hal0.errors import Conflict, NotFound
+from tests.capabilities.test_orchestrator_reconciliation import FakeSlotManager
+
+
+@pytest.fixture(autouse=True)
+def _no_spawn_context_refresh(monkeypatch):
+    import hal0.agents.hermes_refresh as _hr
+
+    monkeypatch.setattr(_hr, "spawn_context_refresh", lambda *a, **k: None)
+
+
+def _catalog_rows(*, downloaded: bool, pullable: bool = True) -> list[dict[str, Any]]:
+    """One embed model advertised on gpu-vulkan, shaped like models_for_capability."""
+    return [
+        {
+            "id": "bge-base-en-v1.5-q4_k_m",
+            "capabilities": ["embed"],
+            "size_gb": 0.1,
+            "backends": [
+                {
+                    "id": "gpu-vulkan",
+                    "provider": "llama-server",
+                    "downloaded": downloaded,
+                    "pullable": pullable,
+                }
+            ],
+        }
+    ]
+
+
+@pytest.fixture
+def home(tmp_hal0_home: str) -> Path:
+    """Minimal on-disk state: an embed slot TOML, no capabilities.toml."""
+    home = Path(tmp_hal0_home)
+    slots_dir = home / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "embed.toml").write_text(
+        "\n".join(
+            [
+                'name = "embed"',
+                "port = 8082",
+                'backend = "vulkan"',
+                'provider = "llama-server"',
+                "[model]",
+                'default = "bge-base-en-v1.5-q4_k_m"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return home
+
+
+def _patch_catalog(monkeypatch: pytest.MonkeyPatch, rows: list[dict[str, Any]]) -> None:
+    monkeypatch.setattr(
+        "hal0.capabilities.orchestrator.models_for_capability",
+        lambda capability, registry=None: rows,
+    )
+
+
+def _apply_body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "enabled": True,
+        "backend": "gpu-vulkan",
+        "provider": "llama-server",
+        "model": "bge-base-en-v1.5-q4_k_m",
+    }
+    body.update(overrides)
+    return body
+
+
+async def test_enabled_apply_of_undownloaded_row_is_409_and_spawns_nothing(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_catalog(monkeypatch, _catalog_rows(downloaded=False, pullable=True))
+    fake = FakeSlotManager()
+    orch = CapabilityOrchestrator(slot_manager=fake)
+
+    with pytest.raises(Conflict) as exc:
+        await orch.apply("embed", "embed", _apply_body())
+
+    assert exc.value.status == 409
+    assert exc.value.code == "capability.model_not_downloaded"
+    details = exc.value.details
+    assert details["model"] == "bge-base-en-v1.5-q4_k_m"
+    assert details["downloaded"] is False
+    assert details["pullable"] is True
+    # The remediation names the pull job endpoint the operator must hit.
+    assert details["pull_endpoint"] == "/api/models/bge-base-en-v1.5-q4_k_m/pull"
+    assert "/api/models/bge-base-en-v1.5-q4_k_m/pull" in str(exc.value)
+
+    # No lifecycle call fired — most importantly no load/swap/create that
+    # would spawn llama-server with the bare model id.
+    lifecycle = [c for c in fake.calls if c[0] in {"load", "swap", "create", "unload"}]
+    assert lifecycle == [], f"unexpected lifecycle calls: {fake.calls}"
+
+    # Nothing was persisted: the gate rejects before the store commit, so
+    # capabilities.toml never materialises and the slot TOML is untouched.
+    assert not (home / "etc" / "hal0" / "capabilities.toml").exists()
+    with open(home / "etc" / "hal0" / "slots" / "embed.toml", "rb") as f:
+        on_disk = tomllib.load(f)
+    assert on_disk.get("backend") == "vulkan"
+
+
+async def test_unpullable_undownloaded_row_409_without_pull_endpoint(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_catalog(monkeypatch, _catalog_rows(downloaded=False, pullable=False))
+    fake = FakeSlotManager()
+    orch = CapabilityOrchestrator(slot_manager=fake)
+
+    with pytest.raises(Conflict) as exc:
+        await orch.apply("embed", "embed", _apply_body())
+
+    assert exc.value.code == "capability.model_not_downloaded"
+    assert exc.value.details["pullable"] is False
+    assert "pull_endpoint" not in exc.value.details
+    assert [c for c in fake.calls if c[0] == "load"] == []
+
+
+async def test_unknown_model_is_404_and_spawns_nothing(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_catalog(monkeypatch, _catalog_rows(downloaded=True))
+    fake = FakeSlotManager()
+    orch = CapabilityOrchestrator(slot_manager=fake)
+
+    with pytest.raises(NotFound) as exc:
+        await orch.apply("embed", "embed", _apply_body(model="no-such-model"))
+
+    assert exc.value.status == 404
+    assert exc.value.code == "capability.unknown_model"
+    assert [c for c in fake.calls if c[0] in {"load", "swap", "create"}] == []
+
+
+async def test_downloaded_row_happy_path_unchanged(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_catalog(monkeypatch, _catalog_rows(downloaded=True))
+    fake = FakeSlotManager()
+    orch = CapabilityOrchestrator(slot_manager=fake)
+
+    result = await orch.apply("embed", "embed", _apply_body())
+
+    loads = [c for c in fake.calls if c[0] == "load"]
+    assert loads == [("load", "embed", {"model_id": "bge-base-en-v1.5-q4_k_m"})]
+    assert result["enabled"] is True
+    assert result["model"] == "bge-base-en-v1.5-q4_k_m"
+
+
+async def test_disable_never_trips_the_downloaded_gate(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Turning a selection off must succeed even when its weights vanished."""
+    _patch_catalog(monkeypatch, _catalog_rows(downloaded=False))
+    caps_path = home / "etc" / "hal0" / "capabilities.toml"
+    caps_path.write_text(
+        "\n".join(
+            [
+                "[selections.embed.embed]",
+                'backend = "gpu-vulkan"',
+                'provider = "llama-server"',
+                'model = "bge-base-en-v1.5-q4_k_m"',
+                "enabled = true",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake = FakeSlotManager()
+    orch = CapabilityOrchestrator(slot_manager=fake)
+
+    result = await orch.apply("embed", "embed", {"enabled": False})
+
+    assert result["enabled"] is False
+    assert [c for c in fake.calls if c[0] == "unload"], "expected an unload"
+
+
+async def test_staging_model_while_disabled_is_allowed(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Picking an undownloaded model with enabled=false persists (no spawn)."""
+    _patch_catalog(monkeypatch, _catalog_rows(downloaded=False))
+    fake = FakeSlotManager()
+    orch = CapabilityOrchestrator(slot_manager=fake)
+
+    result = await orch.apply("embed", "embed", _apply_body(enabled=False))
+
+    assert result["enabled"] is False
+    assert result["model"] == "bge-base-en-v1.5-q4_k_m"
+    assert [c for c in fake.calls if c[0] in {"load", "swap"}] == []
+
+
+def test_npu_backend_is_exempt_from_the_downloaded_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NPU-trio selections toggle the FLM anchor; they never spawn a bare-id
+    llama-server, and FLM weights pull via ``flm pull``, not the registry."""
+    monkeypatch.setattr(
+        "hal0.capabilities.orchestrator.models_for_capability",
+        lambda capability, registry=None: [
+            {
+                "id": "flm-embedder",
+                "capabilities": ["embed"],
+                "backends": [{"id": "npu", "downloaded": False, "pullable": True}],
+            }
+        ],
+    )
+    orch = CapabilityOrchestrator(slot_manager=FakeSlotManager())  # type: ignore[arg-type]
+    # Must not raise despite downloaded=False.
+    orch._validate_model_in_catalog(
+        "embed", "embed", "flm-embedder", "npu", require_downloaded=True
+    )
+
+
+def test_registry_only_model_with_missing_weights_is_409(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The permissive registry fallback still gates on weights-on-disk."""
+
+    class FakeEntry:
+        path = str(tmp_path / "gone.gguf")  # never created
+        hf_repo = "org/repo"
+        hf_filename = "gone.gguf"
+
+    class FakeRegistry:
+        def has(self, model_id: str) -> bool:
+            return model_id == "user-model"
+
+        def get(self, model_id: str) -> FakeEntry:
+            return FakeEntry()
+
+    monkeypatch.setattr(
+        "hal0.capabilities.orchestrator.models_for_capability",
+        lambda capability, registry=None: [],
+    )
+    orch = CapabilityOrchestrator(
+        slot_manager=FakeSlotManager(),  # type: ignore[arg-type]
+        registry=FakeRegistry(),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(Conflict) as exc:
+        orch._validate_model_in_catalog(
+            "embed", "embed", "user-model", "gpu-vulkan", require_downloaded=True
+        )
+    assert exc.value.code == "capability.model_not_downloaded"
+    assert exc.value.details["pullable"] is True
+
+    # And with the weights actually present the same selection passes.
+    present = tmp_path / "here.gguf"
+    present.write_bytes(b"gguf")
+
+    class FakeEntryPresent(FakeEntry):
+        path = str(present)
+
+    class FakeRegistryPresent(FakeRegistry):
+        def get(self, model_id: str) -> FakeEntry:
+            return FakeEntryPresent()
+
+    orch2 = CapabilityOrchestrator(
+        slot_manager=FakeSlotManager(),  # type: ignore[arg-type]
+        registry=FakeRegistryPresent(),  # type: ignore[arg-type]
+    )
+    orch2._validate_model_in_catalog(
+        "embed", "embed", "user-model", "gpu-vulkan", require_downloaded=True
+    )

--- a/tests/capabilities/test_npu_phase2_integration.py
+++ b/tests/capabilities/test_npu_phase2_integration.py
@@ -93,7 +93,7 @@ async def test_npu_phase2_embed_enable_end_to_end(
     monkeypatch.setattr(
         CapabilityOrchestrator,
         "_validate_model_in_catalog",
-        lambda self, slot, child, model_id, backend_id: None,
+        lambda self, slot, child, model_id, backend_id, **kw: None,
     )
     home = Path(tmp_hal0_home)
     slots_dir = home / "etc" / "hal0" / "slots"

--- a/tests/capabilities/test_orchestrator_reconciliation.py
+++ b/tests/capabilities/test_orchestrator_reconciliation.py
@@ -164,7 +164,7 @@ def orchestrator(
     monkeypatch.setattr(
         CapabilityOrchestrator,
         "_validate_model_in_catalog",
-        lambda self, slot, child, model_id, backend_id: None,
+        lambda self, slot, child, model_id, backend_id, **kw: None,
     )
     fake = FakeSlotManager()
     orch = CapabilityOrchestrator(slot_manager=fake)
@@ -216,7 +216,7 @@ async def test_apply_reconciles_before_load(
     monkeypatch.setattr(
         CapabilityOrchestrator,
         "_validate_model_in_catalog",
-        lambda self, slot, child, model_id, backend_id: None,
+        lambda self, slot, child, model_id, backend_id, **kw: None,
     )
 
     class DiskPeekSlotManager(FakeSlotManager):
@@ -370,7 +370,7 @@ async def test_disable_hides_slot_from_routing(
     monkeypatch.setattr(
         CapabilityOrchestrator,
         "_validate_model_in_catalog",
-        lambda self, slot, child, model_id, backend_id: None,
+        lambda self, slot, child, model_id, backend_id, **kw: None,
     )
     home = Path(tmp_hal0_home)
     slots_dir = home / "etc" / "hal0" / "slots"
@@ -426,7 +426,7 @@ async def test_apply_lifecycle_failure_still_persists_intent(
     monkeypatch.setattr(
         CapabilityOrchestrator,
         "_validate_model_in_catalog",
-        lambda self, slot, child, model_id, backend_id: None,
+        lambda self, slot, child, model_id, backend_id, **kw: None,
     )
 
     class ExplodingSlotManager(FakeSlotManager):
@@ -561,7 +561,7 @@ def npu_orchestrator(
     monkeypatch.setattr(
         CapabilityOrchestrator,
         "_validate_model_in_catalog",
-        lambda self, slot, child, model_id, backend_id: None,
+        lambda self, slot, child, model_id, backend_id, **kw: None,
     )
     fake = FakeSlotManager()
     fake.set_configs(
@@ -820,7 +820,7 @@ async def test_npu_embed_anchor_offline_still_pending(
     monkeypatch.setattr(
         CapabilityOrchestrator,
         "_validate_model_in_catalog",
-        lambda self, slot, child, model_id, backend_id: None,
+        lambda self, slot, child, model_id, backend_id, **kw: None,
     )
     fake = FakeSlotManager()
     # No anchor record at all → "offline".
@@ -932,7 +932,7 @@ async def test_npu_embed_enable_container_anchor_without_external_runtime(
     monkeypatch.setattr(
         CapabilityOrchestrator,
         "_validate_model_in_catalog",
-        lambda self, slot, child, model_id, backend_id: None,
+        lambda self, slot, child, model_id, backend_id, **kw: None,
     )
     fake = FakeSlotManager()
     fake.set_configs(

--- a/tests/capabilities/test_stt_capability_switch.py
+++ b/tests/capabilities/test_stt_capability_switch.py
@@ -305,7 +305,7 @@ async def test_apply_npu_stt_drives_flm_trio_without_slot_spawn(
     monkeypatch.setattr(
         CapabilityOrchestrator,
         "_validate_model_in_catalog",
-        lambda self, slot, child, model_id, backend_id: None,
+        lambda self, slot, child, model_id, backend_id, **kw: None,
     )
     home = Path(tmp_hal0_home)
     slots_dir = home / "etc" / "hal0" / "slots"

--- a/ui/src/dash/__tests__/capability-selection-pure.test.ts
+++ b/ui/src/dash/__tests__/capability-selection-pure.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveProvider, rowId } from '../settings/pages/capabilities/selection-pure.js'
+import { resolveProvider, rowId, rowNeedsPull } from '../settings/pages/capabilities/selection-pure.js'
 
 describe('rowId', () => {
   it('prefers id, then model_id, then the bare value', () => {
@@ -22,5 +22,25 @@ describe('resolveProvider (#1470 semantics)', () => {
   })
   it('empty model resolves to empty provider', () => {
     expect(resolveProvider(catalog, '', selection)).toBe('')
+  })
+})
+
+describe('rowNeedsPull (#2026 semantics)', () => {
+  it('marks a row whose every backend is undownloaded', () => {
+    expect(rowNeedsPull({ id: 'm', backends: [
+      { id: 'gpu-vulkan', downloaded: false, pullable: true },
+      { id: 'cpu', downloaded: false, pullable: true },
+    ] })).toBe(true)
+  })
+  it('does not mark a row with at least one downloaded backend', () => {
+    expect(rowNeedsPull({ id: 'm', backends: [
+      { id: 'gpu-vulkan', downloaded: false },
+      { id: 'cpu', downloaded: true },
+    ] })).toBe(false)
+  })
+  it('never marks rows without a backends list (legacy fixtures, bare ids)', () => {
+    expect(rowNeedsPull({ id: 'm' })).toBe(false)
+    expect(rowNeedsPull({ id: 'm', backends: [] })).toBe(false)
+    expect(rowNeedsPull('bare')).toBe(false)
   })
 })

--- a/ui/src/dash/settings/pages/capabilities/selection-pure.js
+++ b/ui/src/dash/settings/pages/capabilities/selection-pure.js
@@ -15,3 +15,15 @@ export function resolveProvider(catalogItems, model, selection) {
   return row?.provider
     || (model && model === (selection?.model || "") ? selection?.provider : "") || ""
 }
+
+// #2026: ⬇ marker for pullable-but-absent catalog rows. A grouped picker row
+// is "not downloaded" when every backend it advertises reports
+// downloaded:false — applying it enabled can only 409
+// (capability.model_not_downloaded) until the weights are pulled from the
+// Models view. Rows without a backends list (legacy fixtures, free-text ids)
+// are never marked.
+export function rowNeedsPull(m) {
+  const backends = m?.backends
+  if (!Array.isArray(backends) || backends.length === 0) return false
+  return backends.every(b => b?.downloaded === false)
+}

--- a/ui/src/dash/settings/pages/capabilities/shared.jsx
+++ b/ui/src/dash/settings/pages/capabilities/shared.jsx
@@ -4,7 +4,7 @@
 // FieldInfoIcon is a window global (dash/primitives.jsx) — used unimported,
 // same as every settings page.
 import { SRow } from '../../shared/SRow.jsx'
-import { rowId } from './selection-pure.js'
+import { rowId, rowNeedsPull } from './selection-pure.js'
 
 export const selStyle = { fontFamily: "var(--jbm)", fontSize: 11, background: "var(--bg-2)", color: "var(--fg)", border: "1px solid var(--line)", borderRadius: 4, padding: "3px 6px" }
 export const inputStyle = (width) => ({ ...selStyle, width })
@@ -70,7 +70,13 @@ export function ModelRow({ items, value, onChange, placeholder, emptyHint }) {
           // select as "— unset —" while the form state still holds the id.
           <option value={value}>{value} (saved)</option>
         )}
-        {items.map(m => <option key={rowId(m)} value={rowId(m)}>{rowId(m)}</option>)}
+        {items.map(m => (
+          // #2026: pullable-but-absent rows carry the ⬇ marker the catalog
+          // documents — picking one 409s until the weights are pulled.
+          <option key={rowId(m)} value={rowId(m)}>
+            {rowId(m)}{rowNeedsPull(m) ? " · ⬇ not downloaded" : ""}
+          </option>
+        ))}
       </select>
     ) : (
       <input value={value} onChange={e => onChange(e.target.value)} placeholder={placeholder}


### PR DESCRIPTION
Fixes #2026

rc-validate register key: `capability-apply-skips-model-pull`.

## Contract

**Before:** `POST /api/capabilities/{slot}/{child}` naming a catalog row with `downloaded:false` went straight to `SlotManager.load` — the runner was spawned with the bare model id as `--model`, llama-server crash-looped instantly (`failed to open GGUF file '<id>'`), the apply blocked for the full ~180 s health-wait, then returned HTTP 200 `{"status":"warming"}`. No pull job was created, the broken selection was persisted, and the crash-looping slot was left behind.

**After:** the apply arms a downloaded gate whenever the merged selection is enabled (`CapabilityOrchestrator._validate_model_in_catalog(..., require_downloaded=merged.enabled)`), raised **before** the store commit and before any lifecycle call:

- enabled apply of an undownloaded (model, backend) catalog row → typed **409** `capability.model_not_downloaded`, details carrying `downloaded:false`, `pullable`, a `remediation` string, and — when the row is pullable — `pull_endpoint: /api/models/{id}/pull`. Nothing is persisted, nothing is spawned, no 3-minute block.
- registry-only model (permissive fallback) whose recorded path no longer resolves → same typed 409 (`pullable` derived from its HF coords).
- unknown name → **404** `capability.unknown_model` (pre-existing, now pinned), never a slot launch.
- installed model → unchanged happy path (slot loads/swaps exactly as before).
- disabling a selection whose weights vanished always succeeds; picking a model while the child is disabled remains legal staging — the gate fires on enable.
- NPU-trio selections (`backend=npu`) are exempt: they toggle the FLM anchor (`pending_reload`), never spawn a bare-id standalone process, and FLM weights pull via `flm pull`, not the registry pull path.

Also ships the ⬇ marker the catalog API documented all along (`catalog.py _entry_to_row`): the capabilities pickers' model dropdowns now suffix `· ⬇ not downloaded` on rows whose every backend reports `downloaded:false` (`rowNeedsPull` in `selection-pure.js`).

**Out of scope, per the issue's own carve-outs:** the 200-vs-typed-500 honesty gap when the quadlet's StartLimitBurst outlives the apply health window (may be filed/fixed independently), the crash-line journal gap (#2221), and the installer staging the rerank.toml default model.

## Test evidence

- New `tests/capabilities/test_apply_model_not_downloaded.py` (8 tests) pinning: 409 + no lifecycle call + nothing persisted; unpullable variant without `pull_endpoint`; unknown → 404; happy path load unchanged; disable never gated; staging-while-disabled allowed; npu exempt; registry-fallback gate both ways.
- New `rowNeedsPull` vitest cases in `ui/src/dash/__tests__/capability-selection-pure.test.ts`.
- `pytest tests/capabilities tests/stacks tests/slot_config` — 277 passed.
- `pytest tests/slots tests/cli` — 1751 passed, 26 skipped.
- `pytest tests/api` — 1987 passed; the 5 failures (`test_updater_routes` ×4, `test_slot_logs_stream_redact`) fail identically on base `f8ec89ee` (pre-existing on this darwin dev host, untouched by this change).
- `cd ui && npm run test:unit` — 475 passed.
- `ruff check` / `ruff format --check` clean on touched files; `mypy src/hal0/capabilities/orchestrator.py` reports only the 2 errors already present on base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181rff5wtNoioAHumZsYCD4
