### PR TITLE
feat(installer): tee'd log, failure report, pull retry, --summary-json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,37 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+
+- **Installer forensics**: every install now leaves evidence behind instead of
+  only a terminal scrollback. `install.sh` tees the whole run to
+  `/var/log/hal0/install-<ts>.log` (falling back to `/tmp/hal0-install-<ts>.log`
+  when not root), prints that path at the start and end, and includes the
+  latest one in `hal0 doctor bundle`'s `logs/` section. An ERR-trapped abort
+  now also writes `hal0-install-report-<ts>.txt` next to the log — redacted
+  environment (mirrors `hal0.api._redact`'s key-name pattern), port owners,
+  hal0 unit status, a hardware summary, and a log tail — via the new
+  `installer/lib/failure-report.sh`, and the trap prints its path alongside
+  the existing step-specific recovery advice. Every `installer/lib/*.sh` and
+  `install.sh`'s own top now carries the `Purpose / Expects / Provides /
+  Modder notes` header convention (documented in `installer/README.md`) so a
+  future decomposition of the 4,000-line script into standalone steps has a
+  contract to extract against. `ui_step` gained an optional per-step time
+  estimate (`EST. TIME: ~30s`) and now measures real per-step durations
+  (`UI_STEP_DURATIONS`), with total elapsed time printed at the end. A new
+  `--summary-json=PATH` flag writes a versioned (`hal0.install-summary.v1`),
+  atomically-written machine-readable install summary — versions, dev/no-start
+  mode, network bind info, hardware class, the brain model pulled, warning/
+  error counts, and per-step durations — documented in
+  `docs/getting-started/install.mdx`. Container-image pulls (the OpenWebUI
+  background warm-cache pull in `install.sh`, and the dashboard's
+  runner-image pull job in `hal0.registry.runner_pull`) now retry transient
+  failures with backoff (`installer/lib/pull-retry.sh` on the bash side,
+  `is_retryable_pull_error`/`pull_backoff_delay` in Python), classify
+  auth/404/manifest-unknown/disk-full failures as non-retryable so they fail
+  fast instead of spinning, and verify the image actually landed in local
+  storage after an apparent success before declaring victory.
+
 ### Fixed
 
 - MCP admin tools no longer report a tool failure for a successful read of a

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Full step list and the complete env-var table:
 | `HAL0_PY_AUTOINSTALL=1` | Let the installer install a compatible `python3.12` |
 | `HAL0_SKIP_HINDSIGHT=1`, `HAL0_SKIP_OPENWEBUI=1`, `HAL0_SKIP_HERMES=1`, `HAL0_SKIP_COMFYUI=1` | Skip individual companion services |
 | `--no-start` | Provision everything, leave services stopped |
+| `--summary-json=PATH` | Write a versioned, machine-readable install summary (see [`installer/README.md`](./installer/README.md#--summary-jsonpath)) |
 
 ### Proxmox VE, one line
 

--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -108,6 +108,7 @@ curl -fsSL https://hal0.dev/install.sh | sudo bash -s -- --no-start --models-dir
 | `--dev` | Local-only editable install under `$PWD/.hal0ai` — no systemd, no host package changes |
 | `--no-start` | Set everything up but do not enable/start the units |
 | `--models-dir=PATH` | Absolute path where Hugging Face pulls land (same as `HAL0_MODELS_DIR`) |
+| `--summary-json=PATH` | Write a versioned, machine-readable install summary to `PATH` once the install finishes (see below) |
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -119,6 +120,29 @@ curl -fsSL https://hal0.dev/install.sh | sudo bash -s -- --no-start --models-dir
 | `HAL0_NO_PROBE` | _(unset)_ | Set to `1` to skip the hardware probe / first-run seeding |
 | `HAL0_SKIP_HINDSIGHT` | _(unset)_ | Set to `1` to skip installing the Hindsight memory service |
 | `HAL0_PY_AUTOINSTALL` | _(unset)_ | Set to `1` to let the installer auto-install a Python 3.12 interpreter when the default is too old |
+
+### Install log and failure reports
+
+Every run tees its full output to `/var/log/hal0/install-<ts>.log`
+(`/tmp/hal0-install-<ts>.log` when not root) — the path is printed at the
+start and end, and `hal0 doctor bundle` includes the latest one. If the
+installer aborts, it also writes a redacted `hal0-install-report-<ts>.txt`
+next to the log (environment, port owners, unit status, hardware summary,
+log tail) and prints its path. See `installer/README.md` for the full
+breakdown of what each report contains.
+
+### `--summary-json`
+
+```sh
+sudo bash installer/install.sh --summary-json=/tmp/hal0-install-summary.json
+```
+
+Writes a `schema: "hal0.install-summary.v1"` JSON document — hal0 version,
+`--dev`/`--no-start` flags, models dir, network bind info, the detected
+hardware class, which brain model was pulled, a warning/error count, and
+measured per-step durations — atomically, so a script polling for the file
+never reads a half-written one. Full field reference and an example payload
+are in `installer/README.md`.
 
 ## Production filesystem layout
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -111,6 +111,8 @@ These are the variables `installer/install.sh` actually reads:
 | `HAL0_AGENT_MODEL` | _(unset)_ | Force a specific rung of the agent model ladder instead of the hardware-derived pick |
 | `HAL0_SKIP_SETUP` | _(unset)_ | Set to `1` to skip first-run seeding (`hal0 setup --auto --no-pull`) **and** both the brain and agent model steps |
 | `HAL0_OPENWEBUI_PORT` † | `3001` | OpenWebUI host port — **dev mode only** |
+| `HAL0_PULL_MAX_ATTEMPTS` | `4` | Max attempts for a retryable container-image pull failure (backoff between attempts — see [Installer forensics](#installer-forensics) below) |
+| `HAL0_PULL_RETRY_DELAYS` | `5 15 30 60` | Space-separated backoff seconds for pull retries; past the end of the list the last value doubles per extra attempt |
 
 † `HAL0_OPENWEBUI_PORT` is honored by `scripts/dev-bootstrap.sh` (the dev-mode launcher). The installed `hal0-openwebui.service` hardcodes `:3001`; to change it post-install, edit `/etc/systemd/system/hal0-openwebui.service` and reload.
 
@@ -119,6 +121,98 @@ Example:
 ```sh
 HAL0_PORT=9090 sudo bash installer/install.sh
 ```
+
+## Installer forensics
+
+### Module header convention
+
+Every file under `installer/lib/*.sh`, plus `install.sh`'s own top comment
+block, carries the same four-label header:
+
+```sh
+# installer/lib/<name>.sh
+#
+# Purpose: what this file is for, one or two sentences.
+# Expects: what has to be true before it's sourced/run (globals, prior
+#          sourcing order, privileges).
+# Provides: the public functions/globals other files may use.
+# Modder notes: anything a future editor needs to know before changing
+#          behaviour here (a footgun, a knob to prefer over an edit).
+```
+
+Keep new installer files (bash) on this convention — it is what lets
+`hal0 doctor` and future step-extraction tooling treat each file as a
+contract rather than re-reading its whole body.
+
+### Install log
+
+Every run tees its full output — narrator lines and every spawned command's
+stdout/stderr — to `/var/log/hal0/install-<ts>.log` (falling back to
+`/tmp/hal0-install-<ts>.log` when not root, e.g. `--dev`). The path is
+printed right after the banner and again at the end, and `hal0 doctor
+bundle` includes the most recent one (redacted) under `logs/install.log`.
+Implemented in `installer/lib/logging.sh`; degrades to no log (rather than
+aborting the install) if neither location is writable.
+
+### Failure report
+
+If `install.sh` aborts (its `ERR` trap fires), it writes
+`hal0-install-report-<ts>.txt` next to the install log and prints its path
+alongside the existing step-specific recovery advice. The report bundles a
+redacted environment dump (same key-name pattern as
+`hal0.api._redact` — `SECRET|TOKEN|PASSWORD|PASS|API_KEY|PRIVATE_KEY|
+ENCRYPTION_KEY|SALT|_KEY$|^KEY$`, case-insensitive), the owner of the
+hal0-api/OpenWebUI ports (`ss -ltnp`), `systemctl status` of the hal0
+units, `/etc/hal0/hardware.json`, and the last 200 lines of the install
+log — one file to attach to a bug report instead of a re-pasted
+scrollback. Implemented in `installer/lib/failure-report.sh`.
+
+### `--summary-json=PATH`
+
+Writes a versioned, machine-readable install summary once the install
+finishes, atomically (tempfile + fsync + `os.replace`, so a reader never
+sees a half-written file):
+
+```sh
+sudo bash installer/install.sh --summary-json=/tmp/hal0-install-summary.json
+```
+
+```json
+{
+  "schema": "hal0.install-summary.v1",
+  "generated_at": "2026-09-05T12:00:00+00:00",
+  "hal0_version": "1.3.0",
+  "install": { "dev_mode": false, "no_start": false, "prefix": "/usr/lib/hal0/hal0-1.3.0", "models_dir": "/var/lib/hal0/models" },
+  "network": { "bind_host": "0.0.0.0", "port": 8080, "openwebui_port": 3001 },
+  "hardware_class": { "id": "gfx1151", "label": "AMD Strix Halo" },
+  "brain_model": "lfm2.5-2.6b",
+  "warnings": 1,
+  "errors": 0,
+  "elapsed_seconds": 612,
+  "step_durations_seconds": { "Pre-flight checks": 6, "Python environment": 54, "...": 0 }
+}
+```
+
+`hardware_class` reads `/etc/hal0/hardware.json` (absent → `"unknown"`/
+`"unknown"`); `brain_model` is `null` when the brain pull was skipped
+(`HAL0_SKIP_BRAIN_MODEL`/`HAL0_SKIP_SETUP`) or never completed. There is no
+`auth` field — see [Authentication & TLS](#authentication--tls): hal0-api
+binds open, so there is no posture to report here.
+
+### Pull retry discipline
+
+Container-image pulls back off and retry transient failures instead of
+either failing on the first blip or retrying forever: the OpenWebUI
+background warm-cache pull in `install.sh` (`installer/lib/pull-retry.sh`)
+and the dashboard's runner-image pull job (`hal0.registry.runner_pull`,
+Python) both classify auth/permission, 404/manifest-unknown, and
+out-of-space failures as **non-retryable** (fail immediately — retrying
+never fixes them) and back off `HAL0_PULL_RETRY_DELAYS` (default `5 15 30
+60`, doubling past the end) up to `HAL0_PULL_MAX_ATTEMPTS` (default `4`)
+attempts for everything else. An apparent success is verified — the image
+must actually be present in local storage — before it's trusted; a pull
+that exits 0 without landing the image is treated as a retryable failure,
+not a false success.
 
 ## Authentication & TLS
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1,5 +1,32 @@
 #!/usr/bin/env bash
-# hal0 installer — idempotent, non-interactive.
+# installer/install.sh
+#
+# Purpose: hal0's single user-facing install entry point — idempotent,
+#          non-interactive by default. Provisions the system user,
+#          filesystem layout, Python venv, dashboard UI, config, systemd
+#          units, container slot seeds, hardware probe, curated models,
+#          and starts the service.
+# Expects: A systemd Linux on x86_64 (or `--dev` for a non-systemd,
+#          non-FHS local checkout under $PWD/.hal0ai). Root for a real
+#          install; any user for `--dev`. See `--help` (below) for flags
+#          and the "Env overrides" table for every env var this script
+#          reads.
+# Provides: The installed hal0 system (see installer/README.md "What the
+#          installer does" for the full 16-step breakdown) plus, for
+#          other tooling in this tree: a tee'd install log at
+#          $HAL0_INSTALL_LOG (installer/lib/logging.sh), a failure report
+#          on any ERR-trapped abort (installer/lib/failure-report.sh), and
+#          an optional --summary-json=<path> machine-readable install
+#          summary (schema hal0.install-summary.v1).
+# Modder notes:
+#   4,000+ lines by design — one script an operator can read top to bottom
+#   while an install runs, no framework indirection. ui_step's 16-step
+#   count is asserted against UI_STEP_TOTAL by
+#   tests/installer/test_install_single_entry_point.py; keep them in
+#   lockstep when adding/removing a step. Function/step names in this file
+#   are read by teammates decomposing install.sh into standalone step
+#   scripts — keep new blocks named after their `ui_step` title so that
+#   extraction stays mechanical.
 #
 # Usage:
 #   sudo bash install.sh             # standard install at /usr/lib/hal0
@@ -34,6 +61,28 @@ umask 022
 # trap below. Honors HAL0_PLAIN=1 and NO_COLOR=1 for non-fancy terms.
 # shellcheck source=lib/ui.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/ui.sh"
+
+# Tee'd install log (installer/lib/logging.sh) — every line this script and
+# every command it runs prints from here on also lands in HAL0_INSTALL_LOG,
+# so a failed or partial install leaves forensic evidence on disk. Sourced
+# and initialised immediately after ui.sh so even the banner below is
+# captured. hal0_install_log_init degrades to HAL0_INSTALL_LOG="" (no log)
+# on an unwritable /var/log AND /tmp rather than aborting the install.
+# shellcheck source=lib/logging.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/logging.sh"
+hal0_install_log_init || warn "could not open an install log — continuing without one"
+
+# Failure report (installer/lib/failure-report.sh) — the ERR trap below
+# calls hal0_write_failure_report to leave a redacted, shareable
+# hal0-install-report-<ts>.txt next to the install log on any abort.
+# shellcheck source=lib/failure-report.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/failure-report.sh"
+
+# Backoff + non-retryable classification for container-image pulls
+# (installer/lib/pull-retry.sh) — used by the OpenWebUI background pull
+# below instead of a single bare `podman pull`.
+# shellcheck source=lib/pull-retry.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/pull-retry.sh"
 
 # Distro / package-manager detection (distro_id / pkg_mgr / pkg_install_cmd /
 # python_venv_hint). One place knows "what distro is this and how do I name an
@@ -98,14 +147,19 @@ MODELS_DIR="${HAL0_MODELS_DIR:-}"
 # choice is never re-asked at the TTY prompt below.
 MODELS_DIR_EXPLICIT=0
 [[ -n "${MODELS_DIR}" ]] && MODELS_DIR_EXPLICIT=1
+# --summary-json=PATH: write a machine-readable install summary (schema
+# hal0.install-summary.v1) at PATH once the install finishes (or fails —
+# see the ERR trap). Empty means "don't write one" (the default).
+SUMMARY_JSON_PATH=""
 for arg in "$@"; do
     case "$arg" in
         --dev) DEV_MODE=1 ;;
         --no-start) NO_START=1 ;;
         --models-dir=*) MODELS_DIR="${arg#--models-dir=}" ;;
+        --summary-json=*) SUMMARY_JSON_PATH="${arg#--summary-json=}" ;;
         --help|-h)
             cat <<EOF
-Usage: install.sh [--dev] [--no-start] [--models-dir=PATH]
+Usage: install.sh [--dev] [--no-start] [--models-dir=PATH] [--summary-json=PATH]
   --dev               install under \$PWD/.hal0ai/, no systemd setup
   --no-start          set up everything but don't enable/start the API
   --models-dir=PATH   absolute path where HuggingFace pulls land
@@ -113,6 +167,10 @@ Usage: install.sh [--dev] [--no-start] [--models-dir=PATH]
                       under --dev). Can also be set with HAL0_MODELS_DIR=PATH.
                       Omit it and the installer asks on an interactive terminal;
                       a piped (\`curl … | bash\`) or headless run takes the default.
+  --summary-json=PATH write a machine-readable install summary (versions,
+                      ports, bind host, model pulled, per-step durations,
+                      warning count) to PATH as JSON, atomically. See
+                      docs/getting-started/install.mdx.
 
 Interactive prompts (models dir, HuggingFace token, Hermes terminal tool) only
 run when stdin is a terminal. Set HAL0_NONINTERACTIVE=1 to force the flag/env
@@ -131,6 +189,7 @@ done
 # Banner first — before any info/warn so the brand greets the user
 # rather than hiding behind a "Dev mode …" line.
 ui_banner
+[[ -n "${HAL0_INSTALL_LOG:-}" ]] && info "Install log: ${HAL0_INSTALL_LOG}"
 
 HAL0_PORT="${HAL0_PORT:-8080}"
 PY="${HAL0_PYTHON:-python3}"
@@ -245,6 +304,10 @@ fi
 # now asserts the two agree).
 UI_STEP_TOTAL=16
 
+# _hal0_report_path IS assigned below, inside this same single-quoted trap
+# body — shellcheck's SC2154 is a known false positive for vars set-and-used
+# inside a `trap '...'` string.
+# shellcheck disable=SC2154
 trap 'err "install failed at line ${LINENO} during: ${CURRENT_STEP:-pre-init}"
     case "${CURRENT_STEP}" in
         "Pre-flight checks")
@@ -266,9 +329,11 @@ trap 'err "install failed at line ${LINENO} during: ${CURRENT_STEP:-pre-init}"
             warn "Recovery: rerun with HAL0_NO_PROBE=1 and file an issue with"
             warn "         /etc/hal0/hardware.json (if present) attached." ;;
     esac
+    _hal0_report_path="$(hal0_write_failure_report "${CURRENT_STEP:-pre-init}" 2>/dev/null || true)"
+    [[ -n "${_hal0_report_path}" ]] && warn "Failure report saved: ${_hal0_report_path} — attach it to a bug report."
     exit 1' ERR
 
-ui_step "Pre-flight checks"
+ui_step "Pre-flight checks" "~5-10s"
 
 if [[ "${DEV_MODE}" -eq 0 && "$(id -u)" -ne 0 ]]; then
     if command -v sudo >/dev/null; then
@@ -717,7 +782,7 @@ fi
 # Q1), so the render/video group membership below is settled before any
 # later step that depends on group membership or on the user existing
 # (the FLM cache / HF cache / STATE.md ownership work further down).
-ui_step "System user"
+ui_step "System user" "~1-2s"
 
 if [[ "${DEV_MODE}" -eq 1 ]]; then
     # Dev installs never create system users or touch systemd.
@@ -802,7 +867,7 @@ else
     fi
 fi
 
-ui_step "Filesystem layout"
+ui_step "Filesystem layout" "~2-5s"
 
 mkdir -p \
     "${PREFIX}" \
@@ -1030,7 +1095,7 @@ PYEOF
     fi
 fi
 
-ui_step "Python environment"
+ui_step "Python environment" "~30-90s"
 
 if [[ ! -d "${VENV_DIR}" ]]; then
     "${PY}" -m venv "${VENV_DIR}"
@@ -1098,7 +1163,7 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
     fi
 fi
 
-ui_step "Node.js toolchain"
+ui_step "Node.js toolchain" "~5-60s (skipped if Node is already present)"
 
 UI_DIR="${REPO_ROOT}/ui"
 UI_DIST="${UI_DIR}/dist"
@@ -1124,7 +1189,7 @@ else
     warn "  install manually: https://nodejs.org/en/download (or your distro's nodejs/NodeSource package), then re-run install.sh"
 fi
 
-ui_step "Dashboard UI"
+ui_step "Dashboard UI" "~60-180s (skipped when a prebuilt ui/dist ships)"
 
 # Staleness gate for source trees (same class as the venv same-version trap):
 # "dist exists" is NOT "dist is current". Stamp a local build with the ui/
@@ -1194,7 +1259,7 @@ else
     warn "  install Node 20 LTS, then: cd ${UI_DIR} && npm install && npm run build"
 fi
 
-ui_step "Configuration"
+ui_step "Configuration" "~1-2s"
 
 HAL0_TOML="${ETC_DIR}/hal0.toml"
 if [[ ! -f "${HAL0_TOML}" ]]; then
@@ -1569,7 +1634,7 @@ else
     warn "failed to write openwebui.env — OpenWebUI may not start"
 fi
 
-ui_step "Systemd units"
+ui_step "Systemd units" "~2-5s"
 
 # WorkingDirectory follows `current` in prod so a `hal0 update` symlink swap
 # moves it to the new tree without rewriting the unit; dev uses the checkout.
@@ -2170,16 +2235,18 @@ fi
 # The unit also has ExecStartPre=podman pull (idempotent), so a missed
 # background pull never breaks correctness — only first-boot latency.
 if [[ "${DEV_MODE}" -eq 0 && "${NO_START}" -eq 0 ]] && command -v podman >/dev/null 2>&1; then
-    # Background the actual pull, but spin briefly so the user sees we
-    # kicked it off. The hal0-openwebui unit also has ExecStartPre=podman
-    # pull (idempotent), so missing this background pull only costs first
-    # -boot latency, not correctness.
-    (podman pull "${OPENWEBUI_IMAGE}" >/dev/null 2>&1 || true) &
+    # Background the actual pull (with retry/backoff — lib/pull-retry.sh —
+    # so a single transient registry blip doesn't waste the warm-cache
+    # attempt entirely), but spin briefly so the user sees we kicked it
+    # off. The hal0-openwebui unit also has ExecStartPre=podman pull
+    # (idempotent), so missing this background pull only costs first-boot
+    # latency, not correctness.
+    (hal0_pull_with_retry podman "${OPENWEBUI_IMAGE}" >/dev/null 2>&1 || true) &
     disown
     ui_spinner_run "Pulling ${OPENWEBUI_IMAGE} in background" sleep 3
 fi
 
-ui_step "Container slot seeds"
+ui_step "Container slot seeds" "~1-2s"
 
 # ── Container slot seeds (A10) ────────────────────────────────────────────
 # Pre-populate /etc/hal0/slots/{flm,tts,rerank,utility,img,agent,brain,…}.toml
@@ -2325,7 +2392,7 @@ if (( SEEDED_EXISTING_SLOTS > 0 )) && (( ${#SEEDED_NEW_SLOTS[@]} > 0 )); then
     info "      not a stray slot — each stays inert until you bind a model to it."
 fi
 
-ui_step "Hardware probe"
+ui_step "Hardware probe" "~10-30s"
 
 if [[ "${HAL0_SKIP_SETUP:-0}" == "1" || "${HAL0_NO_PROBE:-0}" == "1" ]]; then
     info "Skipping first-run seeding (HAL0_SKIP_SETUP/HAL0_NO_PROBE set)."
@@ -2451,7 +2518,7 @@ fi
 # UI_STEP_TOTAL is unchanged) because it is the second half of one story: the
 # brain pull makes the steward work out of the box (chat AND native tool
 # calls); the agent pull adds the bigger fallback tool-caller.
-ui_step "Steward + agent models"
+ui_step "Steward + agent models" "~1-5 min (model download; size varies)"
 
 if [[ "${DEV_MODE}" -eq 1 ]]; then
     info "dev mode — skipping the brain model pull (no system writes)"
@@ -2578,7 +2645,7 @@ fi
 #      (NPU-less hal0 still ships — FLM trio gates on `flm validate`).
 #
 # Refs: ADR-0009 (FLM trio NPU packing).
-ui_step "NPU prerequisites (FastFlowLM)"
+ui_step "NPU prerequisites (FastFlowLM)" "~10-60s (apt hosts only)"
 
 # Pinned FLM .deb — bump in lockstep with ADR-0009 and the toolbox image
 # tag in manifest.json (both 0.9.44 as of v0.9.6). NOTE (since 0.9.43):
@@ -3040,7 +3107,7 @@ fi
 # (#984, also resolves #874).  We still create the model-share subdirectories
 # and seed the optional helper assets (custom nodes, extra_model_paths.yaml)
 # because the img slot bind-mounts the same paths.
-ui_step "ComfyUI model share"
+ui_step "ComfyUI model share" "~2-10s"
 
 COMFYUI_CUSTOM_NODES_SRC="${REPO_ROOT}/installer/comfyui/custom_nodes"
 COMFYUI_MODELS_ROOT="/mnt/ai-models/comfyui"
@@ -3178,7 +3245,7 @@ fi
 # Idempotent: re-running install.sh overwrites each manifest. Manifests
 # are tiny (a few KB) and the copy is fast, so we don't bother with
 # content hashing.
-ui_step "Bundle picker manifests"
+ui_step "Bundle picker manifests" "~1s"
 
 BUNDLES_SRC="${REPO_ROOT}/installer/manifests/omni"
 BUNDLES_DST="${VAR_DIR}/models/collections/omni"
@@ -3208,7 +3275,7 @@ fi
 # (also on external_dirs): new skills install just by dropping a folder in, and
 # editing is a plain file edit. This must run BEFORE the hermes provision in
 # "Service start" so the mirror finds the shipped source. Idempotent.
-ui_step "Bundled agent skills"
+ui_step "Bundled agent skills" "~2-5s"
 
 SKILLS_SRC="${REPO_ROOT}/installer/agent-skills"
 SKILLS_SHIP="/usr/share/hal0/skills"
@@ -3231,7 +3298,7 @@ else
     info "dev mode — skipping system skill install (/usr/share/hal0/skills)"
 fi
 
-ui_step "Service start"
+ui_step "Service start" "~30-90s"
 
 # P4-model-layout backstop: the v0.1→v0.2 model-layout migration
 # (src/hal0/cli/migrate_commands.py) reads registry.toml + the on-disk
@@ -3977,6 +4044,126 @@ SUMMARY_LINES+=(
 )
 
 ui_box "hal0 is ready" "${SUMMARY_LINES[@]}"
+
+# Close out the last step's measured duration (ui_step only closes the
+# PREVIOUS step when the next one starts, so "Service start" needs this
+# explicit finalize) and report the total wall-clock time.
+ui_step_finalize
+info "Total install time: $((SECONDS / 60))m $((SECONDS % 60))s"
+
+# ── --summary-json ───────────────────────────────────────────────────────────
+# Versioned, machine-readable install summary (docs/getting-started/install.mdx).
+# Written atomically (tempfile + fsync + os.replace) so a reader never sees a
+# half-written file. Best-effort: a write failure here never fails the install
+# that already succeeded.
+if [[ -n "${SUMMARY_JSON_PATH}" ]]; then
+    _summary_hw_class_id="unknown"
+    _summary_hw_class_label="unknown"
+    if [[ -f /etc/hal0/hardware.json ]]; then
+        read -r _summary_hw_class_id _summary_hw_class_label < <(
+            "${PY}" - <<'PYEOF' 2>/dev/null || printf 'unknown unknown\n'
+import json
+try:
+    data = json.load(open("/etc/hal0/hardware.json"))
+except Exception:
+    print("unknown unknown")
+else:
+    hc = data.get("hardware_class") or {}
+    cid = str(hc.get("id", "unknown")).replace(" ", "_") or "unknown"
+    label = str(hc.get("label", "unknown")).replace(" ", "_") or "unknown"
+    print(f"{cid} {label}")
+PYEOF
+        )
+    fi
+    _summary_brain_model="$(grep -m1 '^  brain model: ' "${HAL0_INSTALL_LOG:-/dev/null}" 2>/dev/null \
+        | sed -E 's/^  brain model: ([^ ]+).*/\1/')"
+
+    _summary_steps_blob=""
+    for _summary_step_title in "${!UI_STEP_DURATIONS[@]}"; do
+        _summary_steps_blob+="${_summary_step_title}=${UI_STEP_DURATIONS[$_summary_step_title]}"$'\x1e'
+    done
+    export HAL0_STEP_DURATIONS_BLOB="${_summary_steps_blob}"
+
+    "${PY}" - \
+        "${SUMMARY_JSON_PATH}" \
+        "$(_ui_read_version)" \
+        "${DEV_MODE}" "${NO_START}" \
+        "${LIB_DIR:-}" "${MODELS_DIR:-}" \
+        "0.0.0.0" "${HAL0_PORT}" "3001" \
+        "${_summary_hw_class_id}" "${_summary_hw_class_label}" \
+        "${_summary_brain_model:-none}" \
+        "${UI_WARN_COUNT:-0}" "${UI_ERR_COUNT:-0}" \
+        "${SECONDS}" \
+        <<'PYEOF' || warn "could not write --summary-json to ${SUMMARY_JSON_PATH}"
+import json
+import os
+import pathlib
+import sys
+import tempfile
+from datetime import datetime, timezone
+
+(
+    out_file, version, dev_mode, no_start, prefix, models_dir,
+    bind_host, port, openwebui_port, hw_class_id, hw_class_label,
+    brain_model, warn_count, err_count, elapsed_seconds,
+) = sys.argv[1:]
+
+# UI_STEP_DURATIONS (bash assoc array "Title=seconds") is exported as one
+# NUL-joined blob via HAL0_STEP_DURATIONS_BLOB below rather than argv, since
+# step titles contain spaces/parens that don't survive positional argv cleanly.
+steps = {}
+blob = os.environ.get("HAL0_STEP_DURATIONS_BLOB", "")
+for entry in blob.split("\x1e"):
+    if "=" not in entry:
+        continue
+    title, _, secs = entry.rpartition("=")
+    if title:
+        try:
+            steps[title] = int(secs)
+        except ValueError:
+            pass
+
+payload = {
+    "schema": "hal0.install-summary.v1",
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "hal0_version": version,
+    "install": {
+        "dev_mode": dev_mode == "1",
+        "no_start": no_start == "1",
+        "prefix": prefix or None,
+        "models_dir": models_dir or None,
+    },
+    "network": {
+        "bind_host": bind_host,
+        "port": int(port),
+        "openwebui_port": int(openwebui_port),
+    },
+    "hardware_class": {"id": hw_class_id, "label": hw_class_label},
+    "brain_model": None if brain_model == "none" else brain_model,
+    "warnings": int(warn_count),
+    "errors": int(err_count),
+    "elapsed_seconds": int(elapsed_seconds),
+    "step_durations_seconds": steps,
+}
+
+path = pathlib.Path(out_file)
+path.parent.mkdir(parents=True, exist_ok=True)
+fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(json.dumps(payload, indent=2) + "\n")
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, str(path))
+except BaseException:
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    raise
+print(f"[INFO] Wrote install summary JSON: {out_file}")
+PYEOF
+fi
 
 # ── No Stage-2 handoff (v1.0) ───────────────────────────────────────────────
 # There used to be a "Launch the guided hal0 setup now? [Y/n]" prompt here

--- a/installer/lib/distro.sh
+++ b/installer/lib/distro.sh
@@ -1,32 +1,35 @@
 #!/usr/bin/env bash
-# installer/lib/distro.sh — distro / package-manager detection.
+# installer/lib/distro.sh
 #
-# Sourced by install.sh, lib/preflight.sh, and `hal0 doctor` so the one
-# place that knows "what distro is this and how do I name an install
-# command" lives here instead of being string-matched in three files.
-#
-# All functions are pure: they read /etc/os-release and probe PATH, echo
-# a result, and return 0/1. None of them mutate the caller's environment
-# (os-release is sourced in a subshell so its ID/NAME/VERSION vars never
-# leak in and clobber installer state).
-#
-# Sourcing this file twice is a no-op (guard below), so install.sh can
-# source it explicitly and preflight.sh can source it again for its
-# standalone `hal0 doctor` path without double-defining anything.
-#
-# Public API:
-#   distro_id            — /etc/os-release ID            (fedora, ubuntu, arch…)
-#   distro_id_like       — /etc/os-release ID_LIKE       (e.g. "debian", "arch")
-#   distro_pretty        — human name (PRETTY_NAME → NAME → ID → "this host")
-#   pkg_mgr              — host package manager command   (apt-get|dnf|yum|
-#                          zypper|pacman|apk) or non-zero if none recognised
-#   distro_family        — ecosystem bucket              (debian|fedora|suse|
-#                          arch|alpine) used to pick package names
-#   pkg_install_cmd PKG… — the full one-liner an operator runs to install
-#                          PKG… with the detected manager (incl. sudo)
-#   python_venv_hint     — install one-liner for a `python3 -m venv`-capable
-#                          Python on this distro (Debian splits out
-#                          python3-venv; most others bundle it)
+# Purpose: Distro / package-manager detection — the one place that knows
+#          "what distro is this and how do I name an install command",
+#          instead of that being string-matched in three files.
+# Expects: Sourced by install.sh, lib/preflight.sh, and `hal0 doctor`.
+#          Reads /etc/os-release and probes PATH; sourcing it twice is a
+#          no-op (guard below). All functions are pure — they read state
+#          and return 0/1, never mutating the caller's environment
+#          (os-release is sourced in a subshell so its ID/NAME/VERSION
+#          vars never leak in and clobber installer state).
+# Provides: distro_id            — /etc/os-release ID (fedora, ubuntu, arch…)
+#          distro_id_like       — /etc/os-release ID_LIKE (e.g. "debian", "arch")
+#          distro_pretty        — human name (PRETTY_NAME → NAME → ID → "this host")
+#          pkg_mgr              — host package manager command (apt-get|dnf|
+#                                 yum|zypper|pacman|apk) or non-zero if none
+#                                 recognised
+#          distro_family        — ecosystem bucket (debian|fedora|suse|
+#                                 arch|alpine) used to pick package names
+#          pkg_install_cmd PKG… — the full one-liner an operator runs to
+#                                 install PKG… with the detected manager
+#                                 (incl. sudo)
+#          python_venv_hint     — install one-liner for a
+#                                 `python3 -m venv`-capable Python on this
+#                                 distro (Debian splits out python3-venv;
+#                                 most others bundle it)
+# Modder notes:
+#   Add a new distro by extending the ID/ID_LIKE matches in `pkg_mgr` and
+#   `distro_family` together — they must stay in lockstep, since every
+#   caller picks package names from `distro_family` but the install
+#   *command* from `pkg_mgr`.
 
 [[ -n "${_HAL0_DISTRO_SH_LOADED:-}" ]] && return 0
 _HAL0_DISTRO_SH_LOADED=1

--- a/installer/lib/failure-report.sh
+++ b/installer/lib/failure-report.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# installer/lib/failure-report.sh
+#
+# Purpose: On installer failure, write one bounded, shareable
+#          `hal0-install-report-<ts>.txt` an operator can attach to a bug
+#          report — redacted env, port owners, hal0 unit status, a log
+#          tail, and a hardware summary — instead of asking them to
+#          re-paste a scrollback by hand.
+# Expects: Called from install.sh's ERR trap (CURRENT_STEP, HAL0_INSTALL_LOG
+#          from lib/logging.sh, and lib/ui.sh's warn()/err() are already in
+#          scope by the time the trap fires). Works with none of those set
+#          too — every field degrades to "unknown" rather than erroring.
+# Provides: hal0_write_failure_report(phase) -> prints the report path on
+#           stdout and returns 0, or returns 1 if the report could not be
+#           written anywhere.
+# Modder notes:
+#   The redaction list here is a bash mirror of
+#   src/hal0/api/_redact.py's _SENSITIVE_RE key-name pattern — the two
+#   must be kept in sync by hand (there is no shared source between a
+#   Python regex and a bash one); test_failure_report_redaction.py pins
+#   both against the same fixture set so a drift is caught in CI.
+
+# shellcheck shell=bash
+
+[[ -n "${_HAL0_FAILURE_REPORT_SH_LOADED:-}" ]] && return 0
+_HAL0_FAILURE_REPORT_SH_LOADED=1
+
+if ! command -v warn >/dev/null 2>&1; then
+    warn() { printf 'WARN  %s\n' "$*" >&2; }
+fi
+
+# Mirrors hal0.api._redact._SENSITIVE_RE: SECRET|TOKEN|PASSWORD|PASS|
+# API_KEY|PRIVATE_KEY|ENCRYPTION_KEY|SALT|_KEY$|^KEY$ (case-insensitive).
+_hal0_report_key_is_sensitive() {
+    local key="$1"
+    shopt -s nocasematch
+    local hit=1
+    if [[ "$key" =~ (SECRET|TOKEN|PASSWORD|PASS|API_KEY|PRIVATE_KEY|ENCRYPTION_KEY|SALT|_KEY$|^KEY$) ]]; then
+        hit=0
+    fi
+    shopt -u nocasematch
+    return $hit
+}
+
+# Redact a KEY=value env-style stream on stdin: sensitive keys keep their
+# name but lose their value (matches _redact.py's {value: "***REDACTED***"}
+# projection, adapted to flat env-file text).
+_hal0_report_redact_env_stream() {
+    local line key
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)= ]]; then
+            key="${BASH_REMATCH[1]}"
+            if _hal0_report_key_is_sensitive "$key"; then
+                printf '%s=***REDACTED***\n' "$key"
+                continue
+            fi
+        fi
+        printf '%s\n' "$line"
+    done
+}
+
+_hal0_report_port_line() {
+    local label="$1" port="$2"
+    local detail=""
+    if command -v ss >/dev/null 2>&1; then
+        detail="$(ss -ltnp 2>/dev/null | awk -v p=":${port}\$" '$4 ~ p {print}')"
+    fi
+    if [[ -n "$detail" ]]; then
+        printf -- '- %s :%s occupied\n%s\n' "$label" "$port" "$(printf '%s\n' "$detail" | sed 's/^/    /')"
+    else
+        printf -- '- %s :%s free (or ss unavailable / needs root to show the owner)\n' "$label" "$port"
+    fi
+}
+
+hal0_write_failure_report() {
+    local phase="${1:-unknown}"
+    local dir stamp report
+    stamp="$(date -u +%Y%m%d-%H%M%S)"
+    if [[ -n "${HAL0_INSTALL_LOG:-}" ]]; then
+        dir="$(dirname "${HAL0_INSTALL_LOG}")"
+    elif [[ "$(id -u)" -eq 0 ]]; then
+        dir="/var/log/hal0"
+    else
+        dir="/tmp"
+    fi
+    mkdir -p "$dir" 2>/dev/null || dir="/tmp"
+    report="${dir}/hal0-install-report-${stamp}.txt"
+
+    {
+        echo "hal0 install failure report"
+        echo "Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        echo "Phase: ${phase}"
+        echo ""
+        echo "Privacy note"
+        echo "- Environment values whose KEY name looks like a secret are redacted."
+        echo "- Review before posting publicly."
+        echo ""
+        echo "Summary"
+        echo "- hal0 version: $(_ui_read_version 2>/dev/null || echo unknown)"
+        echo "- Install log: ${HAL0_INSTALL_LOG:-none}"
+        echo "- Prefix: ${LIB_DIR:-${HAL0_PREFIX:-unknown}}"
+        echo ""
+        echo "Environment (redacted)"
+        env | sort | _hal0_report_redact_env_stream
+        echo ""
+        echo "Port owners"
+        _hal0_report_port_line "hal0-api" "${HAL0_PORT:-8080}"
+        _hal0_report_port_line "hal0-openwebui" "3001"
+        echo ""
+        echo "hal0 systemd units"
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl status --no-pager -l 'hal0-api' 'hal0-openwebui' 'hal0.target' 2>&1 | sed -n '1,120p'
+        else
+            echo "systemctl not found (--dev / non-systemd host)"
+        fi
+        echo ""
+        echo "Hardware probe (/etc/hal0/hardware.json)"
+        if [[ -f /etc/hal0/hardware.json ]]; then
+            cat /etc/hal0/hardware.json
+        else
+            echo "not present"
+        fi
+        echo ""
+        echo "Install log tail (last 200 lines)"
+        if [[ -n "${HAL0_INSTALL_LOG:-}" && -f "${HAL0_INSTALL_LOG}" ]]; then
+            tail -n 200 "${HAL0_INSTALL_LOG}"
+        else
+            echo "install log unavailable"
+        fi
+    } >"$report" 2>&1
+
+    if [[ -s "$report" ]]; then
+        printf '%s\n' "$report"
+        return 0
+    fi
+    return 1
+}

--- a/installer/lib/logging.sh
+++ b/installer/lib/logging.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# installer/lib/logging.sh
+#
+# Purpose: Tee every line the installer prints — narrator output plus every
+#          spawned command's stdout/stderr — to a durable on-disk log, so a
+#          failed or partial install leaves forensic evidence behind instead
+#          of living only in a terminal scrollback nobody saved.
+# Expects: Sourced once, early in install.sh, before any output the caller
+#          wants captured. No dependency on lib/ui.sh (this file works
+#          standalone), though install.sh sources it right after ui.sh by
+#          convention so the banner itself is captured too.
+# Provides: hal0_install_log_path()  — pure: prints the path this run would
+#             use, without creating anything.
+#           hal0_install_log_init()  — picks the path, creates its directory,
+#             and re-points the CALLING SHELL's stdout/stderr through
+#             `tee -a` so every subsequent line (including output from
+#             sourced libs, subshells, and third-party tools like pip/npm/
+#             apt-get) lands in the log. Exports HAL0_INSTALL_LOG.
+# Modder notes:
+#   exec-based teeing (not a per-`echo` wrapper) so nothing in the rest of
+#   the ~4,000-line install.sh has to change to be captured. Root gets
+#   /var/log/hal0/install-<ts>.log (FHS: persistent host logs); anything
+#   without root (a `--dev` run, or `bash install.sh` without sudo) falls
+#   back to /tmp/hal0-install-<ts>.log since /var/log/hal0 is root-owned.
+#   A read-only /tmp (rare, but seen on some hardened containers) degrades
+#   to no log rather than aborting the install over forensics — check
+#   `HAL0_INSTALL_LOG` for emptiness before relying on it.
+
+# shellcheck shell=bash
+
+[[ -n "${_HAL0_LOGGING_SH_LOADED:-}" ]] && return 0
+_HAL0_LOGGING_SH_LOADED=1
+
+hal0_install_log_path() {
+    local ts
+    ts="$(date -u +%Y%m%d-%H%M%S)"
+    if [[ "$(id -u)" -eq 0 ]]; then
+        printf '/var/log/hal0/install-%s.log\n' "$ts"
+    else
+        printf '/tmp/hal0-install-%s.log\n' "$ts"
+    fi
+}
+
+# hal0_install_log_init — idempotent (a second call is a no-op once
+# HAL0_INSTALL_LOG is set), so install.sh can call it unconditionally even
+# if a future refactor sources this file more than once.
+hal0_install_log_init() {
+    [[ -n "${HAL0_INSTALL_LOG:-}" ]] && return 0
+
+    local path
+    path="$(hal0_install_log_path)"
+    if ! mkdir -p "$(dirname "$path")" 2>/dev/null || ! : >"$path" 2>/dev/null; then
+        # Root's /var/log/hal0 couldn't be created/written (read-only FS,
+        # unusual SELinux policy, ...) — fall back to /tmp before giving up
+        # on a log entirely.
+        path="/tmp/hal0-install-$(date -u +%Y%m%d-%H%M%S).log"
+        if ! : >"$path" 2>/dev/null; then
+            HAL0_INSTALL_LOG=""
+            export HAL0_INSTALL_LOG
+            return 1
+        fi
+    fi
+    chmod 0644 "$path" 2>/dev/null || true
+
+    HAL0_INSTALL_LOG="$path"
+    export HAL0_INSTALL_LOG
+    # Duplicate every line of stdout/stderr into the log while still showing
+    # it on the terminal. Two independent `tee`s (rather than one merged
+    # stream) keep stdout/stderr on their original fds for anything
+    # downstream that distinguishes them (e.g. `2>/dev/null` callers).
+    exec > >(tee -a "$path") 2> >(tee -a "$path" >&2)
+}

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-# installer/lib/preflight.sh — re-runnable pre-flight checks.
+# installer/lib/preflight.sh
 #
-# Sourceable: install.sh dot-sources this to do its inline preflight.
-# Executable: `bash installer/lib/preflight.sh` runs preflight_all and
-#             exits with the aggregate status. `hal0 doctor` shells
-#             this in executable mode.
-#
-# Public API (all functions return 0 on success, non-zero on failure;
-# none of them exit the calling shell):
+# Purpose: Re-runnable pre-flight checks (systemd, Python floor, container
+#          runtime, GPU/NPU device visibility, disk, ports, privileged-seam
+#          verification, ...) shared between install.sh and `hal0 doctor`.
+# Expects: Sourceable — install.sh dot-sources this to do its inline
+#          preflight. Executable — `bash installer/lib/preflight.sh` runs
+#          preflight_all and exits with the aggregate status; `hal0 doctor`
+#          shells this in executable mode.
+# Provides (all functions return 0 on success, non-zero on failure; none
+# of them exit the calling shell):
 #   hal0_lxc_kind              — platform classification: none |
 #                                lxc-privileged | lxc-unprivileged. Decides
 #                                which remedies are possible from inside (a
@@ -110,6 +112,12 @@
 #                        (see HAL0_GPU_RC_*) instead of always 0, so install.sh
 #                        can smart-block a broken LXC passthrough. Default 0 →
 #                        soft/advisory mode for `hal0 doctor`.
+#
+# Modder notes:
+#   Each preflight_* function is soft-by-default (returns 0 with a warning)
+#   and only gates the install when its matching HAL0_*_REQUIRED/_GATE env
+#   is set — keep new checks on that same pattern so `hal0 doctor` (which
+#   never sets those flags) stays purely advisory.
 
 # shellcheck shell=bash
 

--- a/installer/lib/pull-retry.sh
+++ b/installer/lib/pull-retry.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# installer/lib/pull-retry.sh
+#
+# Purpose: Backoff + non-retryable classification for container-image pulls,
+#          so a flaky registry connection gets a few honest retries while an
+#          auth/404/out-of-space failure fails fast instead of spinning.
+# Expects: A sourced installer environment — `warn`/`err`/`info` from
+#          lib/ui.sh (used for progress messages; falls back to plain
+#          `echo` if ui.sh was not sourced, so this file also works
+#          standalone under a bats/pytest harness).
+# Provides: hal0_pull_backoff_delay(attempt), hal0_pull_is_retryable(text),
+#           hal0_pull_with_retry(runtime, image, [max_attempts])
+# Modder notes:
+#   The backoff table and non-retryable pattern are the two knobs a modder
+#   is likely to want to change; both are overridable via env
+#   (HAL0_PULL_RETRY_DELAYS, HAL0_PULL_MAX_ATTEMPTS) rather than requiring an
+#   edit here. The post-pull `inspect` verification catches the case where
+#   the pull subprocess exits 0 but the image never lands in local storage
+#   (seen with some rootless podman + overlay combinations under disk
+#   pressure) — do not remove it as a "redundant" check.
+
+# shellcheck shell=bash
+
+# Fall back to plain stderr writers when lib/ui.sh was not sourced (e.g. a
+# standalone test harness) so this file has no hard dependency on it.
+if ! command -v warn >/dev/null 2>&1; then
+    warn() { printf 'WARN  %s\n' "$*" >&2; }
+fi
+if ! command -v err >/dev/null 2>&1; then
+    err() { printf 'ERROR %s\n' "$*" >&2; }
+fi
+if ! command -v info >/dev/null 2>&1; then
+    info() { printf 'INFO  %s\n' "$*"; }
+fi
+
+# Non-retryable failure signatures: auth/permission, 404/manifest-unknown,
+# and out-of-space/daemon-unreachable are never fixed by trying again.
+# Everything else (DNS blip, connection reset, registry 5xx, timeout) is
+# treated as transient and gets the backoff table below.
+_HAL0_PULL_NONRETRYABLE_RE='unauthorized|authentication required|denied|forbidden|not[[:space:]-]?found|manifest unknown|\b404\b|no space left on device|cannot connect to the .*daemon'
+
+# hal0_pull_is_retryable TEXT — 0 (retry it) unless TEXT matches a known
+# non-retryable signature, in which case 1 (give up now).
+hal0_pull_is_retryable() {
+    local text="$1"
+    if printf '%s' "$text" | grep -qiE "${_HAL0_PULL_NONRETRYABLE_RE}"; then
+        return 1
+    fi
+    return 0
+}
+
+# hal0_pull_backoff_delay ATTEMPT — seconds to sleep before retry #ATTEMPT
+# (1-indexed: the wait before the 2nd overall attempt is delay(1)). Reads
+# HAL0_PULL_RETRY_DELAYS (space-separated seconds) or falls back to
+# "5 15 30 60"; past the end of the table the last value doubles per extra
+# step, same shape as the ODS reference implementation.
+hal0_pull_backoff_delay() {
+    local attempt="$1"
+    local default_delays=(5 15 30 60)
+    local -a delays
+    # shellcheck disable=SC2206  # word-splitting HAL0_PULL_RETRY_DELAYS is intentional
+    delays=(${HAL0_PULL_RETRY_DELAYS:-${default_delays[*]}})
+    [[ ${#delays[@]} -eq 0 ]] && delays=("${default_delays[@]}")
+
+    local idx=$((attempt - 1))
+    local delay="${delays[$idx]:-}"
+    if [[ -z "$delay" ]]; then
+        local last_idx=$((${#delays[@]} - 1))
+        delay="${delays[$last_idx]}"
+        [[ "$delay" =~ ^[0-9]+$ ]] || delay="${default_delays[-1]}"
+        local extra=$((idx - last_idx)) step
+        for ((step = 0; step < extra; step++)); do
+            delay=$((delay * 2))
+        done
+    fi
+    [[ "$delay" =~ ^[0-9]+$ ]] || delay=30
+    printf '%s\n' "$delay"
+}
+
+# hal0_pull_with_retry RUNTIME IMAGE [MAX_ATTEMPTS]
+#
+# Runs `RUNTIME pull IMAGE`, retrying transient failures with backoff up to
+# MAX_ATTEMPTS (default HAL0_PULL_MAX_ATTEMPTS or 4). A non-retryable
+# failure (see hal0_pull_is_retryable) returns immediately. On an apparent
+# success, verifies the image actually landed in local storage with
+# `RUNTIME image exists` (falling back to `RUNTIME inspect` for older
+# podman/docker without the `image exists` subcommand) before declaring
+# victory — a pull that exits 0 without the image present is treated as a
+# retryable failure.
+hal0_pull_with_retry() {
+    local runtime="$1" image="$2"
+    local max_attempts="${3:-${HAL0_PULL_MAX_ATTEMPTS:-4}}"
+    [[ "$max_attempts" =~ ^[0-9]+$ && "$max_attempts" -ge 1 ]] || max_attempts=4
+
+    local attempt log
+    for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+        if ((attempt > 1)); then
+            local backoff
+            backoff="$(hal0_pull_backoff_delay $((attempt - 1)))"
+            warn "retry ${attempt}/${max_attempts} pulling ${image} (waiting ${backoff}s)"
+            sleep "$backoff"
+        fi
+
+        log="$(mktemp -t hal0-pull.XXXXXX)"
+        if "${runtime}" pull "${image}" >"${log}" 2>&1; then
+            if "${runtime}" image exists "${image}" 2>/dev/null \
+                || "${runtime}" inspect "${image}" >/dev/null 2>&1; then
+                rm -f "$log"
+                return 0
+            fi
+            warn "${runtime} pull ${image} exited 0 but the image is not in local storage — retrying"
+            rm -f "$log"
+            continue
+        fi
+
+        if ! hal0_pull_is_retryable "$(cat "$log")"; then
+            err "non-retryable failure pulling ${image}: $(tail -n1 "$log")"
+            rm -f "$log"
+            return 1
+        fi
+        warn "attempt ${attempt}/${max_attempts} failed pulling ${image}: $(tail -n1 "$log")"
+        rm -f "$log"
+    done
+
+    err "failed to pull ${image} after ${max_attempts} attempts"
+    return 1
+}

--- a/installer/lib/run-as-hal0.sh
+++ b/installer/lib/run-as-hal0.sh
@@ -1,28 +1,29 @@
 # shellcheck shell=sh
-# run-as-hal0.sh — sourced privilege-drop guard for hal0-managed wrappers.
+# run-as-hal0.sh
 #
-# hal0_ensure_runas <user> <cmd> [args...]
-#
-#   When the caller is root, RE-EXEC <cmd> as <user> with that user's HOME and
-#   a sanitized env (HERMES_HOME stripped), so a hal0-managed process never runs
-#   as root. Running as root would resolve `~/.hermes` to /root/.hermes (a
-#   split-brain state tree the hal0 service never reads) and create root:root
-#   files the hal0 user later can't read — the "root-clobber regression" (#843).
-#
+# Purpose: Sourced privilege-drop guard for hal0-managed wrappers —
+#          `hal0_ensure_runas <user> <cmd> [args...]` re-execs <cmd> as
+#          <user> (with that user's HOME and a sanitized env, HERMES_HOME
+#          stripped) when the caller is root, so a hal0-managed process
+#          never runs as root. Running as root would resolve `~/.hermes` to
+#          /root/.hermes (a split-brain state tree the hal0 service never
+#          reads) and create root:root files the hal0 user later can't read
+#          (the "root-clobber regression", #843).
+# Expects: POSIX sh (not bash — wrappers sourcing this may run under dash).
+#          HAL0_RUNAS_TEST_UID overrides the detected euid — TEST ONLY (we
+#          can't become root in CI); never set it in production.
+# Provides: hal0_ensure_runas <user> <cmd> [args...]
 #   * non-root caller      -> return 0; the caller proceeds with its own perms.
 #   * root + HAL0_ALLOW_ROOT (1/true/yes) -> return 0; deliberate root debug.
 #   * root, no <user>       -> return 0; nothing to drop to.
 #   * root                  -> exec <cmd...> as <user> (this process is replaced).
 #   * root, no dropper tool -> return non-zero + a refusal on stderr; we never
 #                              proceed silently as root.
-#
+# Modder notes:
 #   Privilege-drop tool preference: runuser (util-linux, sets HOME via passwd)
 #   -> setpriv --init-groups -> sudo -H. The command is always wrapped in
 #   `env HOME=<home> -u HERMES_HOME` so HOME is correct and any inherited
 #   HERMES_HOME is dropped regardless of which tool is used.
-#
-#   HAL0_RUNAS_TEST_UID overrides the detected euid — TEST ONLY (we can't become
-#   root in CI). Never set it in production.
 
 hal0_ensure_runas() {
     _hru_user="${1:-}"

--- a/installer/lib/ui.sh
+++ b/installer/lib/ui.sh
@@ -1,27 +1,29 @@
 #!/usr/bin/env bash
-# installer/lib/ui.sh — shared UI helpers for the hal0 installer family.
+# installer/lib/ui.sh
 #
-# Source from a sibling script with:
-#     source "$(dirname "${BASH_SOURCE[0]}")/lib/ui.sh"
-#
-# Public API
-#   ui_banner                    — 5-line ASCII banner with version
-#   ui_step "Title"              — incremental "── (n/N) Title ──"
-#   ui_spinner_run desc cmd...   — run cmd in background, foreground spinner
-#   ui_box "Title" "line1" ...   — Unicode box around a multi-line block
-#   info / warn / err / die      — log helpers (signatures unchanged)
-#
-# Globals honoured
-#   HAL0_PLAIN=1                 — disable banner/colors/box/spinner glyphs
-#   NO_COLOR=1                   — disable colors only (https://no-color.org)
-#   UI_STEP_TOTAL                — total step count (caller sets before first ui_step)
-#   HAL0_VERSION                 — override the version string
-#
-# Globals exported (for back-compat with existing scripts)
-#   RED YEL GRN BLU AMBER BOLD DIM RST
-#   UI_STEP_NUM                  — count of ui_step calls so far
-#   CURRENT_STEP                 — most recent ui_step title (useful in traps)
-#   UI_PLAIN                     — 1 if degraded mode is active
+# Purpose: Shared terminal UI for the hal0 installer family — banner, the
+#          "(n/N) Title" step counter with per-step time estimates and
+#          measured durations, a spinner for long-running commands, a
+#          boxed summary, and the info/warn/err/die log helpers.
+# Expects: Source from a sibling script with
+#          `source "$(dirname "${BASH_SOURCE[0]}")/lib/ui.sh"`. Honors
+#          HAL0_PLAIN=1 (disable banner/colors/box/spinner glyphs),
+#          NO_COLOR=1 (colors only, https://no-color.org), UI_STEP_TOTAL
+#          (caller sets before the first ui_step call), HAL0_VERSION
+#          (override the detected version string).
+# Provides: ui_banner; ui_step TITLE [ESTIMATE]; ui_step_finalize (closes
+#          out the last step's measured duration); ui_spinner_run desc
+#          cmd...; ui_box "Title" "line1" ...; info/warn/err/die.
+#          Exported for back-compat with existing scripts: RED YEL GRN BLU
+#          AMBER BOLD DIM RST, UI_STEP_NUM (count of ui_step calls so far),
+#          UI_STEP_DURATIONS (assoc array, title -> elapsed seconds),
+#          CURRENT_STEP (most recent ui_step title, read by the ERR trap),
+#          UI_PLAIN (1 if degraded mode is active).
+# Modder notes:
+#   Change the CRT-free hal0 theme (banner, box glyphs, spinner style) here.
+#   ui_step's estimate is advisory text only — it is never used for timing
+#   logic; UI_STEP_DURATIONS is the actual measured source of truth and is
+#   what --summary-json reports.
 
 # shellcheck shell=bash
 
@@ -143,17 +145,45 @@ ui_banner() {
 # ── ui_step ─────────────────────────────────────────────────────────────────
 # Caller sets UI_STEP_TOTAL before the first ui_step call. If unset, we
 # print "?" so a missing-config bug is visible rather than silently absent.
+#
+# ui_step TITLE [ESTIMATE]
+#   ESTIMATE is an optional honest range ("~10-30s", "~1-5 min") printed
+#   next to the title so an operator watching a quiet step (a pip install,
+#   a multi-GB model pull) knows whether to expect seconds or minutes.
+#   Omit it for a step with no meaningful wait.
+#
+# Measures wall-clock time PER STEP (via bash's $SECONDS, zero subprocess
+# cost) into UI_STEP_DURATIONS, keyed by title — install.sh's
+# `ui_step_finalize` (call once, after the last step's work is done) closes
+# out the final step's duration so --summary-json can report real numbers
+# instead of only estimates. Durations are best-effort bookkeeping, never
+# consulted for control flow, so a caller that never touches
+# UI_STEP_DURATIONS pays nothing extra beyond the array writes.
 UI_STEP_NUM=${UI_STEP_NUM:-0}
 CURRENT_STEP=""
+declare -A UI_STEP_DURATIONS 2>/dev/null || true
+_UI_STEP_LAST_TITLE=""
+_UI_STEP_LAST_START=0
 
 ui_step() {
+    local title="$1" estimate="${2:-}"
+
+    if [[ -n "${_UI_STEP_LAST_TITLE}" ]]; then
+        UI_STEP_DURATIONS["${_UI_STEP_LAST_TITLE}"]=$((SECONDS - _UI_STEP_LAST_START))
+    fi
+    _UI_STEP_LAST_TITLE="$title"
+    _UI_STEP_LAST_START="$SECONDS"
+
     UI_STEP_NUM=$((UI_STEP_NUM + 1))
-    CURRENT_STEP="$*"
+    CURRENT_STEP="$title"
     local total="${UI_STEP_TOTAL:-?}"
-    local title="$*"
+    local suffix=""
+    [[ -n "$estimate" ]] && suffix="  ${DIM}(EST. TIME: ${estimate})${RST}"
 
     if [[ "${UI_PLAIN}" == "1" ]]; then
-        printf '\n== (%s/%s) %s\n' "$UI_STEP_NUM" "$total" "$title"
+        local plain_suffix=""
+        [[ -n "$estimate" ]] && plain_suffix="  (EST. TIME: ${estimate})"
+        printf '\n== (%s/%s) %s%s\n' "$UI_STEP_NUM" "$total" "$title" "$plain_suffix"
         return 0
     fi
 
@@ -163,7 +193,19 @@ ui_step() {
     pad=$(( cols - ${#label} ))
     [[ $pad -lt 3 ]] && pad=3
     fill="$(_ui_repeat "${UI_GLYPH_BOX_H}" "$pad")"
-    printf '\n%s%s%s%s%s\n' "${BOLD}${AMBER}" "$label" "${RST}${AMBER}" "$fill" "${RST}"
+    printf '\n%s%s%s%s%s%s\n' "${BOLD}${AMBER}" "$label" "${RST}${AMBER}" "$fill" "${RST}" "$suffix"
+}
+
+# ui_step_finalize — close out the LAST step's duration. Call once, after
+# the final step's work completes and before reading UI_STEP_DURATIONS
+# (the success box, --summary-json) — otherwise the last entry is missing
+# since ui_step only closes out the *previous* step when the *next* one
+# starts.
+ui_step_finalize() {
+    if [[ -n "${_UI_STEP_LAST_TITLE}" ]]; then
+        UI_STEP_DURATIONS["${_UI_STEP_LAST_TITLE}"]=$((SECONDS - _UI_STEP_LAST_START))
+        _UI_STEP_LAST_TITLE=""
+    fi
 }
 
 # ── ui_spinner_run ──────────────────────────────────────────────────────────

--- a/src/hal0/cli/doctor_bundle.py
+++ b/src/hal0/cli/doctor_bundle.py
@@ -443,7 +443,50 @@ def _write_logs_section(out: Path, *, lines: int = 500) -> list[str]:
         dest = out / "logs" / f"{unit}.log"
         _run_one(argv, dest)
         captured.append(f"logs/{unit}.log")
+    captured += _write_install_log(out)
     return captured
+
+
+#: Where installer/lib/logging.sh's hal0_install_log_path() puts the tee'd
+#: install log — root gets /var/log/hal0, a --dev / non-root install falls
+#: back to /tmp. Both are globbed here so the bundle picks up whichever one
+#: this box actually has, newest first.
+_INSTALL_LOG_GLOBS: tuple[tuple[str, str], ...] = (
+    ("/var/log/hal0", "install-*.log"),
+    ("/tmp", "hal0-install-*.log"),
+)
+
+
+def _latest_install_log() -> Path | None:
+    candidates: list[Path] = []
+    for directory, pattern in _INSTALL_LOG_GLOBS:
+        d = Path(directory)
+        if d.is_dir():
+            candidates.extend(d.glob(pattern))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def _write_install_log(out: Path, *, lines: int = 500) -> list[str]:
+    """Copy the tail of the most recent installer log (installer/lib/logging.sh)
+    into the bundle, redacted like every other free-text capture (§3.1).
+
+    Best-effort: no install log on this box (a long-lived install predating
+    this feature, or a box whose /tmp was cleaned) writes nothing rather
+    than failing the bundle.
+    """
+    src = _latest_install_log()
+    if src is None:
+        return []
+    dest = out / "logs" / "install.log"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        tail = src.read_text(encoding="utf-8", errors="replace").splitlines()[-lines:]
+    except OSError:
+        return []
+    dest.write_text(_redact_text("\n".join(tail)) + "\n")
+    return ["logs/install.log"]
 
 
 # ── orchestration ────────────────────────────────────────────────────────────

--- a/src/hal0/registry/runner_pull.py
+++ b/src/hal0/registry/runner_pull.py
@@ -30,6 +30,7 @@ import re
 import secrets
 import tempfile
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -352,6 +353,51 @@ def write_local_marker(image_id: str, image_ref: str) -> Path:
     return path
 
 
+# ── retry discipline ─────────────────────────────────────────────────────────
+#
+# Mirrors installer/lib/pull-retry.sh's bash classifier/backoff so a manual
+# `install.sh` image pull and a dashboard-triggered runner-image pull fail
+# for the same reasons and back off on the same schedule. Kept in sync by
+# hand (there is no shared source between a bash and a Python regex) —
+# tests/registry/test_runner_pull_retry.py pins both against the same
+# fixture strings.
+
+#: Non-retryable failure signatures: auth/permission, 404/manifest-unknown,
+#: and out-of-space/daemon-unreachable are never fixed by trying again.
+_NONRETRYABLE_PULL_RE = re.compile(
+    r"unauthorized|authentication required|denied|forbidden|not[\s-]?found"
+    r"|manifest unknown|\b404\b|no space left on device|cannot connect to the .*daemon",
+    re.IGNORECASE,
+)
+
+#: Seconds to wait before retry N (1-indexed); past the table's end the last
+#: value doubles per extra step (see :func:`pull_backoff_delay`).
+_DEFAULT_PULL_RETRY_DELAYS: tuple[int, ...] = (5, 15, 30, 60)
+
+
+def is_retryable_pull_error(message: str | None) -> bool:
+    """``True`` unless *message* matches a known non-retryable signature.
+
+    Everything else (DNS blip, connection reset, registry 5xx, timeout) is
+    treated as transient and gets the backoff table. An empty/``None``
+    message (an exception with no useful text) is treated as retryable —
+    the conservative default when there's nothing to classify against.
+    """
+    if not message:
+        return True
+    return not _NONRETRYABLE_PULL_RE.search(message)
+
+
+def pull_backoff_delay(attempt: int, delays: tuple[int, ...] = _DEFAULT_PULL_RETRY_DELAYS) -> int:
+    """Seconds to sleep before retry ``#attempt`` (1-indexed: the wait
+    before the 2nd overall attempt is ``pull_backoff_delay(1)``)."""
+    idx = attempt - 1
+    if idx < len(delays):
+        return delays[idx]
+    extra = idx - (len(delays) - 1)
+    return int(delays[-1] * (2**extra))
+
+
 # ── job execution ────────────────────────────────────────────────────────────
 
 
@@ -360,6 +406,8 @@ async def run_runner_pull(
     *,
     store: RunnerImageStore,
     provider: Any,
+    max_attempts: int = 1,
+    sleep_fn: Callable[[float], Awaitable[None]] = asyncio.sleep,
 ) -> None:
     """Drive one runner-image pull to completion, updating ``job`` as it goes.
 
@@ -370,28 +418,89 @@ async def run_runner_pull(
     generator yields (podman itself has no cancel signal short of killing
     the subprocess, which ``pull_image_stream`` already does on generator
     close/GC).
+
+    ``max_attempts`` (default 1 — no retry) bounds how many times a
+    *retryable* failure (see :func:`is_retryable_pull_error`) is retried,
+    with :func:`pull_backoff_delay` backoff between attempts. A
+    non-retryable failure (auth/permission, 404/manifest-unknown, disk-full)
+    ends the job on the first occurrence regardless of ``max_attempts`` —
+    :mod:`hal0.registry.runner_pull_jobs` is the caller that opts real
+    dashboard-triggered pulls into multi-attempt retry; direct callers (and
+    every existing test) that omit the argument keep the original
+    single-attempt behaviour byte-for-byte. ``sleep_fn`` is the backoff
+    sleep, injectable so tests never wait on a real clock.
+
+    On an apparent success, verifies the image actually landed in local
+    storage via ``provider.image_present(image_ref)`` (tri-state: True/False
+    verified, None means "couldn't check" — see
+    :meth:`hal0.providers.container.ContainerProvider.image_present`) when
+    the provider exposes that method; a provider without it (every test
+    fake) skips verification and trusts the ``completed`` event, unchanged
+    from before this was added. ``False`` is treated as a retryable failure
+    — a pull that exits 0 without the image present is not success.
     """
     job.state = "running"
     job._signal()
-    try:
-        agen = provider.pull_image_stream(job.image_ref)
-        async for event in agen:
-            if job.cancel_requested:
-                job.state = "cancelled"
-                job.finished_at = time.time()
-                with contextlib.suppress(Exception):
-                    await agen.aclose()
-                job._signal()
-                return
-            state = event.get("state")
-            if state == "pulling":
-                job.layers_done = int(event.get("layer") or 0)
-                job.layers_total = int(event.get("total_layers") or 0)
-                job.line = event.get("line")
-                job._signal()
-            elif state == "completed":
-                job.layers_done = int(event.get("layer") or job.layers_done)
-                job.layers_total = int(event.get("total_layers") or job.layers_total)
+
+    last_error: str | None = None
+    for attempt in range(1, max_attempts + 1):
+        if job.cancel_requested:
+            job.state = "cancelled"
+            job.finished_at = time.time()
+            job._signal()
+            return
+
+        job.layers_done = 0
+        job.layers_total = 0
+        outcome: str | None = None  # "completed" | "failed" | None (cancelled, returned already)
+
+        try:
+            agen = provider.pull_image_stream(job.image_ref)
+            async for event in agen:
+                if job.cancel_requested:
+                    job.state = "cancelled"
+                    job.finished_at = time.time()
+                    with contextlib.suppress(Exception):
+                        await agen.aclose()
+                    job._signal()
+                    return
+                state = event.get("state")
+                if state == "pulling":
+                    job.layers_done = int(event.get("layer") or 0)
+                    job.layers_total = int(event.get("total_layers") or 0)
+                    job.line = event.get("line")
+                    job._signal()
+                elif state == "completed":
+                    job.layers_done = int(event.get("layer") or job.layers_done)
+                    job.layers_total = int(event.get("total_layers") or job.layers_total)
+                    outcome = "completed"
+                    break
+                elif state == "failed":
+                    last_error = str(event.get("error") or "pull failed")
+                    outcome = "failed"
+                    break
+        except asyncio.CancelledError:
+            job.state = "cancelled"
+            job.finished_at = time.time()
+            job._signal()
+            raise
+        except Exception as exc:  # defensive: never leave a job stuck "running"
+            log.exception("runner_image.pull_unhandled_error image_id=%s", job.image_id)
+            last_error = str(exc)
+            outcome = "failed"
+
+        if outcome == "completed":
+            verify = getattr(provider, "image_present", None)
+            present: bool | None = True
+            if verify is not None:
+                try:
+                    present = await asyncio.to_thread(verify, job.image_ref)
+                except Exception:
+                    present = None  # inconclusive — don't punish a flaky verifier
+            if present is False:
+                last_error = f"pull reported success but {job.image_ref} is not in local storage"
+                outcome = "failed"
+            else:
                 marker = write_local_marker(job.image_id, job.image_ref)
                 job.local_path = str(marker)
                 job.state = "completed"
@@ -404,25 +513,19 @@ async def run_runner_pull(
                     )
                 job._signal()
                 return
-            elif state == "failed":
-                job.state = "failed"
-                job.error = str(event.get("error") or "pull failed")
-                job.error_code = "runner_image.pull_failed"
-                job.finished_at = time.time()
-                job._signal()
-                return
-    except asyncio.CancelledError:
-        job.state = "cancelled"
-        job.finished_at = time.time()
+
+        # outcome == "failed" here (event, exception, or failed post-pull verify).
+        if attempt >= max_attempts or not is_retryable_pull_error(last_error):
+            job.state = "failed"
+            job.error = last_error or "pull failed"
+            job.error_code = "runner_image.pull_failed"
+            job.finished_at = time.time()
+            job._signal()
+            return
+
+        job.line = f"retry {attempt + 1}/{max_attempts} after: {last_error}"
         job._signal()
-        raise
-    except Exception as exc:  # defensive: never leave a job stuck "running"
-        log.exception("runner_image.pull_unhandled_error image_id=%s", job.image_id)
-        job.state = "failed"
-        job.error = str(exc)
-        job.error_code = "runner_image.pull_failed"
-        job.finished_at = time.time()
-        job._signal()
+        await sleep_fn(pull_backoff_delay(attempt))
 
 
 __all__ = [
@@ -434,11 +537,13 @@ __all__ = [
     "RunnerPullJob",
     "RunnerPullJobNotFound",
     "RunnerPullPathEscape",
+    "is_retryable_pull_error",
     "list_persisted_jobs",
     "local_marker_path",
     "make_job",
     "persist_pull_job",
     "persisted_job_files",
+    "pull_backoff_delay",
     "pull_job_file",
     "run_runner_pull",
     "sweep_pull_jobs",

--- a/src/hal0/registry/runner_pull_jobs.py
+++ b/src/hal0/registry/runner_pull_jobs.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import os
 from collections.abc import Coroutine
 from typing import Any
 
@@ -85,6 +86,14 @@ def _default_provider_factory() -> Any:
 #: point this at a fake ``pull_image_stream``-shaped object instead of the
 #: real podman-backed singleton.
 provider_factory: Any = _default_provider_factory
+
+#: Retry attempts for a dashboard-triggered runner-image pull (backoff +
+#: non-retryable classification: see ``runner_pull.is_retryable_pull_error``
+#: / ``pull_backoff_delay``). ``run_runner_pull``'s own default (1, no
+#: retry) is for direct/test callers; this is where the real multi-attempt
+#: policy is opted into for the actual user-facing pull path. Override with
+#: HAL0_RUNNER_PULL_MAX_ATTEMPTS for a slower/flakier network.
+_PULL_MAX_ATTEMPTS = int(os.environ.get("HAL0_RUNNER_PULL_MAX_ATTEMPTS", "4"))
 
 
 async def enqueue(request: Request, *, image_id: str, tag: str | None = None) -> dict[str, object]:
@@ -153,7 +162,9 @@ async def enqueue(request: Request, *, image_id: str, tag: str | None = None) ->
 
     async def _run() -> None:
         try:
-            await run_runner_pull(job, store=store, provider=provider)
+            await run_runner_pull(
+                job, store=store, provider=provider, max_attempts=_PULL_MAX_ATTEMPTS
+            )
         finally:
             persist_pull_job(job)
             if event_bus is not None:

--- a/tests/cli/test_doctor_bundle.py
+++ b/tests/cli/test_doctor_bundle.py
@@ -182,6 +182,51 @@ def test_bundle_no_logs_flag_skips_logs_dir(tmp_hal0_home: str, tmp_path: Path) 
     assert "logs/" not in manifest["sections"]
 
 
+def test_bundle_includes_the_latest_install_log_redacted(
+    tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_dir = tmp_path / "var-log-hal0"
+    log_dir.mkdir()
+    older = log_dir / "install-20260101-000000.log"
+    older.write_text("stale run\nHF_TOKEN=hf_should_not_appear\n")
+    newer = log_dir / "install-20260102-000000.log"
+    newer.write_text("latest run\nAuthorization: Bearer super-secret-token\n")
+    # mtime, not filename order, decides "latest" — make it explicit.
+    import os
+    import time
+
+    now = time.time()
+    os.utime(older, (now - 100, now - 100))
+    os.utime(newer, (now, now))
+
+    monkeypatch.setattr(doctor_bundle, "_INSTALL_LOG_GLOBS", ((str(log_dir), "install-*.log"),))
+
+    out = tmp_path / "bundle"
+    build_bundle(out, include_rocm_smi=False)
+
+    dest = out / "logs" / "install.log"
+    assert dest.is_file()
+    body = dest.read_text()
+    assert "latest run" in body
+    assert "stale run" not in body
+    assert "super-secret-token" not in body
+    assert "Bearer ***REDACTED***" in body
+
+    manifest = jsonlib.loads((out / "manifest.json").read_text())
+    assert "logs/" in manifest["sections"]
+
+
+def test_bundle_with_no_install_log_present_writes_nothing_for_it(
+    tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        doctor_bundle, "_INSTALL_LOG_GLOBS", ((str(tmp_path / "nowhere"), "install-*.log"),)
+    )
+    out = tmp_path / "bundle"
+    build_bundle(out, include_rocm_smi=False)
+    assert not (out / "logs" / "install.log").exists()
+
+
 def test_bundle_returns_nonzero_failed_count_when_probes_missing(
     tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/installer/test_failure_report.py
+++ b/tests/installer/test_failure_report.py
@@ -1,0 +1,147 @@
+"""installer/lib/failure-report.sh — redacted install-failure reports.
+
+Same technique as test_seam_verification.py: source the file and invoke a
+function directly, no root/sudo/provisioned box needed.
+
+The bash redaction key-name pattern mirrors hal0.api._redact._SENSITIVE_RE
+(SECRET|TOKEN|PASSWORD|PASS|API_KEY|PRIVATE_KEY|ENCRYPTION_KEY|SALT|_KEY$|
+^KEY$) — test_redaction_matches_the_python_pattern pins both against the
+same fixture set so a drift is caught in CI.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+FAILURE_REPORT = REPO / "installer" / "lib" / "failure-report.sh"
+
+
+def _is_sensitive(key: str) -> bool:
+    proc = subprocess.run(
+        ["bash", "-c", f'source "{FAILURE_REPORT}"; _hal0_report_key_is_sensitive "{key}"'],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(REPO),
+    )
+    return proc.returncode == 0
+
+
+class TestKeySensitivity:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "HF_TOKEN",
+            "HUGGING_FACE_HUB_TOKEN",
+            "HAL0_ADMIN_KEY",
+            "HAL0_CLIENT_KEY",
+            "DB_PASSWORD",
+            "API_SECRET",
+            "ENCRYPTION_KEY",
+            "SALT",
+            "PRIVATE_KEY",
+        ],
+    )
+    def test_known_secret_shaped_keys_are_flagged(self, key: str) -> None:
+        assert _is_sensitive(key) is True
+
+    @pytest.mark.parametrize(
+        "key",
+        ["HAL0_PORT", "HAL0_PREFIX", "MODELS_DIR", "PATH", "KEY_ROTATION_DAYS", "KEYBOARD_LAYOUT"],
+    )
+    def test_ordinary_keys_are_not_flagged(self, key: str) -> None:
+        assert _is_sensitive(key) is False
+
+    def test_redaction_matches_the_python_pattern(self) -> None:
+        """Fixture-parity check against hal0.api._redact.is_sensitive_key —
+        catches the two regexes drifting apart."""
+        from hal0.api._redact import is_sensitive_key
+
+        fixtures = [
+            "HF_TOKEN",
+            "HAL0_ADMIN_KEY",
+            "HAL0_CLIENT_KEY",
+            "DB_PASSWORD",
+            "API_SECRET",
+            "ENCRYPTION_KEY",
+            "SALT",
+            "PRIVATE_KEY",
+            "HAL0_PORT",
+            "MODELS_DIR",
+            "PATH",
+            "KEY_ROTATION_DAYS",
+            "KEYBOARD_LAYOUT",
+        ]
+        for key in fixtures:
+            assert _is_sensitive(key) == is_sensitive_key(key), key
+
+
+class TestRedactEnvStream:
+    def test_sensitive_values_are_masked_key_preserved(self) -> None:
+        script = f"""
+source "{FAILURE_REPORT}"
+printf 'HAL0_PORT=8080\\nHF_TOKEN=hf_abcdef123456\\nMODELS_DIR=/data\\n' | _hal0_report_redact_env_stream
+"""
+        proc = subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, check=False, cwd=str(REPO)
+        )
+        lines = proc.stdout.splitlines()
+        assert "HAL0_PORT=8080" in lines
+        assert "MODELS_DIR=/data" in lines
+        assert "HF_TOKEN=***REDACTED***" in lines
+        assert "hf_abcdef123456" not in proc.stdout
+
+
+class TestWriteFailureReport:
+    def test_report_is_written_with_expected_sections_and_no_secret_leak(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_log = tmp_path / "install-test.log"
+        fake_log.write_text("some install log content\n")
+        script = f"""
+source "{FAILURE_REPORT}"
+export HAL0_INSTALL_LOG="{fake_log}"
+export HF_TOKEN="hf_super_secret_value"
+export HAL0_PORT="8080"
+report="$(hal0_write_failure_report "Python environment")"
+echo "report=$report"
+cat "$report"
+"""
+        proc = subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, check=False, cwd=str(REPO)
+        )
+        report_line = next(line for line in proc.stdout.splitlines() if line.startswith("report="))
+        report_path = Path(report_line.removeprefix("report="))
+        assert report_path.is_file(), proc.stdout
+
+        body = report_path.read_text()
+        assert "Phase: Python environment" in body
+        assert "Environment (redacted)" in body
+        assert "Port owners" in body
+        assert "hal0 systemd units" in body
+        assert "Hardware probe" in body
+        assert "Install log tail" in body
+        assert "some install log content" in body
+        assert "hf_super_secret_value" not in body
+        assert "HF_TOKEN=***REDACTED***" in body
+
+    def test_falls_back_to_tmp_when_no_install_log_dir_is_known(self, tmp_path: Path) -> None:
+        script = f"""
+source "{FAILURE_REPORT}"
+id() {{ echo 1000; }}
+unset HAL0_INSTALL_LOG
+report="$(hal0_write_failure_report "unknown")"
+echo "report=$report"
+"""
+        proc = subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, check=False, cwd=str(REPO)
+        )
+        report_line = next(line for line in proc.stdout.splitlines() if line.startswith("report="))
+        report_path = Path(report_line.removeprefix("report="))
+        assert report_path.is_file()
+        assert str(report_path).startswith("/tmp/hal0-install-report-")
+        report_path.unlink(missing_ok=True)

--- a/tests/installer/test_install_logging.py
+++ b/tests/installer/test_install_logging.py
@@ -1,0 +1,106 @@
+"""installer/lib/logging.sh — tee'd install log path selection.
+
+Same technique as test_seam_verification.py: source the file and invoke a
+function directly. The full `exec > >(tee ...)` redirect (hal0_install_log_init)
+is exercised through a real subshell so the tee side effect is observable
+without touching this test process's own stdout.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+LOGGING_SH = REPO / "installer" / "lib" / "logging.sh"
+
+
+def _run(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False, cwd=str(REPO)
+    )
+
+
+class TestLogPath:
+    def test_root_gets_a_var_log_hal0_path(self) -> None:
+        script = f"""
+source "{LOGGING_SH}"
+id() {{ echo 0; }}  # pretend to be root
+hal0_install_log_path
+"""
+        proc = _run(script)
+        path = proc.stdout.strip()
+        assert path.startswith("/var/log/hal0/install-"), proc.stdout
+        assert path.endswith(".log")
+
+    def test_non_root_gets_a_tmp_fallback_path(self) -> None:
+        script = f"""
+source "{LOGGING_SH}"
+id() {{ echo 1000; }}  # pretend to be non-root
+hal0_install_log_path
+"""
+        proc = _run(script)
+        path = proc.stdout.strip()
+        assert path.startswith("/tmp/hal0-install-"), proc.stdout
+
+
+class TestLogInit:
+    def test_init_creates_the_log_and_captures_subsequent_output(self, tmp_path: Path) -> None:
+        fake_log_dir = tmp_path / "var-log-hal0"
+        script = f"""
+source "{LOGGING_SH}"
+id() {{ echo 0; }}
+hal0_install_log_path() {{ printf '%s/install-test.log\\n' "{fake_log_dir}"; }}
+hal0_install_log_init
+echo "path=$HAL0_INSTALL_LOG"
+echo "hello from the installer"
+warn_line() {{ echo "a warning" >&2; }}
+warn_line
+"""
+        proc = _run(script)
+        assert "rc=" not in proc.stdout  # no crash marker expected
+        log_path_line = next(line for line in proc.stdout.splitlines() if line.startswith("path="))
+        log_path = log_path_line.removeprefix("path=")
+        assert Path(log_path).is_file()
+        captured = Path(log_path).read_text()
+        assert "hello from the installer" in captured
+        assert "a warning" in captured
+        # Still visible on the terminal too — tee, not redirect.
+        assert "hello from the installer" in proc.stdout
+        assert "a warning" in proc.stderr
+
+    def test_init_is_idempotent(self, tmp_path: Path) -> None:
+        fake_log_dir = tmp_path / "var-log-hal0"
+        script = f"""
+source "{LOGGING_SH}"
+id() {{ echo 0; }}
+hal0_install_log_path() {{ printf '%s/install-test.log\\n' "{fake_log_dir}"; }}
+hal0_install_log_init
+first="$HAL0_INSTALL_LOG"
+hal0_install_log_init
+second="$HAL0_INSTALL_LOG"
+[[ "$first" == "$second" ]] && echo "same"
+"""
+        proc = _run(script)
+        assert "same" in proc.stdout, proc.stdout
+
+    def test_an_unwritable_primary_path_falls_back_to_tmp(self) -> None:
+        """The FHS path (root-owned /var/log/hal0) can be unwritable even as
+        root — a read-only /var, an unusual mount policy. Fall back to /tmp
+        rather than aborting the install over forensics."""
+        script = f"""
+source "{LOGGING_SH}"
+id() {{ echo 0; }}
+hal0_install_log_path() {{ printf '/nonexistent-root-only-dir/install-test.log\\n'; }}
+hal0_install_log_init
+echo "rc=$?"
+echo "log=$HAL0_INSTALL_LOG"
+echo "still running"
+"""
+        proc = _run(script)
+        assert "still running" in proc.stdout, proc.stdout
+        log_line = next(line for line in proc.stdout.splitlines() if line.startswith("log="))
+        fallback_path = log_line.removeprefix("log=")
+        assert fallback_path.startswith("/tmp/hal0-install-"), proc.stdout
+        assert Path(fallback_path).is_file()
+        Path(fallback_path).unlink(missing_ok=True)

--- a/tests/installer/test_prebuilt_ui_install.py
+++ b/tests/installer/test_prebuilt_ui_install.py
@@ -19,7 +19,7 @@ _INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
 def _node_and_ui_block() -> str:
     text = _INSTALL_SH.read_text(encoding="utf-8")
     match = re.search(
-        r'ui_step "Node\.js toolchain"\n(.*?)\nui_step "Configuration"',
+        r'ui_step "Node\.js toolchain"[^\n]*\n(.*?)\nui_step "Configuration"',
         text,
         re.DOTALL,
     )

--- a/tests/installer/test_pull_retry.py
+++ b/tests/installer/test_pull_retry.py
@@ -1,0 +1,185 @@
+"""installer/lib/pull-retry.sh — backoff table + non-retryable classifier.
+
+Same technique as test_seam_verification.py: source the file and invoke a
+function directly, no root/sudo/provisioned box needed. Mirrors
+tests/registry/test_runner_pull_retry.py's Python-side classifier so the
+bash and Python pull paths fail for the same reasons.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PULL_RETRY = REPO / "installer" / "lib" / "pull-retry.sh"
+
+
+def _call(func: str, *args: str) -> subprocess.CompletedProcess[str]:
+    script = f"""
+set -uo pipefail
+source "{PULL_RETRY}"
+{func} {" ".join(f'"{a}"' for a in args)}
+echo "rc=$?"
+"""
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False, cwd=str(REPO)
+    )
+
+
+class TestClassifier:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "unauthorized: authentication required",
+            "Error: denied: requested access to the resource is denied",
+            "manifest unknown",
+            "Error: reading manifest latest: manifest unknown",
+            "Error: initializing source docker://ghcr.io/x:y: 404 Not Found",
+            "write /var/lib/containers/storage/...: no space left on device",
+            "Cannot connect to the Docker daemon at unix:///var/run/docker.sock",
+        ],
+    )
+    def test_non_retryable_signatures_return_1(self, message: str) -> None:
+        proc = _call("hal0_pull_is_retryable", message)
+        assert "rc=1" in proc.stdout, proc.stdout
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "connection reset by peer",
+            "context deadline exceeded",
+            "TLS handshake timeout",
+            "unexpected EOF",
+            "",
+        ],
+    )
+    def test_transient_or_unclassified_messages_return_0(self, message: str) -> None:
+        proc = _call("hal0_pull_is_retryable", message)
+        assert "rc=0" in proc.stdout, proc.stdout
+
+
+class TestBackoffTable:
+    def test_default_table_first_entries(self) -> None:
+        for attempt, expected in ((1, "5"), (2, "15"), (3, "30"), (4, "60")):
+            proc = _call("hal0_pull_backoff_delay", str(attempt))
+            assert proc.stdout.splitlines()[0] == expected, proc.stdout
+
+    def test_past_the_table_end_the_last_value_doubles(self) -> None:
+        proc = _call("hal0_pull_backoff_delay", "5")
+        assert proc.stdout.splitlines()[0] == "120"
+        proc = _call("hal0_pull_backoff_delay", "6")
+        assert proc.stdout.splitlines()[0] == "240"
+
+    def test_custom_table_is_honoured_via_env(self) -> None:
+        script = f"""
+set -uo pipefail
+source "{PULL_RETRY}"
+HAL0_PULL_RETRY_DELAYS="1 2 3"
+hal0_pull_backoff_delay 1
+hal0_pull_backoff_delay 3
+hal0_pull_backoff_delay 4
+"""
+        proc = subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, check=False, cwd=str(REPO)
+        )
+        assert proc.stdout.splitlines() == ["1", "3", "6"], proc.stdout
+
+
+class TestPullWithRetry:
+    def _fake_runtime(self, tmp_path: Path, script_body: str) -> Path:
+        """A fake `podman`/`docker`-shaped executable driven by a counter file."""
+        runtime = tmp_path / "fake-runtime"
+        runtime.write_text(f"#!/usr/bin/env bash\n{script_body}\n")
+        runtime.chmod(0o755)
+        return runtime
+
+    def test_a_retryable_failure_is_retried_then_succeeds(self, tmp_path: Path) -> None:
+        counter = tmp_path / "count"
+        counter.write_text("0")
+        runtime = self._fake_runtime(
+            tmp_path,
+            f"""
+case "$1" in
+    pull)
+        n=$(($(cat "{counter}") + 1)); echo "$n" > "{counter}"
+        if [[ "$n" -lt 2 ]]; then echo "connection reset by peer" >&2; exit 1; fi
+        exit 0
+        ;;
+    image) [[ "$2" == "exists" ]] && exit 0 ;;
+    inspect) exit 0 ;;
+esac
+""",
+        )
+        script = f"""
+set -uo pipefail
+export HAL0_PULL_RETRY_DELAYS="0"
+source "{PULL_RETRY}"
+hal0_pull_with_retry "{runtime}" myimage:latest 4
+echo "rc=$?"
+echo "attempts=$(cat "{counter}")"
+"""
+        proc = subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, check=False, cwd=str(REPO)
+        )
+        assert "rc=0" in proc.stdout, proc.stderr
+        assert "attempts=2" in proc.stdout
+
+    def test_a_non_retryable_failure_stops_after_the_first_attempt(self, tmp_path: Path) -> None:
+        counter = tmp_path / "count"
+        counter.write_text("0")
+        runtime = self._fake_runtime(
+            tmp_path,
+            f"""
+n=$(($(cat "{counter}") + 1)); echo "$n" > "{counter}"
+echo "unauthorized: authentication required" >&2
+exit 1
+""",
+        )
+        script = f"""
+set -uo pipefail
+export HAL0_PULL_RETRY_DELAYS="0"
+source "{PULL_RETRY}"
+hal0_pull_with_retry "{runtime}" myimage:latest 4
+echo "rc=$?"
+echo "attempts=$(cat "{counter}")"
+"""
+        proc = subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, check=False, cwd=str(REPO)
+        )
+        assert "rc=1" in proc.stdout, proc.stderr
+        assert "attempts=1" in proc.stdout
+        assert "non-retryable" in proc.stderr
+
+    def test_a_pull_that_exits_0_without_the_image_present_is_retried(self, tmp_path: Path) -> None:
+        counter = tmp_path / "count"
+        counter.write_text("0")
+        runtime = self._fake_runtime(
+            tmp_path,
+            f"""
+case "$1" in
+    pull) exit 0 ;;
+    image)
+        n=$(($(cat "{counter}") + 1)); echo "$n" > "{counter}"
+        [[ "$3" == "myimage:latest" && "$n" -ge 2 ]] && exit 0
+        exit 1
+        ;;
+    inspect) exit 1 ;;
+esac
+""",
+        )
+        script = f"""
+set -uo pipefail
+export HAL0_PULL_RETRY_DELAYS="0"
+source "{PULL_RETRY}"
+hal0_pull_with_retry "{runtime}" myimage:latest 4
+echo "rc=$?"
+echo "checks=$(cat "{counter}")"
+"""
+        proc = subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, check=False, cwd=str(REPO)
+        )
+        assert "rc=0" in proc.stdout, proc.stderr
+        assert "checks=2" in proc.stdout

--- a/tests/registry/test_runner_pull_retry.py
+++ b/tests/registry/test_runner_pull_retry.py
@@ -1,0 +1,226 @@
+"""Retry/backoff discipline for runner-image pulls (installer-forensics brief).
+
+Mirrors installer/lib/pull-retry.sh's bash classifier so a manual
+`install.sh` pull and a dashboard-triggered runner-image pull fail for the
+same reasons. ``run_runner_pull``'s own default (``max_attempts=1``) keeps
+every pre-existing direct caller and test (test_runner_pull.py) on the
+original single-attempt behaviour byte-for-byte — these tests exercise the
+opt-in multi-attempt path explicitly, with an injected ``sleep_fn`` so
+nothing here waits on a real clock.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.registry.runner_image import RunnerImage
+from hal0.registry.runner_image_store import RunnerImageStore
+from hal0.registry.runner_pull import (
+    is_retryable_pull_error,
+    make_job,
+    pull_backoff_delay,
+    run_runner_pull,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> RunnerImageStore:
+    s = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    s.upsert(
+        RunnerImage(
+            id="hal0ai/hal0-toolbox-cpu", image="ghcr.io/hal0ai/hal0-toolbox-cpu", tag="latest"
+        )
+    )
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _isolate_var_lib(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path / "hal0home"))
+
+
+def _job():
+    return make_job("hal0ai/hal0-toolbox-cpu", "ghcr.io/hal0ai/hal0-toolbox-cpu:latest")
+
+
+async def _no_sleep(_seconds: float) -> None:
+    """Injected in place of asyncio.sleep — retry tests never wait on a real clock."""
+
+
+class TestClassifier:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "unauthorized: authentication required",
+            "denied: requested access to the resource is denied",
+            "manifest unknown",
+            "pull access denied for ghcr.io/x, repository does not exist or may require 'docker login'",
+            "Error: creating build container: writing blob: adding layer: ApplyLayer exit status 1: no space left on device",
+            "Error: initializing source docker://ghcr.io/x:y: reading manifest y: manifest unknown",
+            'Error: authenticating creds for "ghcr.io": 404',
+        ],
+    )
+    def test_non_retryable_signatures_are_rejected(self, message: str) -> None:
+        assert is_retryable_pull_error(message) is False
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "connection reset by peer",
+            "context deadline exceeded",
+            "TLS handshake timeout",
+            "unexpected EOF",
+            "exit code 1",
+            "",
+            None,
+        ],
+    )
+    def test_transient_or_unclassified_messages_are_retryable(self, message) -> None:
+        assert is_retryable_pull_error(message) is True
+
+
+class TestBackoffTable:
+    def test_default_table_first_entries(self) -> None:
+        assert pull_backoff_delay(1) == 5
+        assert pull_backoff_delay(2) == 15
+        assert pull_backoff_delay(3) == 30
+        assert pull_backoff_delay(4) == 60
+
+    def test_past_the_table_end_the_last_value_doubles(self) -> None:
+        assert pull_backoff_delay(5) == 120
+        assert pull_backoff_delay(6) == 240
+
+    def test_custom_table_is_honoured(self) -> None:
+        assert pull_backoff_delay(1, delays=(1, 2, 3)) == 1
+        assert pull_backoff_delay(3, delays=(1, 2, 3)) == 3
+        assert pull_backoff_delay(4, delays=(1, 2, 3)) == 6
+
+
+class _ScriptedProvider:
+    """Yields one scripted event list per call to pull_image_stream — the
+    Nth call (1-indexed) gets the Nth entry of ``attempts``."""
+
+    def __init__(self, attempts: list[list[dict]], *, image_present=None) -> None:
+        self._attempts = attempts
+        self._calls = 0
+        if image_present is not None:
+            self.image_present = image_present  # only set when a caller wants it exposed
+
+    async def pull_image_stream(self, image: str):
+        events = self._attempts[min(self._calls, len(self._attempts) - 1)]
+        self._calls += 1
+        for event in events:
+            yield event
+
+    @property
+    def call_count(self) -> int:
+        return self._calls
+
+
+class TestRetryLoop:
+    async def test_default_max_attempts_never_retries(self, store: RunnerImageStore) -> None:
+        """Byte-for-byte parity with the pre-retry behaviour for every
+        caller that doesn't opt in."""
+        job = _job()
+        provider = _ScriptedProvider(
+            [
+                [{"state": "failed", "error": "connection reset by peer"}],
+                [{"state": "completed", "layer": 1, "total_layers": 1}],
+            ]
+        )
+        await run_runner_pull(job, store=store, provider=provider)
+        assert job.state == "failed"
+        assert provider.call_count == 1
+
+    async def test_a_retryable_failure_is_retried_and_then_succeeds(
+        self, store: RunnerImageStore
+    ) -> None:
+        job = _job()
+        slept: list[float] = []
+
+        async def _spy_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        provider = _ScriptedProvider(
+            [
+                [{"state": "failed", "error": "connection reset by peer"}],
+                [{"state": "failed", "error": "TLS handshake timeout"}],
+                [{"state": "completed", "layer": 1, "total_layers": 1}],
+            ]
+        )
+        await run_runner_pull(
+            job, store=store, provider=provider, max_attempts=4, sleep_fn=_spy_sleep
+        )
+        assert job.state == "completed"
+        assert provider.call_count == 3
+        assert slept == [5, 15]  # pull_backoff_delay(1), pull_backoff_delay(2)
+
+    async def test_a_non_retryable_failure_ends_the_job_on_the_first_attempt(
+        self, store: RunnerImageStore
+    ) -> None:
+        job = _job()
+        provider = _ScriptedProvider(
+            [
+                [{"state": "failed", "error": "unauthorized: authentication required"}],
+                [{"state": "completed", "layer": 1, "total_layers": 1}],
+            ]
+        )
+        await run_runner_pull(
+            job, store=store, provider=provider, max_attempts=4, sleep_fn=_no_sleep
+        )
+        assert job.state == "failed"
+        assert job.error == "unauthorized: authentication required"
+        assert provider.call_count == 1
+
+    async def test_exhausting_every_attempt_ends_failed_with_the_last_error(
+        self, store: RunnerImageStore
+    ) -> None:
+        job = _job()
+        provider = _ScriptedProvider(
+            [[{"state": "failed", "error": "connection reset by peer"}]] * 3
+        )
+        await run_runner_pull(
+            job, store=store, provider=provider, max_attempts=3, sleep_fn=_no_sleep
+        )
+        assert job.state == "failed"
+        assert job.error == "connection reset by peer"
+        assert provider.call_count == 3
+
+    async def test_post_pull_verification_false_is_retried(self, store: RunnerImageStore) -> None:
+        """podman exit 0 but the image never landed — treated as a retryable
+        failure, not a false success."""
+        job = _job()
+        calls: list[str] = []
+
+        def _image_present(image: str) -> bool:
+            calls.append(image)
+            return len(calls) > 1  # missing on the first check, present on the second
+
+        provider = _ScriptedProvider(
+            [
+                [{"state": "completed", "layer": 1, "total_layers": 1}],
+                [{"state": "completed", "layer": 1, "total_layers": 1}],
+            ],
+            image_present=_image_present,
+        )
+        await run_runner_pull(
+            job, store=store, provider=provider, max_attempts=3, sleep_fn=_no_sleep
+        )
+        assert job.state == "completed"
+        assert provider.call_count == 2
+        assert calls == ["ghcr.io/hal0ai/hal0-toolbox-cpu:latest"] * 2
+
+    async def test_a_provider_without_image_present_skips_verification(
+        self, store: RunnerImageStore
+    ) -> None:
+        """Every existing test fake lacks image_present — retry must not
+        require it."""
+        job = _job()
+        provider = _ScriptedProvider([[{"state": "completed", "layer": 1, "total_layers": 1}]])
+        await run_runner_pull(
+            job, store=store, provider=provider, max_attempts=3, sleep_fn=_no_sleep
+        )
+        assert job.state == "completed"
+        assert job.local_path is not None


### PR DESCRIPTION
## Summary

Ports ODS's installer forensics shapes into hal0's `install.sh`: module
headers, a tee'd install log, a redacted failure report on abort, per-step
time estimates + measured durations, a `--summary-json` machine-readable
summary, and backoff/classification for container-image pulls (bash side
in `installer/lib/pull-retry.sh`, Python side in
`hal0.registry.runner_pull`). `hal0 doctor bundle` now includes the latest
install log. See `installer/README.md`'s new "Installer forensics" section
and `docs/getting-started/install.mdx` for full details.

## Risk grade

- [x] med    — user-facing change, new code path, or non-trivial refactor

## Touched surfaces

- [x] Installer (`installer/`, systemd units)
- [x] Docs (`docs/`, `CONTRIBUTING.md`)

## §14.1 high-risk surfaces

None checked — no shell-out to new untrusted input, no download/signature
changes, no privilege changes. The pull-retry paths retry an
already-authorized `podman pull`/runner-image pull with the same image ref;
they add backoff and a stricter non-retryable classifier, nothing new is
executed.

## Rollback

Revert this PR's 3 commits; no schema/migration/on-disk-format changes to
unwind (the install log and failure report are new files under
`/var/log/hal0` or `/tmp`, and `--summary-json` is opt-in).

_Rollback:_ `git revert <merge-commit>`

## Test tiers run

- [x] α  unit (`make test`) — `uv run pytest tests/ -q -n 8`
- [ ] β  integration (`make test-integration`)
- [ ] γ  release-gate (`make release-test`)

Also run and green: `uv run ruff check src tests`, `uv run ruff format
--check src tests`, `uv run mypy` on every file this PR touches,
`python3 scripts/check_sunset.py` (scar baseline unchanged at 193),
`shellcheck` on every `.sh` touched (clean apart from pre-existing
SC1091/SC2034-cross-file/SC2119/SC2120/SC2069 baseline noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bpxd3dvWgxPymLQLtmtujs
