### PR TITLE
docs(parity): at-a-glance, verify checklist, support/validation matrices, generated-files table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+
+- Parity documentation pass: an "At a glance" block and an
+  if-you-know-Ollama/llama.cpp/Open WebUI/LocalAI comparison table in
+  `README.md`; `docs/getting-started/verify.mdx` (the six-step post-install
+  checklist); `docs/reference/support-matrix.mdx` (platform/GPU-lane support,
+  honestly separating installer-level detection from CI- and
+  fleet-exercised coverage); `docs/reference/validation-matrix.mdx` (the
+  α/β/γ test tiers and the `rc-validate` release-validation kit mapped onto
+  a hal0-specific "User Green" definition); `docs/reference/generated-files.mdx`
+  (every config file hal0 generates or rewrites, its writer, and whether
+  operator edits survive it); and an area→required-validation table in
+  `CONTRIBUTING.md` mirroring the PR template's §14.1 high-risk map.
+
 ### Fixed
 
 - MCP admin tools no longer report a tool failure for a successful read of a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,6 +215,34 @@ tag. It walks the per-release gate:
 
 If any of these fail, fix and re-run before `git tag`.
 
+## Area → required validation
+
+The PR template's §14.1 high-risk checklist tells a reviewer *whether* a
+change is high-risk. This table tells a contributor *what to run* before
+opening the PR, by the surface touched — same risk vocabulary
+(low/med/high) the template already uses, so picking a risk grade and
+knowing what validation backs it up are the same lookup.
+
+**On β:** the rows below cite α + β together because that's what this section documents as
+required. As of this writing neither `make test-integration` nor `.github/workflows/integration.yml`
+exist in the tree — both were retired in the toolbox-retirement pass and never restored (filed as
+[#2239](https://github.com/Hal0ai/hal0/issues/2239)). Until that's resolved, treat "+ β" below as
+"+ β once it's restored" and lean harder on γ / `rc-validate` for the areas it names.
+
+| Area | Risk | Required validation |
+|---|---|---|
+| `src/hal0/api/` | med–high | α + β (every PR). A new route must be classified in `src/hal0/security/exposure.py` — the deny-by-default ratchet test (`tests/security/test_exposure.py`) fails an unclassified route rather than letting it default open. |
+| `src/hal0/auth/`, login routes, auth middleware | high | α + β, plus the auth-specific suite (`tests/security/test_kb1_hardening_tail.py`, `test_upstream_auth_contract.py`, `test_secrets_protected_keys.py`). §14.1 high-risk — run γ (`make release-test`) before merge. |
+| `src/hal0/slots/`, `slot_state`, `/v1/load\|unload` | med–high | α + β — β's integration suite is meant to exercise load → chat → swap → unload against a real slot (see the #2239 note above). A change to backend selection (`hardware.recommend`) additionally needs a γ / `rc-validate` `slots` lane pass, since that logic decides which GPU lane a fresh install lands on. |
+| `src/hal0/capabilities/`, `model_meta`, `model_fit` | med | α + β. Changes to device/profile resolution should re-run the γ matrix row for the affected backend (ROCm/Vulkan/CPU/NPU) — see [Validation matrix](docs/reference/validation-matrix.mdx). |
+| `installer/`, systemd units | high | §14.1 high-risk trigger (installer / RCE-class: shell-out, downloads, signature verification, privilege changes). `shellcheck` on every `.sh` touched is a **manual convention, not a CI gate today** — run it yourself (`bash -n` at minimum if `shellcheck` isn't installed). Changes to `installer/bootstrap.sh` specifically must stay byte-identical to the logic `scripts/check-bootstrap-parity.sh` diffs against the live one-liner (`.github/workflows/bootstrap-parity.yml`). A `rc-validate` fresh-install lane pass is expected for anything beyond a comment/log-message change. |
+| `src/hal0/updater/`, the release manifest | high | §14.1 high-risk trigger. α + β, plus the γ script's `updater` row (check-only by design — see `scripts/release-test.sh`) and the `rc-validate` kit's `upgrade`/`post-upgrade` lanes, which are the only place an in-place convergence (schema-version-gated resets included) is exercised end to end. |
+| `src/hal0/api/routes/board_chat.py`, `src/hal0/mcp/admin.py` | high | §14.1 high-risk trigger by name — any addition to `AUTONOMOUS_WRITE_TOOLS` (`src/hal0/mcp/admin.py`) requires the reviewer to run the full γ release-gate before merge, per the PR template. |
+| `src/hal0/config/`, pydantic models | low–high | α always. A schema-version bump needs a migration test under `tests/` for the old→new shape; a new compatibility shim needs a `HAL0-SUNSET` marker and a clean `python3 scripts/check_sunset.py` (anti-scar rule 4). |
+| `ui/src/`, Playwright specs | med | `npm run lint && npm run typecheck && npm run test:unit && npm run build`; a new critical path needs a Playwright spec under `ui/tests/e2e/specs/*-v3.spec.ts` (see `ui/tests/e2e/README.md`). |
+| `docs/`, `CONTRIBUTING.md`, `ARCHITECTURE.md` | low | No code tests required, but a change to operator-visible behavior (CLI verb, flag, config key, endpoint, page) must land its matching doc update in the **same PR** — a docs-only PR that changes behavior description without a code change should fact-check every command/flag/path it cites against the current tree before opening. |
+| `.github/workflows/`, `release.yml` | low–high depending on target | CI-workflow changes can't verify themselves in the run they change — get a second pair of eyes and watch the run through to a real conclusion rather than trusting a self-referential green. Never skip hooks or bypass signing. Anything touching `release.yml`'s asset/signing/pointer steps is high-risk regardless of diff size; run `scripts/release-check.sh` before any tag-affecting change ships. |
+
 ## Release delivery
 
 Tagging is not delivering. The tag publishes immutable, signed assets;

--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ curl -fsSL https://hal0.dev/install.sh | sudo bash
 > brain steward model, and starts the API. When it finishes, open the
 > dashboard and assign models to slots.
 
+## At a glance
+
+| | |
+|---|---|
+| **What it is** | One control plane, `hal0-api` on `:8080`, turning a Linux box into an OpenAI-compatible inference appliance — chat, embeddings, rerank, transcription, speech and image generation, each capability in its own podman container. |
+| **Install** | One `curl \| sudo bash` line. The installer probes hardware, seeds every capability slot, and starts the API — there is no separate setup wizard to run afterward. |
+| **Hardware** | First-class on AMD Strix Halo (ROCm iGPU + XDNA NPU); Vulkan, CUDA and CPU fallbacks everywhere else. See [Hardware matrix](docs/reference/hardware-matrix.mdx). |
+| **Platform** | Linux + systemd + podman, including Proxmox LXC. macOS and Windows are not supported today — see [Support matrix](docs/reference/support-matrix.mdx). |
+| **Auth** | Off by default (trusted-LAN posture) — opt in with `hal0 auth require on`. No TLS termination; front it with a reverse proxy if it's reachable beyond your LAN. |
+| **Chat UI** | OpenWebUI, prewired, on `:3001` — zero config. |
+| **Updates** | Cosign-signed tarball releases via `hal0 update`, with one-flag rollback. |
+
+### If you know Ollama / llama.cpp / Open WebUI / LocalAI, hal0 adds…
+
+| You already know | hal0 adds |
+|---|---|
+| **Ollama** — pull a model, run it, hit one local API. | A dedicated slot per capability (chat, embed, rerank, STT, TTS, image) — each its own podman container with its own hardware backend, typed lifecycle, and per-slot logs, instead of one shared runtime doing everything. |
+| **llama.cpp** / `llama-server` — the inference engine itself. | hal0 runs llama.cpp *inside* systemd-supervised slots, with a state machine (`starting → warming → ready → …`), a model registry, automatic hardware-backend selection (ROCm/Vulkan/CUDA/CPU/NPU), and a benchmarking pipeline (`hal0 bench`) on top of it. |
+| **Open WebUI** — the chat frontend. | hal0 prewires OpenWebUI as the chat surface *and* is the backend it talks to — hardware probing, slot/model management, and a separate operator dashboard sit underneath, not just the chat window. |
+| **LocalAI** — an OpenAI-compatible gateway over multiple backends. | hal0 adds a live operator dashboard, a hardware probe that drives backend selection automatically, systemd-managed container lifecycle per slot, and a signed self-update path with rollback. |
+
 ## Screenshots
 
 <div align="center">

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -85,6 +85,11 @@ backend selection degrades to CPU rather than refusing to run.
     description="Chat from OpenWebUI or curl the OpenAI-compatible endpoint."
   />
   <LinkCard
+    title="Verify the install"
+    href="/docs/getting-started/verify/"
+    description="The six-step 'did it work' checklist: health, models, first chat, dashboard, logs, doctor."
+  />
+  <LinkCard
     title="Install on bare metal"
     href="/docs/getting-started/bare-metal/"
     description="Run the installer directly on a Linux host, no container layer."

--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -143,7 +143,10 @@ journalctl -fu hal0-api
 `hal0 status` reports system + slot + memory health; `hal0 slot list`
 shows configured slots; the `/api/health` curl is a lightweight liveness
 probe (200 the moment the API is serving); `journalctl -fu hal0-api`
-tails the control-plane log if something looks wrong.
+tails the control-plane log if something looks wrong. For the full
+six-step "did it work" checklist — health, model list, first chat,
+dashboard, logs, and `hal0 doctor verify` — see
+[Verify the install](/docs/getting-started/verify/).
 
 ## Uninstall
 

--- a/docs/getting-started/verify.mdx
+++ b/docs/getting-started/verify.mdx
@@ -1,0 +1,105 @@
+---
+title: Verify the install
+description: The six-step "did it work" checklist after install.sh finishes — health, model list, first chat, dashboard, logs, and doctor — with the command and what a good answer looks like for each.
+sidebar:
+  order: 45
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+`install.sh` finishes by starting `hal0-api` and printing a summary. Before
+you trust the box, run these six checks in order — each one rules out a
+different layer (network, model registry, inference, UI, logs, and the
+aggregate self-check), so a failure tells you roughly where to look.
+
+<Steps>
+
+1. **Health** — is the API answering at all?
+
+   ```sh
+   curl http://localhost:8080/api/health
+   ```
+
+   A good answer is `200` with a small JSON body immediately — this is a
+   shallow liveness probe with no dependency on models or slots, the same
+   one systemd's watchdog and the installer poll before anything else is
+   assumed to work. If it doesn't answer, check `hal0-api.service` before
+   anything downstream: `systemctl status hal0-api`.
+
+2. **Model list** — did the installer actually register a model?
+
+   ```sh
+   hal0 model list
+   ```
+
+   A good answer lists at least one entry — the hal0-brain steward model the
+   installer downloads by default. An empty list means the pull step failed
+   or was skipped (`--no-pull`); pull one with `hal0 model pull <ref>` (see
+   [Load your first model](/docs/getting-started/first-model/)).
+
+3. **First chat** — does inference actually run end to end?
+
+   ```sh
+   curl http://localhost:8080/v1/chat/completions \
+     -H "Content-Type: application/json" \
+     -d '{"model": "agent", "messages": [{"role": "user", "content": "Say hello in one sentence."}]}'
+   ```
+
+   A good answer is an OpenAI-shaped completion with real text in
+   `choices[0].message.content`, back within a few seconds on a warm slot
+   (longer on the first request, while the container image pulls and the
+   model loads). `model` here is the **slot name** (`agent`), not a raw
+   model id — hal0 rewrites the alias before dispatching. See
+   [Send your first chat](/docs/getting-started/first-chat/) for the
+   streaming variant and OpenWebUI equivalent.
+
+4. **Dashboard** — is the control plane's own UI serving?
+
+   Open `http://<host>:8080/` in a browser. A good answer is the dashboard
+   loading with the slot list populated (not stuck on a loading spinner or a
+   blank page) and at least one slot showing a `ready` status chip. The
+   dashboard is served by `hal0-api` itself — there is no separate dashboard
+   port or process to check.
+
+5. **Logs** — is the control plane logging cleanly?
+
+   ```sh
+   journalctl -fu hal0-api
+   ```
+
+   A good answer is steady request/response log lines with no repeating
+   tracebacks. `hal0 doctor logs` (default unit `hal0-api`) is the
+   equivalent read via the CLI, with `--level` and `--since` filters if you
+   need to narrow the window.
+
+6. **Doctor** — does the aggregate self-check agree?
+
+   ```sh
+   hal0 doctor verify
+   ```
+
+   A good answer is a pass/warn/fail report card with every row green
+   (`ok`) — API reachability, capability slots, memory, OpenWebUI, Hermes,
+   auth posture, and more, plus the box's live URLs. The command exits
+   non-zero only on a critical failure (no reachable URL, or zero healthy
+   runners); isolated warnings are worth reading but don't fail the check.
+   `hal0 doctor verify --json` gives the same report as structured JSON —
+   the same shape `GET /api/doctor` serves over HTTP.
+
+</Steps>
+
+<Aside type="tip">
+`hal0 doctor all --json` runs every read-only doctor audit in one pass
+(`perms`, `models`, `migrations`, `profiles`, plus the `doctor verify`
+checks) if you want one command that rolls up all six areas above into a
+single report — useful for scripting a post-install gate.
+</Aside>
+
+## If a step fails
+
+- **Health fails** — `systemctl status hal0-api`, then `journalctl -u hal0-api` for the crash reason.
+- **Model list is empty** — re-run the pull: `hal0 model pull <ref>`.
+- **First chat fails or times out** — check the slot: `hal0 slot status agent`, `hal0 slot logs agent`.
+- **Dashboard won't load** — same unit as health; a health failure explains a dashboard failure too.
+- **Logs show repeating tracebacks** — `hal0 doctor bundle` collects a redacted diagnostic archive to attach to a bug report.
+- **Doctor reports a failing row** — the report names the row (`api`, `dns`, `runners`, `capabilities`, `memory`, `openwebui`, `hermes`, `auth`, `models`, …); `hal0 doctor <row>`-shaped subcommands (`doctor perms`, `doctor models`, `doctor profiles`) can fix several of them directly with `--fix`.

--- a/docs/reference/generated-files.mdx
+++ b/docs/reference/generated-files.mdx
@@ -1,0 +1,61 @@
+---
+title: Generated & rewritten files
+description: "Every file hal0 generates or rewrites at runtime — its writer (file:line), when it's rewritten, and whether operator edits survive. Companion to Paths & files, which owns what each path is for."
+sidebar:
+  order: 40
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+[Paths & files](/docs/reference/paths-and-files/) is the map of *what* lives
+where. This page answers the question that map doesn't: for each generated
+or rewritten file, *who* writes it, *when* it gets rewritten, and whether a
+hand edit survives the next write. Read it before touching install-time or
+runtime config code — a fix that only patches one writer of a fact with
+multiple writers reappears the next time the other one runs.
+
+## Config surfaces
+
+| File | Writer (`file:line`) | Rewritten when | Operator edits survive? |
+|---|---|---|---|
+| `/etc/hal0/hal0.toml` | `save_hal0_config()` — `src/hal0/config/loader.py:244`. Every read-modify-write path (installer, `PUT /api/settings`, `hal0 config edit`, `hal0 update` convergence) goes through the single locked RMW seam `hal0_config_txn`/`hal0_config_file_lock` (`loader.py:268` on) so two writers never erase each other's section. | Install-time seeding (only the `[models].store` key, idempotent — `installer/install.sh:896`), any `hal0 config edit`, `PUT /api/settings` (deep-merged, `src/hal0/api/routes/settings.py`), and one-shot `hal0 update` convergence writes. | **Yes.** Every writer is a merge into the existing file under the shared lock, never a blind overwrite — a field the write doesn't touch is untouched. |
+| `/etc/hal0/api.env` | `upsert_env_value()` / `delete_env_value()` — `src/hal0/api/_env_store.py:88` / `:132`, both over the atomic writer at `:58`. Mode `0600` (systemd `EnvironmentFile=` for `hal0-api`). | Per-key upsert on `hal0 auth rotate`, provider-token save (`upstreams/integrations.py`), and settings-route secret writes. The installer's network-derived block (bind host/port) is rewritten on **every** `install.sh` run, not just first install (`installer/install.sh:1272`). | **Partially.** Individual keys are upserted (a key the write doesn't name is untouched), but the installer's network block is unconditionally re-derived from the current run's flags on every re-run — a hand-edit to *those specific* keys does not survive a re-install. |
+| `/etc/hal0/openwebui.env` | `write_openwebui_env()` — `src/hal0/openwebui/env_writer.py:248`, called from `main()` at `:303` with `preserve_existing=True`, invoked by the installer only (`installer/install.sh:1566`; there is no settings route for this file). | Every `install.sh` run (fresh install, repair, upgrade). | **Yes, explicitly** — since #1514, `main()` merges the freshly computed defaults with whatever the file already contains (`env_writer.py:290`) rather than clobbering it, specifically so an operator's hand-edits survive repair and upgrade runs. |
+| `/etc/hal0/hardware.json` | `HardwareProbe.write()` — `src/hal0/hardware/probe.py:1002`, called from the hardware route's refresh path (`src/hal0/api/routes/hardware.py:262`). | Install time, `hal0 config hardware --refresh` (CLI), and the dashboard's re-probe action — all three reach the same route. See [Hardware matrix](/docs/reference/hardware-matrix/) for what triggers a probe. | **No.** This is a machine-owned snapshot serialized fresh from the live probe every time — there is no merge step, so a hand-edit is discarded on the next probe. |
+| `/etc/hal0/manifest.json` | **Nothing writes this by default.** hal0 resolves the release manifest from `/usr/lib/hal0/current/manifest.json` (inside the versioned release tree, atomically swapped by the `current` symlink on install/update) — `/etc/hal0/manifest.json` is checked *first* only as a deliberate operator override (`_find_manifest_path()`, `src/hal0/config/loader.py:1151`). | Never, by hal0. An operator who places a file here is opting out of the shipped pins. | **Always** — hal0 never writes to this path; if it exists, it's 100% operator content. |
+| `/etc/hal0/profiles.toml` | `save_profiles_config()` — `src/hal0/config/loader.py:929` — for operator (non-seed) profile edits. The one-shot v1.0 convergence reset is a separate path: `_backup_profiles_toml()` (`updater.py:2684`) copies the file to `/var/lib/hal0/backups/profiles-<UTC>.toml`, then the reset (`updater.py:2763`) replaces the catalog outright. | Operator edits via `hal0 config edit profiles`, install-time seed injection (absent-file case only), and the one-shot v1.0 schema-version-gated catalog reset. | **Mostly.** Ordinary edits round-trip through the RMW writer untouched. The **one-shot v1.0 reset is the deliberate exception** — it replaces the whole catalog after taking a timestamped backup, specifically because pre-v1.0 profiles carried shapes v1.0 no longer accepts (`config/loader.py:833`, `HAL0-SUNSET: v1.3.0`). |
+| `/etc/hal0/slots/<name>.toml` | `write_slot_toml()` — `src/hal0/slot_config/__init__.py:70`, wrapping the shared `write_toml_atomic`. | `slot create/edit/rename/delete`, and the `slot migrate-*` family (`slot migrate-hw`, `-caps`, `-flags`, `-id-keying`) — see the [CLI reference](/docs/reference/cli/). | **Mostly.** Field-level writes are merged (`merge_slot_config`) so untouched keys survive, but a hardware/profile migration can rewrite backend-tied fields (e.g. `profile`, `image_pin`) across every slot in one pass by design — that's what a migration command is for. |
+| `/var/lib/hal0/registry/registry.toml` | `RegistryStore._atomic_write()` — `src/hal0/registry/store.py:305`, under the sidecar `registry.toml.lock`. | `model add/rm/pull/scan`, `model store --migrate`, `model import-backup`. | **Yes** — writes are read-modify-write against the in-memory model map; an entry the current operation doesn't touch is re-serialized unchanged. `model add --overwrite` / `import-backup --force` are the explicit exceptions, by name. |
+| `/var/lib/hal0/stacks/state.json` | `write_stack_state_atomic()` — `src/hal0/stacks/state.py:82`. | Every stack apply/load. | **N/A** — this is a pointer (active stack id + content hash), not operator-editable content; it's always fully overwritten by design. |
+| `/var/lib/hal0/secrets/hal0-api.env` | Installer bash only, no Python writer — `installer/install.sh:1489`, root:root `0600`. Holds the validated `HF_TOKEN`. | Only when `HF_TOKEN`/`HUGGING_FACE_HUB_TOKEN` is set on that `install.sh` invocation — an explicit env var is treated as an explicit rotate signal. | **Yes when omitted.** Re-running the installer with no token set leaves an existing file here untouched; it's never deleted just because the variable was left out of a later run. |
+
+## Generated infrastructure (not operator-editable)
+
+| File | Writer (`file:line`) | Rewritten when | Operator edits survive? |
+|---|---|---|---|
+| `/etc/containers/systemd/hal0-slot@<token>.container` (Podman Quadlet unit) | `_render_quadlet_from_plan()` — `src/hal0/providers/container.py:803` — produces the unit text via `_render_quadlet_text()` (`:2737`); written by `_SYSTEMCTL_SEAM.write_quadlet()` (`:2695`). | Every slot spawn/load — the unit is fully regenerated from the slot's current TOML + resolved profile each time, including its `Environment=` lines (slot env vars are baked directly into the unit; there is no separate per-slot `.env` file in the current architecture). | **No.** Pure generated infrastructure — never hand-edit; a hand edit is silently discarded on the next spawn. |
+| `/etc/avahi/services/hal0-addon-<id>.service` | `advertise()` / `withdraw()` — `src/hal0/services/mdns.py:100` / `:138`. | Whenever an addon service's mDNS advertisement is enabled/disabled (settings apply, service toggle). | **No** — generated on every state change. The installer-owned main `hal0.service` announcement is a **different file** this module explicitly never touches (`mdns.py` module docstring). |
+
+<Aside type="caution">
+Every atomic writer above uses the same pattern: `tempfile.mkstemp` in the same directory,
+write, `fsync`, then `os.replace` — so a reader never observes a torn write and a crash mid-write
+leaves the previous version intact. See the Temp file prefixes table in
+[Paths & files](/docs/reference/paths-and-files/) for the recognizable `.hal0-*-*.tmp` names this
+produces.
+</Aside>
+
+## Reading this table
+
+"Survives?" is about **the next write from hal0 itself**, not about whether a file is safe to
+read by hand. A `No` doesn't mean "don't look at it" — `hardware.json` and the quadlet units are
+both useful to inspect while debugging — it means the next probe, spawn, or advertisement change
+will discard anything you changed there. A `Yes`/`Mostly` means hal0's own writers merge rather
+than clobber; it says nothing about whether the *installer* or an *upgrade* might still replace
+the file wholesale for reasons of its own (profiles.toml's one-shot v1.0 reset is exactly that
+case, called out above).
+
+## See also
+
+- [Paths & files](/docs/reference/paths-and-files/) — every path, its purpose, and the temp-file/lock conventions.
+- [Config schema](/docs/reference/config-schema/) — the typed shape of `hal0.toml` and `profiles.toml`.
+- [CLI reference](/docs/reference/cli/) — `slot migrate-*`, `hal0 config`, and `hal0 update` in full.

--- a/docs/reference/paths-and-files.mdx
+++ b/docs/reference/paths-and-files.mdx
@@ -140,3 +140,6 @@ entries only hold the *name* of an environment variable (`auth_value_env`); the 
 secret value lives in `api.env` (mode `0600`), written atomically via
 `hal0.config.env.write_env_atomic`.
 </Aside>
+
+For *who* writes each of these files, *when* they get rewritten, and whether a hand
+edit survives the next write, see [Generated & rewritten files](/docs/reference/generated-files/).

--- a/docs/reference/support-matrix.mdx
+++ b/docs/reference/support-matrix.mdx
@@ -1,0 +1,72 @@
+---
+title: Support matrix
+description: "What hal0 supports today, honestly: platform, GPU lanes, CI/fleet coverage, and an explicit not-supported row for macOS and Windows — derived from the CI workflows, installer/lib/distro.sh, and the release-validation fleet."
+sidebar:
+  order: 55
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This page separates three things that are easy to conflate: what the
+installer's package-manager detection can *technically* run on, what CI
+actually *exercises* on every PR, and what the release-validation fleet
+*proves* on real hardware before a release ships. A row can be "installer
+supports it" without being "CI-tested" or "fleet-validated" — say which is
+true, not just whether the code path exists.
+
+## Platform
+
+| Platform | Status | What that means today |
+|---|---|---|
+| **Linux + systemd + podman** | **Supported** | The only supported runtime shape. Every inference workload is a podman container under a `hal0-slot@<name>.service` systemd unit — hal0 has no non-systemd, non-podman code path. |
+| **Proxmox LXC (privileged, Ubuntu)** | **Supported** | First-class, not a workaround: `scripts/proxmox-ve/hal0.sh` provisions a privileged Ubuntu 26.04 LXC with iGPU + XDNA NPU device-node passthrough already wired (`docs/getting-started/proxmox.mdx`). This is also the literal shape of the release-validation fleet's primary box (`tests/release-validation/boxes.toml`) — the Proxmox path isn't a lesser-tested variant of bare metal, it's what the fleet itself runs on. |
+| **WSL2** | **Experimental, CPU-only** | hal0 detects WSL2 but does not work around its limits: no `/dev/kfd` (no ROCm), and the iGPU only appears through Microsoft's `/dev/dxg`, not the native render/kfd nodes hal0's slots expect — untested, don't rely on it. systemd must be enabled manually or preflight fails. `docs/getting-started/wsl.mdx` is explicit: **"Windows is out of scope for hal0 v1."** |
+| **macOS** | **Not supported** | No Darwin handling anywhere in `installer/install.sh` — there is no macOS install path, tested or otherwise. hal0's runtime model (systemd units + podman containers) has no macOS equivalent shipped. |
+| **Windows (native)** | **Not supported** | Same installer has no Windows-native path either; the only way to reach hal0 from Windows today is WSL2 (see above), CPU-only and experimental. See `docs/getting-started/wsl.mdx` for why this is a v1 scope decision, not an oversight. |
+
+<Aside type="note">
+"Supported" here means an install actually happens and is exercised somewhere in CI or the release
+fleet (below) — not "the installer has a `case` branch for this distro's package manager and
+nothing has actively broken it yet." The Package-manager breadth section below draws that
+distinction explicitly.
+</Aside>
+
+## GPU / accelerator lanes
+
+| Lane | Status | Evidence |
+|---|---|---|
+| **ROCm** (`gpu-rocm`) | **Supported, default** | `DEFAULT_DEVICE = "gpu-rocm"` in `hal0.model_meta`. Selected whenever `/dev/kfd` is present and rocm-smi is reachable (`hardware.recommend._backend_for()`). Exercised in the γ release-gate matrix (`make release-test` → `llamacpp-rocm` row) and by the release-validation fleet's update/prod boxes, both of which carry `/dev/kfd`. |
+| **Vulkan** (`gpu-vulkan`) | **Supported** | The lane for iGPU-only boxes with no `/dev/kfd` (render node only) — also the non-llama.cpp GPU runtime for Kokoro TTS, whisper.cpp, and ComfyUI. LLM slots on this device are gated to an explicit image allowlist (`VULKAN_CAPABLE_IMAGE_REFS`, `src/hal0/config/schema.py`), not a version comparison. Exercised in the γ matrix (`llamacpp-vulkan` row) and is the primary lane on the release-validation fleet's fresh-install box, which has no `/dev/kfd`. |
+| **CPU** | **Supported, universal fallback** | Always available; `hardware.recommend._backend_for()` falls back here when no GPU class matches. Exercised on every fresh-install box in the fleet regardless of GPU class. |
+| **NPU (FLM trio)** | **Supported on Strix Halo, opt-in** | AMD XDNA NPU via FastFlowLM — chat + transcription + embedding coresident in one `hal0-toolbox-flm` container (see `docs/concepts/strix-halo.mdx`). Exercised in the γ matrix's `flm` row (chat + trio ASR/embed); `skip`s cleanly on a manifest without a pinned FLM `.deb` rather than failing the release. |
+| **CUDA** (`gpu-cuda`) | **Experimental** | NVIDIA GPUs via llama.cpp CUDA — present in the device taxonomy (`docs/reference/hardware-matrix.mdx`) but not seeded by default and not part of the γ release-gate matrix or the release-validation fleet today. Treat as unvalidated until it appears in a fleet report. |
+
+## CI and fleet coverage — what actually runs where
+
+| Layer | Where it runs | What it covers | What it does NOT cover |
+|---|---|---|---|
+| **CI** (`.github/workflows/ci.yml`) | GitHub-hosted `ubuntu-latest` runners | Unit tests (α tier), lint, mypy, sunset/scar ratchet, UI build + unit tests. Push-to-main also runs the full supported Python range; PRs run 3.12 only. | No other Linux distro, no GPU, no real systemd/podman install. |
+| **Bootstrap parity** (`.github/workflows/bootstrap-parity.yml`) | `ubuntu-latest`, daily | Diffs the in-tree `installer/bootstrap.sh` against the live `hal0.dev/install.sh` one-liner — catches drift between the audited installer and what a `curl \| bash` user actually runs. | Does not install hal0 anywhere; it's a text diff, not a runtime check. |
+| **β integration tier** | Not currently wired into CI | `CONTRIBUTING.md`'s Test tiers section describes a `make test-integration` target and a `.github/workflows/integration.yml` job exercising a real `hal0-lemonade.service` — **neither exists in the tree today.** Both were retired in the toolbox-retirement pass (commit `4c01f0c1`, "PR-9") alongside `tests/slots/test_integration.py`, and no later commit restored them, despite that commit's own message naming a follow-up that would. Filed as [#2239](https://github.com/Hal0ai/hal0/issues/2239). | The α unit tier and the γ release-gate are the only test tiers that actually run today; there is currently no automated tier between them. |
+| **γ release-gate script** (`make release-test`) | An operator-designated `hal0-test` box over SSH (`HAL0_TEST_HOST`) | The 7-row matrix — `llamacpp-vulkan`, `llamacpp-rocm`, `flm` (chat+trio), `whispercpp`, `tts`, `sd-cpp`, `openwebui`, plus an updater round-trip. Structured pass/fail/skip/deferred rows in `tests/release-gate-report.json`. | Distro breadth — it's one box, whichever the operator points it at. |
+| **Release-validation fleet** (`tests/release-validation/`, the `rc-validate` kit) | A private Proxmox-hosted lab fleet: one fresh-install box (privileged Ubuntu, iGPU+NPU passthrough, no `/dev/kfd`), one in-place-upgrade box (Ubuntu, `/dev/kfd` present), one read-only production box (Ubuntu, `/dev/kfd` present) | Agent-driven exploratory lanes over the real product: CLI, API, MCP, Hermes, UI (read-only), then serialized stateful lanes (slots, routing, brain, memory, capabilities, Hermes e2e), then the in-place upgrade lane. See [Validation matrix](/docs/reference/validation-matrix/). | Every box in the fleet runs Ubuntu — no Fedora/Arch/openSUSE/Debian coverage exists anywhere in CI or the fleet today, despite the installer's package-manager detection supporting all of them (below). A second, CPU-only fresh-install box exists in the fleet's roster but isn't part of the default lane matrix and carries its own unresolved AppArmor/podman caveat (`tests/release-validation/boxes.toml`) — so CPU-only fresh-install coverage isn't exercised by default; the CPU lane inside `make release-test` is the reliable CPU-only check today. |
+
+## Package-manager breadth (installer-level, not fleet-tested)
+
+`installer/lib/distro.sh` detects the host package manager by command
+presence — `apt-get`, `dnf`/`yum`, `zypper`, `pacman`, `apk` — and buckets it
+into a `distro_family` (`debian`, `fedora`, `suse`, `arch`, `alpine`) used
+only to pick package *names*, not to gate behavior. This means `install.sh`
+will attempt an install on any of those five package-manager families. **This
+is installer-level generality, not a support claim** — none of Fedora, Arch,
+openSUSE, or Alpine appears in CI or the release-validation fleet (both
+Ubuntu-only, per the table above), so a non-Debian install is exercising a
+code path with detection logic but no end-to-end evidence behind it. Report
+issues on those distros; don't assume they're fleet-proven because the
+`case` statement recognizes them.
+
+## See also
+
+- [Hardware matrix](/docs/reference/hardware-matrix/) — the hardware probe, device taxonomy, and backend-selection decision tree in full.
+- [Validation matrix](/docs/reference/validation-matrix/) — how the α/β/γ test tiers and the release-validation fleet map onto release-readiness gates.
+- [`CONTRIBUTING.md`](https://github.com/Hal0ai/hal0/blob/main/CONTRIBUTING.md#test-tiers) — the α/β/γ test tiers in full, including local commands.

--- a/docs/reference/validation-matrix.mdx
+++ b/docs/reference/validation-matrix.mdx
@@ -1,0 +1,84 @@
+---
+title: Validation matrix
+description: "hal0's α/β/γ test tiers and the rc-validate release-validation kit mapped onto release-readiness gates, plus a 'User Green' definition for hal0 — a fresh box reaching first chat unattended."
+sidebar:
+  order: 56
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+hal0 validates a change at three widening tiers before it reaches a
+release, plus one exploratory layer that runs only against a release
+candidate. This page names what each layer proves, where it runs, and what
+blocks a release — see [`CONTRIBUTING.md`](https://github.com/Hal0ai/hal0/blob/main/CONTRIBUTING.md#test-tiers)
+for the day-to-day commands.
+
+## The four layers
+
+| Tier | What it proves | Where it runs | Blocks what |
+|---|---|---|---|
+| **α — Unit** | Pure logic, mocked systemd/HTTP/Lemonade client. | Any host, no daemons — `make test` | Every commit / PR. |
+| **β — Integration** *(documented, not currently wired)* | Real `hal0-lemonade.service` + a tiny GGUF: load → chat → swap → unload, slot state visible via `/v1/health` — per `CONTRIBUTING.md`'s description. | Neither `make test-integration` nor `.github/workflows/integration.yml` exist in the tree today — both were retired alongside the old per-modality toolboxes (`4c01f0c1`) and never restored, despite that commit's own message naming a follow-up that would. Filed as [#2239](https://github.com/Hal0ai/hal0/issues/2239). | Nothing today — there is no automated tier between α and γ right now. |
+| **γ — Release-gate script** | The 7-row hardware/backend matrix (ROCm, Vulkan, CPU, NPU/FLM, whisper.cpp, Kokoro TTS, sd-cpp, OpenWebUI proxy, updater round-trip) on one designated box. | `hal0-test` LXC over SSH — `make release-test` | Per release candidate, not per commit. Row status `pass\|fail\|skip\|deferred`; only `fail` blocks. |
+| **γ+ — Release-validation fleet (`rc-validate` kit)** | The product as an operator would actually use it — CLI, API, MCP, Hermes, UI, then serialized stateful lanes (slots, routing, brain, memory, capabilities, Hermes e2e), then an in-place upgrade — on real hardware, per `tests/release-validation/`. | A private real-hardware fleet (Proxmox-hosted; see [Support matrix](/docs/reference/support-matrix/)) | Release-candidate confidence. Agent-driven and exploratory, not a fixed pytest suite — findings that prove mechanical get folded back into pytest/`release-test.sh` so they stop needing an agent (`tests/release-validation/README.md`). |
+
+<Aside type="note">
+The γ script and the `rc-validate` kit are complementary, not redundant. `make release-test`
+answers "does each backend row still work" with a fixed, scriptable matrix. The `rc-validate` kit
+answers "does the product still work the way an operator experiences it" — model registry, the
+memory engine, the agent board, upgrade behavior — surfaces a fixed matrix can't reach because
+they depend on multi-step, stateful operator workflows.
+</Aside>
+
+## The release-validation kit, in more detail
+
+`tests/release-validation/` (orchestrated by the `rc-validate` Claude Code workflow) runs seven
+phases in order: **Preflight** (per-box readiness — a version/reachability mismatch aborts the
+run) → **Read-only sweep** (`api`, `cli`, `mcp`, `hermes`, `ui` lanes, parallel, no mutations) →
+**Stateful lane** (`slots` → `routing` → `brain` → `memory` → `capabilities` → `hermes-e2e`,
+strictly serialized on one box — two agents mutating the same install would produce
+unreproducible findings) → **Update lane** (upgrade + post-upgrade checks on a separate box,
+concurrent with the stateful lane) → **Regression probes** (every previously filed finding in
+`regressions.yaml`, re-checked every release) → **Triage + adversarial verify** (dedup, drop
+known issues, one skeptic agent per candidate finding — four of the rc.4 wave's candidates were
+refuted or reclassified as by-design here) → **Synthesis + report**, committed under
+`tests/release-validation/reports/<version>.md`. **Kit curation** is the eighth, standing phase
+that folds newly discovered checks back into the lane briefs and promotes confirmed findings into
+`regressions.yaml`, so the kit gets sharper release over release instead of starting from zero.
+
+## "User Green" for hal0
+
+ODS's release gate names a combined `User Green` result: every enabled release surface either
+passed or was explicitly accounted for. hal0 doesn't yet have a single named gate that plays that
+role end to end, but the equivalent, stated in hal0's own vocabulary, is:
+
+> **User Green, for hal0** — a fresh box reaches first chat **unattended**: `install.sh` completes
+> non-interactively, `hal0-api` comes up healthy (`/api/health` — [Verify the install](/docs/getting-started/verify/)
+> step 1), at least one model is registered (step 2), a `/v1/chat/completions` request against the
+> seeded `agent` slot returns real text (step 3), the dashboard serves (step 4), and
+> `hal0 doctor verify` reports no critical failure (step 6) — with nothing but the one-line
+> installer command and, optionally, a HuggingFace token.
+
+Composed from the same layers as the table above:
+
+| Component | What must be true | Proven by |
+|---|---|---|
+| **Install Green** | The public install path completes on a real fresh box without operator intervention. | `rc-validate`'s Preflight + fresh-install evidence; the fresh-install box in the fleet. |
+| **Product Green** | Core API, dashboard, and OpenWebUI serve; doctor's aggregate check has no critical row. | `hal0 doctor verify` (or `GET /api/doctor`); the read-only lane sweep (`api`, `ui` lanes). |
+| **Capability Green** | A chat completion against the seeded slot returns real generated text, not an error or a timeout. | The first-chat step of [Verify the install](/docs/getting-started/verify/); the `brain`/`slots` stateful lanes. |
+| **Lifecycle Green** | An in-place `hal0 update` converges cleanly and the box remains healthy after. | The update lane (`upgrade`, `post-upgrade`) on the fleet's update box. |
+| **User Green** | All four of the above, for the candidate under test, with any skip or deferral named and justified rather than silently dropped. | The synthesized `rc-validate` report for that release. |
+
+<Aside type="caution">
+This is a documentation mapping, not a new CI gate — hal0 has no automated job today that
+computes a single "User Green" boolean and fails a release on it. Release readiness is currently
+a human judgment call informed by the α/β/γ results plus the `rc-validate` report; this table
+exists so that judgment has a name and a checklist, not a formula.
+</Aside>
+
+## See also
+
+- [Support matrix](/docs/reference/support-matrix/) — the hardware/platform coverage these tiers actually exercise.
+- [Verify the install](/docs/getting-started/verify/) — the six-step checklist an operator runs by hand; steps 1, 2, 3, 4, and 6 are exactly the checks "Product Green" and "Capability Green" above cite.
+- [`tests/release-validation/README.md`](https://github.com/Hal0ai/hal0/blob/main/tests/release-validation/README.md) — the kit's own layout, phase table, and process lessons.
+- [`CONTRIBUTING.md`](https://github.com/Hal0ai/hal0/blob/main/CONTRIBUTING.md#test-tiers) — α/β/γ commands and CI wiring.


### PR DESCRIPTION
## Summary

Adds the parity-docs deliverables from the hal0 × ODS parity program's
"at-a-glance / post-install checklist / support & validation matrices /
generated-config-writers table" brief: a README "At a glance" block and
comparison table, a six-step post-install verify page, a support matrix,
a validation matrix (mapping hal0's α/β/γ tiers and the `rc-validate`
release-validation kit onto a hal0-specific "User Green" definition), a
generated/rewritten-files reference (writer, rewrite trigger, and whether
operator edits survive, per file), and a CONTRIBUTING.md area→required-
validation table mirroring the PR template's §14.1 high-risk map. Every
fact is verified against the current source tree (file:line citations
inline in the new pages) — no ODS text is copied, only the structural
idea of each page. Docs-only; no code changes.

## Risk grade

- [x] low    — docs only, internal refactor, or behaviour-preserving fix
- [ ] med    — user-facing change, new code path, or non-trivial refactor
- [ ] high   — anything touching the §14.1 high-risk surfaces below

## Touched surfaces

- [ ] API (`src/hal0/api/`)
- [ ] Auth / sessions (`src/hal0/auth/`, login routes, middleware)
- [ ] Slots / dispatch (`src/hal0/slots/`, `slot_state`, `/v1/load|unload`)
- [ ] Models / capabilities (`src/hal0/capabilities/`, `model_meta`, `model_fit`)
- [ ] Installer (`installer/`, systemd units)
- [ ] Updater (`src/hal0/updater/`, `hal0.releases.v1` manifest)
- [ ] Board chat / MCP admin (`src/hal0/api/routes/board_chat.py`, `src/hal0/mcp/admin.py`)
- [ ] Config / schema (`src/hal0/config/`, pydantic models)
- [ ] UI (`ui/src/`, Playwright specs)
- [x] Docs (`docs/`, `CONTRIBUTING.md`)
- [ ] CI / release (`.github/workflows/`, `release.yml`)

## §14.1 high-risk surfaces

- [ ] Unauthenticated board routes
- [ ] `AUTONOMOUS_WRITE_TOOLS` additions
- [ ] Installer / updater RCE-class

None apply — this PR touches no code.

## Rollback

_Rollback:_ revert the merge commit; every change is additive documentation plus two CHANGELOG/CONTRIBUTING edits, no code or config behavior changes.

## Test tiers run

- [ ] α  unit (`make test`) — not applicable, no code changed
- [ ] β  integration (`make test-integration`) — not applicable, no code changed
- [ ] γ  release-gate (`make release-test`) — not applicable, no code changed

Verification performed instead: every CLI command, file path, function
name, and `file:line` citation in the new/changed pages was checked
against the current tree (not memory) while writing, and a follow-up
`docs-verifier` pass fact-checked the full claim list against source
before this PR was opened. `python3 scripts/check_sunset.py` is green
(no code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPrCENafeE5LZB4P1VCCST
