### PR TITLE
feat(diagnostics): doctor next steps as data, acting chips, consequence-first status copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,34 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+
+- **The Doctor panel's next steps are now real, not empty.** `health_report.py`'s
+  seven `hal0 doctor verify` classifiers (API, mDNS, runners, capability
+  slots, memory engine, OpenWebUI, Hermes) used to hard-code
+  `next_steps=[]` on every row despite the typed `Diagnosis.next_steps` /
+  `NextStep(kind="command"|"manual"|"doc")` shape already existing — so
+  `GET /api/doctor` and `hal0 doctor verify --json` always answered with an
+  empty list, and the dashboard's `DiagnosisPanel` chips carried the
+  remediation command only as a `title=` tooltip. Every fail/warn branch now
+  emits at least one real `NextStep`: the exact command an operator would
+  run (`hal0 serve`, `hal0 slot restart <name>`, `systemctl restart
+  hal0-api`/`hindsight-api`/`hal0-openwebui`/`hal0-agent@hermes`), a doc
+  link, or a manual instruction where no single command exists. In the
+  dashboard, `command` chips now show the command text inline in mono (not
+  only in a tooltip) and offer **Copy**, plus **Run** through the existing
+  typed `useServiceRepair`/`useSlotRestart` hooks when the command maps onto
+  one of those actions; `doc` chips open the link; `manual` chips expand.
+  A new **StepsDrawer** (numbered steps, same copy/Run/open affordances)
+  appears on any diagnosis with two or more next steps, reusable as-is for
+  a future extension-enable-steps surface. A new `status-copy.ts` module
+  gives every slot lifecycle state (`offline`/`pulling`/`starting`/
+  `warming`/`ready`/`serving`/`idle`/`unloading`/`error`) and companion-service
+  health word (`up`/`stopped`/`down`) a one-sentence, consequence-first
+  "what this means for you" line, surfaced as a tooltip beside the existing
+  precise vocabulary in the slot drawer, the slot card's status dot, and the
+  Services card — the precise words themselves are unchanged.
+
 ### Fixed
 
 - MCP admin tools no longer report a tool failure for a successful read of a

--- a/docs/guides/dashboard-and-settings.mdx
+++ b/docs/guides/dashboard-and-settings.mdx
@@ -115,7 +115,14 @@ one line and a link here rather than a repeat.
   or client key; shows the live route-exposure table. See
   [Auth](/docs/operate/auth).
 - **Doctor** — runs and renders `hal0 doctor`'s typed diagnoses (id,
-  severity, evidence, next steps) over HTTP.
+  severity, evidence, next steps) over HTTP. Every fail/warn row carries at
+  least one real next step, not just a description of the problem: a
+  `command` step shows the exact command in mono and offers **Copy**, plus
+  **Run** when it maps onto an existing repair action (restarting the
+  affected systemd service, or restarting a named runner slot); a `doc` step
+  opens the relevant guide; a `manual` step expands inline. A diagnosis with
+  two or more steps also gets a **Steps** button that opens a numbered
+  drawer with the same actions.
 
 ### MODELS & INFERENCE
 

--- a/src/hal0/health_report.py
+++ b/src/hal0/health_report.py
@@ -23,10 +23,10 @@ their tests) are unaffected.
 from __future__ import annotations
 
 import socket
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
-from hal0.diagnostics import Confidence, Diagnosis, Evidence, Severity
+from hal0.diagnostics import Confidence, Diagnosis, Evidence, NextStep, Severity
 
 # Status vocabulary. A "fail" row that is also ``critical`` renders red and
 # drives the overall verdict; a plain "fail"/"warn" is amber and never blocks.
@@ -49,6 +49,7 @@ class Check:
     status: str  # _PASS | _WARN | _FAIL
     detail: str
     critical: bool = False
+    next_steps: tuple[NextStep, ...] = field(default_factory=tuple)
 
 
 def _url_host(url: Any) -> str | None:
@@ -63,6 +64,41 @@ def _url_host(url: Any) -> str | None:
     return hostport.rsplit(":", 1)[0] if ":" in hostport else hostport
 
 
+# ── shared remediation commands ─────────────────────────────────────────────
+#
+# One owner per command string: these are the exact literals the UI's
+# NextStep-to-action mapping (ui/src/dash/diagnostics/next-step-actions.ts)
+# pattern-matches to offer a "Run" button through the matching typed hook
+# (useServiceRepair / useSlotRestart), instead of copy-only. Keep both sides
+# in sync — a wording change here must be mirrored there.
+
+_RESTART_HAL0_API = NextStep(
+    kind="command", label="systemctl restart hal0-api", target="systemctl restart hal0-api"
+)
+_RESTART_HINDSIGHT_API = NextStep(
+    kind="command",
+    label="systemctl restart hindsight-api",
+    target="systemctl restart hindsight-api",
+)
+
+# Cap the number of per-slot restart chips a single diagnosis offers -- a
+# roster with a dozen errored slots gets one row per slot in `hal0 slot
+# status`, not a diagnosis card wallpapered in chips.
+_MAX_SLOT_RESTART_STEPS = 3
+
+
+def _restart_slot_steps(errored: list[str]) -> tuple[NextStep, ...]:
+    """One ``hal0 slot restart <name>`` command per errored slot (capped)."""
+    return tuple(
+        NextStep(
+            kind="command",
+            label=f"hal0 slot restart {name}",
+            target=f"hal0 slot restart {name}",
+        )
+        for name in errored[:_MAX_SLOT_RESTART_STEPS]
+    )
+
+
 # ── per-check classifiers (pure -- take parsed JSON, return a Check) ───────────
 
 
@@ -75,6 +111,7 @@ def check_api(health: dict[str, Any] | None) -> Check:
             _FAIL,
             "unreachable — start it with `hal0 serve`",
             critical=True,
+            next_steps=(NextStep(kind="command", label="hal0 serve", target="hal0 serve"),),
         )
     version = health.get("version") if isinstance(health, dict) else None
     detail = f"serving (v{version})" if version else "serving"
@@ -102,6 +139,21 @@ def check_dns(urls: dict[str, Any] | None) -> Check:
             "mDNS (.local)",
             _WARN,
             f"{host} does not resolve here (multicast filtered? use the LAN IP)",
+            next_steps=(
+                NextStep(
+                    kind="manual",
+                    label="Use the LAN IP instead",
+                    target=(
+                        f"Browse to hal0 by its LAN IP instead of {host} — check your "
+                        "router's client list or run `hostname -I` on the hal0 host."
+                    ),
+                ),
+                NextStep(
+                    kind="doc",
+                    label="mDNS discovery",
+                    target="/docs/operate/services/#mdns-discovery-toggle",
+                ),
+            ),
         )
     return Check("dns", "mDNS (.local)", _PASS, f"{host} resolves")
 
@@ -114,22 +166,45 @@ def check_runners(system: dict[str, Any] | None) -> Check:
     errored slot names.
     """
     if system is None:
-        return Check("runners", "Runners", _FAIL, "health/system unreachable", critical=True)
+        return Check(
+            "runners",
+            "Runners",
+            _FAIL,
+            "health/system unreachable",
+            critical=True,
+            next_steps=(_RESTART_HAL0_API,),
+        )
     sm = (system.get("checks") or {}).get("slot_manager") if isinstance(system, dict) else None
     if not isinstance(sm, dict) or "slots" not in sm:
-        return Check("runners", "Runners", _FAIL, "slot manager not wired", critical=True)
+        return Check(
+            "runners",
+            "Runners",
+            _FAIL,
+            "slot manager not wired",
+            critical=True,
+            next_steps=(_RESTART_HAL0_API,),
+        )
     total = int(sm.get("slots") or 0)
     errored = list(sm.get("errored") or [])
     healthy = total - len(errored)
     if healthy <= 0:
-        detail = "no healthy runner slots" if total else "no runner slots configured yet"
-        return Check("runners", "Runners", _FAIL, detail, critical=True)
+        if total:
+            detail = "no healthy runner slots"
+            steps = _restart_slot_steps(errored)
+        else:
+            detail = "no runner slots configured yet"
+            steps = (
+                NextStep(kind="command", label="hal0 slot create", target="hal0 slot create"),
+                NextStep(kind="doc", label="Manage slots", target="/docs/guides/manage-slots"),
+            )
+        return Check("runners", "Runners", _FAIL, detail, critical=True, next_steps=steps)
     if errored:
         return Check(
             "runners",
             "Runners",
             _WARN,
             f"{healthy}/{total} healthy — errored: {', '.join(errored)}",
+            next_steps=_restart_slot_steps(errored),
         )
     return Check("runners", "Runners", _PASS, f"{healthy}/{total} slot(s) healthy")
 
@@ -137,13 +212,35 @@ def check_runners(system: dict[str, Any] | None) -> Check:
 def check_capabilities(capabilities: dict[str, Any] | None) -> Check:
     """Capability slots (embed/voice/img) configured -- advisory."""
     if capabilities is None:
-        return Check("capabilities", "Capability slots", _WARN, "unreachable")
+        return Check(
+            "capabilities",
+            "Capability slots",
+            _WARN,
+            "unreachable",
+            next_steps=(_RESTART_HAL0_API,),
+        )
     selections = capabilities.get("selections") if isinstance(capabilities, dict) else None
+    caps_steps = (
+        NextStep(
+            kind="manual",
+            label="Enable a capability",
+            target="Settings → AI Capabilities → pick an embed, voice, image, or vision child.",
+        ),
+        NextStep(
+            kind="doc",
+            label="Capabilities & profiles",
+            target="/docs/concepts/capabilities-and-profiles",
+        ),
+    )
     if not isinstance(selections, dict) or not selections:
-        return Check("capabilities", "Capability slots", _WARN, "none configured")
+        return Check(
+            "capabilities", "Capability slots", _WARN, "none configured", next_steps=caps_steps
+        )
     active = [k for k, v in selections.items() if v]
     if not active:
-        return Check("capabilities", "Capability slots", _WARN, "none active")
+        return Check(
+            "capabilities", "Capability slots", _WARN, "none active", next_steps=caps_steps
+        )
     return Check(
         "capabilities",
         "Capability slots",
@@ -155,7 +252,13 @@ def check_capabilities(capabilities: dict[str, Any] | None) -> Check:
 def check_memory(memory: dict[str, Any] | None) -> Check:
     """Hindsight memory engine + banks -- advisory (memory is optional)."""
     if memory is None:
-        return Check("memory", "Hindsight / banks", _WARN, "memory admin unreachable")
+        return Check(
+            "memory",
+            "Hindsight / banks",
+            _WARN,
+            "memory admin unreachable",
+            next_steps=(_RESTART_HAL0_API,),
+        )
     if not isinstance(memory, dict) or memory.get("engine") is None:
         # engine=None covers two very different states (#1543/#1613): memory
         # deliberately disabled (enabled=False → an honest PASS) vs. memory
@@ -170,19 +273,43 @@ def check_memory(memory: dict[str, Any] | None) -> Check:
                 _WARN,
                 "memory enabled but engine degraded (pgvector fallback) — "
                 "waits for the self-heal re-probe, or restart hal0-api",
+                next_steps=(_RESTART_HAL0_API,),
             )
         return Check("memory", "Hindsight / banks", _PASS, "disabled (no memory engine)")
     if not memory.get("reachable"):
-        return Check("memory", "Hindsight / banks", _WARN, "engine enabled but :9177 unreachable")
+        return Check(
+            "memory",
+            "Hindsight / banks",
+            _WARN,
+            "engine enabled but :9177 unreachable",
+            next_steps=(_RESTART_HINDSIGHT_API,),
+        )
     banks = memory.get("banks_total")
     detail = f"reachable — {banks} bank(s)" if banks is not None else "reachable"
     return Check("memory", "Hindsight / banks", _PASS, detail)
 
 
+#: check_key -> the systemd unit its companion-service restart command names,
+#: bare (no ``.service`` suffix — matches how an operator would type it).
+#: One owner: ui/src/dash/diagnostics/next-step-actions.ts maps the same
+#: bare name (plus ``.service``) to installer.py's _REPAIRABLE_UNITS entry.
+_SERVICE_UNITS: dict[str, str] = {
+    "openwebui": "hal0-openwebui",
+    "hermes": "hal0-agent@hermes",
+}
+
+
 def _service_check(services: dict[str, Any] | None, sid: str, label: str) -> Check:
     """Shared classifier for the two companion services (OWUI, Hermes)."""
+    restart_step = NextStep(
+        kind="command",
+        label=f"systemctl restart {_SERVICE_UNITS[sid]}",
+        target=f"systemctl restart {_SERVICE_UNITS[sid]}",
+    )
     if services is None:
-        return Check(sid, label, _WARN, "services health unreachable")
+        return Check(
+            sid, label, _WARN, "services health unreachable", next_steps=(_RESTART_HAL0_API,)
+        )
     entries = services.get("services") if isinstance(services, dict) else None
     entry = (
         next((s for s in entries if isinstance(s, dict) and s.get("id") == sid), None)
@@ -190,10 +317,10 @@ def _service_check(services: dict[str, Any] | None, sid: str, label: str) -> Che
         else None
     )
     if entry is None:
-        return Check(sid, label, _WARN, "not reported")
+        return Check(sid, label, _WARN, "not reported", next_steps=(restart_step,))
     if entry.get("up"):
         return Check(sid, label, _PASS, str(entry.get("detail") or "up"))
-    return Check(sid, label, _WARN, str(entry.get("detail") or "down"))
+    return Check(sid, label, _WARN, str(entry.get("detail") or "down"), next_steps=(restart_step,))
 
 
 def check_openwebui(services: dict[str, Any] | None) -> Check:
@@ -279,7 +406,7 @@ def to_diagnosis(c: Check) -> Diagnosis:
         summary=c.label,
         detail=c.detail,
         evidence=[Evidence(kind="endpoint", summary=c.detail)],
-        next_steps=[],
+        next_steps=list(c.next_steps),
     )
 
 

--- a/tests/cli/test_doctor_verify_next_steps.py
+++ b/tests/cli/test_doctor_verify_next_steps.py
@@ -1,0 +1,200 @@
+"""Tests for the real ``NextStep`` remediation the doctor-verify family emits.
+
+``health_report.to_diagnosis`` used to hard-code ``next_steps=[]`` for every
+one of the 7 checks (WS-K / §21.4 doctor retrofit had wired the shape but not
+the content). Each ``check_*`` classifier now carries its own remediation for
+every fail/warn branch it can reach — this module pins that per-branch
+content and confirms it survives the ``Check`` -> ``Diagnosis`` adapter.
+"""
+
+from __future__ import annotations
+
+from hal0.cli import doctor_verify as dv
+from hal0.cli.doctor_diagnosis import to_diagnosis
+from hal0.diagnostics import NextStep
+
+# ── check_api ────────────────────────────────────────────────────────────────
+
+
+def test_check_api_unreachable_offers_hal0_serve() -> None:
+    c = dv.check_api(None)
+    assert c.next_steps == (NextStep(kind="command", label="hal0 serve", target="hal0 serve"),)
+
+
+def test_check_api_pass_has_no_steps() -> None:
+    assert dv.check_api({"version": "1.0.0"}).next_steps == ()
+
+
+# ── check_dns ────────────────────────────────────────────────────────────────
+
+
+def test_check_dns_unresolved_offers_manual_and_doc(monkeypatch) -> None:
+    def _boom(_h: str) -> str:
+        raise OSError("no mdns")
+
+    monkeypatch.setattr(dv.socket, "gethostbyname", _boom)
+    c = dv.check_dns({"api": "http://hal0.local:8080"})
+    kinds = [s.kind for s in c.next_steps]
+    assert kinds == ["manual", "doc"]
+    assert c.next_steps[1].target == "/docs/operate/services/#mdns-discovery-toggle"
+
+
+def test_check_dns_pass_has_no_steps(monkeypatch) -> None:
+    monkeypatch.setattr(dv.socket, "gethostbyname", lambda h: "192.0.2.1")
+    assert dv.check_dns({"api": "http://hal0.local:8080"}).next_steps == ()
+
+
+# ── check_runners ────────────────────────────────────────────────────────────
+
+
+def test_check_runners_no_slots_configured_offers_create_and_doc() -> None:
+    c = dv.check_runners({"checks": {"slot_manager": {"slots": 0, "errored": []}}})
+    assert c.next_steps[0] == NextStep(
+        kind="command", label="hal0 slot create", target="hal0 slot create"
+    )
+    assert c.next_steps[1].kind == "doc"
+
+
+def test_check_runners_all_errored_offers_restart_per_slot() -> None:
+    payload = {"checks": {"slot_manager": {"slots": 2, "errored": ["a", "b"]}}}
+    c = dv.check_runners(payload)
+    assert c.status == "fail" and c.critical
+    assert [s.target for s in c.next_steps] == [
+        "hal0 slot restart a",
+        "hal0 slot restart b",
+    ]
+
+
+def test_check_runners_partial_errored_offers_restart_per_slot() -> None:
+    payload = {"checks": {"slot_manager": {"slots": 3, "errored": ["b"]}}}
+    c = dv.check_runners(payload)
+    assert c.status == "warn"
+    assert c.next_steps == (
+        NextStep(kind="command", label="hal0 slot restart b", target="hal0 slot restart b"),
+    )
+
+
+def test_check_runners_errored_steps_are_capped() -> None:
+    errored = [f"slot-{i}" for i in range(5)]
+    payload = {"checks": {"slot_manager": {"slots": 5, "errored": errored}}}
+    c = dv.check_runners(payload)
+    assert len(c.next_steps) == 3
+
+
+def test_check_runners_unreachable_and_not_wired_offer_restart_hal0_api() -> None:
+    restart = NextStep(
+        kind="command", label="systemctl restart hal0-api", target="systemctl restart hal0-api"
+    )
+    assert dv.check_runners(None).next_steps == (restart,)
+    assert dv.check_runners({"checks": {}}).next_steps == (restart,)
+
+
+def test_check_runners_pass_has_no_steps() -> None:
+    payload = {"checks": {"slot_manager": {"slots": 2, "errored": []}}}
+    assert dv.check_runners(payload).next_steps == ()
+
+
+# ── check_capabilities ───────────────────────────────────────────────────────
+
+
+def test_check_capabilities_none_configured_offers_manual_and_doc() -> None:
+    c = dv.check_capabilities({"selections": {}})
+    kinds = [s.kind for s in c.next_steps]
+    assert kinds == ["manual", "doc"]
+    assert c.next_steps[1].target == "/docs/concepts/capabilities-and-profiles"
+
+
+def test_check_capabilities_unreachable_offers_restart_hal0_api() -> None:
+    c = dv.check_capabilities(None)
+    assert c.next_steps[0].target == "systemctl restart hal0-api"
+
+
+def test_check_capabilities_active_has_no_steps() -> None:
+    c = dv.check_capabilities({"selections": {"embed": {"x": 1}}})
+    assert c.next_steps == ()
+
+
+# ── check_memory ─────────────────────────────────────────────────────────────
+
+
+def test_check_memory_admin_unreachable_offers_restart_hal0_api() -> None:
+    assert dv.check_memory(None).next_steps[0].target == "systemctl restart hal0-api"
+
+
+def test_check_memory_degraded_offers_restart_hal0_api() -> None:
+    c = dv.check_memory({"enabled": True, "engine": None})
+    assert c.next_steps[0].target == "systemctl restart hal0-api"
+
+
+def test_check_memory_engine_unreachable_offers_restart_hindsight_api() -> None:
+    c = dv.check_memory({"engine": "hindsight", "reachable": False})
+    assert c.next_steps[0].target == "systemctl restart hindsight-api"
+
+
+def test_check_memory_disabled_and_reachable_have_no_steps() -> None:
+    assert dv.check_memory({"enabled": False, "engine": None}).next_steps == ()
+    assert dv.check_memory({"engine": "hindsight", "reachable": True}).next_steps == ()
+
+
+# ── check_openwebui / check_hermes ──────────────────────────────────────────
+
+
+def test_service_checks_down_offer_matching_restart_unit() -> None:
+    services = {
+        "services": [
+            {"id": "openwebui", "up": False, "detail": "crashed"},
+            {"id": "hermes", "up": False, "detail": "inactive"},
+        ]
+    }
+    owui = dv.check_openwebui(services)
+    hermes = dv.check_hermes(services)
+    assert owui.next_steps[0].target == "systemctl restart hal0-openwebui"
+    assert hermes.next_steps[0].target == "systemctl restart hal0-agent@hermes"
+
+
+def test_service_checks_not_reported_offer_restart_too() -> None:
+    c = dv.check_openwebui({"services": []})
+    assert c.status == "warn"
+    assert c.next_steps[0].target == "systemctl restart hal0-openwebui"
+
+
+def test_service_checks_up_have_no_steps() -> None:
+    services = {"services": [{"id": "openwebui", "up": True, "detail": "reachable"}]}
+    assert dv.check_openwebui(services).next_steps == ()
+
+
+# ── every check offers ≥1 remediation somewhere in its state space ─────────
+
+
+def test_every_check_family_has_at_least_one_actionable_branch(monkeypatch) -> None:
+    """Not every single branch needs a step (e.g. dns's "no host advertised
+    yet" is a downstream symptom of the api check, which already covers it),
+    but every one of the 7 check families must have at least one branch that
+    does — otherwise a real fail/warn would strand the operator."""
+
+    def _boom(_h: str) -> str:
+        raise OSError("no mdns")
+
+    monkeypatch.setattr(dv.socket, "gethostbyname", _boom)
+    assert dv.check_api(None).next_steps
+    assert dv.check_dns({"api": "http://x.local"}).next_steps
+    assert dv.check_runners(None).next_steps
+    assert dv.check_capabilities(None).next_steps
+    assert dv.check_memory(None).next_steps
+    assert dv.check_openwebui({"services": []}).next_steps
+    assert dv.check_hermes({"services": []}).next_steps
+
+
+# ── Check -> Diagnosis adapter carries next_steps through ───────────────────
+
+
+def test_to_diagnosis_carries_next_steps() -> None:
+    c = dv.check_api(None)
+    d = to_diagnosis(c)
+    assert d.next_steps == list(c.next_steps)
+
+
+def test_to_diagnosis_pass_has_empty_next_steps() -> None:
+    c = dv.check_api({"version": "1.0.0"})
+    d = to_diagnosis(c)
+    assert d.next_steps == []

--- a/tests/ui_contracts/test_status_copy_mirror.py
+++ b/tests/ui_contracts/test_status_copy_mirror.py
@@ -1,0 +1,54 @@
+"""The UI's consequence-first status copy covers every SlotState wire value.
+
+Mirrors ``tests/ui_contracts/test_flag_aliases_mirror.py``'s approach: parse
+the JS/TS object literal out of ``status-copy.ts`` so a new
+``hal0.slots.state.SlotState`` member fails CI here instead of silently
+shipping a slot phase with no operator-facing "what this means" sentence.
+"""
+
+import json
+import re
+from pathlib import Path
+
+from hal0.slots.state import SlotState
+
+
+def _parse_ts_string_record(src: str, export_name: str) -> dict[str, str]:
+    """Extract ``export const <export_name>: ... = { ... }``'s strings.
+
+    ``status-copy.ts`` writes each entry as ``key: 'single-quoted value',`` —
+    real TS (with a type annotation on the const), not strict JSON, so this
+    pulls out the object body and re-quotes it into JSON rather than relying
+    on ``json.loads`` directly.
+    """
+    m = re.search(export_name + r"[^=]*=\s*\{(.*?)\n\}", src, re.S)
+    assert m, f"{export_name} object literal not found in status-copy.ts"
+    body = m.group(1)
+    entries = re.findall(r"(\w+):\s*'((?:[^'\\]|\\.)*)'", body)
+    assert entries, f"no key: 'value' entries parsed for {export_name}"
+    return {key: value for key, value in entries}
+
+
+def test_slot_state_copy_covers_every_slotstate_member() -> None:
+    src = Path("ui/src/dash/status-copy.ts").read_text()
+    ui = _parse_ts_string_record(src, "SLOT_STATE_COPY")
+    backend = {s.value for s in SlotState}
+    assert set(ui) == backend
+    for state, copy in ui.items():
+        assert len(copy) > 10, f"{state} has a suspiciously short status line"
+
+
+def test_service_health_copy_covers_up_stopped_down() -> None:
+    src = Path("ui/src/dash/status-copy.ts").read_text()
+    ui = _parse_ts_string_record(src, "SERVICE_HEALTH_COPY")
+    assert set(ui) == {"up", "stopped", "down"}
+
+
+def test_status_copy_json_round_trips_as_a_sanity_check() -> None:
+    """Belt-and-braces: the same entries also parse as valid JSON values once
+    re-quoted, so a stray unescaped quote in a copy string fails loudly here
+    instead of silently truncating the regex match above."""
+    src = Path("ui/src/dash/status-copy.ts").read_text()
+    ui = _parse_ts_string_record(src, "SLOT_STATE_COPY")
+    dumped = json.dumps(ui)
+    assert json.loads(dumped) == ui

--- a/ui/src/dash/diagnostics/DiagnosisPanel.jsx
+++ b/ui/src/dash/diagnostics/DiagnosisPanel.jsx
@@ -10,7 +10,13 @@
 // doctor feed via useDiagnoses. A backend without that route degrades to
 // synthesised GET /api/system-info evidence plus a stub-with-reason.
 
+import { copyTextToClipboard } from '@/lib/clipboard'
 import { useDiagnoses } from '@/api/hooks/useDiagnoses'
+import { openDocTarget } from './next-step-actions'
+import { useNextStepRunner } from './useNextStepRunner'
+import { StepsDrawer } from './StepsDrawer.jsx'
+
+const { useState } = React
 
 // severity → hue. hal0's Severity is info|warn|fail|critical; the CSS palette
 // has --info/--warn/--err/--ok, so fail+critical both map to --err (critical
@@ -28,23 +34,86 @@ const VERDICT = {
   critical: { label: 'critical', hue: 'var(--err)' },
 }
 
-function NextStep({ step }) {
-  const isDoc = step.kind === 'doc'
-  const isCmd = step.kind === 'command'
+const CHIP_STYLE = {
+  fontSize: 10.5,
+  color: 'var(--fg-3)',
+  borderColor: 'var(--line)',
+  background: 'var(--bg-2)',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+}
+
+// One acting chip per NextStep: `command` copies (and, where the command
+// maps to an existing typed mutation, offers Run); `doc` opens the link;
+// `manual` expands the full instruction inline. The command text itself
+// renders in mono next to the label — no longer tooltip-only (D6 chips).
+function NextStep({ step, runner }) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (step.kind === 'doc') {
+    return (
+      <button type="button" className="chip mono" data-testid="diagnosis-next-step" style={CHIP_STYLE} onClick={() => openDocTarget(step.target)}>
+        ↗ {step.label}
+      </button>
+    )
+  }
+
+  if (step.kind === 'manual') {
+    return (
+      <span className="chip mono" data-testid="diagnosis-next-step" style={{ ...CHIP_STYLE, flexDirection: 'column', alignItems: 'flex-start' }}>
+        <button
+          type="button"
+          data-testid="diagnosis-next-step-manual-toggle"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          style={{ background: 'none', border: 'none', color: 'inherit', font: 'inherit', padding: 0, cursor: 'pointer' }}
+        >
+          • {step.label}
+        </button>
+        {expanded && <span style={{ color: 'var(--fg-4)' }}>{step.target}</span>}
+      </span>
+    )
+  }
+
+  // command
+  const action = runner.actionFor(step)
   return (
-    <span
-      className="chip mono"
-      data-testid="diagnosis-next-step"
-      title={step.target}
-      style={{ fontSize: 10.5, color: 'var(--fg-3)', borderColor: 'var(--line)', background: 'var(--bg-2)' }}
-    >
-      {isCmd ? '$ ' : isDoc ? '↗ ' : '• '}{step.label}
+    <span className="chip mono" data-testid="diagnosis-next-step" style={CHIP_STYLE}>
+      $ {step.label}
+      <code style={{ color: 'var(--fg-4)' }}>{step.target}</code>
+      <button
+        type="button"
+        data-testid="diagnosis-next-step-copy"
+        aria-label={`Copy ${step.target}`}
+        onClick={async () => {
+          const ok = await copyTextToClipboard(step.target)
+          toast(ok ? 'Copied to clipboard' : 'Copy failed', ok ? 'ok' : 'err')
+        }}
+        style={{ background: 'none', border: '1px solid var(--line)', borderRadius: 4, color: 'inherit', font: 'inherit', padding: '1px 5px', cursor: 'pointer' }}
+      >
+        Copy
+      </button>
+      {action && (
+        <button
+          type="button"
+          data-testid="diagnosis-next-step-run"
+          disabled={runner.pending}
+          onClick={() => runner.run(step)}
+          style={{ background: 'none', border: '1px solid var(--line)', borderRadius: 4, color: 'inherit', font: 'inherit', padding: '1px 5px', cursor: 'pointer' }}
+        >
+          Run
+        </button>
+      )}
     </span>
   )
 }
 
 function DiagnosisCard({ d }) {
   const sev = SEV[d.severity] || SEV.info
+  const runner = useNextStepRunner()
+  const [stepsOpen, setStepsOpen] = useState(false)
+  const steps = Array.isArray(d.next_steps) ? d.next_steps : []
   return (
     <div
       className="s-row"
@@ -64,6 +133,16 @@ function DiagnosisCard({ d }) {
         <span className="mono" data-testid="diagnosis-id" style={{ fontSize: 11, color: 'var(--fg-4)' }}>{d.id}</span>
         <span style={{ fontSize: 13, color: 'var(--fg)' }}>{d.summary}</span>
         <span style={{ flex: 1 }} />
+        {steps.length >= 2 && (
+          <button
+            type="button"
+            className="btn ghost sm"
+            data-testid="diagnosis-open-steps"
+            onClick={() => setStepsOpen(true)}
+          >
+            Steps ({steps.length})
+          </button>
+        )}
         {d.confidence && (
           <span className="mono" style={{ fontSize: 9.5, color: 'var(--fg-5)' }}>{d.confidence} confidence</span>
         )}
@@ -85,10 +164,20 @@ function DiagnosisCard({ d }) {
       )}
 
       {/* next steps */}
-      {Array.isArray(d.next_steps) && d.next_steps.length > 0 && (
+      {steps.length > 0 && (
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 2 }}>
-          {d.next_steps.map((s, i) => <NextStep key={i} step={s} />)}
+          {steps.map((s, i) => <NextStep key={i} step={s} runner={runner} />)}
         </div>
+      )}
+
+      {steps.length >= 2 && (
+        <StepsDrawer
+          open={stepsOpen}
+          onClose={() => setStepsOpen(false)}
+          eyebrow={d.id}
+          title={d.summary}
+          steps={steps}
+        />
       )}
     </div>
   )

--- a/ui/src/dash/diagnostics/StepsDrawer.jsx
+++ b/ui/src/dash/diagnostics/StepsDrawer.jsx
@@ -1,0 +1,107 @@
+// hal0 dashboard — StepsDrawer (D6 next-steps modal shape).
+//
+// A reusable numbered-steps drawer for any diagnosis with >=2 NextSteps:
+// eyebrow + title (drawer language per COMMON.md's UI section), one numbered
+// row per step, each a command (mono text + Copy, and Run when the command
+// maps to a typed action) or a doc (deep-link button) or a manual step
+// (expands inline). Built for DiagnosisPanel's "Steps" opener but kept
+// generic — reused as-is for extension enable steps (features/*.jsx).
+//
+// Uses the window-global `Drawer` primitive (ui/src/dash/primitives.jsx),
+// same convention as every other dash/*.jsx surface — see
+// ui/eslint.config.js's window-globals allowance.
+
+import { copyTextToClipboard } from '@/lib/clipboard'
+import { openDocTarget } from './next-step-actions'
+import { useNextStepRunner } from './useNextStepRunner'
+
+const { useState } = React
+
+function StepRow({ index, step, runner }) {
+  const [expanded, setExpanded] = useState(false)
+  const action = step.kind === 'command' ? runner.actionFor(step) : null
+
+  return (
+    <div className="s-row" data-testid="steps-drawer-row" style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '10px 0' }}>
+      <span className="mono" style={{ color: 'var(--fg-4)', fontSize: 12, minWidth: 18 }}>{index + 1}.</span>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6, flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, color: 'var(--fg)' }}>{step.label}</div>
+
+        {step.kind === 'command' && (
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+            <code className="mono" style={{ fontSize: 11.5, color: 'var(--fg-3)', background: 'var(--bg-2)', border: '1px solid var(--line)', borderRadius: 4, padding: '3px 7px' }}>
+              {step.target}
+            </code>
+            <button
+              type="button"
+              className="btn ghost sm"
+              data-testid="steps-drawer-copy"
+              onClick={async () => {
+                const ok = await copyTextToClipboard(step.target)
+                toast(ok ? 'Copied to clipboard' : 'Copy failed', ok ? 'ok' : 'err')
+              }}
+            >
+              Copy
+            </button>
+            {action && (
+              <button
+                type="button"
+                className="btn sm"
+                data-testid="steps-drawer-run"
+                disabled={runner.pending}
+                onClick={() => runner.run(step)}
+              >
+                Run
+              </button>
+            )}
+          </div>
+        )}
+
+        {step.kind === 'doc' && (
+          <button
+            type="button"
+            className="btn ghost sm"
+            data-testid="steps-drawer-open-doc"
+            onClick={() => openDocTarget(step.target)}
+          >
+            Open docs ↗
+          </button>
+        )}
+
+        {step.kind === 'manual' && (
+          <>
+            <button
+              type="button"
+              className="btn ghost sm"
+              data-testid="steps-drawer-manual-toggle"
+              onClick={() => setExpanded((v) => !v)}
+              aria-expanded={expanded}
+            >
+              {expanded ? 'Hide details' : 'Show details'}
+            </button>
+            {expanded && (
+              <div className="mono" style={{ fontSize: 12, color: 'var(--fg-3)', lineHeight: 1.5 }}>
+                {step.target}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function StepsDrawer({ open, onClose, eyebrow, title, steps }) {
+  const runner = useNextStepRunner()
+  return (
+    <Drawer open={open} onClose={onClose} eyebrow={eyebrow || 'Next steps'} title={title} width={480}>
+      <div data-testid="steps-drawer" style={{ display: 'flex', flexDirection: 'column' }}>
+        {(steps || []).map((step, i) => (
+          <StepRow key={`${step.kind}-${step.target}-${i}`} index={i} step={step} runner={runner} />
+        ))}
+      </div>
+    </Drawer>
+  )
+}
+
+Object.assign(window, { StepsDrawer })

--- a/ui/src/dash/diagnostics/next-step-actions.test.ts
+++ b/ui/src/dash/diagnostics/next-step-actions.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+//
+// The rest of the unit suite runs in the `node` environment (vitest.config.ts)
+// since nothing else touches the DOM; `openDocTarget` needs a real `window`
+// for the window.open/location.hash assertions below, so this file opts into
+// happy-dom on its own rather than paying the DOM setup cost project-wide.
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { actionForNextStep, isExternalDocTarget, openDocTarget } from './next-step-actions'
+
+describe('actionForNextStep', () => {
+  it('maps the four repairable-service restart commands', () => {
+    expect(actionForNextStep({ kind: 'command', target: 'systemctl restart hal0-api' })).toEqual({
+      kind: 'serviceRestart',
+      unit: 'hal0-api.service',
+    })
+    expect(
+      actionForNextStep({ kind: 'command', target: 'systemctl restart hindsight-api' }),
+    ).toEqual({ kind: 'serviceRestart', unit: 'hindsight-api.service' })
+    expect(
+      actionForNextStep({ kind: 'command', target: 'systemctl restart hal0-openwebui' }),
+    ).toEqual({ kind: 'serviceRestart', unit: 'hal0-openwebui.service' })
+    expect(
+      actionForNextStep({ kind: 'command', target: 'systemctl restart hal0-agent@hermes' }),
+    ).toEqual({ kind: 'serviceRestart', unit: 'hal0-agent@hermes.service' })
+  })
+
+  it('maps a per-slot restart command', () => {
+    expect(actionForNextStep({ kind: 'command', target: 'hal0 slot restart chat' })).toEqual({
+      kind: 'slotRestart',
+      slot: 'chat',
+    })
+  })
+
+  it('returns null for an unmapped command', () => {
+    expect(actionForNextStep({ kind: 'command', target: 'hal0 slot create' })).toBeNull()
+    expect(actionForNextStep({ kind: 'command', target: 'hal0 serve' })).toBeNull()
+  })
+
+  it('returns null for non-command kinds regardless of target text', () => {
+    expect(actionForNextStep({ kind: 'doc', target: 'systemctl restart hal0-api' })).toBeNull()
+    expect(actionForNextStep({ kind: 'manual', target: 'systemctl restart hal0-api' })).toBeNull()
+  })
+})
+
+describe('isExternalDocTarget', () => {
+  it('recognises absolute http(s) urls only', () => {
+    expect(isExternalDocTarget('https://hal0.dev/docs')).toBe(true)
+    expect(isExternalDocTarget('http://hal0.dev/docs')).toBe(true)
+    expect(isExternalDocTarget('/docs/guides/manage-slots')).toBe(false)
+    expect(isExternalDocTarget('#settings/updates')).toBe(false)
+  })
+})
+
+describe('openDocTarget', () => {
+  const originalOpen = window.open
+  let openSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    openSpy = vi.fn()
+    window.open = openSpy as unknown as typeof window.open
+    window.location.hash = ''
+  })
+
+  afterEach(() => {
+    window.open = originalOpen
+  })
+
+  it('opens an external url directly in a new tab', () => {
+    openDocTarget('https://hal0.dev/changelog')
+    expect(openSpy).toHaveBeenCalledWith('https://hal0.dev/changelog', '_blank', 'noopener')
+  })
+
+  it('navigates an in-app hash route without opening a tab', () => {
+    openDocTarget('#settings/updates')
+    expect(window.location.hash).toBe('#settings/updates')
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+
+  it('resolves a docs-site path against hal0.dev', () => {
+    openDocTarget('/docs/operate/services/#mdns-discovery-toggle')
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://hal0.dev/docs/operate/services/#mdns-discovery-toggle',
+      '_blank',
+      'noopener',
+    )
+  })
+})

--- a/ui/src/dash/diagnostics/next-step-actions.ts
+++ b/ui/src/dash/diagnostics/next-step-actions.ts
@@ -1,0 +1,73 @@
+// hal0 dashboard — NextStep -> UI action mapping (D6 remediation chips).
+//
+// `src/hal0/health_report.py` emits `NextStep{kind, label, target}` rows —
+// the same three fields whichever check emitted them (see that module's
+// "shared remediation commands" section, the one owner for the literal
+// command strings below). A `command` step is always safe to copy; a small
+// allowlisted subset also maps onto an EXISTING typed mutation so the panel
+// can offer "Run" instead of "copy, open a terminal, paste" — restarting one
+// of the systemd units `hal0.api.routes.installer._REPAIRABLE_UNITS` already
+// allows (`useServiceRepair`), or restarting one named runner slot
+// (`useSlotRestart`, `POST /api/slots/{name}/restart`).
+//
+// Deliberately NOT string-sniffing every possible command: an unmapped
+// `command` step still copies fine, it just has no "Run" button. Adding a
+// new mapping here always pairs with adding the matching literal in
+// health_report.py's remediation-command section — one owner per string.
+
+export type NextStepKind = 'command' | 'manual' | 'doc'
+
+export interface NextStep {
+  kind: NextStepKind
+  label: string
+  target: string
+}
+
+export type NextStepAction =
+  | { kind: 'serviceRestart'; unit: string }
+  | { kind: 'slotRestart'; slot: string }
+
+// command target (verbatim, as printed) -> systemd unit `useServiceRepair`
+// restarts. Mirrors `hal0.api.routes.installer._REPAIRABLE_UNITS` (the
+// bare-name half — the mutation appends `.service`/uses the literal unit).
+const SERVICE_RESTART_UNITS: Readonly<Record<string, string>> = {
+  'systemctl restart hal0-api': 'hal0-api.service',
+  'systemctl restart hindsight-api': 'hindsight-api.service',
+  'systemctl restart hal0-openwebui': 'hal0-openwebui.service',
+  'systemctl restart hal0-agent@hermes': 'hal0-agent@hermes.service',
+}
+
+const SLOT_RESTART_RE = /^hal0 slot restart (\S+)$/
+
+/** `null` when the step has no matching typed action — copy-only. */
+export function actionForNextStep(step: Pick<NextStep, 'kind' | 'target'>): NextStepAction | null {
+  if (step.kind !== 'command') return null
+  const unit = SERVICE_RESTART_UNITS[step.target]
+  if (unit) return { kind: 'serviceRestart', unit }
+  const m = SLOT_RESTART_RE.exec(step.target)
+  if (m) return { kind: 'slotRestart', slot: m[1] }
+  return null
+}
+
+/** True when `target` is an absolute URL (`doc` steps may be either an
+ *  external https://hal0.dev/... link or an in-app `/docs/...` / `#...` route). */
+export function isExternalDocTarget(target: string): boolean {
+  return /^https?:\/\//i.test(target)
+}
+
+/** Open a `doc` step's target the way the rest of the dashboard opens links:
+ *  a new tab for an external URL, an in-app route change for a hash/path. */
+export function openDocTarget(target: string): void {
+  if (typeof window === 'undefined') return
+  if (isExternalDocTarget(target)) {
+    window.open(target, '_blank', 'noopener')
+    return
+  }
+  if (target.startsWith('#')) {
+    window.location.hash = target.slice(1)
+    return
+  }
+  // A docs-site path (e.g. "/docs/operate/services/#mdns-discovery-toggle")
+  // — the dashboard doesn't serve docs itself, so this always opens externally.
+  window.open(`https://hal0.dev${target}`, '_blank', 'noopener')
+}

--- a/ui/src/dash/diagnostics/useNextStepRunner.js
+++ b/ui/src/dash/diagnostics/useNextStepRunner.js
@@ -1,0 +1,42 @@
+// hal0 dashboard — runs an actionable `command` NextStep through its typed
+// hook (D6 remediation chips). Pairs with next-step-actions.ts, the pure
+// target -> action mapping this hook executes.
+//
+// Two hooks cover every mapped action today: useServiceRepair (the same
+// one-click repair RestartApiPanel.jsx uses) and useSlotRestart (the same
+// mutation the slot card's Restart button uses) — both invalidate their own
+// queries on success, so the panel's next poll picks up the change without
+// this hook doing it again.
+
+import { useServiceRepair } from '@/api/hooks/useServicesHealth'
+import { useSlotRestart } from '@/api/hooks/useSlots'
+import { actionForNextStep } from './next-step-actions'
+
+export function useNextStepRunner() {
+  const repair = useServiceRepair()
+  const slotRestart = useSlotRestart()
+
+  function run(step) {
+    const action = actionForNextStep(step)
+    if (!action) return
+    if (action.kind === 'serviceRestart') {
+      toast(`Restarting ${action.unit}…`, 'warn')
+      repair.mutate(action.unit, {
+        onSuccess: () => toast(`${action.unit} restarted`, 'ok'),
+        onError: (e) => toast(e?.message || `Failed to restart ${action.unit}`, 'err'),
+      })
+      return
+    }
+    toast(`Restarting slot ${action.slot}…`, 'warn')
+    slotRestart.mutate(action.slot, {
+      onSuccess: () => toast(`Slot ${action.slot} restarted`, 'ok'),
+      onError: (e) => toast(e?.message || `Failed to restart slot ${action.slot}`, 'err'),
+    })
+  }
+
+  return {
+    run,
+    actionFor: actionForNextStep,
+    pending: repair.isPending || slotRestart.isPending,
+  }
+}

--- a/ui/src/dash/services-card.jsx
+++ b/ui/src/dash/services-card.jsx
@@ -14,6 +14,7 @@
 // Window-global: Object.assign(window, {ServicesCard})
 
 import { useServicesHealth } from '@/api/hooks/useServicesHealth'
+import { statusCopyForServiceState } from './status-copy'
 import { useComfyui, COMFYUI_FALLBACK } from '@/api/hooks/useComfyui'
 import { useComponents } from '@/api/hooks/useComponents'
 import { pendingCount } from './components-pure'
@@ -92,9 +93,12 @@ function serviceIcon(id) {
 }
 
 // ── Status pill ───────────────────────────────────────────────────────────────
-function StatusPill({ up }) {
+// `title` carries the consequence-first sentence for the service's precise
+// health word (services_health.py's up|stopped|down) beside the pill's own
+// simplified up/idle label — see status-copy.ts.
+function StatusPill({ up, state }) {
   return (
-    <span className={'svc-pill' + (up ? ' svc-pill-up' : ' svc-pill-idle')}>
+    <span className={'svc-pill' + (up ? ' svc-pill-up' : ' svc-pill-idle')} title={statusCopyForServiceState(state)}>
       <span className={'sdot ' + (up ? 'serving' : 'offline')} style={{ width: 6, height: 6 }} />
       {up ? 'up' : 'idle'}
     </span>
@@ -247,7 +251,7 @@ function ServiceRow({ svc, isComfy, comfyReachable, expanded, onToggle }) {
         {/* Name + status pill */}
         <span className="svc-info">
           <span className="svc-name">{svc.name}</span>
-          <StatusPill up={svc.up} />
+          <StatusPill up={svc.up} state={svc.state} />
         </span>
 
         {/* Role/sub line */}

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -60,6 +60,7 @@ import {
 	slotButtonPhase,
 	imageLiveState,
 } from "./slot-status.js";
+import { statusCopyForSlotState } from "./status-copy";
 import { SlotBreakerChip } from "./breaker-chip.jsx";
 import { npuModalityOn } from "./npu-modality.js";
 import { slotModelRow, npuAnchorSlot } from "./slots/slot-shared.js";
@@ -1767,6 +1768,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 							<span
 								data-testid="slot-state-readonly"
 								className={stateChipClass(slot)}
+								title={statusCopyForSlotState(slot.state)}
 							>
 								{slot.state}
 							</span>

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -31,6 +31,7 @@ import {
 } from './inference-pane.jsx'
 import { TelemetryHeader } from './telemetry-header.jsx'
 import { slotIndicatorFromPhase, slotButtonPhase, isSlotLive, imageStatusChip } from './slot-status.js'
+import { statusCopyForSlotState } from './status-copy'
 import { prettyProfile } from './profile-names.js'
 import { slotModelRow } from './slots/slot-shared.js'
 
@@ -69,7 +70,14 @@ function slotIndicator(slot, now = Date.now()) {
 
 function IndicatorDot({ slot }) {
   const ind = slotIndicator(slot);
-  return <span className={"dot " + ind.cls} title={ind.tooltip} />;
+  // The rendered tooltip appends the consequence-first sentence for the
+  // slot's raw lifecycle state (status-copy.ts) after the precise phase
+  // tooltip `slotIndicatorFromPhase` already computes — window.slotIndicator
+  // itself stays byte-for-byte pinned (tests/e2e/specs/slot-indicator.spec.ts
+  // reads its return value directly), only the DOM `title` gains the extra
+  // sentence.
+  const tooltip = `${ind.tooltip} — ${statusCopyForSlotState(slot?.state)}`;
+  return <span className={"dot " + ind.cls} title={tooltip} />;
 }
 
 // Expose for window-scope JSX (legacy pattern in this codebase) + tests.

--- a/ui/src/dash/status-copy.test.ts
+++ b/ui/src/dash/status-copy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SLOT_STATE_COPY,
+  SERVICE_HEALTH_COPY,
+  statusCopyForSlotState,
+  statusCopyForServiceState,
+} from './status-copy'
+
+// The 9 wire values of hal0.slots.state.SlotState — pinned again (in Python)
+// by tests/ui_contracts/test_status_copy_mirror.py so this list can't drift
+// from the backend enum silently.
+const SLOT_STATES = [
+  'offline',
+  'pulling',
+  'starting',
+  'warming',
+  'ready',
+  'serving',
+  'idle',
+  'unloading',
+  'error',
+]
+
+describe('SLOT_STATE_COPY', () => {
+  it('covers every SlotState wire value exactly once, non-empty', () => {
+    expect(Object.keys(SLOT_STATE_COPY).sort()).toEqual([...SLOT_STATES].sort())
+    for (const state of SLOT_STATES) {
+      expect(SLOT_STATE_COPY[state as keyof typeof SLOT_STATE_COPY].length).toBeGreaterThan(10)
+    }
+  })
+
+  it('keeps the precise word out of its own sentence (consequence-first, not a restatement)', () => {
+    // Loose smoke check: the sentence should read as "what it means", not
+    // literally start by repeating the enum word.
+    for (const [state, copy] of Object.entries(SLOT_STATE_COPY)) {
+      expect(copy.toLowerCase().startsWith(state)).toBe(false)
+    }
+  })
+})
+
+describe('SERVICE_HEALTH_COPY', () => {
+  it('covers up | stopped | down exactly', () => {
+    expect(Object.keys(SERVICE_HEALTH_COPY).sort()).toEqual(['down', 'stopped', 'up'])
+  })
+})
+
+describe('statusCopyForSlotState / statusCopyForServiceState', () => {
+  it('resolves every known word', () => {
+    for (const state of SLOT_STATES) {
+      expect(statusCopyForSlotState(state)).toBe(SLOT_STATE_COPY[state as keyof typeof SLOT_STATE_COPY])
+    }
+    expect(statusCopyForServiceState('up')).toBe(SERVICE_HEALTH_COPY.up)
+  })
+
+  it('falls back honestly on an unknown or missing word instead of throwing', () => {
+    expect(statusCopyForSlotState('some-future-state')).toMatch(/unrecognised/i)
+    expect(statusCopyForSlotState(null)).toMatch(/unrecognised/i)
+    expect(statusCopyForServiceState(undefined)).toMatch(/unrecognised/i)
+  })
+})

--- a/ui/src/dash/status-copy.ts
+++ b/ui/src/dash/status-copy.ts
@@ -1,0 +1,69 @@
+// hal0 dashboard — consequence-first status copy (H4 / study 3.5-partial).
+//
+// Slot phase words and service health words are precise-but-internal
+// vocabulary ("warming", "idle", "stopped") — accurate for an operator who
+// already knows the state machine, opaque to one who doesn't. This module is
+// the single owner of a one-sentence "what this means for you" line per
+// word, kept SEPARATE from the vocabulary itself: callers render the precise
+// word first (unchanged) and this sentence alongside it (tooltip / drawer),
+// never as a replacement — ODS's STATUS_DESCRIPTIONS pattern
+// (ods/extensions/services/dashboard/src/pages/Extensions.jsx:60-84) without
+// its icon/color duplication, since hal0 already owns those via
+// slot-status.js / services.jsx.
+//
+// `SLOT_STATE_COPY`'s keys are `src/hal0/slots/state.py`'s `SlotState` wire
+// values exactly — pinned by `tests/ui_contracts/test_status_copy_mirror.py`
+// so a new lifecycle state can't ship without also getting a sentence here.
+// `SERVICE_HEALTH_COPY`'s keys are the three words
+// `src/hal0/api/routes/services_health.py`'s `_owui_state`/`_hermes_state`
+// helpers emit (`up` | `stopped` | `down`) — no Python enum backs those (they
+// are literal strings), so there is nothing to mirror-test against; the
+// vitest completeness test below is the whole contract.
+
+export type SlotStateWord =
+  | 'offline'
+  | 'pulling'
+  | 'starting'
+  | 'warming'
+  | 'ready'
+  | 'serving'
+  | 'idle'
+  | 'unloading'
+  | 'error'
+
+export type ServiceHealthWord = 'up' | 'stopped' | 'down'
+
+export const SLOT_STATE_COPY: Readonly<Record<SlotStateWord, string>> = {
+  offline: 'Not running — no requests reach it until something starts it or a request wakes it.',
+  pulling: 'Downloading its model files — not ready to serve yet.',
+  starting: 'Container is booting — requests queue until it reports healthy.',
+  warming: 'Loading the model into memory — the first request through this may wait longer than usual.',
+  ready: 'Loaded and healthy, waiting for a request — nothing to do here.',
+  serving: 'Answering a request right now.',
+  idle: 'Loaded but unused recently — a candidate to unload and free its memory.',
+  unloading: 'Shutting down to free its memory — requests will not reach it until it restarts.',
+  error: 'Failed to load or crashed — nothing is routed here until it is fixed and restarted.',
+}
+
+export const SERVICE_HEALTH_COPY: Readonly<Record<ServiceHealthWord, string>> = {
+  up: 'Reachable and answering normally.',
+  stopped: 'Not running on purpose — it starts on demand when something needs it.',
+  down: 'Crashed or failed — it will not come back on its own; restart it.',
+}
+
+const SLOT_STATE_FALLBACK = 'Unrecognised lifecycle state — treat as unavailable until confirmed otherwise.'
+const SERVICE_HEALTH_FALLBACK = 'Unrecognised health word — treat as unavailable until confirmed otherwise.'
+
+export function statusCopyForSlotState(state: string | null | undefined): string {
+  if (state && Object.prototype.hasOwnProperty.call(SLOT_STATE_COPY, state)) {
+    return SLOT_STATE_COPY[state as SlotStateWord]
+  }
+  return SLOT_STATE_FALLBACK
+}
+
+export function statusCopyForServiceState(state: string | null | undefined): string {
+  if (state && Object.prototype.hasOwnProperty.call(SERVICE_HEALTH_COPY, state)) {
+    return SERVICE_HEALTH_COPY[state as ServiceHealthWord]
+  }
+  return SERVICE_HEALTH_FALLBACK
+}

--- a/ui/tests/e2e/specs/diagnostics-next-steps-v3.spec.ts
+++ b/ui/tests/e2e/specs/diagnostics-next-steps-v3.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * diagnostics-next-steps-v3 — w1a "Doctor next steps as data" (H4).
+ *
+ * `health_report.py`'s classifiers now emit real `NextStep`s (previously
+ * hard-coded to `[]`) and `DiagnosisPanel.jsx` renders them as ACTING chips
+ * — copy-to-clipboard for every command, a "Run" button for the subset that
+ * maps onto an existing typed mutation, and a numbered StepsDrawer once a
+ * diagnosis carries >=2 steps. This spec pins that behaviour against a
+ * mocked `/api/doctor` feed shaped like the real one.
+ */
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+const DOCTOR_FEED = {
+  verdict: 'critical',
+  diagnoses: [
+    {
+      id: 'HAL0-API-UNREACHABLE',
+      severity: 'info',
+      confidence: 'high',
+      summary: 'hal0 API reachable',
+      detail: '',
+      fixable: false,
+      evidence: [],
+      next_steps: [],
+    },
+    {
+      id: 'HAL0-HERMES-DOWN',
+      severity: 'warn',
+      confidence: 'high',
+      summary: 'Hermes is not responding',
+      detail: 'hal0-agent@hermes.service is inactive.',
+      fixable: false,
+      evidence: [],
+      // A single actionable command step — renders inline, no Steps opener.
+      next_steps: [
+        {
+          kind: 'command',
+          label: 'systemctl restart hal0-agent@hermes',
+          target: 'systemctl restart hal0-agent@hermes',
+        },
+      ],
+    },
+    {
+      id: 'HAL0-RUNNERS-NONE-HEALTHY',
+      severity: 'critical',
+      confidence: 'high',
+      summary: 'no runner is healthy',
+      detail: 'Every configured slot is offline or errored.',
+      fixable: false,
+      evidence: [],
+      // Two steps -> the Steps drawer opener must appear.
+      next_steps: [
+        { kind: 'command', label: 'hal0 slot restart chat', target: 'hal0 slot restart chat' },
+        { kind: 'doc', label: 'Manage slots', target: '/docs/guides/manage-slots' },
+      ],
+    },
+  ],
+}
+
+async function mockDoctor(page: Page) {
+  await page.route('**/api/doctor', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(DOCTOR_FEED) }),
+  )
+}
+
+async function openDoctor(page: Page) {
+  await page.goto('/#settings')
+  await page.locator('.settings-nav .nav-item', { hasText: 'Doctor' }).click()
+  await expect(page.getByTestId('diagnosis-panel')).toBeVisible()
+}
+
+test.describe('Diagnosis next steps act (w1a)', () => {
+  test('a command step shows its text in mono and copies to the clipboard', async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+    await mockDoctor(page)
+    await openDoctor(page)
+
+    const card = page.getByTestId('diagnosis-card-HAL0-HERMES-DOWN')
+    const step = card.getByTestId('diagnosis-next-step').first()
+    await expect(step).toContainText('systemctl restart hal0-agent@hermes')
+
+    await step.getByTestId('diagnosis-next-step-copy').click()
+    await expect(page.locator('.toast-msg').last()).toContainText(/copied/i)
+    const clip = await page.evaluate(() => navigator.clipboard.readText())
+    expect(clip).toBe('systemctl restart hal0-agent@hermes')
+  })
+
+  test('a command mapped to a repairable service offers Run', async ({ page }) => {
+    await mockDoctor(page)
+    await openDoctor(page)
+
+    const card = page.getByTestId('diagnosis-card-HAL0-HERMES-DOWN')
+    const run = card.getByTestId('diagnosis-next-step-run')
+    await expect(run).toBeVisible()
+    await run.click()
+    await expect(page.locator('.toast-msg').last()).toContainText(/hal0-agent@hermes/i)
+  })
+
+  test('a doc step is a real link that opens the target', async ({ page, context }) => {
+    // The doc target resolves against the public docs site — stub it so the
+    // popup never makes a real network request in CI.
+    await context.route('https://hal0.dev/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'text/html', body: '<!doctype html><title>docs stub</title>' }),
+    )
+    await mockDoctor(page)
+    await openDoctor(page)
+
+    const card = page.getByTestId('diagnosis-card-HAL0-RUNNERS-NONE-HEALTHY')
+    const [popup] = await Promise.all([
+      context.waitForEvent('page'),
+      card.getByTestId('diagnosis-next-step').filter({ hasText: 'Manage slots' }).click(),
+    ])
+    await expect
+      .poll(() => popup.url())
+      .toContain('/docs/guides/manage-slots')
+  })
+
+  test('a diagnosis with >=2 steps offers a Steps drawer with numbered rows', async ({ page }) => {
+    await mockDoctor(page)
+    await openDoctor(page)
+
+    const card = page.getByTestId('diagnosis-card-HAL0-RUNNERS-NONE-HEALTHY')
+    await expect(card.getByTestId('diagnosis-open-steps')).toContainText('2')
+    await card.getByTestId('diagnosis-open-steps').click()
+
+    const drawer = page.getByTestId('steps-drawer')
+    await expect(drawer).toBeVisible()
+    const rows = drawer.getByTestId('steps-drawer-row')
+    await expect(rows).toHaveCount(2)
+    await expect(rows.nth(0)).toContainText('hal0 slot restart chat')
+    await expect(rows.nth(1)).toContainText('Manage slots')
+  })
+
+  test('a diagnosis with a single step has no Steps opener', async ({ page }) => {
+    await mockDoctor(page)
+    await openDoctor(page)
+
+    const card = page.getByTestId('diagnosis-card-HAL0-HERMES-DOWN')
+    await expect(card.getByTestId('diagnosis-open-steps')).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary

`health_report.py`'s 7 `hal0 doctor verify` classifiers (API, mDNS,
runners, capability slots, memory engine, OpenWebUI, Hermes) hard-coded
`next_steps=[]` on every row (`src/hal0/health_report.py:282` before this
PR) even though the typed `Diagnosis.next_steps` /
`NextStep(kind="command"|"manual"|"doc")` shape already existed
(`src/hal0/diagnostics.py:41-56`) and `ui/src/dash/diagnostics/DiagnosisPanel.jsx:31-44`
already rendered chips for it — so `GET /api/doctor` always answered with
an empty list and a remediation command was reachable only via a `title=`
tooltip. This PR:

1. Populates a real `NextStep` for every fail/warn branch each classifier
   can reach — the exact command an operator would run (`hal0 serve`,
   `hal0 slot restart <name>`, `hal0 slot create`, or `systemctl restart
   hal0-api|hindsight-api|hal0-openwebui|hal0-agent@hermes`), a doc link,
   or a manual instruction where no single command exists — built at the
   same point each classifier already produces its human-readable detail
   string, so message and remedy can't drift apart.
2. Makes `DiagnosisPanel.jsx`'s chips act: `command` chips show the
   command inline in mono with **Copy**, plus **Run** when it maps onto an
   existing typed mutation (`useServiceRepair` — the same one-click repair
   `RestartApiPanel.jsx` uses, restricted server-side to
   `installer.py`'s `_REPAIRABLE_UNITS` — or `useSlotRestart`); `doc`
   chips open the link; `manual` chips expand.
3. Adds a reusable `StepsDrawer` (numbered steps, same affordances) that
   opens for any diagnosis with ≥2 next steps — generic enough to reuse
   later for extension enable steps.
4. Adds `status-copy.ts`: a one-sentence, consequence-first "what this
   means for you" line for every slot lifecycle state
   (`offline`/`pulling`/`starting`/`warming`/`ready`/`serving`/`idle`/
   `unloading`/`error`) and companion-service health word
   (`up`/`stopped`/`down`), shown as a tooltip beside the existing precise
   vocabulary in the slot drawer, the slot card's status dot, and the
   Services card — the precise words themselves are unchanged.

The auth-posture check's remedy is intentionally **not** included — it
depends on teammate w0a's check landing in the shared classifier first;
noted as a follow-up, not stubbed in code.

## Risk grade

- [x] med — new code path (real remediation data + acting UI), no schema
      break (`NextStep`'s 3-field shape is unchanged, existing pinned
      tests confirm it)

## Touched surfaces

- [x] API (`src/hal0/api/routes/doctor.py` unchanged — consumes
      `to_diagnosis()` verbatim; `src/hal0/health_report.py` is the
      classifier module it composes)
- [x] UI (`ui/src/`, Playwright specs)
- [x] Docs (`docs/`)

## §14.1 high-risk surfaces

None apply — no new routes, no `AUTONOMOUS_WRITE_TOOLS` changes, no
installer/updater shell-out.

## Rollback

Revert this PR's 4 commits; `Check.next_steps` defaults to an empty tuple
and `to_diagnosis()` reverting to `next_steps=[]` restores prior behavior
exactly (no data migration, no persisted state).

## Test tiers run

- [x] α unit — `uv run pytest tests/ -q -n 8`: 12787 passed, 21 skipped, 1
      xfailed, **3 failed** — the same 3 pre-existing failures this dev box
      always has (`test_moonshine_server.py` needs `ffmpeg` the box lacks;
      `test_pressure_eviction.py::test_pressure_evict_noop_when_probe_fails`
      is flaky on this box per the parity program's baseline notes), none
      touched by this diff.
      `uv run ruff check/format`, `uv run mypy`, `python3
      scripts/check_sunset.py` all clean.
- [ ] β integration — not run (no local Lemonade/systemd harness available
      in this worktree; nothing in this diff touches the integration
      surface — pure classifier logic + UI).
- UI: `npm run lint && npm run typecheck && npm run test:unit && npm run
      build` all green (497 unit tests). A new Playwright spec
      (`diagnostics-next-steps-v3.spec.ts`) covers copy-to-clipboard,
      Run, doc-open, and the StepsDrawer against a mocked `/api/doctor`
      feed, but **could not be executed on this dev box** —
      `chromium_headless_shell` fails to launch here
      (`libnspr4.so: cannot open shared object file`, no sudo available to
      install it); the two pre-existing diagnostics Playwright specs fail
      identically unmodified, confirming a host-level gap rather than a
      regression in this change. CI has full browser deps and should
      confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbAfiRnPCuPwn3E7YMMgan
