### PR TITLE
feat(settings): schema-driven settings fields + one ChangeSet for preview/apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,44 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+
+- **Schema-driven settings**: `GET /api/settings/fields` returns one labelled
+  row per operator-editable `Hal0Config` key — group, label, a
+  consequence-first description, type/enum/range, default, current value,
+  reload class, secret flag, and (for a `hal0/<slot>`-shaped value) whether
+  it currently resolves to a loaded slot. Every leaf's description is a
+  hard requirement, enforced by a completeness ratchet
+  (`tests/api/test_settings_fields.py`) the same shape as the exposure
+  ratchet: a new config field ships with no dashboard row until it's
+  documented. Settings → Integrations gains a new **Realtime** page for the
+  previously entirely unexposed `[realtime]` WS voice-endpoint config
+  (#2108).
+- **One ChangeSet for settings preview and apply**: `POST
+  /api/settings/preview` computes the exact diff a `PUT /api/settings` with
+  the same body would apply — before/after per key, added/changed/removed,
+  reload class, and services affected — without writing anything. `PUT
+  /api/settings` now returns the same payload under `_hal0.changeset`
+  (additive alongside the existing `_hal0.apply_plan`), since both routes
+  call the one `compute_settings_changeset` function. Closes the shape of
+  four related bugs (a hardcoded changed-fields list that lies on a no-op,
+  a preview that bills additions but not removals, a round-trip that can
+  silently drop a key, and a preview whose promise the apply doesn't keep)
+  as regression fixtures against the general settings surface (#1967,
+  #2195, #2203, #1511).
+
 ### Fixed
 
+- `[brain_chat].tool_model` — the one `[brain_chat]` key with real routing
+  consequences (where a tool-calling round reroutes when the chat model
+  can't emit tool calls this runtime parses) — had no dashboard path at
+  all; the Agent Chat settings page saved every other key but silently
+  dropped this one. It now renders as a `RichSelect` over every configured
+  chat-capable slot, an explicit "same as chat model" preset, and a
+  "Disabled" choice, with a plain-language banner when the saved value has
+  no live target — the shipped `hal0/agent` default ships unbound on a
+  fresh install, so the gap is now visible in the dashboard instead of
+  discovered mid-chat (#2108).
 - MCP admin tools no longer report a tool failure for a successful read of a
   slot whose lifecycle state is `error`. The tool-result wrapper's failure
   sentinel keyed on `status == "error"` alone, which collides with the slot

--- a/docs/concepts/brain.mdx
+++ b/docs/concepts/brain.mdx
@@ -103,8 +103,11 @@ key fails validation rather than being silently ignored.
 | `completion_timeout_s` | float | `300.0` | `> 0`. Transport timeout for each LLM round. |
 
 The dashboard's Agent Chat settings page (Settings → Integrations) edits
-`enabled`, `read_only`, `model`, `max_rounds`, and `completion_timeout_s`
-live — `tool_model` is not exposed there; it's a `hal0.toml`-only knob today.
+every key above live, including `tool_model` — a picker over every
+configured chat-capable slot, an explicit "same as chat model" preset, and
+a "Disabled" choice. When the saved value has no live target (the
+fresh-install gap below), the page says so with a plain-language banner
+instead of the operator discovering it mid-chat.
 
 ### How tool routing resolves
 

--- a/docs/guides/dashboard-and-settings.mdx
+++ b/docs/guides/dashboard-and-settings.mdx
@@ -154,8 +154,17 @@ one line and a link here rather than a repeat.
   restart) so a gated or large pull can authenticate right away. See
   "Secrets" on [REST API index](/docs/reference/api/rest-api/) for the
   write path.
-- **Agent Chat** — the `[brain_chat]` policy surface (kill switch, target
-  slot override, loop knobs). See [Brain](/docs/concepts/brain).
+- **Agent Chat** — the `[brain_chat]` policy surface: kill switch,
+  read-only guardrail, chat model override, tool-routing model, and loop
+  knobs. `tool_model` (where a tool-calling round reroutes when the chat
+  model can't emit tool calls this runtime parses) has its own picker
+  here, with a warning banner when the saved value has no loaded slot to
+  route to — the shipped `hal0/agent` default on a fresh install, before
+  a model is pulled into that slot. See [Brain](/docs/concepts/brain).
+- **Realtime** — the `[realtime]` WS voice-endpoint surface: kill switch,
+  sample rate, which slots serve speech-to-text/text-to-speech, the
+  energy-VAD turn-detection thresholds, and output framing. Every key
+  applies on the next connection — no restart.
 
 ## Settings ▸ Storage, in detail
 

--- a/docs/reference/api/rest-api.mdx
+++ b/docs/reference/api/rest-api.mdx
@@ -73,7 +73,7 @@ silently paper over.
 |---|---|---|
 | `/api/auth` | Mixed | `login`/`status`/`logout` are OPEN (you can't require a cookie to obtain one); `require` (toggle enforcement) and `rotate` (mint a new admin/client key) are ADMIN; `exposure` (serialize this whole rule table) is ADMIN. |
 | `/api/secrets` | ADMIN | Operator-managed secrets store. See "Secrets" below — dedicated section, not just a table row. |
-| `/api/settings` | ADMIN | Root config read/write/reload, JSON schema, apply-plan preview. |
+| `/api/settings` | ADMIN | Root config read/write/reload, JSON schema, apply-plan registry, schema-driven field metadata (`fields`), and a dry-run ChangeSet preview (`preview`) sharing the same diff the write path applies. |
 | `/api/settings/models/store` | ADMIN | Model store path get/set/migrate (part of the `/api/settings` prefix). |
 | `/api/settings/proxmox` | ADMIN | Proxmox integration config (host/token) + live cluster status. See "Proxmox integration" below — no dedicated exposure rule; it inherits ADMIN from the generic `/api/settings` prefix. |
 | `/api/slots` | CLIENT (list) / ADMIN (else) | Slot lifecycle — list, create, delete, restart, model swap, resolved-argv provenance, metrics, capacity. See [Slot lifecycle](/docs/reference/slot-lifecycle/). |

--- a/src/hal0/api/_settings_apply.py
+++ b/src/hal0/api/_settings_apply.py
@@ -235,6 +235,10 @@ _HAL0_REGISTRY: dict[str, ApplyPlanEntry] = {
     # unit the same way publish_host is; preload_evict_* are SlotManager
     # constructor args fixed at create_app time.
     "slots.network_mode": {"apply_class": "service-restart", "services": [SERVICE_SLOTS]},
+    # Per-runner-family default-image overrides are read by
+    # _resolve_image_ref when a slot's container spec is rendered; a change
+    # only affects the next slot (re)start, same as network_mode/publish_host.
+    "slots.default_images": {"apply_class": "service-restart", "services": [SERVICE_SLOTS]},
     "slots.preload_evict_enabled": {
         "apply_class": "service-restart",
         "services": [SERVICE_HAL0_API],

--- a/src/hal0/api/_settings_changeset.py
+++ b/src/hal0/api/_settings_changeset.py
@@ -1,0 +1,218 @@
+"""One ChangeSet computation for hal0.toml settings preview and apply.
+
+Four issues found in adjacent parts of the codebase share one root cause:
+a "what changed" diff computed twice, by two call sites that can drift.
+
+  * #1967 — ``save_slot_config``'s round-trip silently drops keys nobody
+    told it to keep, because nothing forces the read path and the write
+    path to agree on the field set.
+  * #2195 — the stack-apply preview bills added/changed flags but not
+    removed ones, because the preview's copy-scope was hand-picked rather
+    than derived from the one diff the apply itself uses.
+  * #2203 — ``POST /api/models/{id}/seed-profile`` emits a hardcoded
+    ``changed_fields`` list instead of comparing before/after, so a no-op
+    re-stamp still claims two fields changed.
+  * #1511 — the stack Load dialog previews what will be loaded but never
+    what converge will silently unload, because the preview and the apply
+    read different projections of the same operation.
+
+:func:`compute_settings_changeset` is hal0's general-settings answer:
+``POST /api/settings/preview`` and ``PUT /api/settings``
+(``hal0.api.routes.settings``) both call this ONE function over the same
+``(current config, patch body)`` pair. Preview literally cannot show
+something apply wouldn't do, because they are the same computation.
+
+Design choices that keep the four bug shapes from recurring here:
+
+  * A touched key whose value did not actually change is dropped from
+    ``changes`` (never a phantom "changed" entry — the #2203 shape).
+  * A key is classified ``removed`` when its value goes missing (a dict
+    entry cleared via the ``null``-clears idiom, e.g.
+    ``[slots].default_images``) rather than folded into ``changed`` or
+    silently absent (the #2195 shape).
+  * Every touched leaf is either classified via
+    :data:`hal0.api._settings_apply.REGISTRY` or explicitly listed in
+    ``unknown`` — never dropped without a trace (the #1967 shape).
+  * ``services`` (the #1511 shape: what a save affects beyond the value
+    itself) rides on every change entry, not bolted on after the fact.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from hal0.api._redact import redact_config
+from hal0.api._settings_apply import REGISTRY, ApplyPlanResult, apply_plan
+from hal0.config.schema import Hal0Config
+
+
+def deep_merge(base: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
+    """Recursive dict merge: patch wins, but nested dicts are merged not replaced.
+
+    Lists and scalars are replaced wholesale (no append/extend semantics)
+    because the schema doesn't define list identities — the caller's intent
+    when sending ``{"slots": {"port_range_end": 8090}}`` is to set that
+    one knob, not to clobber the rest of ``slots``.
+    """
+    out = dict(base)
+    for k, v in patch.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def dotted_leaf_keys(node: dict[str, Any], prefix: str = "") -> list[str]:
+    """Flatten a nested PATCH body into dotted leaf paths (``"slots.max_slots"``).
+
+    Recurses into every dict value, including a runtime dict-shaped field
+    like ``[slots].default_images`` — a PATCH clearing one family
+    (``{"slots": {"default_images": {"rocmfpx": null}}}``) flattens to
+    ``"slots.default_images.rocmfpx"``, which is exactly the granularity
+    :func:`compute_settings_changeset` needs to report that one family's
+    removal rather than folding it into a blob-level "changed".
+    """
+    out: list[str] = []
+    for k, v in node.items():
+        path = f"{prefix}{k}"
+        if isinstance(v, dict):
+            out.extend(dotted_leaf_keys(v, f"{path}."))
+        else:
+            out.append(path)
+    return out
+
+
+def dotted_get(tree: dict[str, Any], path: str) -> Any:
+    """Walk ``tree`` by a dotted leaf path (``"memory.embedding.rerank_model"``)."""
+    node: Any = tree
+    for part in path.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+@dataclass(frozen=True)
+class SettingsKeyChange:
+    """One leaf's before/after, with its reload consequence attached.
+
+    ``kind`` is ``"added"`` (no prior value — a fresh dict entry or a
+    forward-compat key), ``"removed"`` (the value is now missing — a dict
+    entry cleared via ``null``), or ``"changed"`` (both sides present and
+    different). A leaf whose value is unchanged never gets an entry — see
+    the module docstring's #2203 note.
+    """
+
+    path: str
+    before: Any
+    after: Any
+    kind: str
+    apply_class: str | None
+    services: list[str]
+
+
+@dataclass(frozen=True)
+class SettingsChangeSet:
+    """The one diff both preview and apply render from.
+
+    ``plan`` is byte-identical to ``apply_plan(touched_keys)`` over the
+    raw patch's flattened keys (see ``tests/api/test_settings_apply.py``)
+    — kept for the existing ``_hal0.apply_plan`` response contract, which
+    classifies every TOUCHED key regardless of whether its value actually
+    changed. ``changes`` is the newer, stricter view: only leaves whose
+    value differs, each carrying its own before/after and reload class.
+    """
+
+    merged: Hal0Config
+    changes: tuple[SettingsKeyChange, ...]
+    unknown: tuple[str, ...]
+    plan: ApplyPlanResult
+
+    @property
+    def changed(self) -> bool:
+        """True when applying this ChangeSet would alter any value."""
+        return bool(self.changes)
+
+
+def compute_settings_changeset(current: Hal0Config, patch: dict[str, Any]) -> SettingsChangeSet:
+    """Diff ``current`` deep-merged with ``patch`` against ``current`` itself.
+
+    Raises ``pydantic.ValidationError`` when the merged result fails schema
+    validation — same failure the caller (``update_settings``) already
+    turns into ``ConfigInvalidError``; this function doesn't wrap it so
+    both the preview and apply routes can share one ``except`` clause.
+
+    Both routes pass the SAME two inputs through the SAME function — that
+    is the whole point (see module docstring): preview cannot show a
+    different plan than apply computes, because there is only one
+    computation.
+    """
+    merged_raw = deep_merge(current.model_dump(mode="python"), patch)
+    merged = Hal0Config.model_validate(merged_raw)
+
+    before_view = redact_config(current.model_dump(mode="json"))
+    after_view = redact_config(merged.model_dump(mode="json"))
+
+    touched = dotted_leaf_keys(patch)
+    changes: list[SettingsKeyChange] = []
+    unknown: list[str] = []
+
+    for path in touched:
+        before_v = dotted_get(before_view, path)
+        after_v = dotted_get(after_view, path)
+        if before_v == after_v:
+            continue
+        kind = "added" if before_v is None else ("removed" if after_v is None else "changed")
+        entry = REGISTRY.get(path)
+        if entry is None:
+            unknown.append(path)
+        changes.append(
+            SettingsKeyChange(
+                path=path,
+                before=before_v,
+                after=after_v,
+                kind=kind,
+                apply_class=entry["apply_class"] if entry else None,
+                services=list(entry["services"]) if entry else [],
+            )
+        )
+
+    return SettingsChangeSet(
+        merged=merged,
+        changes=tuple(changes),
+        unknown=tuple(sorted(unknown)),
+        plan=apply_plan(touched),
+    )
+
+
+def changeset_payload(cs: SettingsChangeSet) -> dict[str, Any]:
+    """Render a :class:`SettingsChangeSet` into the wire shape both
+    ``POST /api/settings/preview`` and ``PUT /api/settings`` (under
+    ``_hal0.changeset``) return."""
+    return {
+        "changes": [
+            {
+                "path": c.path,
+                "before": c.before,
+                "after": c.after,
+                "kind": c.kind,
+                "apply_class": c.apply_class,
+                "services": c.services,
+            }
+            for c in cs.changes
+        ],
+        "unknown": list(cs.unknown),
+    }
+
+
+__all__ = [
+    "SettingsChangeSet",
+    "SettingsKeyChange",
+    "changeset_payload",
+    "compute_settings_changeset",
+    "deep_merge",
+    "dotted_get",
+    "dotted_leaf_keys",
+]

--- a/src/hal0/api/_settings_fields.py
+++ b/src/hal0/api/_settings_fields.py
@@ -1,0 +1,256 @@
+"""Schema-driven settings field metadata (#2108, #1967, #2195, #2203, #1511).
+
+hal0's Settings pages used to be hand-built: each page authored its own
+FormRow list, so a schema field the page's author didn't know about (or
+added after the page shipped) had no dashboard path at all — the origin
+of #2108's ``[brain_chat].tool_model`` gap. ODS's dashboard-api instead
+derives every settings row from the schema itself
+(``ods/extensions/services/dashboard-api/settings.py:194-241``,
+``_build_env_fields``): whatever the schema declares is automatically a
+labelled, described row.
+
+This module is that projection for ``Hal0Config``: :func:`walk_settings_schema`
+recursively walks every nested pydantic model under it and returns one
+:class:`SettingsFieldSpec` per LEAF field (skipping the container models
+themselves), driven entirely by ``pydantic.fields.FieldInfo`` — no
+hand-maintained field list to fall out of sync with the schema.
+
+Every leaf's ``Field(description=...)`` is REQUIRED — a missing one raises
+:class:`SettingsFieldSchemaError` at wall-time, which
+``tests/api/test_settings_fields.py`` turns into a completeness ratchet
+(the same shape as the exposure-classification ratchet in
+``tests/security/test_exposure.py``): a new config field with no
+description fails CI immediately instead of shipping as an unlabelled or
+silently-hidden row.
+"""
+
+from __future__ import annotations
+
+import types
+import typing
+from dataclasses import dataclass
+from typing import Any, Final, get_args, get_origin
+
+import pydantic
+from pydantic.fields import FieldInfo
+
+from hal0.api._redact import is_sensitive_key, redact_config
+from hal0.api._settings_apply import REGISTRY
+from hal0.config.schema import Hal0Config
+
+# Segments that should render fully upper-case in a humanized label
+# (acronyms a Title Case pass would otherwise mangle to "Tts"/"Vad").
+_ACRONYM_WORDS: Final[frozenset[str]] = frozenset(
+    {"id", "url", "tts", "stt", "vad", "npu", "mcp", "gpu", "flm"}
+)
+
+
+class SettingsFieldSchemaError(RuntimeError):
+    """A leaf settings field is missing schema metadata the renderer needs.
+
+    Raised for a missing ``description`` — every operator-editable config
+    key must document its consequence (CONTRIBUTING.md's "no ghost-doc
+    citations" rule, applied to the schema itself: an undocumented field
+    is worse than a wrong doc, because there is nothing to catch it).
+    """
+
+
+def _humanize(leaf_name: str) -> str:
+    """``"port_range_start"`` -> ``"Port range start"``; acronym segments upper-cased."""
+    words = leaf_name.replace("_", " ").split()
+    out = []
+    for w in words:
+        out.append(w.upper() if w.lower() in _ACRONYM_WORDS else w)
+    if out:
+        out[0] = out[0][:1].upper() + out[0][1:]
+    return " ".join(out)
+
+
+def _unwrap_optional(annotation: Any) -> Any:
+    """Strip a bare ``X | None`` down to ``X`` for type/enum classification.
+
+    ``int | None`` (PEP 604) and ``Optional[int]`` (``typing.Union``) are
+    two distinct origins in Python's typing machinery even though schema.py
+    uses them interchangeably (``str | None`` throughout,
+    ``list[str] | tuple[str, ...]`` elsewhere) — both must unwrap the same
+    way or a PEP-604 optional silently falls through to the ``string``
+    default below instead of its real type.
+    """
+    origin = get_origin(annotation)
+    if origin is typing.Union or origin is types.UnionType:
+        args = [a for a in get_args(annotation) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return annotation
+
+
+def _field_type(annotation: Any) -> tuple[str, list[str] | None]:
+    """Classify a field's annotation into the renderer's small type vocabulary.
+
+    Returns ``(type, enum_values | None)``. ``enum`` covers ``Literal[...]``
+    (e.g. ``ReleaseKind``); everything else maps to one of
+    ``boolean`` / ``number`` / ``string`` / ``string[]`` / ``map``.
+    """
+    ann = _unwrap_optional(annotation)
+    origin = get_origin(ann)
+    if origin is typing.Literal:
+        return "enum", [str(v) for v in get_args(ann)]
+    if ann is bool:
+        return "boolean", None
+    if ann in (int, float):
+        return "number", None
+    if ann is str:
+        return "string", None
+    if origin in (list,):
+        return "string[]", None
+    if origin in (dict,):
+        return "map", None
+    return "string", None
+
+
+def _constraints(field: FieldInfo) -> dict[str, float]:
+    """Extract ``ge``/``le``/``gt``/``lt`` numeric bounds from pydantic metadata."""
+    out: dict[str, float] = {}
+    for constraint in field.metadata:
+        for attr in ("ge", "le", "gt", "lt"):
+            value = getattr(constraint, attr, None)
+            if value is not None:
+                out[attr] = value
+    return out
+
+
+@dataclass(frozen=True)
+class SettingsFieldSpec:
+    """One operator-editable leaf of ``Hal0Config``, schema metadata only.
+
+    ``group`` is the top-level ``Hal0Config`` section name the field lives
+    under (``"brain_chat"``, ``"memory.embedding"``, ...) — which Settings
+    page renders which group is a frontend concern (``ui/src/dash/settings/
+    data/fieldGroups.ts``), kept out of this module so re-organizing pages
+    never needs a backend redeploy.
+    """
+
+    path: str
+    group: str
+    label: str
+    description: str
+    type: str
+    enum: list[str] | None
+    constraints: dict[str, float]
+    default: Any
+    secret: bool
+
+
+def walk_settings_schema(
+    model_cls: type[pydantic.BaseModel] = Hal0Config,
+    prefix: str = "",
+) -> list[SettingsFieldSpec]:
+    """Recursively project every leaf field of ``model_cls`` into a spec.
+
+    A field whose annotation is itself a nested ``BaseModel`` is recursed
+    into (not emitted as a row) — the schema's grouping structure IS the
+    settings' row structure, so no separate "which keys are leaves" list
+    needs maintaining alongside ``Hal0Config``.
+    """
+    out: list[SettingsFieldSpec] = []
+    for name, field in model_cls.model_fields.items():
+        path = f"{prefix}{name}"
+        unwrapped = _unwrap_optional(field.annotation)
+        is_nested_model = isinstance(unwrapped, type) and issubclass(unwrapped, pydantic.BaseModel)
+        if is_nested_model:
+            out.extend(walk_settings_schema(unwrapped, f"{path}."))
+            continue
+        if not field.description:
+            raise SettingsFieldSchemaError(
+                f"{model_cls.__module__}.{model_cls.__qualname__}.{name} "
+                f"({path!r}) has no Field(description=...) — every "
+                "operator-editable settings key must document its "
+                "consequence before it can render as a row."
+            )
+        type_, enum = _field_type(field.annotation)
+        group = prefix.rstrip(".") or path
+        out.append(
+            SettingsFieldSpec(
+                path=path,
+                group=group,
+                label=_humanize(name),
+                description=field.description,
+                type=type_,
+                enum=enum,
+                constraints=_constraints(field),
+                default=field.get_default(call_default_factory=True),
+                secret=is_sensitive_key(name),
+            )
+        )
+    return out
+
+
+def _get_in(node: Any, dotted: str) -> Any:
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def build_settings_fields(cfg: Hal0Config) -> list[dict[str, Any]]:
+    """Project every ``Hal0Config`` leaf into the one payload Settings pages render.
+
+    Joins three single-owner facts with no duplication of any of them:
+
+      * schema metadata (group/label/description/type/enum/constraints/default)
+        from :func:`walk_settings_schema`, owned by the ``Field(description=...)``
+        calls in :mod:`hal0.config.schema`;
+      * the reload classification (``apply_class``/``services``), owned by
+        :data:`hal0.api._settings_apply.REGISTRY` — same key name that
+        endpoint's own response uses, so a caller reading both never sees
+        two names for the same concept;
+      * the current value, owned by ``cfg`` itself — read through
+        :func:`hal0.api._redact.redact_config` so a ``secret`` row's current
+        value is never echoed in the clear (mirrors ``_config_to_dict`` in
+        ``routes/settings.py``, which every other config-echoing endpoint
+        routes through).
+
+    ``test_every_leaf_field_is_classified_in_the_apply_registry``
+    (``tests/api/test_settings_fields.py``) already guarantees every row
+    returned by :func:`walk_settings_schema` has a ``REGISTRY`` entry, so
+    ``apply_class`` is never the ``None`` placeholder here — that only
+    happens for a touched key on the raw ``PUT`` body (e.g. a typo, or a
+    forward-compat top-level table), not for a schema-declared row.
+
+    Pure and synchronous — deliberately does not know about live slot state,
+    so it stays trivially testable without a running app. The route
+    (``GET /api/settings/fields``) is the one that also asks "does this
+    field's current value resolve to a loaded slot right now" (#2108's
+    fresh-install ``tool_model`` gap) and merges that in as ``live_target``,
+    because that question needs a live ``Request`` this function never sees.
+    """
+    redacted = redact_config(cfg.model_dump(mode="json"))
+    out: list[dict[str, Any]] = []
+    for row in walk_settings_schema():
+        entry = REGISTRY.get(row.path)
+        out.append(
+            {
+                "path": row.path,
+                "group": row.group,
+                "label": row.label,
+                "description": row.description,
+                "type": row.type,
+                "enum": row.enum,
+                "constraints": row.constraints,
+                "default": row.default,
+                "current": _get_in(redacted, row.path),
+                "apply_class": entry["apply_class"] if entry else None,
+                "services": list(entry["services"]) if entry else [],
+                "secret": row.secret,
+            }
+        )
+    return out
+
+
+__all__ = [
+    "SettingsFieldSchemaError",
+    "SettingsFieldSpec",
+    "build_settings_fields",
+    "walk_settings_schema",
+]

--- a/src/hal0/api/routes/settings.py
+++ b/src/hal0/api/routes/settings.py
@@ -11,9 +11,15 @@ Endpoints:
                                       existing config, validated against
                                       the pydantic schema, then atomically
                                       written. Response includes
-                                      ``_hal0.apply_plan`` so the UI can
-                                      render the right effect badge
-                                      without a second round-trip.
+                                      ``_hal0.apply_plan`` and
+                                      ``_hal0.changeset`` so the UI can
+                                      render the right effect badge and
+                                      toast from the real diff without a
+                                      second round-trip.
+    POST /api/settings/preview      — same body shape as the PUT, same
+                                      ChangeSet computation, writes
+                                      nothing — for a confirm-before-apply
+                                      drawer (#1967, #2195, #2203, #1511).
     POST /api/settings/reload       — re-read /etc/hal0/hal0.toml from
                                       disk into the running process.
     GET  /api/settings/schema       — pydantic JSON schema of Hal0Config
@@ -22,6 +28,12 @@ Endpoints:
     GET  /api/settings/apply-plan   — full key→apply-class registry the
                                       dashboard mounts once to render
                                       per-row effect badges (#552).
+    GET  /api/settings/fields       — one row per operator-editable schema
+                                      key (group/label/description/type/
+                                      enum/range/default/current/reload
+                                      class/secret) so the dashboard can
+                                      render a labelled row for every
+                                      config key automatically (#2108).
 
 Validation failures return the structured error envelope with
 ``code: "config.invalid"`` and ``details`` containing a per-field
@@ -39,7 +51,9 @@ from fastapi import APIRouter, Request
 from pydantic import ValidationError
 
 from hal0.api._redact import redact_config
-from hal0.api._settings_apply import APPLY_CLASSES, apply_plan, get_registry
+from hal0.api._settings_apply import APPLY_CLASSES, get_registry
+from hal0.api._settings_changeset import changeset_payload, compute_settings_changeset
+from hal0.api._settings_fields import build_settings_fields
 from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.config.loader import hal0_config_txn, load_hal0_config
 from hal0.config.schema import Hal0Config
@@ -63,23 +77,6 @@ class ConfigInvalidError(Hal0Error):
 
     code = "config.invalid"
     status = 400
-
-
-def _deep_merge(base: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
-    """Recursive dict merge: patch wins, but nested dicts are merged not replaced.
-
-    Lists and scalars are replaced wholesale (no append/extend semantics)
-    because the schema doesn't define list identities — the caller's intent
-    when sending ``{"slots": {"port_range_end": 8090}}`` is to set that
-    one knob, not to clobber the rest of ``slots``.
-    """
-    out = dict(base)
-    for k, v in patch.items():
-        if isinstance(v, dict) and isinstance(out.get(k), dict):
-            out[k] = _deep_merge(out[k], v)
-        else:
-            out[k] = v
-    return out
 
 
 def _validation_error_details(exc: ValidationError) -> dict[str, str]:
@@ -144,11 +141,15 @@ async def update_settings(request: Request) -> dict[str, Any]:
     # (#1717 review: a settings PUT waiting behind a ~60s graph PUT used to
     # resume on the stale cached snapshot, merge its own unrelated patch into
     # it, and overwrite the graph section the graph route had just written).
+    #
+    # ``compute_settings_changeset`` is the SAME function
+    # ``POST /api/settings/preview`` calls (#1967/#2195/#2203/#1511-shaped
+    # fixtures in tests/api/test_settings_changeset.py) — one diff, read
+    # here under the write lock so it can never see a value a concurrent
+    # writer is mid-changing.
     async with hal0_config_txn(request) as txn:
-        merged_raw = _deep_merge(txn.config.model_dump(mode="python"), body)
-
         try:
-            merged = Hal0Config.model_validate(merged_raw)
+            cs = compute_settings_changeset(txn.config, body)
         except ValidationError as exc:
             raise ConfigInvalidError(
                 "hal0 config failed schema validation",
@@ -158,7 +159,7 @@ async def update_settings(request: Request) -> dict[str, Any]:
         # Atomic write via the txn — which also refreshes
         # ``app.state.hal0_config`` so no writer can leave that cache stale.
         try:
-            txn.save(merged)
+            txn.save(cs.merged)
         except OSError as exc:
             raise Hal0Error(
                 f"could not persist hal0 config: {exc}",
@@ -183,36 +184,57 @@ async def update_settings(request: Request) -> dict[str, Any]:
     # manual operator action *before* it renders the success toast, so
     # the partition rides along in the response under ``_hal0.apply_plan``.
     # The top-level config dict stays the same shape — this is purely
-    # additive (#545).
+    # additive (#545). ``cs.plan`` is byte-identical to the old inline
+    # ``apply_plan(_dotted_leaf_keys(body))`` call — every touched leaf,
+    # whether or not its value actually changed, classified or landed in
+    # ``unknown`` (never silently dropped).
     #
-    # The touched-keys list flattens the nested PATCH body into dotted
-    # leaf paths ("slots.max_slots") — the form the registry keys on. A
-    # normal nested PUT ({"slots": {"max_slots": 4}}) previously produced
-    # an all-empty plan because only top-level body keys were matched
-    # against the registry, so the UI's restart hint never fired for
-    # generic-endpoint edits.
-    #
-    # Every touched leaf goes to apply_plan() unfiltered — a key the
-    # registry doesn't know about lands in ApplyPlanResult.unknown rather
-    # than being silently dropped here. Pre-filtering with `if k in
-    # REGISTRY` made `unknown` structurally always `[]` on this route,
-    # contradicting the documented contract on ApplyPlanResult (the UI is
-    # supposed to render an informational chip for a gap key instead of
-    # guessing at its class).
-    def _dotted_leaf_keys(node: dict[str, Any], prefix: str = "") -> list[str]:
-        out: list[str] = []
-        for k, v in node.items():
-            path = f"{prefix}{k}"
-            if isinstance(v, dict):
-                out.extend(_dotted_leaf_keys(v, f"{path}."))
-            else:
-                out.append(path)
-        return out
-
-    touched_keys = _dotted_leaf_keys(body)
-    config_view = _config_to_dict(merged)
-    config_view["_hal0"] = {"apply_plan": apply_plan(touched_keys)}
+    # ``_hal0.changeset`` is the newer, stricter view (#1967/#2195/#2203/
+    # #1511): only leaves whose value actually changed, each with its own
+    # before/after and reload class, so the UI can toast from truth
+    # instead of re-deriving "what changed" from the raw PATCH body.
+    config_view = _config_to_dict(cs.merged)
+    config_view["_hal0"] = {"apply_plan": cs.plan, "changeset": changeset_payload(cs)}
     return config_view
+
+
+@router.post("/preview")
+async def preview_settings(request: Request) -> dict[str, Any]:
+    """Compute the ChangeSet a PUT with this body would apply, without writing.
+
+    Calls :func:`hal0.api._settings_changeset.compute_settings_changeset` —
+    the exact same function ``update_settings`` calls — so preview and
+    apply can never disagree about what a PATCH would do (the class of bug
+    behind #1967/#2195/#2203/#1511: two call sites independently deriving
+    "what changed"). Body shape is identical to ``PUT /api/settings``.
+
+    Reads against the live in-process config (``app.state.hal0_config``),
+    not a fresh disk re-read under the write lock — a preview never blocks
+    on, or competes with, a concurrent writer. The actual apply always
+    re-reads fresh under the lock in ``update_settings``, so a preview is a
+    best-effort snapshot, same caveat as any dry-run.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise Hal0Error("request body must be valid JSON", details={"error": str(exc)}) from exc
+    if not isinstance(body, dict):
+        raise Hal0Error("request body must be a JSON object")
+
+    cfg = getattr(request.app.state, "hal0_config", None)
+    if cfg is None:
+        cfg = load_hal0_config()
+        request.app.state.hal0_config = cfg
+
+    try:
+        cs = compute_settings_changeset(cfg, body)
+    except ValidationError as exc:
+        raise ConfigInvalidError(
+            "hal0 config failed schema validation",
+            details=_validation_error_details(exc),
+        ) from exc
+
+    return {"changeset": changeset_payload(cs), "apply_plan": cs.plan}
 
 
 @router.post("/reload")
@@ -272,6 +294,71 @@ async def get_apply_plan() -> dict[str, Any]:
         "apply_classes": list(APPLY_CLASSES),
         "registry": get_registry(),
     }
+
+
+async def _live_target_for(request: Request, value: Any) -> bool | None:
+    """Whether a ``hal0/<slot>``-style value currently resolves to a loaded slot.
+
+    Returns ``None`` when ``value`` isn't a virtual model reference (nothing
+    to say), ``True``/``False`` otherwise. Used to flag #2108's fresh-install
+    gap: ``[brain_chat].tool_model`` defaults to ``hal0/agent``, and that
+    slot ships unbound by design, so the default has nowhere live to route
+    tool turns until an operator pulls a model into it — this lets the
+    renderer say so plainly instead of the operator discovering it mid-chat.
+    """
+    if not isinstance(value, str) or not value.startswith("hal0/"):
+        return None
+    try:
+        from hal0.api.routes.v1 import _normalize_loaded_models, _normalize_slot_views
+        from hal0.normalize.resolver import LiveSlotResolver
+
+        views = await _normalize_slot_views(request)
+        resolver = LiveSlotResolver(
+            slot_views_provider=lambda: views,
+            loaded_models_provider=lambda: _normalize_loaded_models(request),
+        )
+        res = await resolver.resolve(value)
+    except Exception:
+        return None
+    if res is None:
+        return None
+    return not res.fallback
+
+
+@router.get("/fields")
+async def get_settings_fields(request: Request) -> dict[str, Any]:
+    """Schema-driven settings field metadata (#2108, #1967, #2195, #2203, #1511).
+
+    One row per operator-editable ``Hal0Config`` leaf — group, label,
+    description, type/enum/range, default, current value, reload class
+    (``apply_class``/``services``), and secret flag — so the dashboard
+    renders a labelled row for every schema key automatically instead of
+    requiring a hand-authored FormRow per field (the gap that left
+    ``[brain_chat].tool_model`` with no dashboard path).
+
+    :func:`hal0.api._settings_fields.build_settings_fields` supplies
+    everything a live config alone can answer (schema metadata + current
+    value + reload class, joined from the same
+    :data:`hal0.api._settings_apply.REGISTRY` ``/api/settings/apply-plan``
+    serves, so the two endpoints can never disagree on a key's reload
+    effect — see ``tests/api/test_settings_fields.py`` for the ratchet that
+    keeps every schema leaf classified in that registry). This route adds
+    the one thing that needs a live ``Request``: ``live_target``, populated
+    only for a ``hal0/<slot>``-shaped current value, ``true``/``false`` for
+    whether that alias currently resolves to a loaded slot — ``null`` for
+    every other field. That flags #2108's fresh-install gap directly:
+    ``tool_model`` defaults to ``hal0/agent``, and that slot ships unbound
+    by design, so a fresh box's row renders with ``live_target: false``
+    instead of the operator discovering the gap mid-chat.
+    """
+    cfg = getattr(request.app.state, "hal0_config", None)
+    if cfg is None:
+        cfg = load_hal0_config()
+        request.app.state.hal0_config = cfg
+    fields = build_settings_fields(cfg)
+    for row in fields:
+        row["live_target"] = await _live_target_for(request, row["current"])
+    return {"fields": fields}
 
 
 # ── Model storage (Settings → Models · FirstRun "Storage" step) ────────────

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -3224,8 +3224,22 @@ class ActivityConfig(BaseModel):
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
-    enabled: bool = True
-    retention_days: int = Field(default=30, ge=1)
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Whether config-mutating actions and system state changes are "
+            "recorded to the durable activity store. Consumed once at "
+            "create_app(), so a change needs a hal0-api restart."
+        ),
+    )
+    retention_days: int = Field(
+        default=30,
+        ge=1,
+        description=(
+            "How long an activity row survives before pruning. Overridden "
+            "at the env layer by HAL0_ACTIVITY_RETENTION_DAYS."
+        ),
+    )
     # None disables the row cap (retention_days still applies).
     #
     # PERSISTENCE (#1665): ``save_hal0_config``/``_maybe_run_config_migrations``
@@ -3240,7 +3254,15 @@ class ActivityConfig(BaseModel):
     # ``BrainChatConfig.tool_model`` / ``BRAIN_TOOL_MODEL_DISABLED`` (#1644):
     # give the unrepresentable sentinel a real word/value on disk instead of
     # relying on ``exclude_none`` to round-trip it.
-    max_rows: int | None = Field(default=50_000, ge=100)
+    max_rows: int | None = Field(
+        default=50_000,
+        ge=100,
+        description=(
+            "Row cap for the activity table; oldest rows are pruned past "
+            "this count regardless of retention_days. Set to 0 to disable "
+            "the cap (retention_days still applies)."
+        ),
+    )
 
     @field_validator("max_rows", mode="before")
     @classmethod
@@ -3320,12 +3342,26 @@ class BrainChatConfig(BaseModel):
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
-    enabled: bool = True
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Hard kill switch for the dashboard's agent-chat steward. When "
+            "false, every chat turn is refused and the slide-out chat is off."
+        ),
+    )
     # Ships TRUE (KB-2/3): the steward answers and reads state out of the box,
     # but every mutating / admin-write tool is refused server-side until an
     # operator explicitly opts in with [brain_chat] read_only=false. Safe
     # default over convenient default — the widening path is one config line.
-    read_only: bool = True
+    read_only: bool = Field(
+        default=True,
+        description=(
+            "When true (the shipped default), the steward answers and reads "
+            "state but every mutating or admin-write tool is refused "
+            "server-side — independently of the persona's own tool policy. "
+            "Set false to let the steward act on the instance through tools."
+        ),
+    )
     # Empty → persona preferred_model (hal0/brain). Set to a virtual slot model
     # like "hal0/npu" / "hal0/utility" to drive the steward on that slot; an
     # explicit per-request ``model`` in the chat body still wins over this.
@@ -3333,7 +3369,16 @@ class BrainChatConfig(BaseModel):
     # via the hal0/brain -> agent resolver fallback) needs >= 8k context —
     # the steward system prompt alone is ~7.3k tokens — and must actually be
     # LOADED, or the chat 404s (see BrainChatConfig docstring above).
-    model: str = ""
+    model: str = Field(
+        default="",
+        description=(
+            "Which model/slot drives the steward chat. Empty keeps the "
+            "persona's preferred_model (hal0/brain, itself falling back to "
+            "the agent slot); set to a virtual slot like 'hal0/npu' to pin "
+            "the steward there. Whatever this resolves to must be loaded "
+            "with >= 8k context, or the chat fails outright."
+        ),
+    )
     # Route tool-calling ROUNDS to a capable, tool-format-compatible model —
     # the escape hatch for boxes whose ``model`` (the shipped ~1.1B brain slot)
     # can't emit tool calls the local runtime parses natively (it leaks/500s).
@@ -3357,9 +3402,37 @@ class BrainChatConfig(BaseModel):
     # box was found with `[brain_chat] tool_model = ""`, which silently
     # overrode this default; it is now coerced back to the default with a loud
     # warning. Opting OUT is spelled explicitly: "off" / "none" / "disabled".
-    tool_model: str = BRAIN_TOOL_MODEL_DEFAULT
-    max_rounds: int = Field(default=8, ge=1, le=100)
-    completion_timeout_s: float = Field(default=300.0, gt=0)
+    tool_model: str = Field(
+        default=BRAIN_TOOL_MODEL_DEFAULT,
+        description=(
+            "Where a tool-calling ROUND reroutes when the chat model can't "
+            "emit tool calls this runtime parses. Default 'hal0/agent' — the "
+            "always-on fallback anchor — but that slot ships unbound on a "
+            "fresh install, so the first tool turn has nowhere to go until "
+            "an operator pulls a model into it. Per-round, not per-"
+            "conversation: plain chat stays on 'model'. An empty string is "
+            "coerced back to the default with a warning — to genuinely "
+            "disable tool routing, set 'off', 'none', or 'disabled'."
+        ),
+    )
+    max_rounds: int = Field(
+        default=8,
+        ge=1,
+        le=100,
+        description=(
+            "Runaway backstop: max tool-calling rounds in one chat turn "
+            "before the steward stops and returns whatever it has."
+        ),
+    )
+    completion_timeout_s: float = Field(
+        default=300.0,
+        gt=0,
+        description=(
+            "Transport timeout (seconds) for each LLM round against the "
+            "target slot. A round that exceeds this fails the turn with a "
+            "timeout error instead of hanging indefinitely."
+        ),
+    )
 
     @field_validator("tool_model", mode="before")
     @classmethod
@@ -3508,19 +3581,91 @@ class RealtimeConfig(BaseModel):
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
-    enabled: bool = True
-    sample_rate: int = Field(default=24000, ge=8000, le=48000)
-    default_model: str = ""
-    stt_model: str = ""
-    tts_model: str = "kokoro"
-    tts_voice: str = ""
-    vad_energy_threshold: float = Field(default=0.02, ge=0.0, le=1.0)
-    vad_silence_ms: int = Field(default=500, ge=50, le=10000)
-    vad_min_speech_ms: int = Field(default=200, ge=0, le=10000)
-    vad_window_ms: int = Field(default=20, ge=5, le=100)
-    frame_ms: int = Field(default=20, ge=5, le=200)
-    approval_wait_s: float = Field(default=20.0, gt=0, le=300.0)
-    max_buffer_seconds: float = Field(default=30.0, gt=0, le=600.0)
+    enabled: bool = Field(
+        default=True,
+        description="Hard kill switch for the WS /v1/realtime voice endpoint.",
+    )
+    sample_rate: int = Field(
+        default=24000,
+        ge=8000,
+        le=48000,
+        description=(
+            "Fixed pcm16 sample rate (Hz). 24 kHz matches the demo client and "
+            "kokoro's native output — changing this does not resample either "
+            "direction, so a mismatched client will hear distorted audio."
+        ),
+    )
+    default_model: str = Field(
+        default="",
+        description="Fallback chat model for a realtime session when neither stt_model nor tts_model names one.",
+    )
+    stt_model: str = Field(
+        default="",
+        description=(
+            "Loaded slot the gateway calls over loopback for speech-to-text. "
+            "Empty falls back to the session's chat model."
+        ),
+    )
+    tts_model: str = Field(
+        default="kokoro",
+        description=("Loaded slot the gateway calls over loopback for text-to-speech."),
+    )
+    tts_voice: str = Field(
+        default="",
+        description="Voice name passed to the tts slot. Empty lets the slot's own default apply.",
+    )
+    vad_energy_threshold: float = Field(
+        default=0.02,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Normalized RMS (0-1) above which incoming audio counts as "
+            "speech for the zero-dependency energy-VAD turn detector."
+        ),
+    )
+    vad_silence_ms: int = Field(
+        default=500,
+        ge=50,
+        le=10000,
+        description="Trailing silence (ms) that ends a voice turn.",
+    )
+    vad_min_speech_ms: int = Field(
+        default=200,
+        ge=0,
+        le=10000,
+        description=(
+            "Minimum voiced-audio duration (ms) to count as speech rather "
+            "than noise; shorter segments never fire a turn."
+        ),
+    )
+    vad_window_ms: int = Field(
+        default=20,
+        ge=5,
+        le=100,
+        description="Analysis window size (ms) the energy-VAD detector evaluates at a time.",
+    )
+    frame_ms: int = Field(
+        default=20,
+        ge=5,
+        le=200,
+        description="Output audio frame size (ms) — the response.output_audio.delta granularity.",
+    )
+    approval_wait_s: float = Field(
+        default=20.0,
+        gt=0,
+        le=300.0,
+        description=(
+            "How long a gated steward tool may leave the voice session "
+            "silent before the assistant speaks a 'still waiting' notice "
+            "and ends the turn, instead of blocking up to 300s."
+        ),
+    )
+    max_buffer_seconds: float = Field(
+        default=30.0,
+        gt=0,
+        le=600.0,
+        description="Cap on buffered audio (seconds) held for a single realtime turn.",
+    )
 
 
 class Hal0Config(BaseModel):

--- a/tests/api/test_settings_apply.py
+++ b/tests/api/test_settings_apply.py
@@ -110,6 +110,7 @@ def test_registry_declares_three_apply_classes() -> None:
         # like publish_host; preload_evict_* are SlotManager constructor
         # args fixed at create_app time.
         ("slots.network_mode", "service-restart", [SERVICE_SLOTS]),
+        ("slots.default_images", "service-restart", [SERVICE_SLOTS]),
         ("slots.preload_evict_enabled", "service-restart", [SERVICE_HAL0_API]),
         ("slots.preload_evict_headroom_mb", "service-restart", [SERVICE_HAL0_API]),
         # [dispatcher] — same create_app-time wiring as the other two knobs.

--- a/tests/api/test_settings_changeset.py
+++ b/tests/api/test_settings_changeset.py
@@ -1,0 +1,161 @@
+"""One ChangeSet for preview and apply — #1967, #2195, #2203, #1511 fixtures.
+
+``compute_settings_changeset`` (``hal0.api._settings_changeset``) is the one
+function both ``POST /api/settings/preview`` and ``PUT /api/settings`` call.
+These tests exercise it at the HTTP layer with fixtures shaped after four
+bugs found in adjacent parts of the codebase — none of which are touched by
+this suite; they're reproduced here as scenarios the general settings
+surface must not repeat:
+
+  * #2203 — a route emitted a hardcoded ``changed_fields`` list even for a
+    no-op re-stamp. Here: re-PUTting an identical value must produce an
+    EMPTY changeset for that key, not a phantom "changed" entry.
+  * #1967 — a round-trip silently dropped keys nobody told it to keep.
+    Here: a validator's silent normalisation (``tool_model``'s empty-string
+    coercion) must still surface as a real changeset entry, because the
+    diff runs over the actual post-validation values, not the caller's
+    touched-key list.
+  * #2195 — a preview billed added/changed flags but never removed ones.
+    Here: clearing a ``[slots].default_images`` family via the documented
+    null-idiom must appear in the changeset as a ``"removed"`` entry.
+  * #1511 — a preview and its apply read different projections of the same
+    operation. Here: preview and apply, given the same body against the
+    same starting config, must produce byte-identical changesets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+
+
+@pytest.fixture
+def isolated_client(tmp_hal0_home: str) -> Iterator[TestClient]:
+    app: FastAPI = create_app()
+    with TestClient(app) as c:
+        yield c
+
+
+def test_preview_and_apply_report_the_same_changeset(isolated_client: TestClient) -> None:
+    """#1511: preview cannot show something apply wouldn't do — same body,
+    same starting config, byte-identical changeset."""
+    body = {"telemetry": {"enabled": True}, "slots": {"idle_timeout_s": 120}}
+
+    preview = isolated_client.post("/api/settings/preview", json=body)
+    assert preview.status_code == 200, preview.text
+    preview_changeset = preview.json()["changeset"]
+
+    apply = isolated_client.put("/api/settings", json=body)
+    assert apply.status_code == 200, apply.text
+    apply_changeset = apply.json()["_hal0"]["changeset"]
+
+    assert preview_changeset == apply_changeset
+    assert preview_changeset["changes"], "expected at least one real change"
+
+
+def test_preview_does_not_write_to_disk(isolated_client: TestClient) -> None:
+    """A preview is a dry run — hal0.toml must be untouched afterwards."""
+    isolated_client.post("/api/settings/preview", json={"telemetry": {"enabled": True}})
+    r = isolated_client.get("/api/settings")
+    assert r.json()["telemetry"]["enabled"] is False  # still the shipped default
+
+
+def test_reapplying_the_same_value_produces_no_changes(isolated_client: TestClient) -> None:
+    """#2203 shape: a route that hardcodes 'changed' even for a no-op
+    re-stamp lies about what happened. Applying an already-current value
+    a second time must report an EMPTY changeset for that key."""
+    isolated_client.put("/api/settings", json={"telemetry": {"enabled": True}})
+
+    r = isolated_client.put("/api/settings", json={"telemetry": {"enabled": True}})
+    assert r.status_code == 200, r.text
+    changes = r.json()["_hal0"]["changeset"]["changes"]
+    assert changes == [], f"re-applying an unchanged value must diff to nothing, got {changes}"
+    # The touched-keys apply_plan bucket still fires (back-compat contract,
+    # tests/api/test_settings_apply.py) — only the stricter changeset is empty.
+    assert r.json()["_hal0"]["apply_plan"]["immediate"] == ["telemetry.enabled"]
+
+
+def test_validator_normalisation_surfaces_as_a_real_change(isolated_client: TestClient) -> None:
+    """#1967 shape: a lossy round-trip silently drops what the caller
+    thought it was setting. Here the opposite failure mode is guarded
+    against: BrainChatConfig._normalise_tool_model coerces an explicit
+    empty string back to the default (schema.py's tool_model validator) —
+    the changeset must show the REAL post-validation value, not silently
+    report "no change" or echo the caller's raw empty string as `after`."""
+    isolated_client.put("/api/settings", json={"brain_chat": {"tool_model": "off"}})
+
+    r = isolated_client.put("/api/settings", json={"brain_chat": {"tool_model": ""}})
+    assert r.status_code == 200, r.text
+    changes = {c["path"]: c for c in r.json()["_hal0"]["changeset"]["changes"]}
+    assert "brain_chat.tool_model" in changes
+    change = changes["brain_chat.tool_model"]
+    assert change["before"] == "off"
+    # Coerced back to the default — never the raw "" the caller sent.
+    assert change["after"] == "hal0/agent"
+    assert change["kind"] == "changed"
+
+
+def test_default_images_null_clear_reports_a_removal(isolated_client: TestClient) -> None:
+    """#2195 shape: a preview that bills additions/changes but not removals
+    under-reports the real delta. Clearing one family via the documented
+    null-idiom (schema.py's `_default_images_known_families` validator)
+    must appear in the changeset as a ``"removed"`` entry, not be silently
+    absent or folded into a same-key "changed" that hides the family name."""
+    isolated_client.put(
+        "/api/settings", json={"slots": {"default_images": {"rocmfpx": "ghcr.io/hal0ai/hal0:test"}}}
+    )
+
+    r = isolated_client.put("/api/settings", json={"slots": {"default_images": {"rocmfpx": None}}})
+    assert r.status_code == 200, r.text
+    changes = {c["path"]: c for c in r.json()["_hal0"]["changeset"]["changes"]}
+    assert "slots.default_images.rocmfpx" in changes
+    change = changes["slots.default_images.rocmfpx"]
+    assert change["kind"] == "removed"
+    assert change["after"] is None
+    assert change["before"] == "ghcr.io/hal0ai/hal0:test"
+
+
+def test_unknown_touched_key_is_classified_unknown_not_dropped(isolated_client: TestClient) -> None:
+    """A forward-compat top-level key (Hal0Config's extra="allow") has no
+    apply-plan registry entry — it must land in the changeset with
+    apply_class None / kind "added", never be silently dropped."""
+    r = isolated_client.put("/api/settings", json={"totally_new_field": {"foo": "bar"}})
+    assert r.status_code == 200, r.text
+    changes = {c["path"]: c for c in r.json()["_hal0"]["changeset"]["changes"]}
+    assert "totally_new_field.foo" in changes
+    assert changes["totally_new_field.foo"]["kind"] == "added"
+    assert changes["totally_new_field.foo"]["apply_class"] is None
+
+
+def test_preview_validation_error_matches_put_envelope(isolated_client: TestClient) -> None:
+    """Preview and apply share one validation path — an invalid patch fails
+    the same way on both, with the same error code and field-path details."""
+    body = {"telemetry": {"channel": "nonsense"}}
+
+    preview = isolated_client.post("/api/settings/preview", json=body)
+    apply = isolated_client.put("/api/settings", json=body)
+
+    assert preview.status_code == 400, preview.text
+    assert apply.status_code == 400, apply.text
+    assert preview.json()["error"]["code"] == "config.invalid"
+    assert apply.json()["error"]["code"] == "config.invalid"
+    assert preview.json()["error"]["details"].keys() == apply.json()["error"]["details"].keys()
+
+
+def test_secret_leaf_is_redacted_in_the_changeset(isolated_client: TestClient) -> None:
+    """A sensitive-named leaf's before/after must be masked in the
+    changeset the same way GET /api/settings redacts it (#553) — a
+    forward-compat extra key is the only Hal0Config-reachable path that can
+    carry a secret-shaped name today."""
+    r = isolated_client.put("/api/settings", json={"integration_api_key": "sk-super-secret"})
+    assert r.status_code == 200, r.text
+    changes = {c["path"]: c for c in r.json()["_hal0"]["changeset"]["changes"]}
+    assert "integration_api_key" in changes
+    after = changes["integration_api_key"]["after"]
+    assert after != "sk-super-secret"
+    assert "sk-super-secret" not in str(after)

--- a/tests/api/test_settings_fields.py
+++ b/tests/api/test_settings_fields.py
@@ -1,0 +1,163 @@
+"""Schema-driven settings field metadata — completeness ratchet (#2108).
+
+``walk_settings_schema`` is what makes every operator-editable
+``Hal0Config`` key automatically a labelled, described settings row
+instead of requiring a hand-authored FormRow per field (the trap that
+left ``[brain_chat].tool_model`` with no dashboard path — #2108). This
+mirrors the exposure-classification ratchet in
+``tests/security/test_exposure.py``: a new schema field with no
+``Field(description=...)`` must fail loudly here, not ship as a blank or
+missing row.
+"""
+
+from __future__ import annotations
+
+import pydantic
+import pytest
+
+from hal0.api._settings_apply import REGISTRY
+from hal0.api._settings_fields import (
+    SettingsFieldSchemaError,
+    SettingsFieldSpec,
+    walk_settings_schema,
+)
+from hal0.config.schema import Hal0Config
+
+
+def test_every_leaf_field_has_a_description() -> None:
+    """The walk itself raises on a missing description — a clean call
+    over the real ``Hal0Config`` is the ratchet. If this test starts
+    failing, a new field was added to the schema without a
+    ``Field(description=...)``; add one before merging."""
+    rows = walk_settings_schema()
+    assert rows, "walk_settings_schema() returned no fields — schema import broken?"
+    for row in rows:
+        assert row.description, row.path
+        assert row.description.strip(), row.path
+
+
+def test_every_leaf_field_is_classified_in_the_apply_registry() -> None:
+    """A schema key the apply-plan registry doesn't know about would
+    render with no reload-effect badge — the settings-apply-plan
+    equivalent of an unclassified route falling through to
+    deny-by-default. New config fields must gain a registry entry in
+    the same PR (``src/hal0/api/_settings_apply.py``)."""
+    rows = walk_settings_schema()
+    missing = [row.path for row in rows if row.path not in REGISTRY]
+    assert missing == [], f"settings keys missing from the apply-plan registry: {missing}"
+
+
+def test_walk_recurses_into_nested_models_not_emit_them() -> None:
+    """A field whose type is itself a nested BaseModel (``memory.graph``,
+    ``memory.embedding``) must be recursed into, not emitted as a row —
+    there's nothing an operator can "set" a whole nested table to."""
+    rows = walk_settings_schema()
+    paths = {row.path for row in rows}
+    assert "memory.graph" not in paths
+    assert "memory.embedding" not in paths
+    assert "memory.graph.enabled" in paths
+    assert "memory.embedding.rerank_model" in paths
+
+
+def test_tool_model_is_present_and_labelled() -> None:
+    """Regression pin for #2108: tool_model must appear as a row with a
+    real label and description, not silently skipped."""
+    rows = {row.path: row for row in walk_settings_schema()}
+    assert "brain_chat.tool_model" in rows
+    row = rows["brain_chat.tool_model"]
+    assert row.label == "Tool model"
+    assert "tool" in row.description.lower()
+    assert row.type == "string"
+
+
+@pytest.mark.parametrize(
+    "path, expected_type, expected_enum",
+    [
+        ("telemetry.enabled", "boolean", None),
+        ("telemetry.channel", "enum", ["stable", "preview", "nightly"]),
+        ("slots.max_slots", "number", None),
+        ("slots.default_images", "map", None),
+        ("models.roots", "string[]", None),
+        ("brain_chat.model", "string", None),
+        ("activity.max_rows", "number", None),  # int | None must not fall through to "string"
+        ("security.require_auth", "boolean", None),  # bool | None
+    ],
+)
+def test_field_type_classification(
+    path: str, expected_type: str, expected_enum: list[str] | None
+) -> None:
+    rows = {row.path: row for row in walk_settings_schema()}
+    row = rows[path]
+    assert row.type == expected_type, path
+    assert row.enum == expected_enum, path
+
+
+def test_numeric_constraints_are_extracted() -> None:
+    rows = {row.path: row for row in walk_settings_schema()}
+    assert rows["slots.max_slots"].constraints == {"ge": 0}
+    assert rows["dispatcher.direct_read_timeout_s"].constraints == {"ge": 30.0, "le": 600.0}
+    assert rows["brain_chat.max_rounds"].constraints == {"ge": 1, "le": 100}
+
+
+def test_default_factory_fields_resolve_to_a_concrete_default() -> None:
+    """``models.roots`` and ``slots.default_images`` use ``default_factory`` —
+    the spec's ``default`` must be the resolved value, not the factory
+    function itself (a raw callable would serialize as garbage in the API
+    response)."""
+    rows = {row.path: row for row in walk_settings_schema()}
+    assert rows["slots.default_images"].default == {}
+    assert isinstance(rows["models.roots"].default, list)
+    assert not callable(rows["models.roots"].default)
+
+
+def test_group_is_the_top_level_hal0_config_section() -> None:
+    rows = {row.path: row for row in walk_settings_schema()}
+    assert rows["brain_chat.tool_model"].group == "brain_chat"
+    assert rows["memory.embedding.rerank_model"].group == "memory.embedding"
+    assert rows["memory.graph.enabled"].group == "memory.graph"
+
+
+def test_missing_description_raises_schema_error() -> None:
+    """The ratchet mechanism itself: a field with no description must
+    raise, not silently emit a blank row."""
+
+    class _Undocumented(pydantic.BaseModel):
+        knob: int = 1
+
+    with pytest.raises(SettingsFieldSchemaError, match="knob"):
+        walk_settings_schema(_Undocumented)
+
+
+def test_walk_settings_schema_covers_every_hal0_config_leaf() -> None:
+    """Cross-check against a fresh manual walk of ``Hal0Config.model_fields``
+    so a future refactor of the walker itself can't silently drop a
+    section (e.g. by forgetting to recurse into a newly-added nested
+    model)."""
+
+    def _count_leaves(model_cls: type[pydantic.BaseModel]) -> int:
+        total = 0
+        for field in model_cls.model_fields.values():
+            ann = field.annotation
+            unwrapped = ann
+            import types
+            import typing
+
+            origin = typing.get_origin(ann)
+            if origin is typing.Union or origin is types.UnionType:
+                args = [a for a in typing.get_args(ann) if a is not type(None)]
+                if len(args) == 1:
+                    unwrapped = args[0]
+            if isinstance(unwrapped, type) and issubclass(unwrapped, pydantic.BaseModel):
+                total += _count_leaves(unwrapped)
+            else:
+                total += 1
+        return total
+
+    assert len(walk_settings_schema()) == _count_leaves(Hal0Config)
+
+
+def test_spec_is_a_frozen_dataclass_instance() -> None:
+    row = walk_settings_schema()[0]
+    assert isinstance(row, SettingsFieldSpec)
+    with pytest.raises(AttributeError):
+        row.path = "mutated"  # type: ignore[misc]

--- a/tests/api/test_settings_routes.py
+++ b/tests/api/test_settings_routes.py
@@ -161,6 +161,48 @@ def test_settings_schema_returns_json_schema(isolated_client: TestClient) -> Non
     assert "telemetry" in body["properties"]
 
 
+def test_settings_fields_returns_every_schema_leaf_as_one_row(
+    isolated_client: TestClient,
+) -> None:
+    """GET /api/settings/fields is the one payload a schema-driven settings
+    page renders from — group/label/description/type/default/current/
+    apply_class/services/secret/live_target per operator-editable key
+    (#2108)."""
+    r = isolated_client.get("/api/settings/fields")
+    assert r.status_code == 200, r.text
+    fields = r.json()["fields"]
+    by_path = {f["path"]: f for f in fields}
+    assert "brain_chat.tool_model" in by_path
+    row = by_path["brain_chat.tool_model"]
+    assert row["label"] == "Tool model"
+    assert row["group"] == "brain_chat"
+    assert row["default"] == "hal0/agent"
+    assert row["current"] == "hal0/agent"
+    assert row["apply_class"] == "immediate"
+    assert row["services"] == []
+    assert row["secret"] is False
+    # #2108: the shipped default has no live target on a fresh install — the
+    # `agent` slot ships unbound, so nothing in the resolver chain is loaded.
+    assert row["live_target"] is False
+    # Every row must carry a real apply class — a schema field with no
+    # registry entry would render with no effect badge (issue-#552 gap).
+    assert all(f["apply_class"] is not None for f in fields)
+    # live_target is only meaningful for a hal0/<slot>-shaped value.
+    assert by_path["telemetry.enabled"]["live_target"] is None
+
+
+def test_settings_fields_reflects_current_value_after_a_save(
+    isolated_client: TestClient,
+) -> None:
+    """``current`` is read off the live config, not the schema default —
+    a save must be visible on the next fetch without a process restart."""
+    isolated_client.put("/api/settings", json={"brain_chat": {"max_rounds": 42}})
+    r = isolated_client.get("/api/settings/fields")
+    by_path = {f["path"]: f for f in r.json()["fields"]}
+    assert by_path["brain_chat.max_rounds"]["current"] == 42
+    assert by_path["brain_chat.max_rounds"]["default"] == 8
+
+
 def test_reload_after_bad_toml_returns_parse_error_envelope(
     isolated_client: TestClient, tmp_hal0_home: str
 ) -> None:

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -353,6 +353,9 @@ export const ENDPOINTS = {
   settingsSchema: '/api/settings/schema',
   // Apply-plan registry — key→{apply_class, services} for all settings (#552).
   settingsApplyPlan: '/api/settings/apply-plan',
+  // One labelled row per operator-editable schema key — group/label/
+  // description/type/default/current/reload class/secret/live_target (#2108).
+  settingsFields: '/api/settings/fields',
   // Single-source-of-truth model storage (Settings → Storage).
   settingsModelsStore: '/api/settings/models/store',
   settingsModelsStoreMigrate: '/api/settings/models/store/migrate',

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -356,6 +356,10 @@ export const ENDPOINTS = {
   // One labelled row per operator-editable schema key — group/label/
   // description/type/default/current/reload class/secret/live_target (#2108).
   settingsFields: '/api/settings/fields',
+  // Dry-run a PATCH: same body shape and ChangeSet computation as the PUT,
+  // writes nothing (#1967, #2195, #2203, #1511) — backs a confirm-before-
+  // apply preview drawer.
+  settingsPreview: '/api/settings/preview',
   // Single-source-of-truth model storage (Settings → Storage).
   settingsModelsStore: '/api/settings/models/store',
   settingsModelsStoreMigrate: '/api/settings/models/store/migrate',

--- a/ui/src/api/hooks/useSettings.ts
+++ b/ui/src/api/hooks/useSettings.ts
@@ -50,6 +50,11 @@ export function useSettingsUpdate() {
     onSuccess: (next) => {
       qc.setQueryData(SETTINGS_KEY, next)
       qc.invalidateQueries({ queryKey: ['models'] })
+      // `current` and `live_target` on every row are stale the instant this
+      // PUT lands — a save that fixes tool_model's live target must clear
+      // AgentsBrainPage's "no live target" banner immediately, not up to
+      // 15s later (see SETTINGS_FIELDS_KEY's staleTime below).
+      qc.invalidateQueries({ queryKey: SETTINGS_FIELDS_KEY })
     },
   })
 }
@@ -58,7 +63,10 @@ export function useSettingsReload() {
   const qc = useQueryClient()
   return useMutation<Hal0Settings, Hal0Error, void>({
     mutationFn: () => apiPost<Hal0Settings>(ENDPOINTS.settingsReload),
-    onSuccess: (next) => qc.setQueryData(SETTINGS_KEY, next),
+    onSuccess: (next) => {
+      qc.setQueryData(SETTINGS_KEY, next)
+      qc.invalidateQueries({ queryKey: SETTINGS_FIELDS_KEY })
+    },
   })
 }
 
@@ -194,6 +202,48 @@ export function useApplyPlan() {
     queryFn: () => apiGet<ApplyPlanRegistry>(ENDPOINTS.settingsApplyPlan),
     // Registry is static for the server's lifetime — never auto-refetch.
     staleTime: Infinity,
+  })
+}
+
+// ── Schema-driven settings fields (#2108) ───────────────────────────────────
+//
+// GET /api/settings/fields is the one payload a schema-driven settings page
+// renders from: one row per operator-editable Hal0Config leaf, joining three
+// single-owner facts — schema metadata (group/label/description/type/enum/
+// constraints/default) from Field(description=...) in hal0.config.schema,
+// reload classification from the same apply-plan registry useApplyPlan()
+// reads, and `current` from the live config. `live_target` is populated only
+// for a `hal0/<slot>`-shaped value (null otherwise) — true/false for whether
+// that alias currently resolves to a loaded slot, closing #2108's "the
+// shipped tool_model default has nowhere live to route on a fresh install"
+// gap server-side instead of the UI re-deriving slot-resolution logic.
+
+export interface SettingsFieldRow {
+  path: string
+  group: string
+  label: string
+  description: string
+  type: 'boolean' | 'number' | 'string' | 'string[]' | 'map' | 'enum'
+  enum: string[] | null
+  constraints: Record<string, number>
+  default: unknown
+  current: unknown
+  secret: boolean
+  apply_class: 'immediate' | 'service-restart' | 'manual-restart' | null
+  services: string[]
+  live_target: boolean | null
+}
+
+const SETTINGS_FIELDS_KEY = ['settings', 'fields'] as const
+
+export function useSettingsFields() {
+  return useQuery({
+    queryKey: SETTINGS_FIELDS_KEY,
+    queryFn: () => apiGet<{ fields: SettingsFieldRow[] }>(ENDPOINTS.settingsFields),
+    // live_target resolves against the current slot set, so this can't be
+    // Infinity like useSettingsSchema — but a settings page isn't a place
+    // operators watch for slot churn in real time either.
+    staleTime: 15_000,
   })
 }
 

--- a/ui/src/api/hooks/useSettings.ts
+++ b/ui/src/api/hooks/useSettings.ts
@@ -247,6 +247,42 @@ export function useSettingsFields() {
   })
 }
 
+// ── One ChangeSet, shared by preview and apply (#1967, #2195, #2203, #1511) ──
+//
+// POST /api/settings/preview and the `_hal0.changeset` on PUT /api/settings
+// both render this same shape — `hal0.api._settings_changeset.compute_
+// settings_changeset` is the one function behind both, so a preview drawer
+// built from this type shows exactly what the apply will write.
+
+export interface SettingsChange {
+  path: string
+  before: unknown
+  after: unknown
+  kind: 'added' | 'removed' | 'changed'
+  apply_class: 'immediate' | 'service-restart' | 'manual-restart' | null
+  services: string[]
+}
+
+export interface SettingsChangesetPayload {
+  changes: SettingsChange[]
+  unknown: string[]
+}
+
+export interface SettingsPreviewResponse {
+  changeset: SettingsChangesetPayload
+  apply_plan: unknown
+}
+
+// Dry-run mutation — deliberately not cached (queryClient has no notion of
+// "preview for this exact patch"), and never writes to SETTINGS_KEY: a
+// preview must never be mistaken for a save by anything reading react-query
+// state.
+export function useSettingsPreview() {
+  return useMutation<SettingsPreviewResponse, Hal0Error, Partial<Hal0Settings>>({
+    mutationFn: (patch) => apiPost<SettingsPreviewResponse>(ENDPOINTS.settingsPreview, patch),
+  })
+}
+
 export function useModelStoreMigrate() {
   const qc = useQueryClient()
   return useMutation<SetStoreResponse, Hal0Error, { path: string }>({

--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -307,7 +307,7 @@ export function ConfirmDialog({ open, onCancel, onConfirm, title, message, confi
 
 // ─── Banner ───────────────────────────────────────────────────────────────
 // Reusable shell: icon + heading + body + actions + dismiss × · amber/red tones.
-function Banner({ kind = "warn", heading, body, actions, onDismiss, eyebrow }) {
+export function Banner({ kind = "warn", heading, body, actions, onDismiss, eyebrow }) {
   return (
     <div className={"banner banner-" + kind} role={kind === "err" ? "alert" : "status"}>
       <div className="banner-ic">

--- a/ui/src/dash/settings/SettingsNav.jsx
+++ b/ui/src/dash/settings/SettingsNav.jsx
@@ -39,6 +39,7 @@ export const NAV_GROUPS = [
     items: [
       { id: "secrets", label: "Secrets" },
       { id: "agents", label: "Agent Chat" },
+      { id: "realtime", label: "Realtime" },
     ],
   },
 ];

--- a/ui/src/dash/settings/SettingsShell.jsx
+++ b/ui/src/dash/settings/SettingsShell.jsx
@@ -31,6 +31,7 @@ import { MemoryPage } from './pages/data/MemoryPage.jsx'
 import { UpdatesPage } from './pages/diagnostics/UpdatesPage.jsx'
 import { AdvancedPage } from './pages/diagnostics/AdvancedPage.jsx'
 import { SecretsPage } from './pages/integrations/SecretsPage.jsx'
+import { RealtimePage } from './pages/integrations/RealtimePage.jsx'
 import { AgentsBrainPage } from './pages/routing/AgentsBrainPage.jsx'
 
 export function SettingsShell({ param }) {
@@ -56,6 +57,7 @@ export function SettingsShell({ param }) {
       case "advanced": return <AdvancedPage />;
       case "secrets": return <SecretsPage />;
       case "agents": return <AgentsBrainPage />;
+      case "realtime": return <RealtimePage />;
       default: return <OverviewPage />;
     }
   };

--- a/ui/src/dash/settings/data/useSettingsForm.js
+++ b/ui/src/dash/settings/data/useSettingsForm.js
@@ -101,6 +101,10 @@ export function useSettingsForm(client, keys) {
     clearConfirm,
     submit,
     commit,
+    // Exposed so a page can preview the pending patch (POST
+    // /api/settings/preview) before committing — same shape `commit()`
+    // sends, so the preview can't drift from what a save would do.
+    buildPatch,
     registry,
   }
 }

--- a/ui/src/dash/settings/pages/integrations/RealtimePage.jsx
+++ b/ui/src/dash/settings/pages/integrations/RealtimePage.jsx
@@ -8,11 +8,12 @@
 // renderer closes: every row here comes from GET /api/settings/schema (via
 // AdvRow / useSettingsForm, the same machinery AdvancedPage uses), grouped
 // by the operator's own questions rather than the TOML's flat key order.
-import { Fragment } from 'react'
+import { Fragment, useState } from 'react'
 import { useSettingsClient } from '../../data/settingsClient.js'
 import { useSettingsForm } from '../../data/useSettingsForm.js'
-import { ConfirmDialog } from '../../../primitives.jsx'
+import { useSettingsPreview } from '@/api/hooks/useSettings'
 import { AdvRow, _getIn } from '../../shared/SchemaRow.jsx'
+import { SettingsPreviewDrawer } from '../../shared/SettingsPreviewDrawer.jsx'
 
 const REALTIME_GROUPS = [
   { title: "Core", sub: "Kill switch, sample rate, and which slots serve STT/TTS", keys: [
@@ -35,12 +36,29 @@ export function RealtimePage() {
 
   const allKeys = REALTIME_GROUPS.flatMap(g => g.keys);
   const form = useSettingsForm(client, allKeys);
-  const { buf, fields, dirtyKeys, invalidKeys, canSave, confirmKeys } = form;
+  const { buf, fields, dirtyKeys, invalidKeys, canSave } = form;
   const onChange = form.set;
+  const preview = useSettingsPreview();
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewData, setPreviewData] = useState(null);
 
-  const doSave = async () => {
+  // Preview before apply (#1967, #2195, #2203, #1511) — see AgentsBrainPage
+  // for the full rationale; same drawer, same one server ChangeSet function
+  // behind both the preview and the eventual PUT.
+  const onSaveClick = async () => {
+    try {
+      const resp = await preview.mutateAsync(form.buildPatch());
+      setPreviewData(resp.changeset);
+      setPreviewOpen(true);
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Preview failed — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  const confirmApply = async () => {
     try {
       const { needsRestart } = await form.commit();
+      setPreviewOpen(false);
       window.__hal0Toast && window.__hal0Toast(
         needsRestart ? "Saved — restart to apply the marked changes" : "Realtime settings saved",
         needsRestart ? "warn" : "ok",
@@ -48,12 +66,6 @@ export function RealtimePage() {
     } catch (e) {
       window.__hal0Toast && window.__hal0Toast(`Save failed — ${e?.message || "see logs"}`, "err");
     }
-  };
-
-  const onSaveClick = async () => {
-    const manual = dirtyKeys.filter(k => client.reloadClass(k)?.apply_class === "manual-restart");
-    if (manual.length > 0) { form.submit(); return; }
-    doSave();
   };
 
   const loading = settings.isPending || schemaQuery.isPending;
@@ -106,24 +118,19 @@ export function RealtimePage() {
             </span>
             <div style={{display: "inline-flex", gap: 8}}>
               <button className="btn ghost sm" disabled={dirtyKeys.length === 0 || update.isPending} onClick={form.reset}>Reset</button>
-              <button className="btn" disabled={!canSave} onClick={onSaveClick}>{update.isPending ? "Saving…" : "Save changes"}</button>
+              <button className="btn" disabled={!canSave || preview.isPending} onClick={onSaveClick}>
+                {preview.isPending ? "Checking…" : "Review & save"}
+              </button>
             </div>
           </div>
 
-          <ConfirmDialog
-            open={!!confirmKeys}
-            onCancel={form.clearConfirm}
-            onConfirm={() => { form.clearConfirm(); doSave(); }}
-            title="Manual restart required"
-            message={
-              <span>
-                {confirmKeys && confirmKeys.length === 1
-                  ? <>The setting <b className="mono">{confirmKeys[0]}</b> requires</>
-                  : <>These settings ({confirmKeys && confirmKeys.map(k => <b className="mono" key={k}>{k} </b>)}) require</>}{" "}
-                a <b>manual operator restart</b> to take effect. Values are persisted now.
-              </span>
-            }
-            confirmLabel="Save anyway"
+          <SettingsPreviewDrawer
+            open={previewOpen}
+            onClose={() => setPreviewOpen(false)}
+            changes={previewData?.changes}
+            unknown={previewData?.unknown}
+            onConfirm={confirmApply}
+            confirming={update.isPending}
           />
         </>
       )}

--- a/ui/src/dash/settings/pages/integrations/RealtimePage.jsx
+++ b/ui/src/dash/settings/pages/integrations/RealtimePage.jsx
@@ -1,0 +1,132 @@
+// INTEGRATIONS ▸ Realtime — the OpenAI-Realtime WebSocket surface ([realtime]).
+//
+// hal0 has shipped a WS /v1/realtime voice endpoint (schema.py's
+// RealtimeConfig) since HP-realtime inc-1, but every one of its 13 knobs —
+// including the enabled kill switch — had no dashboard page at all; the
+// only way to see or change them was `hal0 config edit`. This is the exact
+// "settings fields exist only for hand-picked keys" gap the schema-driven
+// renderer closes: every row here comes from GET /api/settings/schema (via
+// AdvRow / useSettingsForm, the same machinery AdvancedPage uses), grouped
+// by the operator's own questions rather than the TOML's flat key order.
+import { Fragment } from 'react'
+import { useSettingsClient } from '../../data/settingsClient.js'
+import { useSettingsForm } from '../../data/useSettingsForm.js'
+import { ConfirmDialog } from '../../../primitives.jsx'
+import { AdvRow, _getIn } from '../../shared/SchemaRow.jsx'
+
+const REALTIME_GROUPS = [
+  { title: "Core", sub: "Kill switch, sample rate, and which slots serve STT/TTS", keys: [
+    "realtime.enabled", "realtime.sample_rate", "realtime.default_model",
+    "realtime.stt_model", "realtime.tts_model", "realtime.tts_voice",
+  ]},
+  { title: "Voice detection", sub: "Zero-dependency energy-RMS turn detector", keys: [
+    "realtime.vad_energy_threshold", "realtime.vad_silence_ms",
+    "realtime.vad_min_speech_ms", "realtime.vad_window_ms",
+  ]},
+  { title: "Turn behavior", sub: "Output framing and how long a gated tool may leave the session silent", keys: [
+    "realtime.frame_ms", "realtime.approval_wait_s", "realtime.max_buffer_seconds",
+  ]},
+];
+
+export function RealtimePage() {
+  const client = useSettingsClient({ schema: true });
+  const { settings, update, schema: schemaQuery, registry } = client;
+  const live = settings.data || null;
+
+  const allKeys = REALTIME_GROUPS.flatMap(g => g.keys);
+  const form = useSettingsForm(client, allKeys);
+  const { buf, fields, dirtyKeys, invalidKeys, canSave, confirmKeys } = form;
+  const onChange = form.set;
+
+  const doSave = async () => {
+    try {
+      const { needsRestart } = await form.commit();
+      window.__hal0Toast && window.__hal0Toast(
+        needsRestart ? "Saved — restart to apply the marked changes" : "Realtime settings saved",
+        needsRestart ? "warn" : "ok",
+      );
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Save failed — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  const onSaveClick = async () => {
+    const manual = dirtyKeys.filter(k => client.reloadClass(k)?.apply_class === "manual-restart");
+    if (manual.length > 0) { form.submit(); return; }
+    doSave();
+  };
+
+  const loading = settings.isPending || schemaQuery.isPending;
+
+  return (
+    <div className="s-section">
+      <h2>Realtime</h2>
+      <p className="desc">
+        The <span className="mono">WS /v1/realtime</span> voice endpoint: which local slots serve
+        speech-to-text and text-to-speech, the turn-detection thresholds, and the output framing.
+        Every key here is read live on each connection, so changes apply immediately.
+      </p>
+
+      {loading && <div style={{padding: 16, color: "var(--fg-4)", fontFamily: "var(--jbm)", fontSize: 12}}>Loading config schema…</div>}
+      {(settings.isError || schemaQuery.isError) && (
+        <div className="err">{settings.error?.message || schemaQuery.error?.message || "Failed to load settings"}</div>
+      )}
+
+      {!loading && !settings.isError && !schemaQuery.isError && (
+        <>
+          {REALTIME_GROUPS.map(g => (
+            <Fragment key={g.title}>
+              <div className="s-panel" style={{marginBottom: 12}}>
+                <div className="s-row" style={{paddingBottom: 4, borderBottom: "1px solid var(--line)"}}>
+                  <div className="k"><span>{g.title}</span><FieldInfoIcon description={g.sub} /></div>
+                </div>
+                {g.keys.map(k => (
+                  <AdvRow
+                    key={k}
+                    dotKey={k}
+                    field={fields[k]}
+                    live={_getIn(live, k)}
+                    buf={buf[k]}
+                    onChange={onChange}
+                    registry={registry}
+                  />
+                ))}
+              </div>
+            </Fragment>
+          ))}
+
+          <div style={{marginTop: 2, marginBottom: 18, display: "flex", justifyContent: "space-between", alignItems: "center"}}>
+            <span className="mono" style={{fontSize: 11, color: "var(--fg-4)"}}>
+              Stored at <span style={{color: "var(--fg-3)"}}>/etc/hal0/hal0.toml</span> · [realtime]
+              {dirtyKeys.length > 0 && (
+                <span style={{marginLeft: 8, color: invalidKeys.length ? "var(--err)" : "var(--warn)"}}>
+                  · {invalidKeys.length ? `${invalidKeys.length} invalid value${invalidKeys.length === 1 ? "" : "s"}` : `${dirtyKeys.length} unsaved change${dirtyKeys.length === 1 ? "" : "s"}`}
+                </span>
+              )}
+            </span>
+            <div style={{display: "inline-flex", gap: 8}}>
+              <button className="btn ghost sm" disabled={dirtyKeys.length === 0 || update.isPending} onClick={form.reset}>Reset</button>
+              <button className="btn" disabled={!canSave} onClick={onSaveClick}>{update.isPending ? "Saving…" : "Save changes"}</button>
+            </div>
+          </div>
+
+          <ConfirmDialog
+            open={!!confirmKeys}
+            onCancel={form.clearConfirm}
+            onConfirm={() => { form.clearConfirm(); doSave(); }}
+            title="Manual restart required"
+            message={
+              <span>
+                {confirmKeys && confirmKeys.length === 1
+                  ? <>The setting <b className="mono">{confirmKeys[0]}</b> requires</>
+                  : <>These settings ({confirmKeys && confirmKeys.map(k => <b className="mono" key={k}>{k} </b>)}) require</>}{" "}
+                a <b>manual operator restart</b> to take effect. Values are persisted now.
+              </span>
+            }
+            confirmLabel="Save anyway"
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/dash/settings/pages/routing/AgentsBrainPage.jsx
+++ b/ui/src/dash/settings/pages/routing/AgentsBrainPage.jsx
@@ -1,81 +1,178 @@
 // INTEGRATIONS ▸ Agent Chat — the dashboard steward chat ([brain_chat]).
-// Extracted verbatim from settings.jsx AgentsBrainSection (P3-ui split
-// phase 1). Filed under ROUTING (closest fit among the target IA groups —
-// this is the only existing agent-policy surface in settings.jsx; the
-// spec's Mode&Fallback/providers/agent-profiles ROUTING content is still
-// G[§21 D1/§4] MISSING).
 //
-// Wires the [brain_chat] config (schema.BrainChatConfig) into the UI: the hard
-// kill switch, read-only guardrail, target-slot override, and loop knobs. Every
-// key applies live (board_chat._brain_chat_config reads app.state per turn), so
-// the ApplyBadge shows "live". Saves via the generic PUT /api/settings.
-import { useState, useEffect } from 'react'
+// Schema-driven (R5 data seam): enabled / read_only / max_rounds /
+// completion_timeout_s render through the same AdvRow + useSettingsForm
+// machinery AdvancedPage uses, so their copy and effect badges come from the
+// server schema + apply-plan registry instead of hand-authored strings that
+// can drift. `model` and `tool_model` stay custom RichSelect widgets — they
+// need slot-aware option lists a generic AdvRow can't build — but both still
+// read the SAME useSettingsForm buffer/dirty/patch/confirm-gate loop as the
+// generic rows, so Save/Reset/manual-restart-confirm behave identically.
+//
+// tool_model (#2108): previously had no dashboard path at all — this page
+// only ever saved enabled/read_only/model/max_rounds/completion_timeout_s.
+// The picker below offers the shipped default (hal0/agent), every configured
+// chat-capable slot, an explicit "disabled" choice, and — when `model` names
+// a specific slot — a "same as chat model" preset. Each option chips whether
+// its target slot currently has a model loaded, and GET /api/settings/fields'
+// server-computed `live_target` drives a plain-language banner when the
+// SAVED value has nowhere live to route a tool call (the fresh-install gap
+// #2108 documents: the `agent` slot ships with no bound model).
+import { useMemo } from 'react'
 import { useSettingsClient } from '../../data/settingsClient.js'
+import { useSettingsForm } from '../../data/useSettingsForm.js'
+import { useSettingsFields } from '@/api/hooks/useSettings'
 import { useSlots } from '@/api/hooks/useSlots'
+import { ConfirmDialog, Banner } from '../../../primitives.jsx'
+import { RichSelect } from '@/dash/rich-select.jsx'
+import { AdvRow, _getIn } from '../../shared/SchemaRow.jsx'
 import { ApplyBadge } from '../../shared/ApplyBadge.jsx'
 import { SRow } from '../../shared/SRow.jsx'
-import { _advInputStyle } from '../../shared/SchemaRow.jsx'
+
+// Mirrors the canonical chains in hal0.normalize.resolver.DEFAULT_CHAINS —
+// advisory only, for the picker's per-option "loaded" chip before a save.
+// The authoritative answer for the SAVED value is the server's
+// GET /api/settings/fields `live_target` (real resolver, real slot state).
+const _CANONICAL_CHAINS = {
+  'hal0/agent': ['agent'],
+  'hal0/utility': ['utility', 'agent'],
+  'hal0/npu': ['npu', 'utility', 'agent'],
+  'hal0/brain': ['brain', 'agent'],
+};
+
+function _chainFor(value) {
+  if (!value || !value.startsWith('hal0/')) return null;
+  if (_CANONICAL_CHAINS[value]) return _CANONICAL_CHAINS[value];
+  return [value.slice(5), 'agent'];
+}
+
+// First slot in the alias's fallback chain that has a model bound, or null.
+function _resolvedSlotName(value, slots) {
+  const chain = _chainFor(value);
+  if (!chain) return null;
+  const byName = new Map((slots || []).map(s => [s.name, s]));
+  for (const name of chain) {
+    const s = byName.get(name);
+    if (s && s.model) return name;
+  }
+  return null;
+}
+
+function toolModelOptions(llmSlots, model) {
+  const byName = new Map(llmSlots.map(s => [s.name, s]));
+  const chip = (name) => {
+    const s = byName.get(name);
+    if (!s) return <span className="chip warn">not configured</span>;
+    return s.model
+      ? <span className="chip ok">{s.model}</span>
+      : <span className="chip warn">no model loaded</span>;
+  };
+  const opts = [
+    {
+      id: 'hal0/agent',
+      row: 'hal0/agent (default)',
+      right: chip('agent'),
+      desc: "The always-on anchor every fallback chain ends in. Ships with no model bound — pull one into the agent slot before relying on this default.",
+    },
+  ];
+  if (model && model.trim() && model !== 'hal0/agent') {
+    opts.push({
+      id: model,
+      row: `Same as chat model (${model})`,
+      right: chip(_resolvedSlotName(model, llmSlots) || model.replace(/^hal0\//, '')),
+      desc: "Route tool-calling rounds to whatever slot the chat model itself uses — no separate reroute target.",
+    });
+  }
+  for (const s of llmSlots) {
+    const virtual = `hal0/${s.name}`;
+    if (virtual === 'hal0/agent' || virtual === model) continue;
+    opts.push({
+      id: virtual,
+      row: virtual,
+      right: s.model ? <span className="chip ok">{s.model}</span> : <span className="chip warn">no model loaded</span>,
+      desc: s.model ? `Loaded: ${s.model}` : "Configured, but no model is currently loaded on this slot.",
+    });
+  }
+  opts.push({
+    id: 'off',
+    row: 'Disabled',
+    desc: "No reroute — a chat model that can't emit tool calls this runtime parses will say so instead of silently failing.",
+  });
+  return opts;
+}
+
+function modelOptions(llmSlots, liveModel) {
+  const opts = [
+    { id: '', row: 'Persona default (hal0/brain)', desc: "Falls back through hal0/brain → the agent slot." },
+  ];
+  for (const s of llmSlots) {
+    opts.push({
+      id: `hal0/${s.name}`,
+      row: `hal0/${s.name}`,
+      right: s.model ? <span className="chip ok">{s.model}</span> : <span className="chip warn">no model loaded</span>,
+    });
+  }
+  // Keep a currently-set custom value selectable even if its slot isn't listed.
+  if (liveModel && !opts.some(o => o.id === liveModel)) {
+    opts.push({ id: liveModel, row: liveModel, desc: "Currently set; slot not in the live list." });
+  }
+  return opts;
+}
 
 export function AgentsBrainPage() {
-  // R5 data seam: one typed client instead of three ad-hoc hooks.
-  const { settings, update, registry } = useSettingsClient();
+  const client = useSettingsClient({ schema: true });
+  const { settings, update, registry } = client;
   const slotsQuery = useSlots();
+  const fieldsQuery = useSettingsFields();
 
   const live = settings.data?.brain_chat || {};
-  const liveEnabled = live.enabled !== false;
-  const liveReadOnly = live.read_only === true;
-  const liveModel = live.model || "";
-  const liveRounds = live.max_rounds ?? 8;
-  const liveTimeout = live.completion_timeout_s ?? 300;
+  const llmSlots = useMemo(
+    () => (slotsQuery.data || []).filter(s => s.type === 'llm'),
+    [slotsQuery.data],
+  );
 
-  const [enabled, setEnabled] = useState(liveEnabled);
-  const [readOnly, setReadOnly] = useState(liveReadOnly);
-  const [model, setModel] = useState(liveModel);
-  const [rounds, setRounds] = useState(String(liveRounds));
-  const [timeoutS, setTimeoutS] = useState(String(liveTimeout));
+  const KEYS = [
+    'brain_chat.enabled', 'brain_chat.read_only', 'brain_chat.model',
+    'brain_chat.tool_model', 'brain_chat.max_rounds', 'brain_chat.completion_timeout_s',
+  ];
+  const form = useSettingsForm(client, KEYS);
+  const { buf, set, fields, dirtyKeys, invalidKeys, canSave, confirmKeys } = form;
 
-  useEffect(() => { setEnabled(liveEnabled); }, [liveEnabled]);
-  useEffect(() => { setReadOnly(liveReadOnly); }, [liveReadOnly]);
-  useEffect(() => { setModel(liveModel); }, [liveModel]);
-  useEffect(() => { setRounds(String(liveRounds)); }, [liveRounds]);
-  useEffect(() => { setTimeoutS(String(liveTimeout)); }, [liveTimeout]);
+  const modelValue = buf['brain_chat.model'] !== undefined ? buf['brain_chat.model'] : (live.model || '');
+  const toolModelValue = buf['brain_chat.tool_model'] !== undefined
+    ? buf['brain_chat.tool_model']
+    : (live.tool_model || 'hal0/agent');
 
-  // Slot picker: "" = persona default (hal0/brain), plus hal0/<slot> for every
-  // configured slot so the operator can target e.g. the NPU chat slot.
-  const slotModels = (slotsQuery.data || []).map(s => `hal0/${s.name}`);
-  // Keep a currently-set custom value visible even if its slot isn't listed.
-  const modelOptions = ["", ...new Set([...slotModels, ...(liveModel ? [liveModel] : [])])];
-
-  const roundsNum = Number(rounds);
-  const timeoutNum = Number(timeoutS);
-  const roundsValid = Number.isInteger(roundsNum) && roundsNum >= 1 && roundsNum <= 100;
-  const timeoutValid = timeoutNum > 0;
-  const dirty =
-    enabled !== liveEnabled || readOnly !== liveReadOnly || model !== liveModel ||
-    roundsNum !== liveRounds || timeoutNum !== liveTimeout;
+  const fieldsByPath = useMemo(() => {
+    const out = {};
+    for (const f of fieldsQuery.data?.fields || []) out[f.path] = f;
+    return out;
+  }, [fieldsQuery.data]);
+  // #2108: only meaningful for the SAVED value (server resolves against real
+  // slot state) — a dirty, unsaved edit shows the picker's own per-option
+  // chip instead, so this only ever warns about what's live right now.
+  const savedToolModelHasNoLiveTarget = fieldsByPath['brain_chat.tool_model']?.live_target === false
+    && !dirtyKeys.includes('brain_chat.tool_model');
 
   const doSave = async () => {
-    if (!roundsValid || !timeoutValid) {
-      window.__hal0Toast && window.__hal0Toast("Fix the highlighted fields first", "err");
-      return;
-    }
     try {
-      await update.mutateAsync({
-        brain_chat: {
-          enabled, read_only: readOnly, model,
-          max_rounds: roundsNum, completion_timeout_s: timeoutNum,
-        },
-      });
-      window.__hal0Toast && window.__hal0Toast("Brain chat settings saved", "ok");
+      const { needsRestart } = await form.commit();
+      window.__hal0Toast && window.__hal0Toast(
+        needsRestart ? "Saved — restart to apply the marked changes" : "Brain chat settings saved",
+        needsRestart ? "warn" : "ok",
+      );
     } catch (e) {
       window.__hal0Toast && window.__hal0Toast(`Save failed — ${e?.message || "see logs"}`, "err");
     }
   };
 
-  const reset = () => {
-    setEnabled(liveEnabled); setReadOnly(liveReadOnly); setModel(liveModel);
-    setRounds(String(liveRounds)); setTimeoutS(String(liveTimeout));
+  const onSaveClick = async () => {
+    const manual = dirtyKeys.filter(k => client.reloadClass(k)?.apply_class === "manual-restart");
+    if (manual.length > 0) { form.submit(); return; }
+    doSave();
   };
+
+  const loading = settings.isPending || client.schema.isPending;
 
   return (
     <div className="s-section">
@@ -86,66 +183,87 @@ export function AgentsBrainPage() {
         server-side, independent of the persona's tool allowlist, and apply live.
       </p>
 
-      <div className="s-panel" style={{marginBottom: 12}}>
-        <SRow
-          k="Enabled"
-          sub="Master switch. When off, the chat refuses every turn (no model call)."
-          v={
-            <input type="checkbox" checked={enabled}
-              onChange={e => setEnabled(e.target.checked)} style={{accentColor: "var(--accent)"}} />
-          }
-          actions={<ApplyBadge settingsKey="brain_chat.enabled" registry={registry} />}
-        />
-        <SRow
-          k="Read-only"
-          sub="Reads still answer, but every mutating / admin-write tool is refused."
-          v={
-            <input type="checkbox" checked={readOnly}
-              onChange={e => setReadOnly(e.target.checked)} style={{accentColor: "var(--accent)"}} />
-          }
-          actions={<ApplyBadge settingsKey="brain_chat.read_only" registry={registry} />}
-        />
-        <SRow
-          k="Model / slot override"
-          sub="Which slot the steward drives. Empty = persona default (hal0/brain → agent)."
-          v={
-            <select value={model} onChange={e => setModel(e.target.value)} style={_advInputStyle}>
-              {modelOptions.map(m => (
-                <option key={m || "__default"} value={m}>
-                  {m === "" ? "Persona default (hal0/brain)" : m}
-                </option>
-              ))}
-            </select>
-          }
-          actions={<ApplyBadge settingsKey="brain_chat.model" registry={registry} />}
-        />
-        <SRow
-          k="Max rounds"
-          sub="Per-turn tool-loop cap (1–100). Runaway backstop."
-          v={
-            <input type="number" min={1} max={100} value={rounds}
-              onChange={e => setRounds(e.target.value)}
-              style={{..._advInputStyle, width: 80, borderColor: roundsValid ? "var(--line)" : "var(--err)"}} />
-          }
-          actions={<ApplyBadge settingsKey="brain_chat.max_rounds" registry={registry} />}
-        />
-        <SRow
-          k="Completion timeout (s)"
-          sub="Transport timeout for each LLM round against the target slot."
-          v={
-            <input type="number" min={1} step={5} value={timeoutS}
-              onChange={e => setTimeoutS(e.target.value)}
-              style={{..._advInputStyle, width: 80, borderColor: timeoutValid ? "var(--line)" : "var(--err)"}} />
-          }
-          actions={<ApplyBadge settingsKey="brain_chat.completion_timeout_s" registry={registry} />}
-        />
-        <div style={{display: "flex", justifyContent: "flex-end", gap: 8, padding: "8px 12px 4px"}}>
-          {dirty && <button className="btn ghost sm" onClick={reset}>Reset</button>}
-          <button className="btn sm" disabled={!dirty || update.isPending} onClick={doSave}>
-            {update.isPending ? "Saving…" : "Save"}
-          </button>
+      {loading && <div style={{padding: 16, color: "var(--fg-4)", fontFamily: "var(--jbm)", fontSize: 12}}>Loading config schema…</div>}
+
+      {!loading && (
+        <div className="s-panel" style={{marginBottom: 12}}>
+          <AdvRow dotKey="brain_chat.enabled" field={fields['brain_chat.enabled']}
+            live={_getIn(live, 'enabled')} buf={buf['brain_chat.enabled']} onChange={set} registry={registry} label="Enabled" />
+          <AdvRow dotKey="brain_chat.read_only" field={fields['brain_chat.read_only']}
+            live={_getIn(live, 'read_only')} buf={buf['brain_chat.read_only']} onChange={set} registry={registry} label="Read-only" />
+
+          <SRow
+            k="Model / slot override"
+            sub={fields['brain_chat.model']?.description}
+            v={
+              <RichSelect
+                value={modelValue}
+                options={modelOptions(llmSlots, live.model)}
+                onChange={(id) => set('brain_chat.model', id)}
+                aria-label="Chat model override"
+                data-testid="brain-chat-model-select"
+              />
+            }
+            actions={<ApplyBadge settingsKey="brain_chat.model" registry={registry} />}
+          />
+
+          <SRow
+            k="Tool model"
+            sub={fields['brain_chat.tool_model']?.description}
+            v={
+              <RichSelect
+                value={toolModelValue}
+                options={toolModelOptions(llmSlots, modelValue)}
+                onChange={(id) => set('brain_chat.tool_model', id)}
+                aria-label="Tool-routing model"
+                data-testid="brain-chat-tool-model-select"
+              />
+            }
+            actions={<ApplyBadge settingsKey="brain_chat.tool_model" registry={registry} />}
+          />
+          {savedToolModelHasNoLiveTarget && (
+            <div style={{padding: "0 12px 8px"}}>
+              <Banner
+                kind="warn"
+                body={
+                  <span>
+                    <span className="mono">{toolModelValue}</span> has no live target — tool-calling
+                    turns will fail until a model is loaded on that slot, or you pick a loaded target above.
+                  </span>
+                }
+              />
+            </div>
+          )}
+
+          <AdvRow dotKey="brain_chat.max_rounds" field={fields['brain_chat.max_rounds']}
+            live={_getIn(live, 'max_rounds')} buf={buf['brain_chat.max_rounds']} onChange={set} registry={registry} label="Max rounds" />
+          <AdvRow dotKey="brain_chat.completion_timeout_s" field={fields['brain_chat.completion_timeout_s']}
+            live={_getIn(live, 'completion_timeout_s')} buf={buf['brain_chat.completion_timeout_s']} onChange={set} registry={registry} label="Completion timeout (s)" />
+
+          <div style={{display: "flex", justifyContent: "flex-end", gap: 8, padding: "8px 12px 4px"}}>
+            {dirtyKeys.length > 0 && <button className="btn ghost sm" onClick={form.reset}>Reset</button>}
+            <button className="btn sm" disabled={!canSave} onClick={onSaveClick}>
+              {update.isPending ? "Saving…" : "Save"}
+            </button>
+          </div>
         </div>
-      </div>
+      )}
+
+      <ConfirmDialog
+        open={!!confirmKeys}
+        onCancel={form.clearConfirm}
+        onConfirm={() => { form.clearConfirm(); doSave(); }}
+        title="Manual restart required"
+        message={
+          <span>
+            {confirmKeys && confirmKeys.length === 1
+              ? <>The setting <b className="mono">{confirmKeys[0]}</b> requires</>
+              : <>These settings ({confirmKeys && confirmKeys.map(k => <b className="mono" key={k}>{k} </b>)}) require</>}{" "}
+            a <b>manual operator restart</b> to take effect. Values are persisted now.
+          </span>
+        }
+        confirmLabel="Save anyway"
+      />
     </div>
   );
 }

--- a/ui/src/dash/settings/pages/routing/AgentsBrainPage.jsx
+++ b/ui/src/dash/settings/pages/routing/AgentsBrainPage.jsx
@@ -18,16 +18,17 @@
 // server-computed `live_target` drives a plain-language banner when the
 // SAVED value has nowhere live to route a tool call (the fresh-install gap
 // #2108 documents: the `agent` slot ships with no bound model).
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useSettingsClient } from '../../data/settingsClient.js'
 import { useSettingsForm } from '../../data/useSettingsForm.js'
-import { useSettingsFields } from '@/api/hooks/useSettings'
+import { useSettingsFields, useSettingsPreview } from '@/api/hooks/useSettings'
 import { useSlots } from '@/api/hooks/useSlots'
-import { ConfirmDialog, Banner } from '../../../primitives.jsx'
+import { Banner } from '../../../primitives.jsx'
 import { RichSelect } from '@/dash/rich-select.jsx'
 import { AdvRow, _getIn } from '../../shared/SchemaRow.jsx'
 import { ApplyBadge } from '../../shared/ApplyBadge.jsx'
 import { SRow } from '../../shared/SRow.jsx'
+import { SettingsPreviewDrawer } from '../../shared/SettingsPreviewDrawer.jsx'
 
 // Mirrors the canonical chains in hal0.normalize.resolver.DEFAULT_CHAINS —
 // advisory only, for the picker's per-option "loaded" chip before a save.
@@ -136,7 +137,10 @@ export function AgentsBrainPage() {
     'brain_chat.tool_model', 'brain_chat.max_rounds', 'brain_chat.completion_timeout_s',
   ];
   const form = useSettingsForm(client, KEYS);
-  const { buf, set, fields, dirtyKeys, invalidKeys, canSave, confirmKeys } = form;
+  const { buf, set, fields, dirtyKeys, canSave } = form;
+  const preview = useSettingsPreview();
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewData, setPreviewData] = useState(null);
 
   const modelValue = buf['brain_chat.model'] !== undefined ? buf['brain_chat.model'] : (live.model || '');
   const toolModelValue = buf['brain_chat.tool_model'] !== undefined
@@ -154,9 +158,25 @@ export function AgentsBrainPage() {
   const savedToolModelHasNoLiveTarget = fieldsByPath['brain_chat.tool_model']?.live_target === false
     && !dirtyKeys.includes('brain_chat.tool_model');
 
-  const doSave = async () => {
+  // Preview before apply (#1967, #2195, #2203, #1511): the drawer renders
+  // the exact ChangeSet POST /api/settings/preview computes for the pending
+  // patch; Apply below re-sends that same patch through PUT /api/settings,
+  // which computes the identical ChangeSet server-side — preview can't show
+  // something apply wouldn't do, because it's the same function.
+  const onSaveClick = async () => {
+    try {
+      const resp = await preview.mutateAsync(form.buildPatch());
+      setPreviewData(resp.changeset);
+      setPreviewOpen(true);
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Preview failed — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  const confirmApply = async () => {
     try {
       const { needsRestart } = await form.commit();
+      setPreviewOpen(false);
       window.__hal0Toast && window.__hal0Toast(
         needsRestart ? "Saved — restart to apply the marked changes" : "Brain chat settings saved",
         needsRestart ? "warn" : "ok",
@@ -164,12 +184,6 @@ export function AgentsBrainPage() {
     } catch (e) {
       window.__hal0Toast && window.__hal0Toast(`Save failed — ${e?.message || "see logs"}`, "err");
     }
-  };
-
-  const onSaveClick = async () => {
-    const manual = dirtyKeys.filter(k => client.reloadClass(k)?.apply_class === "manual-restart");
-    if (manual.length > 0) { form.submit(); return; }
-    doSave();
   };
 
   const loading = settings.isPending || client.schema.isPending;
@@ -242,27 +256,20 @@ export function AgentsBrainPage() {
 
           <div style={{display: "flex", justifyContent: "flex-end", gap: 8, padding: "8px 12px 4px"}}>
             {dirtyKeys.length > 0 && <button className="btn ghost sm" onClick={form.reset}>Reset</button>}
-            <button className="btn sm" disabled={!canSave} onClick={onSaveClick}>
-              {update.isPending ? "Saving…" : "Save"}
+            <button className="btn sm" disabled={!canSave || preview.isPending} onClick={onSaveClick}>
+              {preview.isPending ? "Checking…" : "Review & save"}
             </button>
           </div>
         </div>
       )}
 
-      <ConfirmDialog
-        open={!!confirmKeys}
-        onCancel={form.clearConfirm}
-        onConfirm={() => { form.clearConfirm(); doSave(); }}
-        title="Manual restart required"
-        message={
-          <span>
-            {confirmKeys && confirmKeys.length === 1
-              ? <>The setting <b className="mono">{confirmKeys[0]}</b> requires</>
-              : <>These settings ({confirmKeys && confirmKeys.map(k => <b className="mono" key={k}>{k} </b>)}) require</>}{" "}
-            a <b>manual operator restart</b> to take effect. Values are persisted now.
-          </span>
-        }
-        confirmLabel="Save anyway"
+      <SettingsPreviewDrawer
+        open={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        changes={previewData?.changes}
+        unknown={previewData?.unknown}
+        onConfirm={confirmApply}
+        confirming={update.isPending}
       />
     </div>
   );

--- a/ui/src/dash/settings/shared/SettingsPreviewDrawer.jsx
+++ b/ui/src/dash/settings/shared/SettingsPreviewDrawer.jsx
@@ -1,0 +1,94 @@
+// ─── settings preview drawer (#1967, #2195, #2203, #1511) ──────────────────
+//
+// Renders the ChangeSet POST /api/settings/preview returns — before/after
+// per key, kind (added/removed/changed), and reload class per key — so the
+// operator sees exactly what a save will write BEFORE committing. The apply
+// (PUT /api/settings) returns the identical shape under `_hal0.changeset`
+// (same server function, hal0.api._settings_changeset.compute_settings_
+// changeset, behind both), so this drawer can never promise something the
+// apply doesn't keep.
+//
+// `Drawer` is a window global (dash/primitives.jsx), used unimported per
+// the established convention (see capabilities/shared.jsx's FieldInfoIcon
+// note) — right-side drawer, never a new modal dialog, per COMMON.md.
+import { ApplyBadge } from './ApplyBadge.jsx'
+
+function formatChangeValue(v) {
+  if (v === null || v === undefined) {
+    return <span className="mono" style={{color: "var(--fg-4)"}}>—</span>;
+  }
+  if (typeof v === "object") {
+    return <span className="mono">{JSON.stringify(v)}</span>;
+  }
+  return <span className="mono">{String(v)}</span>;
+}
+
+const KIND_LABEL = { added: "added", removed: "removed", changed: "changed" };
+
+/**
+ * @param {{
+ *   open: boolean,
+ *   onClose: () => void,
+ *   changes: Array<{path: string, before: unknown, after: unknown, kind: string, apply_class: string|null, services: string[]}>,
+ *   unknown?: string[],
+ *   onConfirm: () => void,
+ *   confirming?: boolean,
+ * }} props
+ */
+export function SettingsPreviewDrawer({ open, onClose, changes, unknown, onConfirm, confirming = false }) {
+  const rows = changes || [];
+  // Fake a registry keyed by path so ApplyBadge — which normally resolves a
+  // key against the shared apply-plan registry — can render straight off
+  // this ChangeSet's own apply_class/services instead of a second lookup.
+  const registry = {};
+  for (const c of rows) registry[c.path] = { apply_class: c.apply_class, services: c.services };
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      eyebrow="Review before apply"
+      title={rows.length === 1 ? "1 setting will change" : `${rows.length} settings will change`}
+      width={480}
+      foot={
+        <>
+          <span style={{color: "var(--fg-4)"}}>Values persist immediately on Apply.</span>
+          <span style={{display: "inline-flex", gap: 8}}>
+            <button className="btn ghost sm" onClick={onClose}>Cancel</button>
+            <button className="btn sm" disabled={confirming || rows.length === 0} onClick={onConfirm}>
+              {confirming ? "Applying…" : "Apply"}
+            </button>
+          </span>
+        </>
+      }
+    >
+      {rows.length === 0 && (
+        <div style={{color: "var(--fg-4)", fontSize: 12, padding: "8px 0"}}>No changes to apply.</div>
+      )}
+      {rows.map(c => (
+        <div key={c.path} className="s-row" style={{alignItems: "flex-start", flexWrap: "wrap"}}>
+          <div className="k" style={{flexBasis: "100%"}}>
+            <span className="mono">{c.path}</span>
+            <span
+              className="mono"
+              style={{marginLeft: 8, fontSize: 10, color: "var(--fg-4)", textTransform: "uppercase", letterSpacing: "0.04em"}}
+            >
+              {KIND_LABEL[c.kind] || c.kind}
+            </span>
+          </div>
+          <div className="v" style={{display: "flex", alignItems: "center", gap: 6}}>
+            {formatChangeValue(c.before)}
+            <span style={{color: "var(--fg-4)"}}>→</span>
+            {formatChangeValue(c.after)}
+          </div>
+          <div className="ac"><ApplyBadge settingsKey={c.path} registry={registry} /></div>
+        </div>
+      ))}
+      {unknown && unknown.length > 0 && (
+        <div className="err" style={{marginTop: 12, fontSize: 11}}>
+          No reload-effect data for: {unknown.join(", ")}
+        </div>
+      )}
+    </Drawer>
+  );
+}

--- a/ui/tests/e2e/specs/settings-agent-chat-v3.spec.ts
+++ b/ui/tests/e2e/specs/settings-agent-chat-v3.spec.ts
@@ -169,9 +169,13 @@ test.describe('Settings → Agent Chat (schema-driven, #2108)', () => {
     await mockSettingsSurface(page, { toolModel: 'hal0/agent', liveTarget: false })
     await openAgentChat(page)
 
+    // The static "Disabled" option is always the last entry `toolModelOptions`
+    // pushes regardless of which slots are configured — picking it (rather
+    // than a slot-derived id) keeps this assertion independent of the exact
+    // slot list a shared fixture happens to seed elsewhere in the suite.
     const trigger = page.getByTestId('brain-chat-tool-model-select')
-    await pickRichOption(trigger, 'hal0/utility')
-    await expect(trigger).toContainText('hal0/utility')
+    await pickRichOption(trigger, 'off')
+    await expect(trigger).toContainText('Disabled')
 
     let previewBody: unknown = null
     await page.route('**/api/settings/preview', (route) => {
@@ -185,7 +189,7 @@ test.describe('Settings → Agent Chat (schema-driven, #2108)', () => {
               {
                 path: 'brain_chat.tool_model',
                 before: 'hal0/agent',
-                after: 'hal0/utility',
+                after: 'off',
                 kind: 'changed',
                 apply_class: 'immediate',
                 services: [],
@@ -203,8 +207,8 @@ test.describe('Settings → Agent Chat (schema-driven, #2108)', () => {
     // The preview drawer shows the real diff before anything is written.
     await expect(page.locator('.drawer.open')).toContainText('brain_chat.tool_model')
     await expect(page.locator('.drawer.open')).toContainText('hal0/agent')
-    await expect(page.locator('.drawer.open')).toContainText('hal0/utility')
-    expect(previewBody).toEqual({ brain_chat: { tool_model: 'hal0/utility' } })
+    await expect(page.locator('.drawer.open')).toContainText('off')
+    expect(previewBody).toEqual({ brain_chat: { tool_model: 'off' } })
 
     let putBody: unknown = null
     await page.route('**/api/settings', (route) => {
@@ -214,11 +218,11 @@ test.describe('Settings → Agent Chat (schema-driven, #2108)', () => {
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
-          brain_chat: brainChatConfig({ tool_model: 'hal0/utility' }),
+          brain_chat: brainChatConfig({ tool_model: 'off' }),
           _hal0: {
             apply_plan: { immediate: ['brain_chat.tool_model'], service_restart: {}, manual_restart: [], unknown: [] },
             changeset: {
-              changes: [{ path: 'brain_chat.tool_model', before: 'hal0/agent', after: 'hal0/utility', kind: 'changed', apply_class: 'immediate', services: [] }],
+              changes: [{ path: 'brain_chat.tool_model', before: 'hal0/agent', after: 'off', kind: 'changed', apply_class: 'immediate', services: [] }],
               unknown: [],
             },
           },
@@ -230,7 +234,7 @@ test.describe('Settings → Agent Chat (schema-driven, #2108)', () => {
 
     // The exact patch previewed is the exact patch applied — same body,
     // preview and apply agree because they're the same ChangeSet.
-    expect(putBody).toEqual({ brain_chat: { tool_model: 'hal0/utility' } })
+    expect(putBody).toEqual({ brain_chat: { tool_model: 'off' } })
     await expect(page.locator('.drawer.open')).toHaveCount(0)
     await expect(page.locator('.hal0-toast')).toContainText(/saved/i)
   })

--- a/ui/tests/e2e/specs/settings-agent-chat-v3.spec.ts
+++ b/ui/tests/e2e/specs/settings-agent-chat-v3.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * settings-agent-chat-v3 — Settings → Integrations → Agent Chat, schema-driven
+ * rendering + the #2108 tool_model gap + the preview-before-apply drawer.
+ *
+ * `[brain_chat].tool_model` previously had no dashboard path at all
+ * (AgentsBrainPage.jsx never read or wrote it). This spec pins:
+ *   1. the row renders (RichSelect + description) — the schema-driven
+ *      renderer closes the gap for any Hal0Config leaf, not just this one;
+ *   2. the fresh-install "no live target" banner (#2108 part 2: the `agent`
+ *      slot ships with no bound model) renders from the server's
+ *      GET /api/settings/fields `live_target`, not a frontend guess;
+ *   3. Save opens a preview drawer showing the real before/after ChangeSet
+ *      (POST /api/settings/preview) before anything is written, and Apply
+ *      sends the identical patch through PUT /api/settings.
+ *
+ * None of `/api/settings*` or `/api/slots` are in apiMock's in-bundle mock
+ * allowlist, so every route below is a per-spec `page.route` override —
+ * the catch-all in apiMock.ts would otherwise answer them with `{}`.
+ */
+import { test, expect } from '../fixtures/apiMock'
+import { pickRichOption } from '../fixtures/richSelect'
+import type { Page } from '@playwright/test'
+
+// Trimmed pydantic JSON Schema for Hal0Config, extracted verbatim via
+// `Hal0Config.model_json_schema()` (see tests/api/test_settings_fields.py
+// for the backend-side pin on this same shape) — real field names, real
+// descriptions, real constraints, so `_schemaField`'s $ref/allOf walk is
+// exercised the same way it is against the live schema.
+const SETTINGS_SCHEMA = {
+  properties: {
+    brain_chat: { $ref: '#/$defs/BrainChatConfig' },
+  },
+  $defs: {
+    BrainChatConfig: {
+      type: 'object',
+      title: 'BrainChatConfig',
+      properties: {
+        enabled: { type: 'boolean', default: true, description: "Hard kill switch for the dashboard's agent-chat steward." },
+        read_only: { type: 'boolean', default: true, description: 'When true, every mutating or admin-write tool is refused server-side.' },
+        model: { type: 'string', default: '', description: "Which model/slot drives the steward chat. Empty keeps the persona's preferred_model." },
+        tool_model: {
+          type: 'string',
+          default: 'hal0/agent',
+          description:
+            "Where a tool-calling ROUND reroutes when the chat model can't emit tool calls this runtime parses. Default 'hal0/agent' — the always-on fallback anchor — but that slot ships unbound on a fresh install.",
+        },
+        max_rounds: { type: 'integer', default: 8, minimum: 1, maximum: 100, description: 'Runaway backstop: max tool-calling rounds in one chat turn.' },
+        completion_timeout_s: { type: 'number', default: 300.0, exclusiveMinimum: 0, description: 'Transport timeout (seconds) for each LLM round.' },
+      },
+    },
+  },
+}
+
+const APPLY_PLAN_REGISTRY = {
+  'brain_chat.enabled': { apply_class: 'immediate', services: [] },
+  'brain_chat.read_only': { apply_class: 'immediate', services: [] },
+  'brain_chat.model': { apply_class: 'immediate', services: [] },
+  'brain_chat.tool_model': { apply_class: 'immediate', services: [] },
+  'brain_chat.max_rounds': { apply_class: 'immediate', services: [] },
+  'brain_chat.completion_timeout_s': { apply_class: 'immediate', services: [] },
+}
+
+function brainChatConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    enabled: true,
+    read_only: true,
+    model: '',
+    tool_model: 'hal0/agent',
+    max_rounds: 8,
+    completion_timeout_s: 300,
+    ...overrides,
+  }
+}
+
+async function mockSettingsSurface(
+  page: Page,
+  { toolModel = 'hal0/agent', liveTarget = false }: { toolModel?: string; liveTarget?: boolean } = {},
+) {
+  const live = brainChatConfig({ tool_model: toolModel })
+
+  await page.route('**/api/settings/schema', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SETTINGS_SCHEMA) }),
+  )
+  await page.route('**/api/settings/apply-plan', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ apply_classes: ['immediate', 'service-restart', 'manual-restart'], registry: APPLY_PLAN_REGISTRY }),
+    }),
+  )
+  await page.route('**/api/settings/fields', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        fields: [
+          {
+            path: 'brain_chat.tool_model',
+            group: 'brain_chat',
+            label: 'Tool model',
+            description: SETTINGS_SCHEMA.$defs.BrainChatConfig.properties.tool_model.description,
+            type: 'string',
+            enum: null,
+            constraints: {},
+            default: 'hal0/agent',
+            current: toolModel,
+            secret: false,
+            apply_class: 'immediate',
+            services: [],
+            live_target: liveTarget,
+          },
+        ],
+      }),
+    }),
+  )
+  await page.route('**/api/slots', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { name: 'agent', type: 'llm', device: 'gpu', model: '', state: 'empty', metrics: {} },
+        { name: 'utility', type: 'llm', device: 'cpu', model: 'qwen3-0.6b', state: 'ready', metrics: {} },
+      ]),
+    }),
+  )
+  // GET/PUT /api/settings share one handler so a save is reflected on the
+  // next read within the same test (react-query refetches after mutate).
+  await page.route('**/api/settings', (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ brain_chat: live }) })
+    }
+    return route.continue()
+  })
+}
+
+async function openAgentChat(page: Page) {
+  await page.goto('/#settings/agents')
+  await expect(page.locator('.settings-content h2').first()).toHaveText('Agent Chat')
+}
+
+test.describe('Settings → Agent Chat (schema-driven, #2108)', () => {
+  test('tool_model renders as a labelled RichSelect row', async ({ page }) => {
+    await mockSettingsSurface(page)
+    await openAgentChat(page)
+
+    await expect(page.locator('.s-row .k', { hasText: 'Tool model' })).toBeVisible()
+    const trigger = page.getByTestId('brain-chat-tool-model-select')
+    await expect(trigger).toBeVisible()
+    // The closed trigger already renders the current value's row text.
+    await expect(trigger).toContainText('hal0/agent')
+  })
+
+  test('a fresh-install tool_model with no live target shows the plain-language banner', async ({ page }) => {
+    await mockSettingsSurface(page, { toolModel: 'hal0/agent', liveTarget: false })
+    await openAgentChat(page)
+
+    await expect(page.locator('.banner-warn')).toContainText(/no live target/i)
+    await expect(page.locator('.banner-warn')).toContainText('hal0/agent')
+  })
+
+  test('a live-target tool_model shows no banner', async ({ page }) => {
+    await mockSettingsSurface(page, { toolModel: 'hal0/utility', liveTarget: true })
+    await openAgentChat(page)
+
+    await expect(page.locator('.banner-warn')).toHaveCount(0)
+  })
+
+  test('Review & save previews the real ChangeSet, then Apply persists it', async ({ page }) => {
+    await mockSettingsSurface(page, { toolModel: 'hal0/agent', liveTarget: false })
+    await openAgentChat(page)
+
+    const trigger = page.getByTestId('brain-chat-tool-model-select')
+    await pickRichOption(trigger, 'hal0/utility')
+    await expect(trigger).toContainText('hal0/utility')
+
+    let previewBody: unknown = null
+    await page.route('**/api/settings/preview', (route) => {
+      previewBody = route.request().postDataJSON()
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          changeset: {
+            changes: [
+              {
+                path: 'brain_chat.tool_model',
+                before: 'hal0/agent',
+                after: 'hal0/utility',
+                kind: 'changed',
+                apply_class: 'immediate',
+                services: [],
+              },
+            ],
+            unknown: [],
+          },
+          apply_plan: { immediate: ['brain_chat.tool_model'], service_restart: {}, manual_restart: [], unknown: [] },
+        }),
+      })
+    })
+
+    await page.getByRole('button', { name: /review & save/i }).click()
+
+    // The preview drawer shows the real diff before anything is written.
+    await expect(page.locator('.drawer.open')).toContainText('brain_chat.tool_model')
+    await expect(page.locator('.drawer.open')).toContainText('hal0/agent')
+    await expect(page.locator('.drawer.open')).toContainText('hal0/utility')
+    expect(previewBody).toEqual({ brain_chat: { tool_model: 'hal0/utility' } })
+
+    let putBody: unknown = null
+    await page.route('**/api/settings', (route) => {
+      if (route.request().method() !== 'PUT') return route.continue()
+      putBody = route.request().postDataJSON()
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          brain_chat: brainChatConfig({ tool_model: 'hal0/utility' }),
+          _hal0: {
+            apply_plan: { immediate: ['brain_chat.tool_model'], service_restart: {}, manual_restart: [], unknown: [] },
+            changeset: {
+              changes: [{ path: 'brain_chat.tool_model', before: 'hal0/agent', after: 'hal0/utility', kind: 'changed', apply_class: 'immediate', services: [] }],
+              unknown: [],
+            },
+          },
+        }),
+      })
+    })
+
+    await page.locator('.drawer.open').getByRole('button', { name: /^apply$/i }).click()
+
+    // The exact patch previewed is the exact patch applied — same body,
+    // preview and apply agree because they're the same ChangeSet.
+    expect(putBody).toEqual({ brain_chat: { tool_model: 'hal0/utility' } })
+    await expect(page.locator('.drawer.open')).toHaveCount(0)
+    await expect(page.locator('.hal0-toast')).toContainText(/saved/i)
+  })
+})

--- a/ui/tests/e2e/specs/settings-v3.spec.ts
+++ b/ui/tests/e2e/specs/settings-v3.spec.ts
@@ -17,7 +17,7 @@ const SECTIONS = [
   'Overview', 'Security', 'Doctor',
   'Loaded Models', 'Model Defaults', 'AI Capabilities',
   'Hardware & Runtimes', 'Storage', 'Memory', 'Updates', 'Advanced',
-  'Secrets', 'Agent Chat',
+  'Secrets', 'Agent Chat', 'Realtime',
 ]
 
 test.describe('Settings v3 (/settings)', () => {


### PR DESCRIPTION
## Summary

Schema-driven settings, part 1: closes the `[brain_chat].tool_model` dashboard
gap (#2108), adds `GET /api/settings/fields` (one labelled row per
operator-editable `Hal0Config` key — group/label/description/type/default/
current/reload class/secret/live-target, with a completeness ratchet so a
future field can't ship without one), and gives preview and apply one shared
`ChangeSet` computation (`POST /api/settings/preview` + `PUT /api/settings`)
so they can't compute different answers for the same patch — closing the
shape of four related bugs (#1967, #2195, #2203, #1511) as fixtures against
the general settings surface. Also adds a Realtime settings page for the
previously entirely-unexposed `[realtime]` section.

Still in progress on this branch (draft): a preview drawer wired into the UI
(the backend endpoint is done and tested; the confirm-before-apply drawer
consuming it is not yet built), Playwright specs, and docs/CHANGELOG.

## Risk grade

- [x] med — user-facing change, new code path

## Touched surfaces

- [x] API (`src/hal0/api/`)
- [x] Config / schema (`src/hal0/config/`, pydantic models)
- [x] UI (`ui/src/`, Playwright specs)
- [ ] Docs (`docs/`, `CONTRIBUTING.md`) — pending
- [ ] CI / release (`.github/workflows/`, `release.yml`)

## §14.1 high-risk surfaces

None checked — no new unauthenticated routes, no `AUTONOMOUS_WRITE_TOOLS`
additions, no installer/updater surface touched.

## Rollback

Revert the merge commit; no migrations, no on-disk format change (the new
`_hal0.changeset` key on the `PUT /api/settings` response is additive next
to the existing `_hal0.apply_plan`).

## Test tiers run

- [x] α unit (`uv run pytest tests/api/test_settings_*.py -q`, `npm run
      test:unit`) — green
- [ ] β integration (full `uv run pytest tests/ -q -n 8`) — pending, will run
      before marking ready
- [ ] γ release-gate — not high-risk, not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuxaNdP5tkR66b6Qg8av1H
