### PR TITLE
docs: reconcile ARCHITECTURE/CLAUDE.md with the code (provisioner, ADR tree, unit docs)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,10 +8,14 @@ Scope/roadmap live in the maintainer planning doc (`docs/.devdocs/PLAN.md`, loca
 live under `docs/` (Starlight `.mdx`).
 
 > **One authoritative doc.** This file replaces the former split across
-> `ARCHITECTURE.md`, `CONTEXT.md`, and `AGENTS.md`. Every standing decision
-> below is explained inline: hal0 keeps no separate ADR tree, so nothing
-> here cites a decision record by number — the rationale lives next to the
-> statement it justifies.
+> `ARCHITECTURE.md`, `CONTEXT.md`, and `AGENTS.md`. A handful of standing
+> decisions are recorded as numbered ADRs in `docs/adr/` (see "Decision
+> records" below); everything else is explained here inline, next to the
+> statement it justifies. Source comments citing `ADR-00NN` for a number
+> with no file in `docs/adr/` are usually pointing at `docs/internal/adr/`
+> — a second, gitignored ADR tree for decisions that carry lab
+> topology/IP data (`.gitignore`, closed by #627/#638) — not at a missing
+> or deleted document.
 
 ## hal0 in one paragraph
 
@@ -101,9 +105,6 @@ src/hal0/
 │                    #   (spec: update system)
 ├── updater/         # self-update (cosign-verified, atomic swap)
 ├── installer/       # first-run wizard backend, hardware probe writer
-├── voice/           # emptied in #620 (in-process Moonshine/Kokoro
-│                    #   providers deleted); STT runs in the npu FLM
-│                    #   container, TTS in the tts container
 ├── openwebui/       # companion service env file writer
 └── cli/             # `hal0` Typer CLI (incl. `capabilities migrate`)
 ```
@@ -270,8 +271,8 @@ model advertised and will 4xx on inference attempts (issue #31).
 A bundled agent in v0.3 is a third-party agent runtime running as a
 sibling systemd unit with hal0 wired in as its local AI provider. Two
 agents ship as first-class bundled agents —
-`BUNDLED_AGENTS = ("pi-coder", "hermes")` in
-`src/hal0/agents/manager.py`, single-pick at install; `hermes` is the
+`BUNDLED_AGENTS = ("hermes", "pi")` in
+`src/hal0/agents/manager.py:117`, single-pick at install; `hermes` is the
 default integration. The boundary is intentionally narrow: hal0 owns
 provisioning, identity, MCP wiring, and the chat-surface proxy. Runtime
 is whatever the bundled upstream does natively.
@@ -301,7 +302,7 @@ bundled agents are not a revival of it.)
 ### Install & lifecycle
 
 ```
-sudo hal0 agent provision hermes         # one-shot 15-phase bootstrap
+sudo hal0 agent install hermes           # one-shot 12-step converging install
 sudo systemctl status hal0-agent@hermes  # unit health
 hal0 agent personas                      # list personas (TOML store)
 hal0 agent personas activate coder       # swap active persona
@@ -314,13 +315,25 @@ and the composite `hal0` upstream config — all idempotently.
 
 ### Surfaces
 
-* **Provision** — `hal0 agent provision hermes` → the 15-phase
-  orchestrator in `src/hal0/agents/hermes_provision.py`
-  (preflight → install → env_probe → home_init → install_artifacts →
-  persona_seed → config_write → mcp_wire → context_link →
-  namespace_register → model_automap → voice_wire →
-  gateway_secrets_wire → smoke_tests → self_report). Idempotent +
-  checkpointed via `/var/lib/hal0/state/agents/hermes/provision.json`.
+* **Provision** — `hal0 agent install hermes` (root: installs the CLI
+  wrapper + hal0-owned skeleton, then re-execs `hal0 agent bootstrap
+  hermes` as the `hal0` user) → the 12-step, deliberately
+  **uncheckpointed** pipeline in `src/hal0/agents/hermes_provision.py`
+  (`_INSTALL_STEPS`, `hermes_provision.py:6582`): `preflight → install →
+  env_probe → home_init → kanban_db_init → install_artifacts → mcp_wire →
+  config_write → context_link → voice_wire → gateway_secrets_wire →
+  smoke_tests`. Every step converges its slice of host state (a
+  re-run over an already-provisioned box mutates nothing —
+  `report.converged`); there is no resumable `provision.json` checkpoint
+  machinery — a last-run report is written to
+  `/var/lib/hal0/state/agents/hermes/provision.json` purely for `hal0
+  agent status`/`log` to render, not to resume from. The brain/persona/
+  memory-identity steps (`persona_seed`, `namespace_register`,
+  `brain_profile_seed`, `brain_profile_mcp_wire`, `self_report`) used to
+  run in this pipeline too; they now run in the `hal0-api` boot lifespan
+  instead (`src/hal0/api/__init__.py`, around the `lifespan()` function) —
+  the phase functions are unchanged and still directly callable, only
+  their membership in `_INSTALL_STEPS` moved.
 * **Service** — `hal0-agent@<id>.service` (template; v0.3 instances:
   `hermes` only). Sandboxed (`NoNewPrivileges`, `ProtectSystem=strict`,
   `ProtectHome=yes`). Type=notify + `WatchdogSec=60`. The agent reaches
@@ -373,10 +386,10 @@ and the composite `hal0` upstream config — all idempotently.
 | Module                                         | Owns                                         |
 |------------------------------------------------|----------------------------------------------|
 | `src/hal0/agents/manager.py`                   | single-pick install / uninstall              |
-| `src/hal0/agents/hermes_provision.py`          | 15-phase Hermes bootstrap orchestrator       |
+| `src/hal0/agents/hermes_provision.py`          | 12-step Hermes install pipeline + brain-lane bootstrap phases |
 | `src/hal0/agents/personas.py`                  | persona TOML store + hot-reload helper       |
 | `src/hal0/agents/mcp_client.py`                | MCP server-axis + tool-axis classifier       |
-| `installer/agents/hermes/plugins/hal0-memory/`| hal0-hindsight MemoryProvider plugin (canonical source) |
+| `src/hal0/agents/hermes/plugins/memory_hindsight/` | hal0-memory `MemoryProvider` plugin (canonical source; mirrored byte-for-byte into `installer/agents/hermes/plugins/hal0-memory/` at install time, guarded by `tests/agents/hermes_plugins/test_seed_parity.py`) |
 | `src/hal0/api/agents/personas.py`              | `/api/agents/{id}/personas[/{pid}/activate]` |
 | `src/hal0/api/agents/chat_proxy.py`            | WS proxy + session REST shim                 |
 | `src/hal0/api/agents/restart.py`               | `POST /api/agents/{id}/restart`              |
@@ -389,8 +402,8 @@ and the composite `hal0` upstream config — all idempotently.
 
 ### Standing decisions
 
-These decisions are settled and explained here inline (hal0 keeps no ADR
-tree):
+These decisions are settled. Some are recorded as ADRs in `docs/adr/`
+(see "Decision records" below); the rest are explained here inline:
 
 * **Agent bundling** — hal0 bundles third-party runtimes
   (`pi-coder`, `hermes`) and runs them as sandboxed sibling units; it
@@ -1257,6 +1270,36 @@ then clean `[gone]` branches.
 **6. Record memory-worthy outcomes** (PR/merge, gotcha, decision) to the
 hal0 Hindsight engine via the `hal0-memory` skill — see the standing rules
 in `CLAUDE.md`.
+
+## Decision records
+
+`docs/adr/` is the public, tracked ADR tree — decisions safe to ship in
+the open-source repo, numbered independently of anything else. As of
+this writing: `0001` (Moonshine CPU STT reinstatement), `0002` (agent
+credential isolation), `0003` (ONNX text-generation via the NPU —
+deferred), `0004` (bundled agents), `0005` (memory namespace grammar),
+`0006` (every shipped runner image is a registry runner), `0012`
+(auth + Caddy removal), `0013` (per-agent MCP client allow-list),
+`0020` (localhost-callback-only OAuth PKCE for OpenRouter), `0023`
+(canonical LLM roles + Hindsight-native memory extraction). `0007`,
+`0008`–`0011`, and `0014`–`0022` (excluding `0020`) are gaps in this
+tree, not missing numbers to fill — see the next paragraph.
+
+A second ADR tree, `docs/internal/adr/`, is gitignored
+(`.gitignore`, closed by #627/#638): decisions whose write-up leans on
+lab topology, box names, or LAN addresses stay there, local to the
+machine that wrote them, the same way `docs/.devdocs/` and
+`docs/superpowers/` do (see this repo's `CLAUDE.md`). Its numbering is
+**independent** of `docs/adr/`'s — the two trees have collided on
+low numbers more than once (e.g. the current `docs/adr/0001` is
+unrelated to the `docs/internal/adr/0001` an early auth ADR once used).
+A source comment citing `ADR-00NN` with no matching file in `docs/adr/`
+is very likely citing the internal tree, not a ghost document; check
+there (if present on your box) before assuming the citation is stale.
+Some early internal ADRs (`0006` Lemonade adoption's era, `0008`–`0010`,
+`0022`) describe the pre-#687 Lemonade-fronted inference runtime, which
+the container-switchover epic replaced — those decisions are superseded
+by the current per-slot podman runtime and are not reconstructed here.
 
 ## See also
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ could not.
 
 Tags older than v0.2.0 ship release notes inside the GitHub release
 page; this CHANGELOG starts at v0.2.0 (the Lemonade migration cut).
-ADR-level architecture decisions are kept internal (the `docs/internal/`
-tree is gitignored, #638) and referenced by number throughout the code.
+ADR-level architecture decisions referenced by number throughout the
+code live in one of two trees: `docs/adr/` (public, tracked) or
+`docs/internal/adr/` (gitignored, #638, for decisions that carry lab
+topology/IP data) — see `ARCHITECTURE.md` "Decision records".
 
 **Release automation.** On a tagged release the matching `## [<version>]`
 section below is bundled into the release tarball as `RELEASE_NOTES.md`, and its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,24 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Changed
+
+- **Docs drift pass: reconciled `ARCHITECTURE.md`/`CONTRIBUTING.md`/`CHANGELOG.md`
+  with the code** they describe. The Hermes provisioner section now
+  documents the real 12-step, uncheckpointed `_INSTALL_STEPS` pipeline
+  (not the retired 15-phase checkpointed one); `BUNDLED_AGENTS`'s value
+  and order now match `src/hal0/agents/manager.py`; the
+  `hal0-agent@.service` unit's `Documentation=` now points at a tracked
+  doc (`docs/guides/run-agents.mdx`) instead of a path that never
+  existed; the "hal0 keeps no ADR tree" claim is replaced with the real
+  rule (a public `docs/adr/` plus a gitignored `docs/internal/adr/`),
+  five ADRs are reconstructed from source + CHANGELOG history
+  (`docs/adr/0004`, `0012`, `0013`, `0020`, `0023`) to close the largest
+  "ghost citation" gaps, and a mislabeled ADR link in
+  `docs/concepts/memory.mdx` is fixed. The stale `voice/` entry (the
+  package was fully deleted in #620, not merely emptied) is removed from
+  `ARCHITECTURE.md`'s module tree. No behavior change. (#2244)
+
 ### Fixed
 
 - MCP admin tools no longer report a tool failure for a successful read of a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,11 +76,13 @@ enforces the ones marked **(gated)**.
    grow. Never widen exposure as a side effect of another change.
 
 9. **No ghost-doc citations.** A decision is either recorded in a real,
-   tracked document or explained inline where it takes effect. Do not cite
-   a doc, ADR, or design note that does not exist in the tree. hal0 keeps
-   no separate ADR tree: rationale lives next to the code or in
-   [`ARCHITECTURE.md`](./ARCHITECTURE.md). Touched documentation must match
-   the code it describes.
+   tracked document (an ADR in `docs/adr/`, or the gitignored
+   `docs/internal/adr/` for a decision that carries lab topology/IP data)
+   or explained inline where it takes effect. Do not cite a doc, ADR, or
+   design note that does not exist in either tree. Most standing decisions
+   are explained inline in [`ARCHITECTURE.md`](./ARCHITECTURE.md); only cite
+   an ADR number when the file actually exists. Touched documentation must
+   match the code it describes.
 
 10. **Test behavior, not framework internals.** Probe routes and effects
     through the public surface; never assert on `app.routes` shape or other

--- a/docs/adr/0004-bundled-agents.md
+++ b/docs/adr/0004-bundled-agents.md
@@ -1,0 +1,90 @@
+# ADR-0004: Bundled agents — bundle third-party runtimes, don't build one
+
+## Status
+
+**ACCEPTED.** First shipped as Phase 8 (v0.2, two candidate runtimes:
+`pi-coder` and `Hermes-Agent`); reconstructed here against the current
+(v0.3+) state. The original write-up lived in the gitignored
+`docs/internal/adr/0004-agents.md` (see `ARCHITECTURE.md` "Decision
+records"); this file restates the decision as it stands today, not the
+v0.2 draft.
+
+## Context
+
+hal0 previously carried a first-party agent runtime (`haloai`) that was
+stripped from the codebase. Re-entering the "an agent that chats and
+takes action" space needed a rule that kept that strip line honest: hal0
+does not get to quietly rebuild what it just deleted.
+
+## Decision
+
+**hal0 bundles third-party agent runtimes; it does not build its own.**
+Concretely:
+
+- `BUNDLED_AGENTS` (`src/hal0/agents/manager.py:117`) is the closed list
+  of agents hal0 knows how to install: `("hermes", "pi")`. Adding a new
+  one is a driver module + a `BUNDLED_AGENTS` entry, not new runtime
+  code.
+- **Single-pick, but only between daemon-kind agents**
+  (`src/hal0/agents/manager.py:294-335`, spec D1). Hermes is a
+  service-shaped, systemd-supervised daemon; a `cli`-kind agent (`pi`)
+  installs alongside anything, since it has no gateway/persona surface
+  to collide over. `hal0 agent install <name> --switch` performs an
+  atomic uninstall-then-install between daemon agents so the operator
+  never ends up with two partially installed.
+- **Sandboxed sibling unit, not an in-process extension.** A daemon
+  agent runs as `hal0-agent@<id>.service`
+  (`installer/systemd/hal0-agent@.service`), `User=hal0`, loopback-only,
+  `NoNewPrivileges`/`ProtectSystem=strict`/`ProtectHome=yes`. The browser
+  never talks to it directly — `src/hal0/api/agents/chat_proxy.py`
+  proxies the chat WebSocket, enforcing an Origin allowlist and a session
+  cookie, carrying the embed token server-side only.
+- **One MCP tool catalog, mapped onto existing routes.** The admin MCP
+  server's tool catalog (`src/hal0/mcp/admin.py`) started as the "a tool
+  ships iff it maps to an existing `/api/*` route" rule; no privileged
+  surface is invented just for the agent (`src/hal0/mcp/admin.py`,
+  "Platform-management expansion" section header cites this ADR by
+  number). Tools are split autonomous-read / autonomous-write / gated,
+  the same two-tier trust model this ADR established.
+- **Gated destructive actions go through an approval inbox, not a trust
+  toggle.** `GET/POST /api/agent/approvals[/{id}/approve|deny]`
+  (`src/hal0/api/routes/approvals.py`) backs the dashboard's approvals
+  bell and the `hal0 agent approvals` CLI off one
+  `hal0.mcp.approval_queue.ApprovalQueue`. There is deliberately no
+  per-agent "trust this agent, skip approval" setting — untrusted content
+  reaching the agent's context must still clear a human click for a
+  destructive call.
+- **Shim-first integration, native where upstream cooperates.** hal0 owns
+  a thin wrapper per agent (e.g. `/usr/local/bin/hal0-hermes`) that wires
+  hal0 in as the agent's local AI provider and MCP client, rather than
+  forking or patching the upstream agent.
+
+## Consequences
+
+- v0.2/v0.3 shipped as a wiring job, not a multi-month runtime-engineering
+  project; MCP is the cross-app contract, so other MCP clients (not just
+  bundled agents) can drive the same admin surface.
+- The tool-catalog rule keeps the agent's privileges from silently
+  outgrowing what the dashboard itself can do — a new admin capability
+  needs a `/api/*` route first, an MCP tool second.
+- Power users wanting two daemon agents installed at once are blocked by
+  single-pick; the escape hatch is installing a second agent through its
+  own upstream path, forgoing hal0's prewiring.
+- The specific agent lineup has changed since v0.2 (`pi-coder` →
+  `pi`, `Hermes-Agent` → `hermes` as the default); this ADR documents the
+  standing rule, not the roster, so it does not need an amendment every
+  time a bundled agent is added or renamed — see `BUNDLED_AGENTS` for the
+  current roster.
+
+## References
+
+- `src/hal0/agents/manager.py:1-38,117,294-338` — module contract,
+  `BUNDLED_AGENTS`, single-pick enforcement
+- `installer/systemd/hal0-agent@.service` — sandboxed daemon unit
+- `src/hal0/api/agents/chat_proxy.py` — WS proxy, Origin allowlist
+- `src/hal0/mcp/admin.py` — tool catalog, "Platform-management expansion"
+  section citing this ADR
+- `src/hal0/api/routes/approvals.py` — approval inbox routes
+- `ARCHITECTURE.md` "Bundled agents (v0.3)" — current process model,
+  surfaces, and module map
+- `docs/concepts/agents.mdx` — operator-facing description

--- a/docs/adr/0012-remove-auth-and-caddy.md
+++ b/docs/adr/0012-remove-auth-and-caddy.md
@@ -1,0 +1,80 @@
+# ADR-0012: Remove auth and Caddy entirely
+
+## Status
+
+**ACCEPTED (2026-05-23).** Shipped for v0.3. Reconstructed here against
+the current state; the original write-up lived in the gitignored
+`docs/internal/adr/0012-remove-auth-and-caddy.md` (see `ARCHITECTURE.md`
+"Decision records").
+
+## Context
+
+An earlier decision moved auth into FastAPI and reduced the bundled
+Caddy reverse proxy to a TLS-only terminator: a fresh install locked
+behind a password, a one-time-password lockfile minted at install, and a
+session-cookie/Bearer-token auth surface gating the dashboard and
+`/v1/*`.
+
+In practice, every real hal0 deployment sits behind an existing upstream
+proxy the operator already runs (Traefik, Cloudflare Tunnel, nginx). The
+bundled Caddy was a middleman with its own failure mode
+(`hal0-caddy.service` could fail independently of `hal0-api`) and its own
+cert story. The first-run password step gated nobody on a trusted LAN,
+and on a hostile network the real auth was the upstream proxy's anyway.
+The auth surface it protected cost roughly 6,000 lines of code and tests
+across `src/hal0/auth/`, `src/hal0/api/auth/`,
+`src/hal0/api/middleware/auth.py`, `src/hal0/api/routes/auth.py`, Caddy's
+packaging, and the corresponding test suites.
+
+## Decision
+
+**Remove the entire FastAPI auth surface and the bundled Caddy reverse
+proxy. Document upstream-proxy patterns as the recommended way to add
+auth and TLS on a hostile network.** `hal0-api` binds `0.0.0.0:8080` with
+no authentication of its own
+(`ARCHITECTURE.md` "The dedicated auth packages ... were removed").
+
+Operators who need a password, TLS, or origin restriction put a real
+reverse proxy in front and own auth at the edge — `docs/operate/auth.mdx`
+documents the Traefik / nginx / Cloudflare Tunnel patterns.
+
+What stayed: `installer/uninstall.sh` still tears down
+`hal0-caddy.service` and the first-run lockfile so pre-v0.3 installs
+clean up correctly. The MCP mount's identity middleware
+(`src/hal0/api/mcp_mount.py`) was kept but repointed — it no longer
+enforces a Bearer token; it reads the caller's identity from an explicit
+`X-hal0-Agent` header instead, which is what routes a write into the
+right `private:<agent_id>` memory namespace.
+
+## Consequences
+
+- ~6,000 fewer lines of auth code, tests, and packaging to maintain; one
+  fewer systemd unit (`hal0-caddy.service` gone).
+- First-run UX is "open the dashboard," not "find the OTP in the install
+  log, paste it into a wizard, set a password."
+- There is no password-protected dashboard and no Bearer-token store:
+  anyone who can reach `:8080` can drive every admin endpoint and every
+  `/v1/*` call. Operators on an untrusted or multi-tenant network **must**
+  add an upstream proxy — the installer offers no "secure by default"
+  fallback, and the docs are loud about that (`docs/operate/auth.mdx`,
+  `docs/concepts/security.mdx`).
+- `X-hal0-Agent` is self-asserted and unauthenticated — hal0 has no
+  credential to check it against post this ADR. It is a namespace-routing
+  signal between cooperating local agents, not a security boundary
+  against a hostile LAN caller (`docs/concepts/security.mdx`).
+- The subsequent OpenRouter OAuth callback work had to explicitly reckon
+  with this LAN-trust posture rather than assume Bearer auth was still
+  available (ADR-0020).
+
+## References
+
+- `ARCHITECTURE.md` — "The dedicated auth packages ... were removed:
+  hal0-api binds `0.0.0.0:8080` open, and LAN trust plus an upstream
+  reverse proxy own authentication."
+- `src/hal0/api/mcp_mount.py` — `X-hal0-Agent` identity header, replacing
+  the retired Bearer-token MCP middleware
+- `docs/operate/auth.mdx` — upstream reverse-proxy patterns
+- `docs/concepts/security.mdx` — the LAN-trust boundary, spelled out for
+  operators
+- ADR-0020 — the OpenRouter OAuth callback design that had to work within
+  this ADR's no-inbound-auth posture

--- a/docs/adr/0013-mcp-client-allow-list.md
+++ b/docs/adr/0013-mcp-client-allow-list.md
@@ -1,0 +1,77 @@
+# ADR-0013: Per-agent MCP client allow-list, default-deny on server and tool
+
+## Status
+
+**ACCEPTED (2026-05-23).** Reconstructed here against the current state;
+the original write-up lived in the gitignored
+`docs/internal/adr/0013-mcp-client-allow-list.md` (see `ARCHITECTURE.md`
+"Decision records").
+
+## Context
+
+hal0 is an MCP *server* host — bundled agents connect into the
+`hal0-admin` and `hal0-memory` MCP servers (ADR-0004). The reverse
+direction needed its own rule: bundled agents are MCP *clients* too, and
+can be pointed at external MCP servers (filesystem, GitHub, third-party
+knowledge bases, user-installed MCPs). Left unscoped, an agent talking to
+an untrusted external MCP server, or calling a destructive tool on one it
+already trusts, is a straightforward prompt-injection footgun.
+
+## Decision
+
+**Default-deny on two independent axes — which servers an agent may
+connect to, and which tools it may call on each — configured per agent,
+never globally.**
+
+- **Config lives at `/etc/hal0/agents/<name>.toml`**, one file per agent,
+  under `[mcp.servers.<name>]` blocks
+  (`src/hal0/agents/hermes_provision.py:2548` reads `[mcp.servers.*]`
+  from this file). A server not listed is unreachable — there is no
+  discover-and-connect fallback.
+- **Three-tier tool classification per server**
+  (`ToolPolicy`, `src/hal0/config/schema.py:2726`): `allow` (autonomous
+  call), `gated` (enqueues through the same approval queue ADR-0004
+  established), `blocked` (hard-rejected client-side, never reaches the
+  server). The three lists must be disjoint — a load-time
+  `ValidationError` catches an operator TOML edit that leaves a tool in
+  two lists rather than silently picking a winner.
+  A server with no `tools` block has zero callable tools by construction
+  — the same default-deny posture applies at the tool axis as at the
+  server axis.
+- **Installer-pinned blocks are load-bearing.** A bundled agent's
+  installer can put a tool (e.g. `delete_repo` on a GitHub MCP) in
+  `blocked`; the dashboard cannot move it out. Only a direct, traceable
+  TOML edit can.
+- **Built-in servers (`hal0-admin`, `hal0-memory`) are always reachable**
+  for a bundled agent and carry the identity header
+  (`mcp_servers.<name>.headers.X-hal0-Agent`,
+  `hermes_provision.py:2020`) that scopes memory writes into the
+  agent's own `private:<agent_id>` namespace (ADR-0005).
+
+## Consequences
+
+- Server-axis and tool-axis default-deny means a freshly registered
+  external MCP server is inert until an operator explicitly reviews and
+  allow-lists its tools — the safe failure mode is "does nothing," not
+  "does everything."
+- The three-tier split (vs. a plain allow/deny) costs one more concept
+  than a binary system, in exchange for letting an agent use a risky-but-
+  needed tool (`gated`) without either fully trusting it (`allow`) or
+  losing it entirely (`blocked`).
+- `AgentConfig` / `MCPServerConfig` / `ToolPolicy`
+  (`src/hal0/config/schema.py`) and `src/hal0/agents/mcp_client.py` are
+  the schema and enforcement point this ADR called for; both exist in the
+  current tree, so the "Pending items" in the original write-up have
+  landed.
+
+## References
+
+- `src/hal0/config/schema.py:2726` (`ToolPolicy`), `:2796`
+  (`MCPServerConfig`), `:2890` (`AgentConfig`)
+- `src/hal0/agents/mcp_client.py` — per-agent MCP client enforcement
+- `src/hal0/agents/hermes_provision.py:2548,2840-2988` (`_phase_mcp_wire`)
+  — reads `[mcp.servers.*]`, probes each allowed connection
+- `ui/src/api/hooks/useAgentMcpClients.ts` — dashboard per-agent
+  MCP-client allow-list view
+- ADR-0004 — bundled agents, the approval-queue surface `gated` reuses
+- ADR-0005 — the `private:<agent_id>` namespace `X-hal0-Agent` routes into

--- a/docs/adr/0020-localhost-callback-only-oauth-pkce.md
+++ b/docs/adr/0020-localhost-callback-only-oauth-pkce.md
@@ -1,0 +1,73 @@
+# ADR-0020: Localhost-callback-only OAuth PKCE (OpenRouter BYOK)
+
+## Status
+
+**ACCEPTED (2026-05-29).** The loopback guard shipped as a Phase 0
+scaffold; the PKCE code-for-token exchange itself is still pending (see
+Status below). Reconstructed here against the current state; the
+original write-up lived in the gitignored
+`docs/internal/adr/0020-localhost-callback-only-oauth-pkce.md` (see
+`ARCHITECTURE.md` "Decision records").
+
+## Context
+
+`hal0-api` binds `0.0.0.0:8080` with no Bearer authentication (ADR-0012).
+That LAN-trust posture holds because every privileged surface is either
+loopback-only or deliberately operator-aware.
+
+OpenRouter's bring-your-own-key delegate-routing flow needs OAuth 2.0
+PKCE: the dashboard opens an authorize URL, the user signs in at
+OpenRouter, OpenRouter redirects back to a callback URL on hal0 with an
+authorization code, and hal0 exchanges the code for tokens. A callback
+URL reachable from the LAN would let any LAN host race a real redirect
+with an attacker-supplied code, or spam the endpoint — PKCE mitigates
+replay, but a credential-issuing endpoint that any LAN host can poke
+still strains ADR-0012's "every privileged surface is operator-aware"
+posture.
+
+## Decision
+
+**The OAuth PKCE callback is constrained to
+`http://127.0.0.1:<port>/api/openrouter/auth/callback` — loopback only,
+enforced per-route rather than by a global middleware** (a global guard
+would force allowlisting the rest of the deliberately open-LAN API).
+
+- `is_loopback_host()` / `require_loopback()`
+  (`src/hal0/api/openrouter/_loopback.py`) accept only `127.0.0.1`,
+  `::1`, and the literal `localhost` — a strict allowlist, not a
+  `127.0.0.0/8` CIDR test, so a spoofed header can't widen it.
+- A non-loopback caller gets `403 loopback_required`, naming this ADR and
+  telling the operator to complete the flow on the hal0 host or over an
+  SSH tunnel to `127.0.0.1:8080`. 403, not 404: the callback URL's
+  existence is not a secret worth hiding.
+- The authorize URL's `redirect_uri` is the loopback address; completing
+  the flow from a remote browser requires being physically at the hal0
+  host or SSH-tunnelling the port.
+
+## Consequences
+
+- ADR-0012's LAN-trust model holds — no new attack surface is visible
+  from the LAN.
+- Remote-browser operators pay a one-time SSH-tunnel setup cost to link
+  an OpenRouter account.
+- A future publicly-hosted dashboard cannot complete this flow without
+  either dual-binding the callback behind its own auth model or running
+  the flow from the host's local browser — explicitly deferred, and
+  re-opens ADR-0012 if pursued.
+
+## Status of the implementation
+
+As of this writing, `GET /api/openrouter/auth/callback`
+(`src/hal0/api/openrouter/auth.py`) is a Phase 0 scaffold: the route is
+registered and the loopback guard is enforced, but the handler returns
+`501` — the PKCE code-for-token exchange and refresh-token persistence
+are still pending a follow-up PR. The loopback constraint this ADR
+decides is already enforced against every request, including in the
+current 501 state.
+
+## References
+
+- `src/hal0/api/openrouter/_loopback.py` — `is_loopback_host`,
+  `require_loopback`
+- `src/hal0/api/openrouter/auth.py` — the Phase 0 callback route
+- ADR-0012 — the no-inbound-auth, LAN-trust posture this ADR works within

--- a/docs/adr/0023-canonical-llm-roles-agent-utility.md
+++ b/docs/adr/0023-canonical-llm-roles-agent-utility.md
@@ -1,0 +1,93 @@
+# ADR-0023: Canonical LLM roles (`agent`/`utility`) + Hindsight-native memory extraction
+
+## Status
+
+**ACCEPTED.** Shipped in `v0.8.0-beta.3` (2026-06-23), per
+`CHANGELOG.md`: "Canonical LLM roles + Hindsight-native memory extraction
+(ADR-0023)." Unlike the other reconstructed ADRs in this tree, no
+pre-cutover copy of this one exists in git history — it was authored
+after `docs/internal/adr/` became gitignored (#627/#638) and lived only
+on the authoring machine. This page is reconstructed from source
+comments and the CHANGELOG entry alone, not from the original document.
+
+## Context
+
+Two related pieces of naming and routing debt had accumulated by
+mid-2026:
+
+1. The slot-routing vocabulary used `chat`/`primary`/`role` inconsistently
+   across the resolver, the seeded slot TOMLs, and the dashboard, with no
+   single canonical anchor name for "the default capable LLM."
+2. The memory subsystem's graph-extraction routing (`[memory.graph]`)
+   still carried config fields (`route`, `upstream`) and a reranker
+   config shaped for the retired cognee engine, even though Hindsight had
+   become the sole memory engine.
+
+## Decision
+
+**Two canonical LLM roles replace the old ad hoc names, and Hindsight
+becomes the platform memory engine with graph extraction routed through
+the normal slot-alias machinery.**
+
+- **`agent`** is the canonical default/anchor slot — every `hal0/<slot>`
+  fallback chain ends in `agent`
+  (`src/hal0/normalize/resolver.py:13-19`, `DEFAULT_CHAINS`). `chat` and
+  `primary` are retired as slot/role names.
+- **`utility`** is the cheap-helper role, seeded on every install, and is
+  never the fallback for general chat — only for its own targeted uses
+  (`resolver.py:29`).
+- **Slot routing key is the slot `name`, not a separate `role` field.**
+  The legacy `role` field on `SlotConfig` is gone; identity IS the
+  routing key for `hal0/<slot>` aliases
+  (`CHANGELOG.md`, `v0.7.x` "Slot routing key is now the slot `name`, not
+  `role` (ADR-0023 §2.1)"). One escape hatch: the special name `npu`
+  additionally matches any slot with `device == "npu"`, so the NPU trio's
+  chat edge answers `hal0/npu` regardless of its literal slot name.
+- **`hal0/<slot>` generalizes to any enabled LLM slot**, not just the
+  three advertised virtual names, so an operator-chosen slot (e.g. a
+  memory-extraction slot) is addressable without a hardcoded resolver
+  entry (`resolver.py:41-46`, ADR-0023 §2).
+- **Hindsight is the platform memory engine; the cognee wrapper is
+  gone.** `[memory.graph].extraction_slot` names a local, enabled LLM
+  slot (resolved via the same `hal0/<slot>` alias machinery) that
+  Hindsight's graph builder uses; `route`/`upstream` config fields from
+  the cognee era are retired (`src/hal0/config/schema.py:2606-2951`,
+  `MemoryGraphConfig`, `MemoryEmbeddingConfig`). Hindsight embeds
+  server-side with its own bundled model, so hal0 no longer pins a
+  separate embedding model for memory.
+- **`extraction_slot` propagates to `hindsight-api` as environment**,
+  resolved by the dispatcher to that slot's live model
+  (`src/hal0/memory/extraction_env.py:1,14`).
+
+## Consequences
+
+- One naming vocabulary (`agent`/`utility`, plus any operator-named slot)
+  replaces three overlapping ones (`chat`/`primary`/`role`), reducing the
+  places a slot's identity could disagree with its routing.
+- Memory graph extraction is reporting-only from Hindsight's perspective
+  (`src/hal0/memory/hindsight_provider.py:479`) but routes through the
+  same live-slot resolution every other virtual model name uses — no
+  parallel routing table to keep in sync.
+- Every `route: self._extraction_slot` field left in
+  `src/hal0/memory/provider.py` / `hindsight_provider.py` /
+  `pgvector_provider.py` is explicitly marked a deprecated mirror kept
+  for backward-compatible API responses, not a second source of truth.
+- This ADR's scope touches an unusually large number of call sites
+  (dispatcher, resolver, CLI, config schema, UI) because it retired two
+  overlapping naming systems at once; that breadth is why it is cited
+  from more files than any other ADR in this tree.
+
+## References
+
+- `CHANGELOG.md`, `v0.8.0-beta.3` — "Canonical LLM roles + Hindsight-native
+  memory extraction (ADR-0023)"; `v0.7.x` — "Slot routing key is now the
+  slot `name`, not `role` (ADR-0023 §2.1)"
+- `src/hal0/normalize/resolver.py:13-46` — `_ANCHOR_NAME`, `DEFAULT_CHAINS`,
+  the `hal0/<slot>` generalization
+- `src/hal0/config/schema.py:2602-2951` — `MemoryGraphConfig`,
+  `MemoryEmbeddingConfig`
+- `src/hal0/memory/extraction_env.py:1,14,91` — extraction-slot env
+  propagation to `hindsight-api`
+- `src/hal0/memory/__init__.py:222` — Hindsight as the platform engine
+- `src/hal0/dispatcher/_capability_resolve.py:28,156,239,248` — rule-9
+  fallback to the `agent` anchor

--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -123,7 +123,7 @@ memory is inert only once you (or the installer) have written
 
 Every memory operation is scoped to a namespace, and the grammar is a closed
 two-value set: `shared` or the caller's own `private:<client_id>`
-([ADR-0004](/docs/adr/0005-memory-namespace-shared-private)). `shared` is the
+([ADR-0005](/docs/adr/0005-memory-namespace-shared-private)). `shared` is the
 default for every write; `private:<agent>` is for memories an agent — or the
 operator — explicitly wants scoped to one identity. Scoping *within* `shared`
 is done with tags (the agent identity cards carry `agent-identity`; project

--- a/installer/systemd/hal0-agent@.service
+++ b/installer/systemd/hal0-agent@.service
@@ -5,7 +5,7 @@
 # v0.4-ready: a future `hal0-agent@piccoder.service` is a drop-in with
 # a per-instance override under hal0-agent@piccoder.service.d/.
 Description=hal0 agent (%i)
-Documentation=https://github.com/Hal0ai/hal0/blob/main/docs/agents/hermes/SERVICE.md
+Documentation=https://github.com/Hal0ai/hal0/blob/main/docs/guides/run-agents.mdx
 
 # No hard dependency on the inference layer: the agent talks to
 # hal0-api over HTTP and tolerates it being down (per-slot podman

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -973,10 +973,13 @@ def _dirs_identical(a: Path, b: Path) -> bool:
 def _phase_install(ctx: _StepCtx) -> PhaseResult:
     """Provision the managed Hermes venv + ``/usr/local/bin/hermes`` + plugins.
 
-    The plugin package at ``installer/agents/hermes/plugins/hal0-memory/`` (the
-    canonical, shipped ``MemoryProvider`` source — see
-    ``tests/agents/test_hal0_memory_client.py`` for its contract tests) is
-    copied into ``$HERMES_HOME/plugins/hal0-memory/``. A concurrent lane ships
+    The plugin package at ``installer/agents/hermes/plugins/hal0-memory/`` (a
+    byte-identical seed mirrored from the canonical ``MemoryProvider`` source
+    at ``src/hal0/agents/hermes/plugins/memory_hindsight/`` — the two are
+    locked together by ``tests/agents/hermes_plugins/test_seed_parity.py``;
+    see ``tests/agents/test_hal0_memory_client.py`` for the provider's own
+    contract tests) is copied into ``$HERMES_HOME/plugins/hal0-memory/``. A
+    concurrent lane ships
     the ``hal0-provider`` model-provider tree, dir-dropped alongside it into
     ``$HERMES_HOME/plugins/model-providers/hal0/`` — the copy tolerates a missing
     source dir (skipped-step report line) until that lane lands.


### PR DESCRIPTION
## Summary

Documentation drift pass (study 0.8; H16): reconciles `ARCHITECTURE.md`,
`CONTRIBUTING.md`, `CHANGELOG.md`, one systemd unit, and one docstring with
the code they describe, and fixes the "hal0 keeps no ADR tree" claim that
was flatly wrong (`docs/adr/` exists). Every claim below was verified
against source before writing, and a haiku `docs-verifier` fact-check pass
confirmed all of them.

- **Hermes provisioner** (`ARCHITECTURE.md` "Bundled agents (v0.3)"):
  described a 15-phase, checkpointed provisioner. The code
  (`src/hal0/agents/hermes_provision.py`) is a 12-step, deliberately
  **uncheckpointed** converging pipeline (`_INSTALL_STEPS`,
  `hermes_provision.py:6582`) — the old `provision.json`/`PHASES`
  checkpoint machinery is gone per the module's own docstring. Rewrote the
  section from `_INSTALL_STEPS` and the real CLI verb (`hal0 agent install
  hermes`, not `agent provision`).
- **`BUNDLED_AGENTS`**: was quoted as `("pi-coder", "hermes")`; the real
  value (`src/hal0/agents/manager.py:117`) is `("hermes", "pi")`.
- **`hal0-agent@.service` `Documentation=`**: pointed at
  `docs/agents/hermes/SERVICE.md`, which has never existed. Repointed at
  the real, tracked `docs/guides/run-agents.mdx`.
- **Byte-identical memory-provider pair**
  (`installer/agents/hermes/plugins/hal0-memory/provider.py` and
  `src/hal0/agents/hermes/plugins/memory_hindsight/provider.py`): a guard
  test (`tests/agents/hermes_plugins/test_seed_parity.py`) already exists
  on `main` and already establishes `src/` as the canonical owner with
  `installer/` as its byte-identical seed — this was already done, just
  not documented correctly. Fixed an inverted comment in
  `hermes_provision.py` that called the installer copy "canonical."
- **ADR tree**: `CLAUDE.md` says `docs/adr/` holds the decision records;
  `ARCHITECTURE.md` and `CONTRIBUTING.md` both said hal0 keeps **no**
  separate ADR tree. Neither was the full picture — most `ADR-00NN`
  citations in source comments resolve to `docs/internal/adr/`, a second,
  **gitignored** ADR tree (`#638`) with independent numbering, the same
  local-only pattern this repo already uses for `docs/.devdocs/` and
  `docs/superpowers/`. Fixed the false claims and added a "Decision
  records" section to `ARCHITECTURE.md` explaining both trees. Reconstructed
  5 of the missing ADRs (`0004`, `0012`, `0013`, `0020`, `0023`) from git
  history (`docs/internal/adr/*.md` was tracked before `#638`, so its
  blobs are still retrievable) and current-code verification, with lab
  topology/hostnames scrubbed. Declined to reconstruct `0008`/`0009`/`0010`/
  `0022` — they describe the Lemonade-fronted inference runtime that the
  container-switchover epic (`#687`) removed entirely; republishing them
  as current would be a ghost architecture, so `ARCHITECTURE.md` notes
  this instead. Fixed a mislabeled ADR-0004→0005 link in
  `docs/concepts/memory.mdx`.
- **Stale `voice/` module-tree entry**: `ARCHITECTURE.md`'s module layout
  listed `src/hal0/voice/` as "emptied in #620"; the directory was fully
  deleted in that commit (`2db4c682`) and doesn't exist on disk. Removed
  the entry (the correct "deleted" explanation already exists elsewhere in
  the same file).

No behavior change — docs, one systemd metadata field, and one docstring.

## Risk grade

- [x] low — docs only, internal refactor, or behaviour-preserving fix

## Touched surfaces

- [x] Installer (`installer/`, systemd units) — `Documentation=` field only
- [x] Docs (`docs/`, `CONTRIBUTING.md`)

## §14.1 high-risk surfaces

None apply.

## Rollback

_Rollback:_ revert this PR; no runtime behavior depends on any of these
files.

## Test tiers run

- [x] α  unit (`uv run pytest tests/ -q -n 8` — 12761 passed, 3 pre-existing
      failures per `CONTRIBUTING.md`/program notes: `test_pressure_evict_noop_when_probe_fails`,
      the two `test_moonshine_server.py` `ffmpeg`-dependent tests; unrelated
      to this diff)
- [x] β  integration (covered by the same full run above)
- [ ] γ  release-gate — not required (docs-only, low risk)

Also ran: `uv run ruff check/format` (clean), `python3 scripts/check_sunset.py`
(green, 193 <= baseline 193), `uv run mypy src/hal0/agents/hermes_provision.py`
(pre-existing errors only, none on touched lines), and a `docs-verifier`
fact-check pass over all 23 claims in the diff (all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BA2Lma4WErDwZXTAgJr1C
