### PR TITLE
fix(providers): ComfyUIProvider.image_ref honors slot-level image_pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ applying. Add those subsections to a version's section to surface them; see
   (an `error` dict carrying a string `code`), a shape no slot payload can
   own; genuine failures (unknown slot, REST 4xx/5xx, bad args) still raise
   `isError: true` with their typed code. (#2025)
+- `ComfyUIProvider.image_ref` now honors the slot-level `image_pin` escape
+  hatch (#2172). The provider resolved only the legacy `image` key and then
+  the runner-registry default, so a pinned img slot persisted (and displayed)
+  its pin but silently launched the resolver default at load/restart.
+  Resolution now matches every other provider's precedence contract
+  (spec-hw-slot-ownership §3): `image_pin` (top-level or `[slot]`-nested,
+  honored verbatim) → legacy `image` string (back-compat) →
+  `resolve_runner_image("comfyui")` (env var → manifest digest pin →
+  bundled tag). flm/kokoro/moonshine/qwen3tts already honored the pin and
+  are unchanged.
 
 - The capability catalog no longer advertises a `gpu-rocm` backend for
   registry models on hosts that cannot run it. The `rocm` tag branch in

--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -183,8 +183,8 @@ class ComfyUIProvider(Provider):
              is honored verbatim, never re-resolved (#2172 — this provider
              previously ignored the pin, so a pinned img slot silently
              launched the resolver default).
-          2. ``slot_cfg["image"]`` — the legacy explicit override from
-             slot TOML (back-compat; the migration lane folds it into
+          2. ``slot_cfg["image"]`` — the pre-pin explicit override from
+             slot TOML (still honored; the migration lane folds it into
              ``image_pin``).
           3. :func:`hal0.runners.resolve_runner_image` on the ``comfyui``
              runner: ``HAL0_TOOLBOX_IMAGE_COMFYUI`` env var →

--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -175,8 +175,18 @@ class ComfyUIProvider(Provider):
 
         Resolution order (§7.1b / ML-4 — now shared with every other
         provider via the runner registry):
-          1. ``slot_cfg["image"]`` — explicit override from slot TOML.
-          2. :func:`hal0.runners.resolve_runner_image` on the ``comfyui``
+          1. ``slot_cfg["image_pin"]`` (top-level or ``[slot]``-nested) —
+             the single canonical per-slot escape hatch
+             (spec-hw-slot-ownership §3, same contract as
+             :func:`hal0.providers.container._resolve_image_ref` and the
+             flm/kokoro/moonshine/qwen3tts providers). A non-empty string
+             is honored verbatim, never re-resolved (#2172 — this provider
+             previously ignored the pin, so a pinned img slot silently
+             launched the resolver default).
+          2. ``slot_cfg["image"]`` — the legacy explicit override from
+             slot TOML (back-compat; the migration lane folds it into
+             ``image_pin``).
+          3. :func:`hal0.runners.resolve_runner_image` on the ``comfyui``
              runner: ``HAL0_TOOLBOX_IMAGE_COMFYUI`` env var →
              ``manifest.json`` digest pin → the fallback tag
              ``ghcr.io/hal0ai/hal0-comfyui:latest``.
@@ -187,6 +197,13 @@ class ComfyUIProvider(Provider):
         into :func:`~hal0.runners.resolve_runner_image` (best-effort — a
         missing/stale manifest never breaks the provider).
         """
+        pin: Any = slot_cfg.get("image_pin")
+        if not (isinstance(pin, str) and pin):
+            nested = slot_cfg.get("slot")
+            pin = nested.get("image_pin") if isinstance(nested, dict) else None
+        if isinstance(pin, str) and pin:
+            return pin
+
         override = slot_cfg.get("image") or slot_cfg.get("slot", {}).get("image")
         # Only a STRING is an image-ref override. In raw slot dicts the
         # [image] TOML section (#599 image-gen settings) shares this key —

--- a/tests/providers/test_comfyui.py
+++ b/tests/providers/test_comfyui.py
@@ -108,6 +108,35 @@ def test_image_ref_slot_cfg_override_wins(provider: ComfyUIProvider) -> None:
     assert provider.image_ref(cfg) == "hal0-toolbox-comfyui:dev"
 
 
+def test_image_ref_honors_image_pin(provider: ComfyUIProvider) -> None:
+    """#2172: image_pin is the canonical per-slot escape hatch — it must
+    launch verbatim, not the resolver default (live ct105: pinned img slot
+    silently launched the old kyuz0 default)."""
+    cfg = {"image_pin": "ghcr.io/hal0ai/hal0-comfyui@sha256:" + "f" * 64}
+    assert provider.image_ref(cfg) == "ghcr.io/hal0ai/hal0-comfyui@sha256:" + "f" * 64
+
+
+def test_image_ref_honors_nested_image_pin(provider: ComfyUIProvider) -> None:
+    """[slot]-nested image_pin works too (same shape as flm/kokoro/qwen3tts)."""
+    cfg = {"slot": {"image_pin": "ghcr.io/dev/comfyui-pin:test"}}
+    assert provider.image_ref(cfg) == "ghcr.io/dev/comfyui-pin:test"
+
+
+def test_image_ref_pin_beats_legacy_image_key(provider: ComfyUIProvider) -> None:
+    """Precedence: image_pin → legacy image → resolver default."""
+    cfg = {"image_pin": "ghcr.io/dev/pin:a", "image": "hal0-toolbox-comfyui:dev"}
+    assert provider.image_ref(cfg) == "ghcr.io/dev/pin:a"
+
+
+def test_image_ref_empty_or_non_string_pin_falls_through(provider: ComfyUIProvider) -> None:
+    """An empty/non-string image_pin is 'no pin' — same contract as
+    container._resolve_image_ref (never str(dict), never empty ref)."""
+    assert provider.image_ref({"image_pin": "", "image": "x:dev"}) == "x:dev"
+    ref = provider.image_ref({"image_pin": {"oops": 1}})
+    assert isinstance(ref, str)
+    assert "hal0ai/hal0-comfyui" in ref  # manifest pin or fallback tag
+
+
 # ─── container_spec ──────────────────────────────────────────────────────────
 
 

--- a/tests/providers/test_comfyui.py
+++ b/tests/providers/test_comfyui.py
@@ -122,8 +122,8 @@ def test_image_ref_honors_nested_image_pin(provider: ComfyUIProvider) -> None:
     assert provider.image_ref(cfg) == "ghcr.io/dev/comfyui-pin:test"
 
 
-def test_image_ref_pin_beats_legacy_image_key(provider: ComfyUIProvider) -> None:
-    """Precedence: image_pin → legacy image → resolver default."""
+def test_image_ref_pin_beats_plain_image_key(provider: ComfyUIProvider) -> None:
+    """Precedence: image_pin → plain image key → resolver default."""
     cfg = {"image_pin": "ghcr.io/dev/pin:a", "image": "hal0-toolbox-comfyui:dev"}
     assert provider.image_ref(cfg) == "ghcr.io/dev/pin:a"
 


### PR DESCRIPTION
Fixes #2172

A slot with an explicit `image_pin` must launch exactly that image. `ComfyUIProvider.image_ref` never read the pin, so a pinned img slot persisted (and displayed) the pin while unload+load and restart launched the resolver default (live ct105 repro in the issue).

## Precedence, before vs after

| Tier | Before (comfyui) | After (comfyui) | Contract (`container._resolve_image_ref`, flm/kokoro/moonshine/qwen3tts) |
|---|---|---|---|
| 1 | — *(pin ignored)* | `image_pin` (top-level or `[slot]`-nested), honored verbatim | `image_pin`, honored verbatim |
| 2 | legacy `image` string (top-level or `[slot]`-nested) | legacy `image` string (back-compat; migration lane folds it into `image_pin`) | *(collapsed into `image_pin` for llama; the tts/stt providers dropped it)* |
| 3 | `resolve_runner_image("comfyui")` (env var → manifest digest pin → bundled tag) | unchanged | `[slots].default_images[family]` (llama path only) → `resolve_runner_image` |

## Other providers checked

- **flm / kokoro / moonshine / qwen3tts** — already honor `image_pin` (top-level and `[slot]`-nested) ahead of the registry default: `src/hal0/providers/flm.py:446`, `kokoro.py:130`, `moonshine.py:295`, `qwen3tts.py:153`. No change needed; comfyui was the one holdout.
- **`[slots].default_images[family]` tier** — only the llama/container path (`container._resolve_image_ref`) consults it today; none of the five non-llama providers do, even though the schema docstring (`config/schema.py:2373`) names their families as valid keys. That is a uniform pre-existing gap orthogonal to the pin bug, left out of this surgical fix (happy to file a follow-up issue).

## Evidence

- `uv run pytest tests/providers -q` → 906 passed, 2 failed — both `test_moonshine_server.py` ffmpeg-argv tests, failing identically on a clean stash of main on this host (no ffmpeg installed); unrelated to this change.
- New tests in `tests/providers/test_comfyui.py`: pin honored verbatim (digest ref), nested `[slot].image_pin`, pin beats legacy `image`, empty/non-string pin falls through (no `str(dict)` regression), plus the existing no-pin → manifest-pin/fallback test still passing.
- `ruff check` + `ruff format --check` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181rff5wtNoioAHumZsYCD4