### PR TITLE
fix(api): gate ADMIN routes when auth is off but the box is LAN-bound (#1822)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Fixed
 
+- **ADMIN-class routes are gated whenever the box is bound past loopback,
+  even with `require_auth` off.** hal0-api binds `0.0.0.0:8080` by default
+  (`installer/install.sh`), so the shipped combination — auth off, bind wide
+  open — let any device on the LAN drive every ADMIN route (model pulls, slot
+  deletes, config writes, approval execution) with no credential at all. An
+  ADMIN request now needs an admin session/key exactly as if enforcement were
+  on, but only when all three hold: an admin key is configured (otherwise the
+  requirement would be unsatisfiable, the same first-run carve-out
+  `AuthClass.BOOTSTRAP` already makes), the listener is not loopback-bound,
+  and this request's own peer did not arrive over loopback. A loopback-bound
+  box — and the operator at the console of a LAN-bound one — stays exactly as
+  frictionless as before; `OPEN`/`CLIENT` reads are untouched. The dashboard
+  answers a resulting 401 with an admin-key challenge drawer rather than a
+  dead-end error, and `hal0 doctor` reports the posture. (#1822)
 - MCP admin tools no longer report a tool failure for a successful read of a
   slot whose lifecycle state is `error`. The tool-result wrapper's failure
   sentinel keyed on `status == "error"` alone, which collides with the slot

--- a/src/hal0/api/auth.py
+++ b/src/hal0/api/auth.py
@@ -18,6 +18,30 @@ Three-tier, deny-by-default auth built around one classification table
   scopes; a denied WebSocket is rejected pre-accept with close code 4403
   (matching :mod:`hal0.api.agents.chat_proxy`'s existing convention).
 
+Posture-coupled ADMIN gate (#1822, H1/H3)
+------------------------------------------
+``require_auth_enabled()`` OFF does not mean "every request is anon-open"
+any more. hal0-api binds ``0.0.0.0:8080`` by default (``install.sh``), so
+the shipped combination — auth off, bind wide open — let any device on the
+LAN drive every ADMIN-class route (model pulls, slot deletes, config
+writes, approval execution) with zero credential. :func:`_lan_admin_gate`
+closes that gap without touching the ``require_auth`` toggle itself: an
+ADMIN-classified request is treated exactly as if enforcement were on
+(needs an admin session/key) whenever ALL of these hold —
+
+1. an admin key has been configured (:func:`has_admin_key`) — otherwise
+   there would be no way to satisfy the requirement at all, the same
+   first-run chicken-egg :class:`~hal0.security.exposure.AuthClass`
+   ``BOOTSTRAP`` already carves out;
+2. the box is bound beyond loopback (:func:`hal0.config.network.is_loopback_bind`
+   is false); and
+3. *this request's* own peer did not arrive over loopback.
+
+A loopback-bound box, or a loopback-originating request against a
+LAN-bound box (the operator at the console), stays fully frictionless —
+"auth off" still means "open on loopback". Reads (``OPEN``/``CLIENT``)
+are unaffected either way.
+
 The browser session cookie is **reused, not reimplemented**: minting and
 verification both delegate to :mod:`hal0.api.agents._auth` (the existing
 HMAC-SHA256 cookie already protecting the agent chat-proxy WS routes), so
@@ -36,6 +60,7 @@ Deliberately NOT covered here (deferred, see the KB-1 delivery report):
 from __future__ import annotations
 
 import hmac
+import ipaddress
 import json
 import os
 from dataclasses import dataclass
@@ -45,6 +70,7 @@ from urllib.parse import parse_qs, urlsplit
 import structlog
 
 from hal0.api.agents._auth import SESSION_COOKIE_NAME, verify_session_cookie
+from hal0.config.network import is_loopback_bind
 from hal0.security.exposure import AuthClass, classify
 
 log = structlog.get_logger(__name__)
@@ -383,6 +409,43 @@ def _origin_allowed(scope: dict[str, Any]) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Posture-coupled ADMIN gate (#1822) — see the module docstring.
+
+
+def _is_loopback_peer(scope: dict[str, Any]) -> bool:
+    """True iff the ASGI ``scope["client"]`` peer address is loopback.
+
+    Missing client info (``None`` — some non-TCP test transports) is
+    treated as NOT loopback: deny-by-default, same philosophy as
+    :mod:`hal0.security.exposure`'s unclassified-path fallback. An
+    unparseable address (shouldn't happen for a real ASGI server) is the
+    same.
+    """
+    client = scope.get("client")
+    if not client:
+        return False
+    try:
+        return ipaddress.ip_address(client[0]).is_loopback
+    except ValueError:
+        return False
+
+
+def _lan_admin_gate(auth_class: AuthClass, scope: dict[str, Any]) -> bool:
+    """True iff this request must be treated as if enforcement were ON.
+
+    Only ever true for :data:`AuthClass.ADMIN`. See the module docstring
+    ("Posture-coupled ADMIN gate") for the full three-condition rule.
+    """
+    if auth_class is not AuthClass.ADMIN:
+        return False
+    if not has_admin_key():
+        return False
+    if is_loopback_bind():
+        return False
+    return not _is_loopback_peer(scope)
+
+
+# ---------------------------------------------------------------------------
 # Enforcement decision
 
 
@@ -439,7 +502,11 @@ class AuthEnforcementMiddleware:
     Dev-open bypass: when :func:`require_auth_enabled` is false (the
     default on loopback with no keys configured), every request passes
     through untouched -- this is what keeps the pre-existing TestClient
-    suite green without modification.
+    suite green without modification. The one exception is the
+    posture-coupled ADMIN gate (:func:`_lan_admin_gate`, #1822): an
+    ADMIN-classified request from a non-loopback peer against a
+    non-loopback bind with an admin key already configured is enforced
+    even while the dev-open bypass is otherwise in effect.
     """
 
     def __init__(self, app: Any) -> None:
@@ -451,15 +518,16 @@ class AuthEnforcementMiddleware:
             await self.app(scope, receive, send)
             return
 
-        if not require_auth_enabled():
-            await self.app(scope, receive, send)
-            return
-
         path = scope.get("path", "/")
         # A WebSocket upgrade is an HTTP GET at the transport level; there
         # is no scope["method"] for a websocket scope, so classify() gets
         # the same pseudo-method the exposure-CI test uses.
         method = scope.get("method", "GET") if scope_type == "http" else "GET"
+        auth_class = classify(method, path)
+
+        if not require_auth_enabled() and not _lan_admin_gate(auth_class, scope):
+            await self.app(scope, receive, send)
+            return
 
         # Origin defence-in-depth: reject browser cross-site WebSocket
         # upgrades and state-changing requests BEFORE tier auth. Requests
@@ -489,7 +557,6 @@ class AuthEnforcementMiddleware:
             await send({"type": "http.response.body", "body": payload})
             return
 
-        auth_class = classify(method, path)
         principal = resolve_principal(scope)
         allowed, status, code = _decide(auth_class, principal)
 

--- a/src/hal0/api/routes/approvals.py
+++ b/src/hal0/api/routes/approvals.py
@@ -23,8 +23,17 @@ queue mutates.
 Auth
 ----
 
-Auth was removed — all routes here are open on the local
-network. This module declares no auth dependency itself.
+Enforcement is central, not per-route: this module declares no auth
+dependency itself, and every route here classifies ``ADMIN`` in
+:mod:`hal0.security.exposure` (the ``"agent approvals"`` prefix rule). An
+approval's ``approve`` executes whatever gated tool call it wraps
+(``model_pull``, ``slot_delete``, ``config_write``, ...), so it carries the
+same posture as any other mutating route: with ``require_auth`` off on a
+loopback-bound box it rides through unauthenticated (dev-open, by design),
+but on a LAN-reachable box with an admin key configured,
+:mod:`hal0.api.auth`'s posture-coupled gate (#1822) requires an admin
+session/key for any caller that didn't arrive over loopback, even though
+the ``require_auth`` toggle itself is still off.
 """
 
 from __future__ import annotations
@@ -44,8 +53,9 @@ from hal0.mcp.approval_queue import ApprovalQueue
 
 router = APIRouter()
 
-# Auth was removed. POST /approve and POST /deny are
-# unrestricted on the local network; access control is LAN-only.
+# ADMIN-classified (exposure.py), like every other route in this module — see
+# the module docstring for the posture-coupled gate that now covers this
+# prefix even while ``require_auth`` is off.
 
 
 # SSE keep-alive cadence — matches /api/events to keep the proxy

--- a/src/hal0/api/routes/auth.py
+++ b/src/hal0/api/routes/auth.py
@@ -25,6 +25,7 @@ from hal0.api.auth import (
     verify_admin_key,
 )
 from hal0.config.loader import hal0_config_txn
+from hal0.config.network import is_loopback_bind
 from hal0.errors import BadRequest, TooManyRequests, Unauthorized
 from hal0.security.exposure import OPEN_ALLOWLIST, RULES, AuthClass
 from hal0.service_identity import rotate_api_env_key
@@ -275,12 +276,17 @@ async def status(request: Request) -> dict[str, object]:
     distinguish "not configured yet" (first-run bootstrap window) from
     "configured, please log in"; ``tier`` is this caller's own resolved
     identity (useful for the dashboard to know if it's already logged in
-    via an existing cookie).
+    via an existing cookie). ``lan_exposed`` (#1822) is true when the box is
+    bound beyond loopback — independent of ``auth_required`` — so the
+    dashboard and ``hal0 doctor all`` can both explain that ADMIN mutations
+    already require a sign-in from off-box callers even while enforcement
+    itself reads as "off" (see :mod:`hal0.api.auth`'s posture-coupled gate).
     """
     principal = resolve_principal_from_scope(request)
     return {
         "auth_required": require_auth_enabled(),
         "has_admin_key": has_admin_key(),
+        "lan_exposed": not is_loopback_bind(),
         "tier": principal.tier,
     }
 

--- a/src/hal0/cli/doctor_all.py
+++ b/src/hal0/cli/doctor_all.py
@@ -60,18 +60,44 @@ console = Console()
 
 
 def check_auth_posture(auth: dict[str, Any] | None) -> Check:
-    """Auth exposure posture from ``GET /api/auth/status`` (advisory).
+    """Auth exposure posture from ``GET /api/auth/status`` (advisory, #1822).
 
     ``auth_required`` + ``has_admin_key`` describe whether the box gates
-    access. The only misconfiguration we flag is "auth required but no admin
-    key configured" (nobody can log in); an intentionally open dev install
-    passes with a note.
+    access; ``lan_exposed`` (added for #1822) says whether the bind reaches
+    beyond loopback. The old version of this check printed PASS "dev/loopback"
+    for ANY box with ``auth_required`` off, never looking at the bind — a
+    LAN-bound, auth-off box (hal0-api's shipped default) got a clean bill of
+    health while reachable from every device on the network. Missing
+    ``lan_exposed`` from an older API build degrades to ``False`` (unknown ->
+    assume loopback) rather than raising, so this stays advisory-safe.
     """
     if auth is None:
         return Check("auth", "Auth posture", _WARN, "auth status unreachable")
     required = bool(auth.get("auth_required"))
     has_key = bool(auth.get("has_admin_key"))
+    lan_exposed = bool(auth.get("lan_exposed"))
     if not required:
+        if lan_exposed:
+            if not has_key:
+                return Check(
+                    "auth",
+                    "Auth posture",
+                    _WARN,
+                    "reachable from your network with auth off and no admin key set — every "
+                    "route, including model pulls, slot deletes and config writes, is "
+                    "unauthenticated from any LAN device. Set an admin key "
+                    "(`hal0 auth rotate admin`) or bind loopback (HAL0_BIND_HOST=127.0.0.1) "
+                    "to close this.",
+                )
+            return Check(
+                "auth",
+                "Auth posture",
+                _WARN,
+                "reachable from your network with auth off — mutating routes already require "
+                "an admin sign-in automatically for off-box callers, but reads and inference "
+                "stay open. `hal0 auth require on` or binding loopback "
+                "(HAL0_BIND_HOST=127.0.0.1) protects everything, including reads.",
+            )
         return Check("auth", "Auth posture", _PASS, "open (auth not required — dev/loopback)")
     if not has_key:
         return Check(

--- a/src/hal0/config/network.py
+++ b/src/hal0/config/network.py
@@ -48,6 +48,22 @@ def bind_host() -> str:
     return raw or _DEFAULT_BIND_HOST
 
 
+def is_loopback_bind(host: str | None = None) -> bool:
+    """True iff *host* (default: :func:`bind_host`) is a loopback-only bind.
+
+    Wildcard binds (``0.0.0.0``/``::``) are NOT loopback — they are exactly
+    the LAN-reachable case this predicate exists to flag. Two consumers
+    (#1822): the posture-coupled ADMIN gate
+    (:mod:`hal0.api.auth`'s ``AuthEnforcementMiddleware``), which keeps
+    loopback-bound boxes frictionless even with ``require_auth`` off but
+    still requires an admin session for ADMIN-class requests on a
+    LAN-reachable box, and ``hal0 doctor all``'s auth-posture check, which
+    previously reported "open (dev/loopback)" without ever looking at the
+    bind host.
+    """
+    return (host if host is not None else bind_host()) in _LOOPBACK_BIND_HOSTS
+
+
 def hostname() -> str:
     """The canonical operator-facing hostname (bare, no ``.local`` suffix).
 
@@ -134,4 +150,5 @@ __all__ = [
     "derive_allowed_origins",
     "detect_lan_ips",
     "hostname",
+    "is_loopback_bind",
 ]

--- a/tests/api/test_auth_core.py
+++ b/tests/api/test_auth_core.py
@@ -320,6 +320,73 @@ def test_decide_admin_requires_admin_tier() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Posture-coupled ADMIN gate (#1822): _is_loopback_peer + _lan_admin_gate
+
+
+def _scope_with_client(client: tuple[str, int] | None) -> dict[str, object]:
+    scope = _scope()
+    scope["client"] = client
+    return scope
+
+
+def test_is_loopback_peer_true_for_v4_and_v6() -> None:
+    assert auth_mod._is_loopback_peer(_scope_with_client(("127.0.0.1", 5000))) is True
+    assert auth_mod._is_loopback_peer(_scope_with_client(("127.5.5.5", 5000))) is True
+    assert auth_mod._is_loopback_peer(_scope_with_client(("::1", 5000))) is True
+
+
+def test_is_loopback_peer_false_for_lan_or_missing() -> None:
+    assert auth_mod._is_loopback_peer(_scope_with_client(("192.168.1.20", 5000))) is False
+    # No client tuple at all (some non-TCP test transports) -- deny-by-default.
+    assert auth_mod._is_loopback_peer(_scope_with_client(None)) is False
+    assert auth_mod._is_loopback_peer(_scope()) is False
+    # TestClient's default fake peer -- not an IP address at all.
+    assert auth_mod._is_loopback_peer(_scope_with_client(("testclient", 50000))) is False
+
+
+def test_lan_admin_gate_only_applies_to_admin_class(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_ADMIN_KEY", "k")
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    scope = _scope_with_client(("192.168.1.20", 5000))
+    assert auth_mod._lan_admin_gate(AuthClass.OPEN, scope) is False
+    assert auth_mod._lan_admin_gate(AuthClass.CLIENT, scope) is False
+    assert auth_mod._lan_admin_gate(AuthClass.BOOTSTRAP, scope) is False
+    assert auth_mod._lan_admin_gate(AuthClass.ADMIN, scope) is True
+
+
+def test_lan_admin_gate_false_without_admin_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No admin key -> nothing to log in with yet; mirrors BOOTSTRAP's own carve-out."""
+    monkeypatch.delenv("HAL0_ADMIN_KEY", raising=False)
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    scope = _scope_with_client(("192.168.1.20", 5000))
+    assert auth_mod._lan_admin_gate(AuthClass.ADMIN, scope) is False
+
+
+def test_lan_admin_gate_false_on_loopback_bind(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_ADMIN_KEY", "k")
+    monkeypatch.delenv("HAL0_BIND_HOST", raising=False)  # defaults to 127.0.0.1
+    scope = _scope_with_client(("192.168.1.20", 5000))
+    assert auth_mod._lan_admin_gate(AuthClass.ADMIN, scope) is False
+
+
+def test_lan_admin_gate_false_for_loopback_peer_even_on_lan_bind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The operator at the console stays frictionless even on a LAN-bound box."""
+    monkeypatch.setenv("HAL0_ADMIN_KEY", "k")
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    scope = _scope_with_client(("127.0.0.1", 5000))
+    assert auth_mod._lan_admin_gate(AuthClass.ADMIN, scope) is False
+
+
+def test_lan_admin_gate_true_when_all_conditions_met(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_ADMIN_KEY", "k")
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    scope = _scope_with_client(("192.168.1.20", 5000))
+    assert auth_mod._lan_admin_gate(AuthClass.ADMIN, scope) is True
+
+
+# ---------------------------------------------------------------------------
 # Route-level: POST /api/auth/login + GET /api/auth/status, and the
 # dev-open bypass end-to-end through a real TestClient app.
 
@@ -346,11 +413,44 @@ def auth_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         yield c
 
 
+@pytest.fixture
+def auth_app_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Factory variant of ``auth_client``: returns a callable that builds a
+    fresh isolated app on demand, so a test can set ``HAL0_ADMIN_KEY`` /
+    ``HAL0_BIND_HOST`` first and then wrap the app in its OWN
+    ``TestClient(app, client=(...))`` with a custom peer tuple -- the fixed
+    ``auth_client`` fixture below always uses ``TestClient``'s default
+    ``("testclient", 50000)`` peer, which is exactly what the loopback-vs-LAN
+    posture gate needs to vary per test (#1822).
+    """
+    import os
+
+    from hal0.api import create_app
+
+    monkeypatch.setenv("HAL0_AGENT_SECRET_PATH", str(tmp_path / "secret.bin"))
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path / "hal0_home"))
+    os.makedirs(tmp_path / "hal0_home" / "etc" / "hal0", exist_ok=True)
+
+    return create_app
+
+
 def test_status_route_reports_posture(auth_client) -> None:
     resp = auth_client.get("/api/auth/status")
     assert resp.status_code == 200
     body = resp.json()
-    assert body == {"auth_required": False, "has_admin_key": False, "tier": "anon"}
+    assert body == {
+        "auth_required": False,
+        "has_admin_key": False,
+        "lan_exposed": False,
+        "tier": "anon",
+    }
+
+
+def test_status_route_reports_lan_exposed(auth_client, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    resp = auth_client.get("/api/auth/status")
+    assert resp.status_code == 200
+    assert resp.json()["lan_exposed"] is True
 
 
 def test_status_route_never_leaks_the_key(auth_client, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -430,3 +530,111 @@ def test_dev_open_bypass_reaches_admin_route_with_no_creds(auth_client) -> None:
     """
     resp = auth_client.get("/api/settings")
     assert resp.status_code not in (401, 403), resp.text
+
+
+# ---------------------------------------------------------------------------
+# Posture-coupled ADMIN gate, end-to-end (#1822): loopback-vs-LAN request
+# classification through a real app + TestClient with a custom peer.
+
+
+def test_posture_gate_blocks_admin_route_from_lan_peer_on_lan_bind(
+    auth_app_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """HAL0_REQUIRE_AUTH is OFF, but a LAN-bound box with a key set still
+    401s an ADMIN route hit from an off-box peer."""
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setenv("HAL0_ADMIN_KEY", "the-real-key")
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    app = auth_app_factory()
+    with TestClient(app, client=("203.0.113.5", 51000)) as c:
+        resp = c.get("/api/settings")
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "auth.required"
+
+
+def test_posture_gate_allows_loopback_peer_on_lan_bind(
+    auth_app_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The operator at the console (loopback peer) stays frictionless even
+    though the box itself is bound to every interface."""
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setenv("HAL0_ADMIN_KEY", "the-real-key")
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    app = auth_app_factory()
+    with TestClient(app, client=("127.0.0.1", 51000)) as c:
+        resp = c.get("/api/settings")
+    assert resp.status_code not in (401, 403), resp.text
+
+
+def test_posture_gate_open_on_loopback_bind_regardless_of_peer(
+    auth_app_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A loopback-bound box never gates on peer -- an unreachable-in-practice
+    scenario (the kernel wouldn't route a real LAN peer to a loopback bind),
+    but the gate must not rely on that; it checks the bind explicitly."""
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setenv("HAL0_ADMIN_KEY", "the-real-key")
+    monkeypatch.delenv("HAL0_BIND_HOST", raising=False)  # defaults to 127.0.0.1
+    app = auth_app_factory()
+    with TestClient(app, client=("203.0.113.5", 51000)) as c:
+        resp = c.get("/api/settings")
+    assert resp.status_code not in (401, 403), resp.text
+
+
+def test_posture_gate_open_without_admin_key_even_on_lan_bind(
+    auth_app_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No admin key yet -> bootstrap window, mirrors AuthClass.BOOTSTRAP:
+    nothing to log in with, so the gate must not lock the operator out."""
+    from fastapi.testclient import TestClient
+
+    monkeypatch.delenv("HAL0_ADMIN_KEY", raising=False)
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    app = auth_app_factory()
+    with TestClient(app, client=("203.0.113.5", 51000)) as c:
+        resp = c.get("/api/settings")
+    assert resp.status_code not in (401, 403), resp.text
+
+
+def test_posture_gate_admin_session_reaches_admin_route_from_lan_peer(
+    auth_app_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A logged-in admin session clears the gate from any peer -- login
+    itself is OPEN-classified, so the gate never blocks reaching it."""
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setenv("HAL0_ADMIN_KEY", "the-real-key")
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    app = auth_app_factory()
+    with TestClient(app, client=("203.0.113.5", 51000)) as c:
+        login = c.post("/api/auth/login", json={"key": "the-real-key"})
+        assert login.status_code == 200
+        resp = c.get("/api/settings")
+    assert resp.status_code not in (401, 403), resp.text
+
+
+def test_posture_gate_covers_approvals_route(
+    auth_app_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The named #1822 scenario: approve executes gated tools (model_pull,
+    slot_delete, config_write); the approvals list route must be gated the
+    same as every other ADMIN route -- refused from an off-box peer, allowed
+    with an admin session."""
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setenv("HAL0_ADMIN_KEY", "the-real-key")
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    app = auth_app_factory()
+    with TestClient(app, client=("203.0.113.5", 51000)) as c:
+        denied = c.get("/api/agent/approvals")
+        assert denied.status_code == 401
+        assert denied.json()["error"]["code"] == "auth.required"
+
+        login = c.post("/api/auth/login", json={"key": "the-real-key"})
+        assert login.status_code == 200
+
+        allowed = c.get("/api/agent/approvals")
+        assert allowed.status_code not in (401, 403), allowed.text

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -42,6 +42,31 @@ def test_auth_required_with_key_passes() -> None:
     assert c.status == "pass"
 
 
+def test_auth_open_loopback_passes_even_missing_lan_exposed_field() -> None:
+    """An older API build with no ``lan_exposed`` field degrades to False
+    (assume loopback) rather than warning on missing data."""
+    c = da.check_auth_posture({"auth_required": False, "has_admin_key": False})
+    assert c.status == "pass"
+
+
+def test_auth_open_lan_exposed_no_key_warns() -> None:
+    c = da.check_auth_posture({"auth_required": False, "has_admin_key": False, "lan_exposed": True})
+    assert c.status == "warn"
+    assert "no admin key" in c.detail
+
+
+def test_auth_open_lan_exposed_with_key_warns() -> None:
+    c = da.check_auth_posture({"auth_required": False, "has_admin_key": True, "lan_exposed": True})
+    assert c.status == "warn"
+    assert "reachable from your network" in c.detail
+
+
+def test_auth_open_loopback_bind_passes_regardless_of_key() -> None:
+    c = da.check_auth_posture({"auth_required": False, "has_admin_key": True, "lan_exposed": False})
+    assert c.status == "pass"
+    assert "open" in c.detail
+
+
 # ── check_model_store ─────────────────────────────────────────────────────────
 
 

--- a/tests/config/test_network.py
+++ b/tests/config/test_network.py
@@ -41,6 +41,7 @@ def test_all_exports_are_callable() -> None:
         "derive_allowed_origins",
         "detect_lan_ips",
         "hostname",
+        "is_loopback_bind",
     }
     for name in network.__all__:
         assert callable(getattr(network, name)), f"network.{name} is not callable"
@@ -68,6 +69,30 @@ class TestBindHost:
     def test_whitespace_only_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("HAL0_BIND_HOST", "   ")
         assert network.bind_host() == "127.0.0.1"
+
+
+# ── is_loopback_bind() (#1822) ──────────────────────────────────────────────
+
+
+class TestIsLoopbackBind:
+    def test_default_unset_is_loopback(self) -> None:
+        assert network.is_loopback_bind() is True
+
+    def test_explicit_loopback_values(self) -> None:
+        assert network.is_loopback_bind("127.0.0.1") is True
+        assert network.is_loopback_bind("localhost") is True
+        assert network.is_loopback_bind("::1") is True
+
+    def test_wildcard_binds_are_not_loopback(self) -> None:
+        assert network.is_loopback_bind("0.0.0.0") is False
+        assert network.is_loopback_bind("::") is False
+
+    def test_concrete_lan_address_is_not_loopback(self) -> None:
+        assert network.is_loopback_bind("10.0.0.5") is False
+
+    def test_reads_bind_host_when_no_argument(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+        assert network.is_loopback_bind() is False
 
 
 # ── hostname() ────────────────────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -270,8 +270,22 @@ def _auth_dev_open_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     runs after this fixture and wins), and the posture-derivation tests in
     ``tests/api/test_auth_core.py`` ``delenv`` it first to exercise the
     bind/key-derived default.
+
+    #1822 added a SECOND consumer of the same leaked ``HAL0_BIND_HOST``: the
+    posture-coupled ADMIN gate (``hal0.api.auth._lan_admin_gate``) fires
+    whenever the bind reads non-loopback, an admin key is configured, AND the
+    request's own peer isn't loopback — and it does that regardless of
+    ``HAL0_REQUIRE_AUTH``. ``TestClient``'s default peer is
+    ``("testclient", 50000)``, not loopback, so a leaked
+    ``HAL0_BIND_HOST=0.0.0.0`` plus any test that also sets
+    ``HAL0_ADMIN_KEY`` would 401 unrelated ADMIN-route tests the same way the
+    old bind-derived ``require_auth_enabled()`` default used to. Pinning
+    ``HAL0_BIND_HOST=127.0.0.1`` here closes that the same way: tests that
+    need the LAN-bound gate set their own ``HAL0_BIND_HOST`` after this
+    fixture runs and win.
     """
     monkeypatch.setenv("HAL0_REQUIRE_AUTH", "0")
+    monkeypatch.setenv("HAL0_BIND_HOST", "127.0.0.1")
 
 
 @pytest.fixture(autouse=True)

--- a/ui/src/api/hooks/useAuthStatus.ts
+++ b/ui/src/api/hooks/useAuthStatus.ts
@@ -5,6 +5,7 @@
 //
 //   { auth_required: bool,   // is the enforcement gate armed at all?
 //     has_admin_key: bool,   // is HAL0_ADMIN_KEY configured? (set/unset)
+//     lan_exposed: bool,     // is the bind reachable beyond loopback? (#1822)
 //     tier: "open"|"client"|"admin" }  // THIS caller's resolved identity
 //
 // It NEVER returns a key value, and it does NOT report: the admin-key
@@ -14,6 +15,12 @@
 // inventing data the backend doesn't send. Key rotation is a SEPARATE route
 // (POST /api/auth/rotate, both tiers — see useAuthActions.ts) and is live;
 // it just isn't reflected back through this status probe.
+//
+// `lan_exposed` is independent of `auth_required` (#1822): a LAN-bound box
+// with enforcement OFF already gates ADMIN mutations for off-box callers
+// (hal0.api.auth's posture-coupled gate) — this field lets the Security page
+// and AuthChallengeDrawer explain why a 401 shows up even though "Require
+// authentication" reads as off.
 
 import { useQuery } from '@tanstack/react-query'
 import { apiGet } from '../client'
@@ -24,6 +31,7 @@ export type AuthTier = 'open' | 'client' | 'admin'
 export interface AuthStatus {
   auth_required: boolean
   has_admin_key: boolean
+  lan_exposed: boolean
   tier: AuthTier
 }
 

--- a/ui/src/dash/auth/AuthChallengeDrawer.jsx
+++ b/ui/src/dash/auth/AuthChallengeDrawer.jsx
@@ -1,0 +1,110 @@
+// hal0 dashboard — sign-in-required drawer (#1822).
+//
+// A LAN-bound box with `require_auth` OFF still gates ADMIN-class
+// mutations (model pulls, slot deletes, config writes, approval execution)
+// for callers that didn't arrive over loopback — see
+// hal0.api.auth's posture-coupled gate. Full-page login (AuthGate/
+// LoginView) never fires for this case: `auth_required` genuinely reads
+// false, so the shell renders the app as usual. The FIRST time a mutation
+// hits that 401, `lib/queryClient.ts`'s global MutationCache.onError routes
+// it here via useAuthChallengeStore instead.
+//
+// Consequence-first copy (COMMON.md): say what happens to the operator,
+// then the mechanism. On a successful login, `retry()` re-executes the
+// SAME mutation that was refused (same variables, same `useMutation`
+// instance), so the original caller's own onSuccess / toast / cache
+// invalidation fires exactly as if the 401 had never happened.
+
+import { useEffect, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiPost } from '@/api/client'
+import { ENDPOINTS } from '@/api/endpoints'
+import { Drawer } from '@/dash/primitives.jsx'
+import { loginErrorMessage } from './gateDecision.js'
+import { useAuthChallengeStore } from '@/stores/useAuthChallengeStore'
+
+export function AuthChallengeDrawer() {
+  const open = useAuthChallengeStore((s) => s.open)
+  const dismiss = useAuthChallengeStore((s) => s.dismiss)
+  const retry = useAuthChallengeStore((s) => s.retry)
+  const qc = useQueryClient()
+
+  const [key, setKey] = useState('')
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!open) {
+      setKey('')
+      setError(null)
+    }
+  }, [open])
+
+  const login = useMutation({
+    mutationFn: (k) => apiPost(ENDPOINTS.authLogin, { key: k }),
+    onSuccess: async () => {
+      setError(null)
+      setKey('')
+      await qc.invalidateQueries({ queryKey: ['auth-status'] })
+      await retry()
+    },
+    onError: (err) => setError(loginErrorMessage(err)),
+  })
+
+  const submit = (e) => {
+    e.preventDefault()
+    if (!key || login.isPending) return
+    setError(null)
+    login.mutate(key)
+  }
+
+  return (
+    <Drawer
+      open={open}
+      onClose={dismiss}
+      eyebrow="Sign-in required"
+      title="This box is reachable from your network"
+      width={420}
+      foot={
+        <button
+          type="submit"
+          form="auth-challenge-form"
+          className="btn"
+          data-testid="auth-challenge-submit"
+          disabled={!key || login.isPending}
+        >
+          {login.isPending ? 'Signing in…' : 'Sign in & retry'}
+        </button>
+      }
+    >
+      <form id="auth-challenge-form" data-testid="auth-challenge-drawer" onSubmit={submit} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg-3, #aaa)' }}>
+          Other devices on your network can reach this box, so changes need the admin key — sign
+          in once and the action you just tried will retry automatically.
+        </p>
+
+        <label className="mono" htmlFor="auth-challenge-key" style={{ fontSize: 11, color: 'var(--fg-4, #888)' }}>
+          Admin key
+        </label>
+        <input
+          id="auth-challenge-key"
+          data-testid="auth-challenge-key-input"
+          type="password"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          autoComplete="current-password"
+          autoFocus
+          spellCheck={false}
+          disabled={login.isPending}
+          placeholder="admin key"
+          className="input mono"
+        />
+
+        {error && (
+          <div data-testid="auth-challenge-error" role="alert" className="mono" style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--err, #e66)' }}>
+            {error.text}
+          </div>
+        )}
+      </form>
+    </Drawer>
+  )
+}

--- a/ui/src/dash/auth/AuthChallengeDrawer.jsx
+++ b/ui/src/dash/auth/AuthChallengeDrawer.jsx
@@ -66,53 +66,55 @@ export function AuthChallengeDrawer() {
   if (!open) return null
 
   return (
-    <Drawer
-      open={open}
-      onClose={dismiss}
-      eyebrow="Sign-in required"
-      title="This box is reachable from your network"
-      width={420}
-      foot={
-        <button
-          type="submit"
-          form="auth-challenge-form"
-          className="btn"
-          data-testid="auth-challenge-submit"
-          disabled={!key || login.isPending}
-        >
-          {login.isPending ? 'Signing in…' : 'Sign in & retry'}
-        </button>
-      }
-    >
-      <form id="auth-challenge-form" data-testid="auth-challenge-drawer" onSubmit={submit} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-        <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg-3, #aaa)' }}>
-          Other devices on your network can reach this box, so changes need the admin key — sign
-          in once and the action you just tried will retry automatically.
-        </p>
+    <div className="auth-challenge-layer">
+      <Drawer
+        open={open}
+        onClose={dismiss}
+        eyebrow="Sign-in required"
+        title="This box is reachable from your network"
+        width={420}
+        foot={
+          <button
+            type="submit"
+            form="auth-challenge-form"
+            className="btn"
+            data-testid="auth-challenge-submit"
+            disabled={!key || login.isPending}
+          >
+            {login.isPending ? 'Signing in…' : 'Sign in & retry'}
+          </button>
+        }
+      >
+        <form id="auth-challenge-form" data-testid="auth-challenge-drawer" onSubmit={submit} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.55, color: 'var(--fg-3, #aaa)' }}>
+            Other devices on your network can reach this box, so changes need the admin key — sign
+            in once and the action you just tried will retry automatically.
+          </p>
 
-        <label className="mono" htmlFor="auth-challenge-key" style={{ fontSize: 11, color: 'var(--fg-4, #888)' }}>
-          Admin key
-        </label>
-        <input
-          id="auth-challenge-key"
-          data-testid="auth-challenge-key-input"
-          type="password"
-          value={key}
-          onChange={(e) => setKey(e.target.value)}
-          autoComplete="current-password"
-          autoFocus
-          spellCheck={false}
-          disabled={login.isPending}
-          placeholder="admin key"
-          className="input mono"
-        />
+          <label className="mono" htmlFor="auth-challenge-key" style={{ fontSize: 11, color: 'var(--fg-4, #888)' }}>
+            Admin key
+          </label>
+          <input
+            id="auth-challenge-key"
+            data-testid="auth-challenge-key-input"
+            type="password"
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+            autoComplete="current-password"
+            autoFocus
+            spellCheck={false}
+            disabled={login.isPending}
+            placeholder="admin key"
+            className="input mono"
+          />
 
-        {error && (
-          <div data-testid="auth-challenge-error" role="alert" className="mono" style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--err, #e66)' }}>
-            {error.text}
-          </div>
-        )}
-      </form>
-    </Drawer>
+          {error && (
+            <div data-testid="auth-challenge-error" role="alert" className="mono" style={{ fontSize: 11.5, lineHeight: 1.5, color: 'var(--err, #e66)' }}>
+              {error.text}
+            </div>
+          )}
+        </form>
+      </Drawer>
+    </div>
   )
 }

--- a/ui/src/dash/auth/AuthChallengeDrawer.jsx
+++ b/ui/src/dash/auth/AuthChallengeDrawer.jsx
@@ -57,6 +57,14 @@ export function AuthChallengeDrawer() {
     login.mutate(key)
   }
 
+  // Mount NOTHING until a challenge is actually raised. `Drawer` renders its
+  // <aside class="drawer" role="dialog"> whether or not it is open — `open`
+  // only adds a class — so an always-mounted instance at the app root would
+  // put a SECOND .drawer / [role="dialog"] on every page, and every spec that
+  // addresses the page's one drawer by class or role becomes a strict-mode
+  // violation. After the hooks above, so hook order stays unconditional.
+  if (!open) return null
+
   return (
     <Drawer
       open={open}

--- a/ui/src/dash/auth/__tests__/AuthChallengeDrawer.smoke.test.tsx
+++ b/ui/src/dash/auth/__tests__/AuthChallengeDrawer.smoke.test.tsx
@@ -1,0 +1,45 @@
+// #1822 — AuthChallengeDrawer mount smoke test.
+//
+// `renderToStaticMarkup` is a server-style render, and zustand's React
+// binding deliberately serves `getInitialState()` (never live state) as the
+// SSR snapshot (zustand/esm/react.mjs's `useStore`) — so a `setState()` made
+// right before an SSR render is invisible to the component, by design (real
+// SSR never mutates a store ahead of hydration). That means this file can
+// only prove the drawer's CLOSED default mounts cleanly; the open →
+// key-entry → submit → retry flow needs a live client render and is covered
+// end-to-end instead by tests/e2e/specs/auth-challenge-v3.spec.ts (a real
+// mutation, a real 401, a real retry) plus the pure-logic coverage in
+// useAuthChallengeStore.test.ts (request/dismiss/retry, no React involved).
+//
+// `@/dash/primitives.jsx`'s `Drawer` is the shared window-globals prototype
+// component (React/Icons read as bare globals at module-eval time); it's
+// stubbed here so this file stays scoped to AuthChallengeDrawer's own logic.
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, expect, it, vi } from 'vitest'
+import { useAuthChallengeStore } from '@/stores/useAuthChallengeStore'
+
+vi.mock('@/dash/primitives.jsx', () => ({
+  Drawer: ({ open, eyebrow, title, children, foot }: any) =>
+    open
+      ? React.createElement('div', { 'data-testid': 'stub-drawer' }, eyebrow, title, children, foot)
+      : null,
+}))
+
+const { AuthChallengeDrawer } = await import('../AuthChallengeDrawer.jsx')
+
+describe('AuthChallengeDrawer (smoke)', () => {
+  it('mounts closed (the default, no challenge pending) without throwing', () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const html = renderToStaticMarkup(
+      React.createElement(QueryClientProvider, { client: qc }, React.createElement(AuthChallengeDrawer)),
+    )
+    expect(html).not.toContain('stub-drawer')
+  })
+
+  it('the store starts closed with nothing pending (the state this mount reflects)', () => {
+    expect(useAuthChallengeStore.getState()).toMatchObject({ open: false, pending: null })
+  })
+})

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -15,6 +15,12 @@ import { MigrationResolveHost } from './migration/MigrationResolveHost.jsx'
 // enforcement is on and the session is anonymous; a no-op on open boxes (the
 // shipped default). Real ESM import, like SettingsShell above.
 import { AuthGate } from './auth/AuthGate.jsx'
+// #1822: sign-in-required drawer for the posture-coupled ADMIN gate (a LAN-
+// bound box gates mutations even with `require_auth` off — see
+// hal0.api.auth). Mounted unconditionally alongside AuthGate: this scenario
+// is by definition one where `auth_required` reads false, so AuthGate always
+// renders the app and this drawer is the only surface for the 401.
+import { AuthChallengeDrawer } from './auth/AuthChallengeDrawer.jsx'
 // VERS-flash (docs/rework/handoff-r5-drive2.md §3): same live-version
 // pattern as AboutPage.jsx — once mounted, keep document.title in sync with
 // the real running backend (not just the build-time stamp baked into
@@ -526,6 +532,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
     <BannerProvider>
       <AuthGate>
         <App />
+        <AuthChallengeDrawer />
       </AuthGate>
     </BannerProvider>
   </Hal0QueryClientProvider>

--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -1199,3 +1199,8 @@ function ImportDialog({
 }
 
 Object.assign(window, { Modal, Drawer, DrawerDock, ConfirmDialog, Banner, BannerStack, BannerProvider, useBanners, BANNER_CATALOG, Menu, UpdateBanner, GpuImageModeBanner, FirstRunBanner, FieldGroup, FieldInfoIcon, PillToggle, MtpControl, NAME_RE, toast, useFocusTrap, FormRow, useForm, FormDrawer, ImportDialog });
+
+// Real ESM export for the newer `dash/auth/*` modules (AuthChallengeDrawer),
+// which import Drawer directly rather than reading the window-globals shim
+// the legacy dash/*.jsx prototype files above rely on.
+export { Drawer };

--- a/ui/src/dash/settings/pages/server/SecurityPage.jsx
+++ b/ui/src/dash/settings/pages/server/SecurityPage.jsx
@@ -151,7 +151,9 @@ export function SecurityPage() {
             <div className="mono" style={{ fontSize: 10.5, color: 'var(--fg-5)', marginTop: 3, lineHeight: 1.55, maxWidth: 460 }}>
               {authArmed
                 ? 'Every route requires the admin key (or a logged-in session). Applies live — no restart.'
-                : 'Auth is off — hal0 runs trusted-LAN open. Enable to require a login; you’ll be asked for the admin key on the next load.'}
+                : s?.lan_exposed
+                  ? 'Auth is off, but this box is reachable from your network — changes (model pulls, slot edits, config writes) already ask for the admin key automatically from other devices; reads and inference stay open. Enable to require a login for everything, including reads.'
+                  : 'Auth is off — hal0 runs trusted-LAN open. Enable to require a login; you’ll be asked for the admin key on the next load.'}
             </div>
           </div>
           {authArmed ? (

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -3052,6 +3052,15 @@ select.npu-sel {
   max-width: 100vw;
 }
 .drawer.open { transform: translateX(0); }
+
+/* The #1822 sign-in challenge is raised BY a refused mutation, and that
+   mutation is often fired from inside a modal (approvals, delete confirms).
+   `.modal-backdrop` is z-index 100 and `.drawer` is 95, so the challenge
+   would render behind the very modal that triggered it and its Sign in
+   button would be unclickable. This layer is the last-resort surface, so it
+   outranks both. */
+.auth-challenge-layer .drawer-backdrop { z-index: 120; }
+.auth-challenge-layer .drawer { z-index: 125; }
 .drawer-h {
   padding: 18px 22px 14px;
   border-bottom: 1px solid var(--line);

--- a/ui/src/lib/queryClient.ts
+++ b/ui/src/lib/queryClient.ts
@@ -9,10 +9,34 @@
 //     all day; refocus pings are noise.
 //   - `retry: 1` — surfaces 404 / 5xx quickly so the per-hook fallback
 //     (mock data or empty list) can render instead of spinning forever.
+//
+// `mutationCache.onError` (#1822): a LAN-bound box with auth off still
+// requires an admin session for ADMIN-class mutations from off-box callers
+// (hal0.api.auth's posture-coupled gate). That 401 (`Hal0Error` with
+// `code: 'auth.required'`) can come from ANY mutation anywhere in the
+// dashboard, so it's caught here once — globally — instead of threading a
+// reauth callback through every `useMutation` call site. It hands the
+// failed `mutation` (a `Mutation.execute(variables)`-capable instance) to
+// `useAuthChallengeStore`, which `AuthChallengeDrawer` renders; a successful
+// login re-runs `execute(variables)` so the original caller's own
+// onSuccess/cache-invalidation still fires normally.
 
-import { QueryClient } from '@tanstack/react-query'
+import { MutationCache, QueryClient } from '@tanstack/react-query'
+import { Hal0Error } from '@/api/client'
+import { useAuthChallengeStore } from '@/stores/useAuthChallengeStore'
+
+function isPostureReauthChallenge(error: unknown): boolean {
+  return error instanceof Hal0Error && error.status === 401 && error.code === 'auth.required'
+}
 
 export const queryClient = new QueryClient({
+  mutationCache: new MutationCache({
+    onError: (error, variables, _context, mutation) => {
+      if (isPostureReauthChallenge(error)) {
+        useAuthChallengeStore.getState().request(mutation, variables)
+      }
+    },
+  }),
   defaultOptions: {
     queries: {
       staleTime: 30_000,

--- a/ui/src/stores/useAuthChallengeStore.test.ts
+++ b/ui/src/stores/useAuthChallengeStore.test.ts
@@ -1,0 +1,56 @@
+// #1822 — the auth-challenge store: request() opens the drawer and pins the
+// mutation+variables to retry, dismiss() clears it without executing
+// anything, and retry() calls Mutation.execute(variables) exactly once then
+// closes.
+
+import { describe, expect, it, vi } from 'vitest'
+import { useAuthChallengeStore } from './useAuthChallengeStore'
+
+function resetStore() {
+  useAuthChallengeStore.setState({ open: false, pending: null })
+}
+
+describe('useAuthChallengeStore', () => {
+  it('request() opens the drawer and pins the mutation for retry', () => {
+    resetStore()
+    const execute = vi.fn().mockResolvedValue(undefined)
+    useAuthChallengeStore.getState().request({ execute }, { id: '123' })
+
+    const state = useAuthChallengeStore.getState()
+    expect(state.open).toBe(true)
+    expect(state.pending?.variables).toEqual({ id: '123' })
+    expect(execute).not.toHaveBeenCalled()
+  })
+
+  it('dismiss() clears the pending challenge without executing it', () => {
+    resetStore()
+    const execute = vi.fn().mockResolvedValue(undefined)
+    useAuthChallengeStore.getState().request({ execute }, { id: '123' })
+
+    useAuthChallengeStore.getState().dismiss()
+
+    const state = useAuthChallengeStore.getState()
+    expect(state.open).toBe(false)
+    expect(state.pending).toBeNull()
+    expect(execute).not.toHaveBeenCalled()
+  })
+
+  it('retry() re-executes the pending mutation with its original variables, then closes', async () => {
+    resetStore()
+    const execute = vi.fn().mockResolvedValue(undefined)
+    useAuthChallengeStore.getState().request({ execute }, { id: 'approval-1' })
+
+    await useAuthChallengeStore.getState().retry()
+
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(execute).toHaveBeenCalledWith({ id: 'approval-1' })
+    const state = useAuthChallengeStore.getState()
+    expect(state.open).toBe(false)
+    expect(state.pending).toBeNull()
+  })
+
+  it('retry() with nothing pending is a safe no-op', async () => {
+    resetStore()
+    await expect(useAuthChallengeStore.getState().retry()).resolves.toBeUndefined()
+  })
+})

--- a/ui/src/stores/useAuthChallengeStore.ts
+++ b/ui/src/stores/useAuthChallengeStore.ts
@@ -1,0 +1,61 @@
+// hal0 v3 dashboard — auth-challenge store (#1822).
+//
+// A LAN-bound box with `require_auth` OFF still requires an admin
+// session/key for ADMIN-class mutations from off-box callers
+// (hal0.api.auth's posture-coupled gate). That 401 (`auth.required`) can
+// land on ANY mutation anywhere in the dashboard, so it's caught once,
+// globally, via the TanStack Query `MutationCache`'s `onError` (see
+// `lib/queryClient.ts`) rather than threaded through every `useMutation`
+// call site.
+//
+// This store holds the ONE pending challenge (a second 401 while a drawer
+// is already open replaces the retry target rather than queueing — the
+// operator only has one login form to fill in at a time) and the retry
+// path: `Mutation.execute(variables)` re-runs the exact call that got
+// refused, through the SAME mutation instance, so its own onSuccess/
+// onError/cache-invalidation still fire normally once the session exists.
+
+import { create } from 'zustand'
+
+// Structurally: a `@tanstack/query-core` `Mutation` instance. Typed loosely
+// here (rather than importing the generic-heavy `Mutation<...>` type) since
+// this store only ever calls `.execute(variables)` on it.
+interface ExecutableMutation {
+  execute: (variables: unknown) => Promise<unknown>
+}
+
+interface PendingChallenge {
+  mutation: ExecutableMutation
+  variables: unknown
+}
+
+interface AuthChallengeState {
+  open: boolean
+  pending: PendingChallenge | null
+  /** Called by the global MutationCache.onError when a mutation 401s with auth.required. */
+  request: (mutation: ExecutableMutation, variables: unknown) => void
+  /** Dismiss without retrying — the original mutation stays failed. */
+  dismiss: () => void
+  /** Re-run the pending mutation (call after a successful login). */
+  retry: () => Promise<void>
+}
+
+export const useAuthChallengeStore = create<AuthChallengeState>((set, get) => ({
+  open: false,
+  pending: null,
+
+  request(mutation, variables) {
+    set({ open: true, pending: { mutation, variables } })
+  },
+
+  dismiss() {
+    set({ open: false, pending: null })
+  },
+
+  async retry() {
+    const pending = get().pending
+    set({ open: false, pending: null })
+    if (!pending) return
+    await pending.mutation.execute(pending.variables)
+  },
+}))

--- a/ui/tests/e2e/specs/auth-challenge-v3.spec.ts
+++ b/ui/tests/e2e/specs/auth-challenge-v3.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * auth-challenge-v3 (#1822) — the posture-coupled ADMIN gate's dashboard UX.
+ *
+ * A LAN-bound box with `require_auth` OFF still requires an admin session
+ * for ADMIN-class mutations from off-box callers (hal0.api.auth's
+ * posture-coupled gate) — model pulls, slot deletes, config writes, and
+ * approval execution alike. `auth_required` genuinely reads false in this
+ * scenario, so the full-page login (AuthGate/LoginView) never fires; the
+ * FIRST mutation that hits the 401 (`auth.required`) is what has to surface
+ * the prompt. `lib/queryClient.ts`'s global `MutationCache.onError` catches
+ * it and routes it to `AuthChallengeDrawer` via `useAuthChallengeStore` —
+ * this spec drives that end-to-end through the approvals flow named in the
+ * brief: mutation → 401 → sign-in → retried OK.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+test.describe('Auth challenge drawer (#1822 posture-coupled gate)', () => {
+  test('approve 401s once, the drawer prompts sign-in, and the retry succeeds', async ({
+    page,
+    mockState,
+  }) => {
+    mockState.approvals = [
+      {
+        id: 'ap-1',
+        tool: 'model_pull',
+        args: { model: 'llama-3.1-8b' },
+        client_id: 'hermes',
+        enqueued_at: Date.now() / 1000 - 60,
+        state: 'pending',
+      },
+    ]
+
+    let approveAttempts = 0
+    await page.route('**/api/agent/approvals/*/approve', async (route) => {
+      approveAttempts += 1
+      if (approveAttempts === 1) {
+        return route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: { code: 'auth.required', message: 'authentication required', details: {} },
+          }),
+        })
+      }
+      // Second attempt (the retry, now "logged in"): succeed and clear the
+      // entry so the modal's own re-render reflects a resolved approval.
+      mockState.approvals = mockState.approvals.filter((a: any) => a.id !== 'ap-1')
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ approval: { id: 'ap-1', state: 'executed' } }),
+      })
+    })
+
+    let loginAttempts = 0
+    await page.route('**/api/auth/login', async (route) => {
+      loginAttempts += 1
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, tier: 'admin' }),
+      })
+    })
+
+    await page.goto('/')
+    await expect(page.getByTestId('tb-bell-badge')).toHaveText('1', { timeout: 6_000 })
+    await page.getByTestId('tb-bell').click()
+    await page.getByTestId('notif-sec-attention').getByRole('button', { name: 'Review' }).click()
+    await expect(page.locator('.approval-modal')).toBeVisible()
+
+    // Approve → 401 → the sign-in drawer appears instead of a silent failure.
+    // (Drawer, per primitives.jsx, always keeps its <aside> mounted and
+    // toggles a `.open` class + `aria-hidden` for its slide transition —
+    // it never unmounts — so "closed" is asserted via those, not absence.)
+    await page.locator('.approval-card').getByRole('button', { name: 'Approve' }).click()
+    const drawer = page.locator('aside.drawer', { hasText: 'Sign-in required' })
+    await expect(drawer).toHaveClass(/\bopen\b/)
+    await expect(drawer).toHaveAttribute('aria-hidden', 'false')
+    await expect(drawer).toContainText('reachable from your network')
+
+    // Sign in — the drawer retries the ORIGINAL approve call automatically.
+    await page.getByTestId('auth-challenge-key-input').fill('the-admin-key')
+    await page.getByTestId('auth-challenge-submit').click()
+
+    await expect(drawer).not.toHaveClass(/\bopen\b/)
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true')
+    expect(loginAttempts).toBe(1)
+    expect(approveAttempts).toBe(2)
+
+    // The retried approve succeeded: the entry is gone from the pending list.
+    await expect(page.getByTestId('approvals-empty')).toBeVisible()
+  })
+
+  test('dismissing the drawer leaves the original mutation failed (no retry)', async ({
+    page,
+    mockState,
+  }) => {
+    mockState.approvals = [
+      {
+        id: 'ap-2',
+        tool: 'slot_delete',
+        args: { slot: 'qwen' },
+        client_id: 'hermes',
+        enqueued_at: Date.now() / 1000 - 30,
+        state: 'pending',
+      },
+    ]
+
+    let approveAttempts = 0
+    await page.route('**/api/agent/approvals/*/approve', async (route) => {
+      approveAttempts += 1
+      return route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: { code: 'auth.required', message: 'authentication required', details: {} },
+        }),
+      })
+    })
+
+    await page.goto('/')
+    await page.getByTestId('tb-bell').click()
+    await page.getByTestId('notif-sec-attention').getByRole('button', { name: 'Review' }).click()
+    await page.locator('.approval-card').getByRole('button', { name: 'Approve' }).click()
+
+    const drawer = page.locator('aside.drawer', { hasText: 'Sign-in required' })
+    await expect(drawer).toHaveClass(/\bopen\b/)
+    await page.keyboard.press('Escape')
+    await expect(drawer).not.toHaveClass(/\bopen\b/)
+
+    // Only the one refused attempt happened — dismissing never retries.
+    expect(approveAttempts).toBe(1)
+  })
+})

--- a/ui/tests/e2e/specs/auth-challenge-v3.spec.ts
+++ b/ui/tests/e2e/specs/auth-challenge-v3.spec.ts
@@ -69,9 +69,12 @@ test.describe('Auth challenge drawer (#1822 posture-coupled gate)', () => {
     await expect(page.locator('.approval-modal')).toBeVisible()
 
     // Approve → 401 → the sign-in drawer appears instead of a silent failure.
-    // (Drawer, per primitives.jsx, always keeps its <aside> mounted and
-    // toggles a `.open` class + `aria-hidden` for its slide transition —
-    // it never unmounts — so "closed" is asserted via those, not absence.)
+    // AuthChallengeDrawer renders NOTHING until a challenge is raised: the
+    // Drawer primitive keeps its <aside class="drawer" role="dialog"> mounted
+    // whether open or not, so an always-mounted instance at the app root would
+    // put a second drawer on every page and every spec that addresses "the
+    // drawer" by class or role would hit a strict-mode violation. "Closed" is
+    // therefore asserted as absence, not as a missing `.open` class.
     await page.locator('.approval-card').getByRole('button', { name: 'Approve' }).click()
     const drawer = page.locator('aside.drawer', { hasText: 'Sign-in required' })
     await expect(drawer).toHaveClass(/\bopen\b/)
@@ -82,8 +85,7 @@ test.describe('Auth challenge drawer (#1822 posture-coupled gate)', () => {
     await page.getByTestId('auth-challenge-key-input').fill('the-admin-key')
     await page.getByTestId('auth-challenge-submit').click()
 
-    await expect(drawer).not.toHaveClass(/\bopen\b/)
-    await expect(drawer).toHaveAttribute('aria-hidden', 'true')
+    await expect(drawer).toHaveCount(0)
     expect(loginAttempts).toBe(1)
     expect(approveAttempts).toBe(2)
 
@@ -126,7 +128,7 @@ test.describe('Auth challenge drawer (#1822 posture-coupled gate)', () => {
     const drawer = page.locator('aside.drawer', { hasText: 'Sign-in required' })
     await expect(drawer).toHaveClass(/\bopen\b/)
     await page.keyboard.press('Escape')
-    await expect(drawer).not.toHaveClass(/\bopen\b/)
+    await expect(drawer).toHaveCount(0)
 
     // Only the one refused attempt happened — dismissing never retries.
     expect(approveAttempts).toBe(1)


### PR DESCRIPTION
hal0-api binds 0.0.0.0:8080 by default, so the shipped combination — auth
off, bind wide open — let any device on the LAN drive every ADMIN-class
route (model pulls, slot deletes, config writes, approval execution) with
no credential at all.

_lan_admin_gate() closes that without touching the require_auth toggle: an
ADMIN-classified request is treated as if enforcement were on whenever all
three hold — an admin key is configured (otherwise the requirement is
unsatisfiable, the same first-run carve-out AuthClass.BOOTSTRAP already
makes), hal0.config.network.is_loopback_bind() is false, and this request's
own peer did not arrive over loopback. A loopback-bound box, or a
loopback-originating request against a LAN-bound one, stays frictionless.
OPEN/CLIENT reads are unaffected.

The dashboard answers the resulting 401 with an admin-key challenge drawer
(useAuthChallengeStore + AuthChallengeDrawer, wired through queryClient)
instead of a dead-end error, and hal0 doctor reports the posture.

Signed-off-by: thinmintdev <alexander@awideweb.com>


## Verification

`ruff check src tests` clean. Full α unit suite (12808 tests) green apart from
three failures that also fail on a clean `main` checkout
(`tests/providers/test_moonshine_server.py` ×2, needs `ffmpeg`, and
`tests/slots/test_pressure_eviction.py::test_pressure_evict_noop_when_probe_fails`).
Integration β not run locally (needs root + a live `hal0-lemonade.service`); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzkumtSWnm3AxixzHG38UG
