### PR TITLE
fix(memory): surface zero-fact retain completions on the operation record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ applying. Add those subsections to a version's section to surface them; see
   (an `error` dict carrying a string `code`), a shape no slot payload can
   own; genuine failures (unknown slot, REST 4xx/5xx, bad args) still raise
   `isError: true` with their typed code. (#2025)
+- **A memory retain that extracts zero facts now says so** instead of
+  finishing as a bare `status=completed, error_message=null` while nothing it
+  stored is ever retrievable. The terminal operation record — served by
+  `GET /api/memory/banks/{bank}/operations/{id}` and the
+  `memory_operation_get` MCP tool — is annotated with `facts_extracted`
+  (from the engine's `result_metadata.unit_ids_count`, falling back to the
+  document's `memory_unit_count` on older engines) plus `nothing_learned:
+  true` and a human-readable `notice` when the retained document holds zero
+  memory units. A zero-yield retain of an *already-known* document (duplicate
+  `content_hash` dedup, adjudicated correct by rc-validate) is distinguished
+  via `document_fact_count` and gets a "content was already known" notice
+  rather than a false alarm. The dashboard's Add-fact flow now watches the
+  async extraction to its terminal state and raises a warn toast — "nothing
+  was learned" — instead of leaving "Fact added" as the last word. Empty
+  yield stays `completed`: it is a legitimate outcome made visible, not
+  reclassified as an error. (#2030)
 - `ComfyUIProvider.image_ref` now honors the slot-level `image_pin` escape
   hatch (#2172). The provider resolved only the legacy `image` key and then
   the runner-registry default, so a pinned img slot persisted (and displayed)

--- a/docs/reference/mcp-tools.mdx
+++ b/docs/reference/mcp-tools.mdx
@@ -247,7 +247,7 @@ same verdict, belt and braces).
 | `memory_directive_list` | none | a bank's directives (standing instructions injected into prompts) |
 | `memory_directive_get` | `id` | one directive |
 | `memory_operation_list` | none | async operations (retain, consolidation, refresh, ...) |
-| `memory_operation_get` | `id` | one async operation's status — the poll target for `memory_add`'s `operation_id`, `memory_mental_model_refresh`, `memory_bank_consolidate` |
+| `memory_operation_get` | `id` | one async operation's status — the poll target for `memory_add`'s `operation_id`, `memory_mental_model_refresh`, `memory_bank_consolidate`. A completed retain reports its extraction yield: `facts_extracted`, plus `nothing_learned` and a `notice` when zero facts made it into memory |
 | `memory_tags_list` | none | tags in use in a bank, with usage counts |
 | `memory_bank_stats` | none | node/link/observation/operation counts for a bank |
 

--- a/src/hal0/api/routes/memory_admin.py
+++ b/src/hal0/api/routes/memory_admin.py
@@ -39,6 +39,7 @@ from hal0.api._audit import record_action
 from hal0.api.routes import _memory_subgraph as _sg
 from hal0.api.routes.memory import MemoryUnavailable
 from hal0.errors import BadRequest, Hal0Error, NotFound, UnprocessableEntity
+from hal0.memory.hindsight_provider import annotate_retain_yield
 
 router = APIRouter()
 
@@ -977,6 +978,30 @@ _CURATE_AUDIT_ACTION = "memory.memory.curate"
 _CACHE_CLEARING_FORWARDS: set[tuple[str, str]] = {_CURATE_TEMPLATE}
 
 
+# ── #2030: zero-fact retain visibility on the single-operation poll ─────────
+#
+# The operation record hindsight returns for a completed retain says nothing
+# about extraction yield in its headline fields — `status=completed,
+# error_message=null` reads as success even when zero facts were extracted
+# and the retained text is unretrievable forever. The single-op GET (the
+# poll target `POST /api/memory/add` hands out via `operation_id`) is where
+# that has to become visible, so annotate it post-forward with
+# `facts_extracted` / `document_fact_count` / `nothing_learned` + `notice`
+# (see hal0.memory.hindsight_provider.annotate_retain_yield). Additive keys
+# only; the engine's own fields pass through verbatim, and the annotation is
+# fail-soft. The *list* passthrough is deliberately NOT annotated: list rows
+# carry no unit counts, so annotating them would cost one document fetch per
+# completed retain row on every dashboard poll tick.
+_OP_GET_TEMPLATE = ("GET", "/v1/default/banks/{bank_id}/operations/{operation_id}")
+
+
+async def _annotate_operation(client: Any, bank_id: str, result: Any) -> Any:
+    async def _doc(document_id: str) -> Any:
+        return await client.get_document(bank_id=bank_id, document_id=document_id)
+
+    return await annotate_retain_yield(result, _doc)
+
+
 def _make_handler(method: str, template: str):
     guard = _SHAPE_GUARDS.get((method, template))
     audit_action = _DELETE_ACTIONS.get(template) if method == "DELETE" else None
@@ -1005,6 +1030,8 @@ def _make_handler(method: str, template: str):
                 _GRAPH_CACHE.clear_bank(bank_id)
         if guard is not None:
             guard(result)
+        if (method, template) == _OP_GET_TEMPLATE:
+            result = await _annotate_operation(client, segments["bank_id"], result)
         return result
 
     return handler

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -2707,7 +2707,9 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
     "memory_operation_list": "List async operations (retain, consolidation, refresh, ...).",
     "memory_operation_get": (
         "Get one async operation's status — the poll target for memory_add's "
-        "operation_id, memory_mental_model_refresh, and memory_bank_consolidate."
+        "operation_id, memory_mental_model_refresh, and memory_bank_consolidate. "
+        "A completed retain reports its extraction yield: facts_extracted, and "
+        "nothing_learned + notice when zero facts made it into memory (#2030)."
     ),
     "memory_operation_cancel": "Cancel a pending/processing operation (aborts in-flight work only).",
     "memory_operation_retry": "Re-queue a failed operation.",

--- a/src/hal0/mcp/memory.py
+++ b/src/hal0/mcp/memory.py
@@ -1961,7 +1961,9 @@ def build_server(
         name="memory_operation_get",
         description=(
             "Get one async operation's status — the poll target for memory_add's "
-            "operation_id, memory_mental_model_refresh, and memory_bank_consolidate."
+            "operation_id, memory_mental_model_refresh, and memory_bank_consolidate. "
+            "A completed retain reports its extraction yield: facts_extracted, and "
+            "nothing_learned + notice when zero facts made it into memory (#2030)."
         ),
         annotations=_ANNOTATIONS["memory_operation_get"],
     )

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -340,6 +340,91 @@ _AUTO_RETRY_MAX_SWEEPS = 5
 _AUTO_RETRY_MAX_OPS = 200
 
 
+# ── zero-fact retain visibility (#2030) ─────────────────────────────────────
+
+#: Operation types whose completion means "fact extraction ran over a
+#: document" — the ones a yield annotation is meaningful for.
+_RETAIN_OP_TYPES = {"retain", "batch_retain"}
+
+
+async def annotate_retain_yield(op: Any, fetch_document: Any) -> Any:
+    """Stamp extraction *yield* onto a terminal retain operation record.
+
+    A retain whose fact extraction produced zero units used to finish as a
+    bare ``status=completed, retry_count=0, error_message=None`` — the raw
+    document was stored, nothing was ever retrievable, and no surface said so
+    (#2030, rc-validate ``memory-retain-zero-yield-reports-completed``). This
+    annotates the engine's record (verified live against hindsight-api 0.9.2:
+    the single-op shape carries ``operation_type`` +
+    ``result_metadata.unit_ids_count``; list rows carry ``task_type`` +
+    ``document_id`` and no unit count) with:
+
+    * ``facts_extracted`` — memory units this operation created
+      (``result_metadata.unit_ids_count``), falling back to the document's
+      total ``memory_unit_count`` on engines whose op record has no
+      ``result_metadata``;
+    * ``document_fact_count`` — the document's total units, fetched only when
+      the operation's own yield is zero or unknown. This is what tells a
+      genuinely-unretrievable retain apart from a duplicate-``content_hash``
+      retain of an already-extracted document (correct dedup, per the rc.7
+      adversarial verification — not a defect);
+    * ``nothing_learned: true`` plus a human-readable ``notice`` — only when
+      the document itself holds zero units, i.e. the retain stored nothing
+      that search/recall can ever return. Empty yield stays ``completed`` —
+      it is a legitimate outcome that must be *visible*, not reclassified as
+      an error.
+
+    Fail-soft by construction: a document fetch that raises leaves
+    ``document_fact_count`` unset rather than failing the poll, and non-dict
+    payloads / non-retain / non-completed ops pass through untouched.
+    ``fetch_document`` is ``async (document_id) -> dict | None``.
+    """
+    if not isinstance(op, dict):
+        return op
+    op_type = op.get("task_type") or op.get("operation_type")
+    if op_type not in _RETAIN_OP_TYPES or op.get("status") != "completed":
+        return op
+    meta = op.get("result_metadata")
+    meta = meta if isinstance(meta, dict) else {}
+    created = meta.get("unit_ids_count")
+    created = created if isinstance(created, int) else None
+
+    doc_units: int | None = None
+    if created is None or created == 0:
+        doc_id = op.get("document_id") or meta.get("document_id")
+        if doc_id and fetch_document is not None:
+            try:
+                doc = await fetch_document(str(doc_id))
+            except Exception:
+                doc = None
+            if isinstance(doc, dict):
+                mu = doc.get("memory_unit_count")
+                doc_units = mu if isinstance(mu, int) else None
+
+    facts = created if created is not None else doc_units
+    if facts is None:
+        return op
+    op["facts_extracted"] = facts
+    if doc_units is not None:
+        op["document_fact_count"] = doc_units
+    if facts == 0:
+        if doc_units:
+            # This op added nothing NEW, but the document's facts exist and
+            # are retrievable — the duplicate-retain / re-ingest case.
+            op["notice"] = (
+                "completed with no new facts: this document's content was "
+                f"already known ({doc_units} fact(s) previously extracted from it)"
+            )
+        else:
+            op["nothing_learned"] = True
+            op["notice"] = (
+                "completed, but nothing was learned: fact extraction produced "
+                "0 memory units from this document — the raw text was stored, "
+                "but nothing from it is retrievable via search or recall"
+            )
+    return op
+
+
 class RecallResults(list):
     """``recall()``'s return value: a ``list[dict]`` of MemoryItem-shaped
     results, PLUS the response-level enrichment Hindsight's RecallResponse
@@ -1869,12 +1954,19 @@ class HindsightProvider(MemoryProvider):
         include_payload: bool | None = None,
     ) -> dict[str, Any]:
         bank = namespace_to_bank(self._write_namespace(dataset, client_id))
-        return await self._call(
+        op = await self._call(
             "get_operation",
             bank_id=bank,
             operation_id=operation_id,
             include_payload=include_payload,
         )
+
+        # #2030: a completed retain that extracted zero facts must say so on
+        # the record every poller reads (memory_operation_get, dashboard).
+        async def _doc(document_id: str) -> Any:
+            return await self._call("get_document", bank_id=bank, document_id=document_id)
+
+        return await annotate_retain_yield(op, _doc)
 
     async def cancel_operation(
         self, operation_id: str, *, dataset: str = _SHARED, client_id: str | None = None

--- a/tests/api/test_memory_admin_routes.py
+++ b/tests/api/test_memory_admin_routes.py
@@ -359,6 +359,78 @@ def test_operation_retry_and_consolidate_forward(client: TestClient, recorder: _
     assert recorder.requests[-1]["path"] == "/v1/default/banks/shared/consolidate"
 
 
+def test_operation_get_flags_zero_fact_retain(client: TestClient, recorder: _Recorder) -> None:
+    """#2030: the single-op poll target must say when a completed retain
+    learned nothing — a bare `completed`/`error_message: null` for a retain
+    that stored nothing retrievable is the regression."""
+    recorder.respond(
+        "GET",
+        "/v1/default/banks/shared/operations/op-1",
+        200,
+        {
+            "operation_id": "op-1",
+            "operation_type": "retain",
+            "status": "completed",
+            "retry_count": 0,
+            "error_message": None,
+            "result_metadata": {"document_id": "doc-1", "unit_ids_count": 0, "items_count": 1},
+        },
+    )
+    recorder.respond(
+        "GET",
+        "/v1/default/banks/shared/documents/doc-1",
+        200,
+        {"id": "doc-1", "memory_unit_count": 0},
+    )
+    r = client.get("/api/memory/banks/shared/operations/op-1")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "completed"  # visible, not reclassified as error
+    assert body["facts_extracted"] == 0
+    assert body["nothing_learned"] is True
+    assert "nothing was learned" in body["notice"]
+
+
+def test_operation_get_nonzero_yield_passes_through_with_count(
+    client: TestClient, recorder: _Recorder
+) -> None:
+    recorder.respond(
+        "GET",
+        "/v1/default/banks/shared/operations/op-2",
+        200,
+        {
+            "operation_id": "op-2",
+            "operation_type": "retain",
+            "status": "completed",
+            "result_metadata": {"document_id": "doc-2", "unit_ids_count": 11},
+        },
+    )
+    r = client.get("/api/memory/banks/shared/operations/op-2")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["facts_extracted"] == 11
+    assert "nothing_learned" not in body
+    assert "notice" not in body
+    # A non-zero yield needs no document fetch — exactly one upstream call.
+    assert [q["path"] for q in recorder.requests] == ["/v1/default/banks/shared/operations/op-2"]
+
+
+def test_operation_get_non_retain_op_is_verbatim(client: TestClient, recorder: _Recorder) -> None:
+    recorder.respond(
+        "GET",
+        "/v1/default/banks/shared/operations/op-3",
+        200,
+        {"operation_id": "op-3", "operation_type": "consolidation", "status": "completed"},
+    )
+    r = client.get("/api/memory/banks/shared/operations/op-3")
+    assert r.status_code == 200
+    assert r.json() == {
+        "operation_id": "op-3",
+        "operation_type": "consolidation",
+        "status": "completed",
+    }
+
+
 def test_mental_model_refresh_forwards(client: TestClient, recorder: _Recorder) -> None:
     r = client.post("/api/memory/banks/shared/mental-models/mm-1/refresh")
     assert r.status_code == 200

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -1141,6 +1141,147 @@ async def test_operation_get_list_cancel_retry():
     assert retried["success"] is True
 
 
+# ── zero-fact retain visibility on the operation record (#2030) ───────────
+#
+# A retain whose fact extraction yields zero units used to finish as a bare
+# `status=completed, error_message=None` — stored raw, never retrievable, no
+# surface saying so. get_operation now annotates the terminal record.
+
+
+@pytest.mark.asyncio
+async def test_operation_get_flags_zero_fact_retain():
+    """Completed retain, 0 units created, document holds 0 units →
+    ``nothing_learned`` + a notice; still ``completed``, never an error."""
+    fake = FakeHindsightClient()
+    fake.operations["op-z"] = {
+        "operation_id": "op-z",
+        "bank_id": "shared",
+        "operation_type": "retain",
+        "status": "completed",
+        "retry_count": 0,
+        "error_message": None,
+        "result_metadata": {"document_id": "doc-z", "unit_ids_count": 0, "items_count": 1},
+    }
+    fake._documents_by_bank["shared"] = {"doc-z": {"id": "doc-z", "memory_unit_count": 0}}
+    p = HindsightProvider(client=fake, client_id="hermes")
+
+    got = await p.get_operation("op-z", dataset="shared", client_id="hermes")
+    assert got["status"] == "completed"  # empty yield is visible, not failed
+    assert got["facts_extracted"] == 0
+    assert got["document_fact_count"] == 0
+    assert got["nothing_learned"] is True
+    assert "nothing was learned" in got["notice"]
+
+
+@pytest.mark.asyncio
+async def test_operation_get_reports_nonzero_yield_without_notice():
+    fake = FakeHindsightClient()
+    fake.operations["op-n"] = {
+        "operation_id": "op-n",
+        "bank_id": "shared",
+        "operation_type": "retain",
+        "status": "completed",
+        "result_metadata": {"document_id": "doc-n", "unit_ids_count": 7},
+    }
+    # No document seeded: a non-zero yield must not need (or attempt) a
+    # document fetch — the count is already on the record.
+    p = HindsightProvider(client=fake, client_id="hermes")
+
+    got = await p.get_operation("op-n", dataset="shared", client_id="hermes")
+    assert got["facts_extracted"] == 7
+    assert "nothing_learned" not in got
+    assert "notice" not in got
+
+
+@pytest.mark.asyncio
+async def test_operation_get_zero_yield_on_known_document_is_dedup_not_loss():
+    """0 units created but the document already holds facts — the rc.7
+    adversarial verification showed this is correct duplicate-content dedup;
+    it must not read as 'nothing was learned'."""
+    fake = FakeHindsightClient()
+    fake.operations["op-d"] = {
+        "operation_id": "op-d",
+        "bank_id": "shared",
+        "operation_type": "batch_retain",
+        "status": "completed",
+        "result_metadata": {"document_id": "doc-d", "unit_ids_count": 0},
+    }
+    fake._documents_by_bank["shared"] = {"doc-d": {"id": "doc-d", "memory_unit_count": 5}}
+    p = HindsightProvider(client=fake, client_id="hermes")
+
+    got = await p.get_operation("op-d", dataset="shared", client_id="hermes")
+    assert got["facts_extracted"] == 0
+    assert got["document_fact_count"] == 5
+    assert "nothing_learned" not in got
+    assert "already known" in got["notice"]
+
+
+@pytest.mark.asyncio
+async def test_operation_get_falls_back_to_document_count_without_result_metadata():
+    """0.8.x-era record shape (``task_type``/``document_id``, no
+    ``result_metadata``): the document's own unit count is the yield."""
+    fake = FakeHindsightClient()
+    fake.operations["op-o"] = {
+        "id": "op-o",
+        "bank_id": "shared",
+        "task_type": "retain",
+        "status": "completed",
+        "document_id": "doc-o",
+    }
+    fake._documents_by_bank["shared"] = {"doc-o": {"id": "doc-o", "memory_unit_count": 0}}
+    p = HindsightProvider(client=fake, client_id="hermes")
+
+    got = await p.get_operation("op-o", dataset="shared", client_id="hermes")
+    assert got["facts_extracted"] == 0
+    assert got["nothing_learned"] is True
+
+
+@pytest.mark.asyncio
+async def test_operation_get_leaves_non_retain_and_failed_ops_untouched():
+    fake = FakeHindsightClient()
+    fake.operations["op-c"] = {
+        "operation_id": "op-c",
+        "bank_id": "shared",
+        "operation_type": "consolidation",
+        "status": "completed",
+    }
+    fake.operations["op-f"] = {
+        "operation_id": "op-f",
+        "bank_id": "shared",
+        "operation_type": "retain",
+        "status": "failed",
+        "error_message": "boom",
+    }
+    p = HindsightProvider(client=fake, client_id="hermes")
+
+    for op_id in ("op-c", "op-f"):
+        got = await p.get_operation(op_id, dataset="shared", client_id="hermes")
+        assert "facts_extracted" not in got
+        assert "nothing_learned" not in got
+        assert "notice" not in got
+
+
+@pytest.mark.asyncio
+async def test_operation_get_zero_yield_fail_soft_on_document_fetch_error():
+    """Document gone / engine hiccup: the op's own 0-unit count still flags,
+    with no document_fact_count claim — and the poll never errors."""
+    fake = FakeHindsightClient()
+    fake.operations["op-g"] = {
+        "operation_id": "op-g",
+        "bank_id": "shared",
+        "operation_type": "retain",
+        "status": "completed",
+        "result_metadata": {"document_id": "doc-gone", "unit_ids_count": 0},
+    }
+    # doc-gone unseeded → FakeHindsightClient.get_document raises 404.
+    p = HindsightProvider(client=fake, client_id="hermes")
+
+    got = await p.get_operation("op-g", dataset="shared", client_id="hermes")
+    assert got["facts_extracted"] == 0
+    assert got["nothing_learned"] is True
+    assert "document_fact_count" not in got
+
+
 # ── tags / bank stats / consolidation ────────────────────────────────────
 
 

--- a/ui/src/api/hooks/__tests__/retainYield.test.ts
+++ b/ui/src/api/hooks/__tests__/retainYield.test.ts
@@ -1,0 +1,70 @@
+// #2030 — zero-fact retain visibility. `watchRetainYield` polls the
+// server-annotated single-operation record after a memory add and surfaces a
+// "nothing was learned" completion as a warn toast. Exercised via injected
+// deps (fetch/notify/sleep) per this suite's pure-logic convention.
+import { describe, expect, it } from 'vitest'
+
+import {
+  NOTHING_LEARNED_FALLBACK,
+  type RetainYieldOperation,
+  watchRetainYield,
+} from '../useMemory'
+
+const noSleep = () => Promise.resolve()
+
+function harness(ops: Array<RetainYieldOperation | Error>) {
+  const toasts: Array<{ msg: string; kind: string }> = []
+  let i = 0
+  const fetchOp = async () => {
+    const next = ops[Math.min(i++, ops.length - 1)]
+    if (next instanceof Error) throw next
+    return next
+  }
+  const notify = (msg: string, kind: 'warn') => {
+    toasts.push({ msg, kind })
+  }
+  return { toasts, deps: { fetchOp, notify, sleep: noSleep, maxPolls: 5 } }
+}
+
+describe('watchRetainYield', () => {
+  it('warns with the server notice on a zero-fact completion', async () => {
+    const { toasts, deps } = harness([
+      { status: 'processing' },
+      { status: 'completed', facts_extracted: 0, nothing_learned: true, notice: 'zero facts' },
+    ])
+    expect(await watchRetainYield('shared', 'op-1', deps)).toBe('nothing_learned')
+    expect(toasts).toEqual([{ msg: 'zero facts', kind: 'warn' }])
+  })
+
+  it('falls back to the built-in message when the record has no notice', async () => {
+    const { toasts, deps } = harness([{ status: 'completed', nothing_learned: true }])
+    expect(await watchRetainYield('shared', 'op-1', deps)).toBe('nothing_learned')
+    expect(toasts[0].msg).toBe(NOTHING_LEARNED_FALLBACK)
+  })
+
+  it('stays silent when facts were extracted', async () => {
+    const { toasts, deps } = harness([{ status: 'completed', facts_extracted: 4 }])
+    expect(await watchRetainYield('shared', 'op-1', deps)).toBe('ok')
+    expect(toasts).toEqual([])
+  })
+
+  it('stays silent on failed/cancelled ops (already loud elsewhere)', async () => {
+    for (const status of ['failed', 'cancelled']) {
+      const { toasts, deps } = harness([{ status }])
+      expect(await watchRetainYield('shared', 'op-1', deps)).toBe('ok')
+      expect(toasts).toEqual([])
+    }
+  })
+
+  it('ends silently when the op fetch errors (engine hiccup, bank mismatch)', async () => {
+    const { toasts, deps } = harness([new Error('404')])
+    expect(await watchRetainYield('shared', 'op-1', deps)).toBe('gone')
+    expect(toasts).toEqual([])
+  })
+
+  it('gives up quietly after the poll budget', async () => {
+    const { toasts, deps } = harness([{ status: 'processing' }])
+    expect(await watchRetainYield('shared', 'op-1', deps)).toBe('timeout')
+    expect(toasts).toEqual([])
+  })
+})

--- a/ui/src/api/hooks/useMemory.ts
+++ b/ui/src/api/hooks/useMemory.ts
@@ -39,18 +39,106 @@ export interface MemoryAddResponse {
   operation_id?: string
 }
 
+// ── #2030: zero-fact retain visibility ──────────────────────────────────────
+//
+// Retain is async: /api/memory/add answers before fact extraction runs, and a
+// retain whose extraction yields ZERO facts still finishes
+// `status=completed, error_message=null` — the raw document is stored but
+// nothing from it is ever retrievable, and the only toast the operator saw
+// was "Fact added". The server now annotates the terminal operation record
+// (`facts_extracted` / `nothing_learned` / `notice` on
+// GET /api/memory/banks/{bank}/operations/{id}); this bounded poll carries
+// that verdict to the surface the operator actually reads. Fail-soft: any
+// fetch error or timeout ends the watch silently — it must never turn an
+// engine hiccup into a scary toast for a write that landed fine.
+
+/** Single-op record slice the yield watch reads (server-annotated, #2030). */
+export interface RetainYieldOperation {
+  status?: string
+  facts_extracted?: number
+  nothing_learned?: boolean
+  notice?: string | null
+}
+
+const RETAIN_YIELD_POLL_MS = 3_000
+// Extraction is model-bound and can queue behind other ops; ~60s covers the
+// fleet-observed completion times without polling forever.
+const RETAIN_YIELD_MAX_POLLS = 20
+
+export const NOTHING_LEARNED_FALLBACK =
+  'Completed, but nothing was learned: extraction produced 0 facts from that text.'
+
+/**
+ * Poll one retain operation to its terminal state and surface a zero-fact
+ * completion as a warn toast. Returns a verdict for tests; production
+ * callers fire-and-forget. `deps` exist for injection in unit tests only.
+ */
+export async function watchRetainYield(
+  bank: string,
+  operationId: string,
+  deps?: {
+    fetchOp?: (bank: string, id: string) => Promise<RetainYieldOperation>
+    notify?: (msg: string, kind: 'warn') => void
+    sleep?: (ms: number) => Promise<void>
+    maxPolls?: number
+  },
+): Promise<'nothing_learned' | 'ok' | 'gone' | 'timeout'> {
+  const fetchOp =
+    deps?.fetchOp ??
+    ((b: string, id: string) =>
+      apiGet<RetainYieldOperation>(
+        `/api/memory/banks/${encodeURIComponent(b)}/operations/${encodeURIComponent(id)}`,
+      ))
+  const notify =
+    deps?.notify ??
+    ((msg: string, kind: 'warn') => {
+      const toast = (window as unknown as { __hal0Toast?: (m: string, k: string) => void })
+        .__hal0Toast
+      if (toast) toast(msg, kind)
+    })
+  const sleep = deps?.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)))
+  const maxPolls = deps?.maxPolls ?? RETAIN_YIELD_MAX_POLLS
+
+  for (let i = 0; i < maxPolls; i++) {
+    await sleep(RETAIN_YIELD_POLL_MS)
+    let op: RetainYieldOperation
+    try {
+      op = await fetchOp(bank, operationId)
+    } catch {
+      return 'gone' // op deleted / bank mismatch / engine unreachable
+    }
+    const status = op?.status
+    if (status === 'failed' || status === 'cancelled') return 'ok' // loud elsewhere
+    if (status === 'completed') {
+      if (op.nothing_learned) {
+        notify(op.notice || NOTHING_LEARNED_FALLBACK, 'warn')
+        return 'nothing_learned'
+      }
+      return 'ok'
+    }
+  }
+  return 'timeout'
+}
+
 export function useMemoryAdd() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (body: MemoryAddBody) =>
       apiPost<MemoryAddResponse>(ENDPOINTS.memoryAdd, body as unknown as Record<string, unknown>),
-    onSuccess: (_d, vars) => {
+    onSuccess: (data, vars) => {
       // Refresh the written bank's unit/stats/tag caches (falls back to a
       // broad memory invalidate if no dataset was given, matching the
       // server's own dataset-resolution fallback).
       void qc.invalidateQueries({
         queryKey: vars.dataset ? ['memory', 'banks', vars.dataset] : ['memory'],
       })
+      // #2030: watch the async extraction to its terminal state so a
+      // zero-fact completion is announced instead of leaving "Fact added"
+      // as the last word. Needs the concrete bank id — the Add modal always
+      // sends one; adds without a dataset skip the watch.
+      if (data.operation_id && vars.dataset) {
+        void watchRetainYield(vars.dataset, data.operation_id)
+      }
     },
   })
 }


### PR DESCRIPTION
Fixes #2030

## Contract

A memory retain whose fact extraction yields **zero units** must be distinguishable from a real success on the surfaces users actually poll, while remaining `status=completed` (empty yield is a legitimate outcome made *visible*, per the issue's Expected — not reclassified as an error):

1. **Operation record** (`HindsightProvider.get_operation` → `memory_operation_get` MCP tool on both the memory and admin servers, and the REST single-op passthrough `GET /api/memory/banks/{bank}/operations/{id}` — the poll target `POST /api/memory/add` hands out via `operation_id`): a terminal completed `retain`/`batch_retain` gains
   - `facts_extracted` — units this operation created (`result_metadata.unit_ids_count`; document `memory_unit_count` fallback for engine records without `result_metadata`),
   - `document_fact_count` — fetched only when yield is zero/unknown,
   - `nothing_learned: true` + human-readable `notice` — **only** when the document itself holds zero units, i.e. the retain genuinely stored nothing retrievable.
2. **Dedup is not a false alarm**: a zero-yield retain of an already-extracted document (duplicate `content_hash`, adjudicated correct dedup by the rc.7 adversarial verification) gets a "content was already known (N facts previously extracted)" notice, never `nothing_learned`.
3. **Dashboard**: `useMemoryAdd` watches the async extraction to its terminal state (bounded fail-soft poll, ~60s) and raises a warn toast with the server's notice instead of leaving "Fact added" as the last word.
4. Fail-soft throughout: annotation never errors a poll; non-retain / non-completed ops and the list passthrough pass through verbatim (list rows carry no unit counts — annotating them would cost a document fetch per completed retain row on every dashboard poll tick, documented in-code).

## Evidence

- Engine shapes verified **live against hindsight-api 0.9.2**: single-op GET carries `operation_type` + `result_metadata.unit_ids_count`; list rows carry `task_type`/`document_id` and no unit count; documents carry `memory_unit_count` (matches the issue's `memory_unit_count=0` observation).
- `uv run pytest tests/memory tests/api/test_memory_admin_routes.py tests/api/test_memory_graph_route.py tests/api/test_memory_write_degraded_status.py tests/mcp tests/cli/test_memory_ops_commands.py` → **all green** (351 passed +1 env-gated skip in memory/api slice; 331 passed in mcp).
- New tests pin: zero-fact → `completed` + `nothing_learned` + notice (provider + route); nonzero → `facts_extracted` present, no notice, **no extra document fetch**; dedup ("already known"); 0.8.x record-shape fallback; failed/non-retain ops verbatim; document-fetch failure fail-soft.
- `ui`: `npm run test:unit` → 43 files / 481 tests passed (incl. new `retainYield.test.ts`: warn-on-zero, fallback message, silence on success/failure/error/timeout); `npm run typecheck` clean; ruff check + format clean on touched Python.
- CHANGELOG `### Fixed` bullet under `## [Unreleased]` (#2030); `docs/reference/mcp-tools.mdx` + MCP tool descriptions updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181rff5wtNoioAHumZsYCD4
