### PR TITLE
fix(mcp): stop mistaking an error-state slot read for a tool failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Fixed
 
+- MCP admin tools no longer report a tool failure for a successful read of a
+  slot whose lifecycle state is `error`. The tool-result wrapper's failure
+  sentinel keyed on `status == "error"` alone, which collides with the slot
+  payload's own lifecycle `status` field — `slot_status`, `slot_by_name` and
+  `slot_by_id` returned `isError: true` with the correct record stringified
+  and `structuredContent` dropped, while REST answered 200 for the identical
+  resource. The sentinel now requires the MCP layer's full failure envelope
+  (an `error` dict carrying a string `code`), a shape no slot payload can
+  own; genuine failures (unknown slot, REST 4xx/5xx, bad args) still raise
+  `isError: true` with their typed code. (#2025)
+
 - The capability catalog no longer advertises a `gpu-rocm` backend for
   registry models on hosts that cannot run it. The `rocm` tag branch in
   `_backend_variants` appended `gpu-rocm` unconditionally — no

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -3119,6 +3119,31 @@ def _validate_catalog() -> None:
 _validate_overlay()
 
 
+def _is_failure_envelope(result: Any) -> bool:
+    """True only for the MCP layer's OWN failure envelope, never domain data.
+
+    Every failure path in this layer (``dispatch``'s policy/arg rejections,
+    ``_call_rest``'s 4xx/5xx wrapping via :func:`_rest_error_payload`, the
+    probe and memory dispatchers) returns ``{"status": "error", "error":
+    {"code": <str>, ...}}`` — ``error`` is always a dict and ``error.code``
+    is always a branchable string (see ``_REST_FALLBACK_ERROR_CODE``).
+
+    A bare ``status == "error"`` check is NOT sufficient: the slot object's
+    own lifecycle ``status`` field is the literal string ``"error"`` for a
+    crashed slot, so ``slot_status`` / ``slot_by_name`` / ``slot_by_id`` on
+    an error-state slot produced ``isError: true`` with the (correct,
+    complete) payload stringified and ``structuredContent`` dropped (#2025).
+    Slot payloads never carry a top-level ``error`` dict with a string
+    ``code`` (``Slot.as_dict`` + ``serialize_slot`` own the key set), so
+    requiring the full envelope shape discriminates transport failure from
+    domain data.
+    """
+    if not isinstance(result, dict) or result.get("status") != "error":
+        return False
+    error = result.get("error")
+    return isinstance(error, dict) and isinstance(error.get("code"), str)
+
+
 # ── FastMCP server builder ───────────────────────────────────────────────────
 
 
@@ -3183,9 +3208,13 @@ def build_server(
             # the content as if it were a successful payload (#1796). Raise
             # here so the lowlevel handler's ``except Exception`` path sets
             # ``isError: true`` the way every MCP client expects to detect
-            # a failed call without string-sniffing the content.
-            if isinstance(result, dict) and result.get("status") == "error":
-                raise ToolError(json.dumps(result.get("error", result)))
+            # a failed call without string-sniffing the content. The check
+            # requires the FULL envelope shape (error dict + string code),
+            # not the bare ``status`` string — a successfully read slot in
+            # lifecycle state ``error`` shares that string and must come
+            # back isError:false with its payload intact (#2025).
+            if _is_failure_envelope(result):
+                raise ToolError(json.dumps(result["error"]))
             return result
 
         _tool.__name__ = tool_name

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -1396,6 +1396,95 @@ async def test_registered_tool_raises_toolerror_on_missing_arg(queue: ApprovalQu
         await server.call_tool("model_show", {"args": {}})
 
 
+# ── #2025: the failure sentinel must not swallow error-STATE resources ───────
+#
+# The #1796 raise keyed on ``result.get("status") == "error"`` alone. A slot
+# whose lifecycle state is ERROR serialises with top-level ``status: "error"``
+# too (``serialize_slot`` mirrors ``state`` into ``status``), so a fully
+# successful ``slot_status`` / ``slot_by_name`` / ``slot_by_id`` read of a
+# crashed slot came back isError:true with the correct payload stringified
+# into the error message and structuredContent dropped — while REST returned
+# 200 for the identical resource. The sentinel must require the MCP layer's
+# full failure envelope (``error`` dict with a string ``code``), which no
+# slot payload can own.
+
+_ERROR_STATE_SLOT: dict[str, Any] = {
+    "name": "gpu-rocm",
+    "state": "error",
+    "status": "error",  # lifecycle mirror — NOT a failure envelope
+    "port": 8083,
+    "model_id": "qwen3:0.6b",
+    "backend": "llamacpp",
+    "metadata": {"backend": "llamacpp"},
+    "last_used_at": None,
+    "kind": "local",
+    "id": 7,
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", ["slot_status", "slot_by_name", "slot_by_id"])
+async def test_error_state_slot_read_is_a_success_not_a_tool_failure(
+    queue: ApprovalQueue, error_transport: dict[str, Any], tool: str
+) -> None:
+    """A 200 read of a slot in lifecycle state ``error`` must NOT raise
+    ToolError — the full slot record flows through as a normal result."""
+    error_transport["status"] = 200
+    error_transport["payload"] = dict(_ERROR_STATE_SLOT)
+
+    args = {"slot_id": 7} if tool == "slot_by_id" else {"name": "gpu-rocm"}
+    server = admin.build_server(approval_queue=queue, base_url="http://t")
+    result = await server.call_tool(tool, {"args": args})
+
+    # convert_result=True hands back ``(content, structured)`` for
+    # dict-returning tools — the structured payload must be the complete
+    # slot record, not a stringified error message.
+    _content, structured = result
+    assert isinstance(structured, dict)
+    assert structured["status"] == "error"  # the slot's own lifecycle field
+    assert structured["name"] == "gpu-rocm"
+    assert structured["state"] == "error"
+    assert structured["model_id"] == "qwen3:0.6b"
+
+
+@pytest.mark.asyncio
+async def test_unknown_slot_read_still_raises_toolerror(
+    queue: ApprovalQueue, error_transport: dict[str, Any]
+) -> None:
+    """A genuine lookup failure (REST 404, typed hal0 envelope) keeps the
+    #1796 behaviour: ToolError → isError:true, code preserved."""
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    error_transport["status"] = 404
+    error_transport["payload"] = {
+        "error": {"code": "slot.not_found", "message": "no such slot", "details": {"name": "nope"}}
+    }
+
+    server = admin.build_server(approval_queue=queue, base_url="http://t")
+    with pytest.raises(ToolError) as excinfo:
+        await server.call_tool("slot_status", {"args": {"name": "nope"}})
+    assert "slot.not_found" in str(excinfo.value)
+
+
+def test_is_failure_envelope_discriminates_envelope_from_domain_data() -> None:
+    """Unit-pin the discriminator: only the MCP layer's own envelope shape
+    (``status=="error"`` + ``error`` dict with string ``code``) is a failure."""
+    # Every internal failure producer's shape → failure.
+    assert admin._is_failure_envelope(
+        {"status": "error", "error": {"code": "mcp.missing_arg", "detail": "name"}}
+    )
+    assert admin._is_failure_envelope(
+        {"status": "error", "http_status": 502, "error": {"code": "mcp.rest_error"}}
+    )
+    # Domain data that merely shares the ``status`` string → not a failure.
+    assert not admin._is_failure_envelope(dict(_ERROR_STATE_SLOT))
+    assert not admin._is_failure_envelope({"status": "error"})
+    assert not admin._is_failure_envelope({"status": "error", "error": "crashed at boot"})
+    assert not admin._is_failure_envelope({"status": "ok", "error": {"code": "x"}})
+    assert not admin._is_failure_envelope("error")
+    assert not admin._is_failure_envelope(None)
+
+
 @pytest.mark.asyncio
 async def test_slot_lifecycle_tools_forward_with_the_lifecycle_budget(
     queue: ApprovalQueue, mock_transport: dict[str, Any]


### PR DESCRIPTION
Fixes #2025

## Root cause

`build_server`'s per-tool wrapper in `src/hal0/mcp/admin.py` (the #1796 fix) signalled transport failure with:

```python
if isinstance(result, dict) and result.get("status") == "error":
    raise ToolError(json.dumps(result.get("error", result)))
```

But `status` is not a reserved envelope key — `serialize_slot` mirrors the slot's lifecycle `state` into a top-level `status` field, so a slot genuinely in state `error` (a real crash, exactly what #2130 made this state mean) produces `{"status": "error", ...}` as *domain data*. `slot_status`, `slot_by_name`, and `slot_by_id` pass that record through bare, so a fully successful read raised `ToolError`: `isError: true`, payload stringified behind `Error executing tool ...`, `structuredContent` dropped — while `GET /api/slots/{name}` returned 200 for the identical resource.

## Fix

New `_is_failure_envelope()` predicate: a result is a failure only when it has `status == "error"` **and** an `error` dict carrying a string `code`. Every failure producer in the MCP layer guarantees exactly that shape (verified: `dispatch`'s policy/arg rejections, `_call_rest` via `_rest_error_payload` — whose contract is "`error.code` is ALWAYS a branchable string" — the probe dispatcher, and the memory dispatcher), and no slot payload can own it (`Slot.as_dict` + `serialize_slot` own the key set; pull-status payloads use `state`, not `status`).

## Before / after

| Call | Before | After |
|---|---|---|
| `slot_status` on error-state slot | `isError: true`, payload stringified, structuredContent dropped | `isError: false`, full slot record in structuredContent |
| `slot_by_name` / `slot_by_id` same slot | same bug | same fix |
| `slot_status` on unknown slot (404) | `isError: true`, `slot.not_found` | unchanged |
| bad/missing args, REST 5xx, policy denial | `isError: true`, typed code | unchanged |

## Evidence

- `tests/mcp/test_admin.py` new pins: error-state slot read via `server.call_tool` returns the structured slot record for all three tools (parametrized); unknown slot still raises `ToolError` with `slot.not_found`; unit test pins the discriminator against every producer shape and against domain look-alikes.
- `uv run pytest tests/mcp/` — 336 passed; `tests/api/test_mcp_routes.py` — 43 passed; ruff check + format clean.
- Register entry `mcp-status-tools-iserror-on-error-state-resource` in `tests/release-validation/regressions.yaml` re-probes this on the next RC.

Note: the audit row's `outcome` field (`dispatch`'s `result.get("status", "ok")`) still logs `outcome=error` for a successful error-state slot read — audit-only cosmetic, left untouched to keep this patch surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181rff5wtNoioAHumZsYCD4
