### PR TITLE
fix(slots): bound every seam call, show progress during slot lifecycle (#1869, #1870)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,24 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Fixed
 
+- **Every `systemctl`/podman seam call a slot load/unload/restart makes is
+  now bounded.** `ContainerProvider._run`'s callers (the Quadlet write,
+  `daemon-reload`, `reset-failed`, and — the one that actually wedged in the
+  field — `systemctl restart`, which spawns the container) used to pass no
+  timeout at all, so a stuck `sudo hal0-systemctl` or a wedged podman/netavark
+  call blocked the executor thread forever with nothing bounding it
+  server-side (#1869). A new `hal0.system.seam.bounded_call()` wraps every
+  such call and turns a `subprocess.TimeoutExpired` into a typed
+  `SeamTimeout` (`slot.seam_timeout`, HTTP 504) carrying the command, its
+  budget, and whatever the child had already printed before being killed;
+  the error propagates to the slot state machine as `error` with that
+  message, same as any other load failure. `hal0 slot load|unload|restart|
+  swap` and `hal0 update --restart-slots` now show an elapsed counter and the
+  slot's live state while they wait (refreshed every ~2s on a TTY; one
+  summary line otherwise), print the seam-timeout remedy (`hal0 slot logs
+  <name>`, `journalctl -u hal0-slot@<name>`) instead of a bare read-timeout
+  error, and gained a `--json` flag — instead of blocking silently for up to
+  ~40 minutes with no output (#1870). (#1869, #1870)
 - MCP admin tools no longer report a tool failure for a successful read of a
   slot whose lifecycle state is `error`. The tool-result wrapper's failure
   sentinel keyed on `status == "error"` alone, which collides with the slot

--- a/docs/guides/manage-slots.mdx
+++ b/docs/guides/manage-slots.mdx
@@ -204,6 +204,42 @@ field is disabled with this same reason while the slot is up.
 </TabItem>
 </Tabs>
 
+### While a lifecycle command is waiting
+
+`load`, `unload`, `restart`, and `swap` all block until the slot converges —
+a cold load can legitimately take minutes (health poll, then the
+output-sanity check). On a terminal, the CLI now shows an elapsed counter and
+the slot's live state, refreshed every couple of seconds:
+
+```sh
+$ hal0 slot load agent
+⠋ Loading agent… 42s elapsed — state=starting
+```
+
+Piped or scripted (`--json`, or stdout redirected) prints one line up front
+instead and stays quiet until the result:
+
+```sh
+$ hal0 slot load agent --json > result.json
+Loading agent (up to 2139s)…
+```
+
+If the wait itself times out — every `systemctl`/podman call the server
+makes on your behalf is now bounded, so this means a specific wedged
+command, not an indefinite hang — the CLI prints the seam's own error and
+where to look next:
+
+```
+Error: `systemctl restart hal0-slot@agent.service` did not return within 180s
+still converging? check `hal0 slot logs agent` or `journalctl -u hal0-slot@agent`.
+```
+
+The slot itself lands in `error` with that same message (`hal0 slot status
+agent`, or `/api/slots/agent`), carrying the typed code `slot.seam_timeout` —
+a load in this state is safe to retry once the stuck command clears (a
+wedged `systemctl`/podman invocation on the host, or a genuinely oversized
+model that needs a wider `[server]` timeout upstream).
+
 ## Swap the model
 
 ```sh

--- a/src/hal0/cli/_shared.py
+++ b/src/hal0/cli/_shared.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 import os
 import sys
-from collections.abc import Iterator
+import threading
+import time
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from typing import Any
 
@@ -273,15 +275,33 @@ def _api_request(
     try:
         with httpx.Client(timeout=_client_timeout(timeout)) as client:
             resp = client.request(method, url, **kwargs)
+    except httpx.TimeoutException as exc:
+        # The client's OWN read budget expired with no response at all — the
+        # server may still be converging (#1832/#1870). Distinct from
+        # CliApiError so a lifecycle command can print the timeout remedy
+        # (``hal0 slot logs``/``journalctl``) instead of a generic error.
+        raise CliApiTimeout(f"{method} {url} did not respond within {timeout:g}s") from exc
     except httpx.HTTPError as exc:
         raise CliApiError(f"{method} {url} failed: {type(exc).__name__}: {exc}") from exc
     if resp.status_code >= 400:
+        code: str | None = None
         try:
             body = resp.json()
-            msg = body.get("error", {}).get("message") or body
+            error = body.get("error") if isinstance(body, dict) else None
+            if isinstance(error, dict):
+                msg = error.get("message") or body
+                code = error.get("code")
+            else:
+                msg = body
         except ValueError:
             msg = resp.text[:300]
-        raise CliApiError(f"{method} {url} → HTTP {resp.status_code}: {msg}")
+        # The server bounded its own seam call and answered with the typed
+        # ``slot.seam_timeout`` envelope (#1869) rather than hanging until
+        # OUR read timeout fired — still "the operation timed out" from the
+        # operator's point of view, so it gets the same remedy treatment.
+        if code == "slot.seam_timeout":
+            raise CliApiTimeout(f"{method} {url} → HTTP {resp.status_code}: {msg}")
+        raise CliApiError(f"{method} {url} → HTTP {resp.status_code}: {msg}", code=code)
     if not resp.content:
         return None
     try:
@@ -291,7 +311,94 @@ def _api_request(
 
 
 class CliApiError(RuntimeError):
-    """Raised by the api_* helpers when the API returns an error."""
+    """Raised by the api_* helpers when the API returns an error.
+
+    ``code`` (when the server answered with the hal0 error envelope) carries
+    the typed ``error.code`` string — ``None`` for a transport-level failure
+    or a non-enveloped response.
+    """
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class CliApiTimeout(CliApiError):
+    """The lifecycle call did not complete within its budget (#1869/#1870).
+
+    Raised either when the CLI's own read timeout expires with no response
+    (the server may still be converging), or when the server answered
+    promptly with its own typed ``slot.seam_timeout`` (#1869) — a wedged
+    ``systemctl``/podman seam call bounded server-side rather than left to
+    hang. Callers print the same remedy either way: check the unit's logs.
+    """
+
+
+#: How often the progress line refreshes while a lifecycle call is in flight.
+PROGRESS_POLL_INTERVAL_S = 2.0
+
+
+def run_with_progress(
+    call: Callable[[], Any],
+    *,
+    console: Console,
+    label: str,
+    timeout_s: float,
+    poll_state: Callable[[], str | None] | None = None,
+    json_out: bool = False,
+    poll_interval_s: float = PROGRESS_POLL_INTERVAL_S,
+) -> Any:
+    """Run a blocking lifecycle ``call()``, printing progress while it waits (#1870).
+
+    Before this, every mutating lifecycle verb (``hal0 slot load|unload|
+    restart|swap``, ``hal0 update --restart-slots``) made ONE blocking
+    ``api_post`` with a multi-minute read timeout (:mod:`hal0.slot_lifecycle_budget`)
+    and printed nothing until it returned — on a slow load an operator staring
+    at a silent terminal for up to ~2400s had no way to tell "still working"
+    from "hung".
+
+    On an interactive TTY (and not ``--json``, which must emit only the final
+    JSON payload): runs ``call()`` on a background thread and refreshes a
+    single status line — elapsed time plus, when ``poll_state`` is given, the
+    slot's current state (``GET /api/slots/{name}``, best-effort: a failed
+    poll just omits the state, never aborts the wait) — every
+    ``poll_interval_s``. Non-TTY or ``--json``: prints one summary line up
+    front (scripts/pipes get a stable, single-line transcript) and blocks.
+
+    Re-raises whatever ``call()`` raises, after the progress line stops.
+    """
+    interactive = console.is_terminal and not json_out
+    if not interactive:
+        if not json_out:
+            console.print(f"[dim]{label} (up to {timeout_s:.0f}s)…[/dim]")
+        return call()
+
+    outcome: dict[str, Any] = {}
+
+    def _run() -> None:
+        try:
+            outcome["value"] = call()
+        except BaseException as exc:
+            outcome["error"] = exc
+
+    worker = threading.Thread(target=_run, daemon=True)
+    start = time.monotonic()
+    worker.start()
+    with console.status(f"{label}…") as status:
+        while worker.is_alive():
+            worker.join(poll_interval_s)
+            elapsed = time.monotonic() - start
+            state = None
+            if poll_state is not None:
+                try:
+                    state = poll_state()
+                except Exception:
+                    state = None
+            state_part = f" — state={state}" if state else ""
+            status.update(f"{label}… {elapsed:.0f}s elapsed{state_part}")
+    if "error" in outcome:
+        raise outcome["error"]
+    return outcome.get("value")
 
 
 def die(msg: str, code: int = 1) -> None:

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -26,6 +26,7 @@ from rich.table import Table
 
 from hal0.cli._shared import (
     CliApiError,
+    CliApiTimeout,
     _api_base,
     _api_unreachable,
     api_delete,
@@ -34,6 +35,7 @@ from hal0.cli._shared import (
     api_put,
     die,
     follow_sse_logs,
+    run_with_progress,
 )
 from hal0.hardware.stats import SLOT_PORT_RANGE_END, SLOT_PORT_RANGE_START
 from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
@@ -193,6 +195,63 @@ def _fmt_state(state: str | None) -> str:
     return f"[{style}]{state}[/{style}]"
 
 
+#: GET /api/slots/{name} while a lifecycle call is in flight, for the progress
+#: line's "state=..." suffix — a short, independent timeout: a slow/failed
+#: poll must never itself contribute to the wait (#1870).
+_STATE_POLL_TIMEOUT_S = 5.0
+
+
+def _poll_slot_state(name: str) -> str | None:
+    """Best-effort current state for the progress line. ``None`` on any failure
+    (API momentarily unreachable, slot renamed mid-op, ...) — the caller
+    renders that as an elapsed-only line, never as an error."""
+    try:
+        snap = api_get(f"/api/slots/{name}", timeout=_STATE_POLL_TIMEOUT_S)
+    except CliApiError:
+        return None
+    if not isinstance(snap, dict):
+        return None
+    return _fmt_state(snap.get("status") or snap.get("state"))
+
+
+def _print_timeout_remedy(name: str) -> None:
+    """Remedy line printed alongside a :class:`CliApiTimeout` (#1869/#1870):
+    the operation may still be converging server-side — these are where to
+    watch it, not a signal that it definitely failed."""
+    console.print(
+        f"[dim]still converging? check `hal0 slot logs {name}` or "
+        f"`journalctl -u hal0-slot@{name}`.[/dim]"
+    )
+
+
+def _run_lifecycle_call(
+    *,
+    name: str,
+    label: str,
+    timeout_s: float,
+    json_out: bool,
+    call: Callable[[], Any],
+) -> Any:
+    """Run one mutating lifecycle POST with the shared progress/timeout UX
+    (#1870): elapsed + polled state on a TTY, one summary line otherwise, and
+    the timeout remedy on :class:`CliApiTimeout` before exiting non-zero."""
+    try:
+        return run_with_progress(
+            call,
+            console=console,
+            label=label,
+            timeout_s=timeout_s,
+            poll_state=lambda: _poll_slot_state(name),
+            json_out=json_out,
+        )
+    except CliApiTimeout as exc:
+        console.print(f"[bold red]Error:[/bold red] {exc}")
+        _print_timeout_remedy(name)
+        raise typer.Exit(1) from exc
+    except CliApiError as exc:
+        die(str(exc))
+
+
 @app.command("list")
 def slot_list(
     json_out: bool = typer.Option(
@@ -314,16 +373,24 @@ def slot_load(
     model: str | None = typer.Option(
         None, "--model", "-m", help="Model ref to assign before loading"
     ),
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit the final /api/slots/{name}/load JSON only (no progress)."
+    ),
 ) -> None:
     """Load a slot (optionally assign a model first)."""
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)
-    try:
-        body = {"model_id": model} if model else {}
-        snap = api_post(f"/api/slots/{name}/load", json=body, timeout=SLOT_LOAD_TIMEOUT_S)
-    except CliApiError as exc:
-        die(str(exc))
+    body = {"model_id": model} if model else {}
+    snap = _run_lifecycle_call(
+        name=name,
+        label=f"Loading {name}",
+        timeout_s=SLOT_LOAD_TIMEOUT_S,
+        json_out=json_out,
+        call=lambda: api_post(f"/api/slots/{name}/load", json=body, timeout=SLOT_LOAD_TIMEOUT_S),
+    )
+    if json_out:
+        typer.echo(jsonlib.dumps(snap, indent=2))
         return
     console.print(
         f"Loaded [bold]{name}[/bold] → state={_fmt_state(snap.get('state'))} model={snap.get('model_id', '—')}"
@@ -333,15 +400,23 @@ def slot_load(
 @app.command("unload")
 def slot_unload(
     name: str = typer.Argument(..., help="Slot name to unload"),
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit the final /api/slots/{name}/unload JSON only (no progress)."
+    ),
 ) -> None:
     """Unload a running slot gracefully."""
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)
-    try:
-        snap = api_post(f"/api/slots/{name}/unload", timeout=SLOT_UNLOAD_TIMEOUT_S)
-    except CliApiError as exc:
-        die(str(exc))
+    snap = _run_lifecycle_call(
+        name=name,
+        label=f"Unloading {name}",
+        timeout_s=SLOT_UNLOAD_TIMEOUT_S,
+        json_out=json_out,
+        call=lambda: api_post(f"/api/slots/{name}/unload", timeout=SLOT_UNLOAD_TIMEOUT_S),
+    )
+    if json_out:
+        typer.echo(jsonlib.dumps(snap, indent=2))
         return
     console.print(f"Unloaded [bold]{name}[/bold] → state={_fmt_state(snap.get('state'))}")
 
@@ -349,15 +424,23 @@ def slot_unload(
 @app.command("restart")
 def slot_restart(
     name: str = typer.Argument(..., help="Slot name to restart"),
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit the final /api/slots/{name}/restart JSON only (no progress)."
+    ),
 ) -> None:
     """Restart a slot (unload then load)."""
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)
-    try:
-        snap = api_post(f"/api/slots/{name}/restart", timeout=SLOT_LIFECYCLE_TIMEOUT_S)
-    except CliApiError as exc:
-        die(str(exc))
+    snap = _run_lifecycle_call(
+        name=name,
+        label=f"Restarting {name}",
+        timeout_s=SLOT_LIFECYCLE_TIMEOUT_S,
+        json_out=json_out,
+        call=lambda: api_post(f"/api/slots/{name}/restart", timeout=SLOT_LIFECYCLE_TIMEOUT_S),
+    )
+    if json_out:
+        typer.echo(jsonlib.dumps(snap, indent=2))
         return
     console.print(f"Restarted [bold]{name}[/bold] → state={_fmt_state(snap.get('state'))}")
 
@@ -393,6 +476,9 @@ def slot_swap(
         "--no-persist",
         help="Hot-swap only — don't update /etc/hal0/slots/<slot>.toml.",
     ),
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit the final /api/slots/{name}/swap JSON only (no progress)."
+    ),
 ) -> None:
     """Swap a slot's model, and (by default) make the change survive a restart.
 
@@ -408,12 +494,18 @@ def slot_swap(
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)
-    try:
-        snap = api_post(
+    snap = _run_lifecycle_call(
+        name=name,
+        label=f"Swapping {name} → {model}",
+        timeout_s=SLOT_LIFECYCLE_TIMEOUT_S,
+        json_out=json_out,
+        call=lambda: api_post(
             f"/api/slots/{name}/swap", json={"model_id": model}, timeout=SLOT_LIFECYCLE_TIMEOUT_S
-        )
-    except CliApiError as exc:
-        die(str(exc))
+        ),
+    )
+
+    if json_out and no_persist:
+        typer.echo(jsonlib.dumps(snap, indent=2))
         return
 
     swapped_id = snap.get("model_id", model)
@@ -429,11 +521,17 @@ def slot_swap(
     try:
         api_put(f"/api/install/slots/{name}/model", json={"model_id": model})
     except CliApiError as exc:
-        console.print(f"Swapped [bold]{name}[/bold] → {swapped_id} state={state}")
+        if json_out:
+            typer.echo(jsonlib.dumps(snap, indent=2))
+        else:
+            console.print(f"Swapped [bold]{name}[/bold] → {swapped_id} state={state}")
         console.print(f"[yellow]Warning:[/yellow] runtime swap succeeded but persist failed: {exc}")
         console.print(f"[dim]Change will revert on next restart of hal0-slot@{name}.service.[/dim]")
         raise typer.Exit(1) from None
 
+    if json_out:
+        typer.echo(jsonlib.dumps(snap, indent=2))
+        return
     console.print(
         f"Swapped [bold]{name}[/bold] → {swapped_id} state={state} [dim](persisted)[/dim]"
     )

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -30,12 +30,14 @@ from rich.table import Table
 
 from hal0.cli._shared import (
     CliApiError,
+    CliApiTimeout,
     _api_base,
     _api_unreachable,
     api_get,
     api_post,
     api_put,
     die,
+    run_with_progress,
 )
 from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
 
@@ -507,6 +509,22 @@ def _fetch_slot_drift() -> dict:
     return body if isinstance(body, dict) else {"count": 0, "slots": []}
 
 
+def _remaining_drift_state(names: list[str]) -> str | None:
+    """Progress-line state for ``--restart-slots`` (#1870): how many of the
+    slots this sweep targeted are still reported drifted.
+
+    Best-effort like :func:`_fetch_slot_drift`: a probe failure renders as no
+    state suffix (elapsed-only line), never as an error — the sweep itself is
+    still running regardless of whether this side probe succeeds.
+    """
+    drift = _fetch_slot_drift()
+    still_drifted = {s.get("slot") for s in (drift.get("slots") or []) if isinstance(s, dict)}
+    remaining = [n for n in names if n in still_drifted]
+    if not remaining:
+        return "converging"
+    return f"{len(remaining)}/{len(names)} still drifted"
+
+
 def _print_drift_banner(drift: dict) -> None:
     """Post-update ``N slots need restart`` banner (or a clean all-good line).
 
@@ -561,12 +579,21 @@ def _restart_drifted_slots() -> None:
         if isinstance(s, dict) and s.get("slot")
     ]
     payload = {"slots": names} if names else None
+    timeout_s = slot_lifecycle_timeout_s(loads=1, unloads=1, slots=max(len(names), count))
     try:
-        body = api_post(
-            "/api/updates/restart-slots",
-            json=payload,
-            timeout=slot_lifecycle_timeout_s(loads=1, unloads=1, slots=max(len(names), count)),
+        body = run_with_progress(
+            lambda: api_post("/api/updates/restart-slots", json=payload, timeout=timeout_s),
+            console=console,
+            label=f"Restarting {len(names)} drifted slot(s)",
+            timeout_s=timeout_s,
+            poll_state=lambda: _remaining_drift_state(names),
         )
+    except CliApiTimeout as exc:
+        console.print(f"[bold red]Error:[/bold red] {exc}")
+        console.print(
+            "[dim]still converging? check `hal0 slot list` or `journalctl -u 'hal0-slot@*'`.[/dim]"
+        )
+        raise typer.Exit(1) from exc
     except CliApiError as exc:
         die(str(exc))
         return

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -87,7 +87,11 @@ from hal0.providers._gpu import (
 )
 from hal0.providers.base import HealthCheck, Mount, Provider, RuntimeLaunchPlan
 from hal0.providers.podman_mutate import PullLineParser
-from hal0.slot_lifecycle_budget import HEALTH_TIMEOUT_S
+from hal0.slot_lifecycle_budget import (
+    HEALTH_TIMEOUT_S,
+    UNIT_ADMIN_CALLS_ALLOWANCE_S,
+    UNIT_START_TIMEOUT_S,
+)
 from hal0.slots.activation import autoload_enabled
 from hal0.slots.argv import ResolvedArgv, resolve_argv
 from hal0.slots.naming import (
@@ -97,7 +101,7 @@ from hal0.slots.naming import (
     slot_unit_name,
 )
 from hal0.slots.state import SlotSpawnFailed
-from hal0.system.seam import SystemCtlSeam, is_hal0_service_user
+from hal0.system.seam import SeamTimeout, SystemCtlSeam, is_hal0_service_user
 
 # ``ContainerSpec`` is the back-compat alias for ``RuntimeLaunchPlan``; some
 # callers/tests still import the old name from this module.
@@ -682,7 +686,25 @@ _HEALTH_REQUEST_TIMEOUT_S = 3.0
 #: generated ``.service`` stays on disk in ``failed`` and the "subsequent load
 #: still converges" promise does not hold. Deliberately under the caller's
 #: budget so the worker unwinds first.
-_UNIT_STOP_TIMEOUT_S = 20.0
+#:
+#: Reused (#1869) for every OTHER fast, should-be-sub-second systemd/seam
+#: admin call this provider makes outside the teardown path — the Quadlet
+#: write and ``daemon-reload`` in :meth:`_write_and_start_unit`,
+#: :meth:`daemon_reload`, :meth:`reset_failed`, :meth:`is_active`, and
+#: :meth:`unit_status` — none of which does real work beyond a sudo
+#: round-trip and a filesystem/systemd-daemon touch. Derived from
+#: ``hal0.slot_lifecycle_budget.UNIT_ADMIN_CALLS_ALLOWANCE_S`` (that budget is
+#: this bound charged three times — the load path's write + daemon-reload +
+#: reset-failed) so the two stay numerically locked together.
+_UNIT_STOP_TIMEOUT_S = UNIT_ADMIN_CALLS_ALLOWANCE_S / 3
+
+#: Wall-clock bound on the ``systemctl restart`` that actually (re)spawns a
+#: slot's container (#1869/#1870) — the one seam call in the load path that
+#: can legitimately take a while (device attach, a cold netavark setup)
+#: rather than being sub-second like the admin calls above. Imported from
+#: ``hal0.slot_lifecycle_budget`` (not a fresh literal) so the CLI's own wait,
+#: derived from the same module, stays in sync with the server's actual bound.
+_UNIT_START_TIMEOUT_S = UNIT_START_TIMEOUT_S
 
 #: Unit properties :meth:`ContainerProvider.unit_status` reads (#1791). All
 #: read-only — ``systemctl show`` needs no privilege and is never routed
@@ -2676,6 +2698,16 @@ class ContainerProvider(Provider):
         ``systemctl enable``. ``restart`` (not bare ``start``) keeps
         this idempotent: it starts a stopped slot and restarts a running one,
         exactly as before. All writes route through the hal0-systemctl seam.
+
+        Every seam call below is bounded (#1869): the write, the reloads and
+        ``reset_failed`` at :data:`_UNIT_STOP_TIMEOUT_S` (fast admin ops), the
+        ``restart`` itself at :data:`_UNIT_START_TIMEOUT_S` (the one call that
+        can legitimately take a while). A timeout raises
+        :class:`hal0.system.seam.SeamTimeout` — deliberately NOT caught here,
+        unlike ``CalledProcessError`` below: it is a distinct failure mode
+        (the seam call never confirmed one way or the other) and propagates
+        with its own ``slot.seam_timeout`` code through ``SlotManager.load``'s
+        generic ``except Exception -> ERROR`` handling.
         """
         unit_path = self._unit_path(slot_name)
         dropin_dir = unit_path.with_name(unit_path.name + ".d")
@@ -2692,9 +2724,9 @@ class ContainerProvider(Provider):
             "container.unit_write",
             extra={"slot": slot_name, "unit_path": str(unit_path)},
         )
-        _SYSTEMCTL_SEAM.write_quadlet(unit_path, unit_text)
+        _SYSTEMCTL_SEAM.write_quadlet(unit_path, unit_text, timeout=_UNIT_STOP_TIMEOUT_S)
         # daemon-reload runs the Quadlet generator, materialising the .service.
-        self._run("systemctl", "daemon-reload")
+        self._run("systemctl", "daemon-reload", timeout=_UNIT_STOP_TIMEOUT_S)
         # #1424/#1791: a unit parked in ``failed`` after StartLimitBurst
         # refuses every ``restart`` for the whole StartLimitIntervalSec window
         # ("Start request repeated too quickly"), so a slot that crash-looped
@@ -2705,7 +2737,7 @@ class ContainerProvider(Provider):
         self.reset_failed(slot_name)
         unit = self._unit_name(slot_name)
         try:
-            self._run("systemctl", "restart", unit)
+            self._run("systemctl", "restart", unit, timeout=_UNIT_START_TIMEOUT_S)
         except subprocess.CalledProcessError as exc:
             # #1424 facet 2: raw, this is not a Hal0Error — it falls through
             # SlotManager.load()'s re-raise into the API's generic Exception
@@ -2888,7 +2920,7 @@ class ContainerProvider(Provider):
         unit_text = self._render_quadlet_text(slot_cfg, model_info)
         if unit_path.read_text() == unit_text:
             return False
-        _SYSTEMCTL_SEAM.write_quadlet(unit_path, unit_text)
+        _SYSTEMCTL_SEAM.write_quadlet(unit_path, unit_text, timeout=_UNIT_STOP_TIMEOUT_S)
         log.info(
             "container.unit_rerendered",
             extra={"slot": token, "unit_path": str(unit_path)},
@@ -2897,7 +2929,7 @@ class ContainerProvider(Provider):
 
     def daemon_reload(self) -> None:
         """``systemctl daemon-reload`` — public for the unit-rerender sweep."""
-        self._run("systemctl", "daemon-reload")
+        self._run("systemctl", "daemon-reload", timeout=_UNIT_STOP_TIMEOUT_S)
 
     def expected_argv(
         self, slot_cfg: dict[str, Any], model_info: dict[str, Any]
@@ -2941,7 +2973,12 @@ class ContainerProvider(Provider):
         log.info("container.unit_stop", extra={"slot": token, "unit": unit})
         try:
             self._run("systemctl", "stop", unit, check=False, timeout=_UNIT_STOP_TIMEOUT_S)
-        except subprocess.TimeoutExpired:
+        except (subprocess.TimeoutExpired, SeamTimeout):
+            # The real (unmocked) seam route raises SeamTimeout (#1869: every
+            # ``_run`` call now goes through ``SystemCtlSeam.systemctl`` ->
+            # ``bounded_call``); ``subprocess.TimeoutExpired`` stays caught too
+            # for callers/tests that stub ``_run`` directly and raise the bare
+            # stdlib error. Either way the stop is best-effort — see below.
             log.warning(
                 "container.unit_stop_timeout",
                 extra={"slot": token, "unit": unit, "timeout_s": _UNIT_STOP_TIMEOUT_S},
@@ -2949,7 +2986,7 @@ class ContainerProvider(Provider):
         # Remove the Quadlet source so daemon-reload regenerates without it.
         unit_path = self._unit_path(token)
         if unit_path.exists():
-            _SYSTEMCTL_SEAM.remove_quadlet(unit_path)
+            _SYSTEMCTL_SEAM.remove_quadlet(unit_path, timeout=_UNIT_STOP_TIMEOUT_S)
             self._run("systemctl", "daemon-reload", timeout=_UNIT_STOP_TIMEOUT_S)
         # A DELIBERATE stop must not leave the unit parked in `failed`.
         # The bounded stop above escalates to SIGKILL (exit 137) — and a
@@ -2977,7 +3014,11 @@ class ContainerProvider(Provider):
         still accepted as an already-resolved token.
         """
         result = self._run(
-            "systemctl", "is-active", self._unit_name(_artefact_token(slot)), check=False
+            "systemctl",
+            "is-active",
+            self._unit_name(_artefact_token(slot)),
+            check=False,
+            timeout=_UNIT_STOP_TIMEOUT_S,
         )
         return result.returncode == 0
 
@@ -2997,7 +3038,9 @@ class ContainerProvider(Provider):
         """
         unit = self._unit_name(_artefact_token(slot))
         args = [f"--property={prop}" for prop in _UNIT_SHOW_PROPS]
-        result = self._run("systemctl", "show", unit, *args, check=False)
+        result = self._run(
+            "systemctl", "show", unit, *args, check=False, timeout=_UNIT_STOP_TIMEOUT_S
+        )
         props: dict[str, str] = {}
         for line in (result.stdout or "").splitlines():
             key, sep, value = line.partition("=")
@@ -3109,7 +3152,13 @@ class ContainerProvider(Provider):
         start it precedes. Routed through the seam's ``reset-failed`` verb on
         a hal0-service-user box (#1424).
         """
-        self._run("systemctl", "reset-failed", self._unit_name(_artefact_token(slot)), check=False)
+        self._run(
+            "systemctl",
+            "reset-failed",
+            self._unit_name(_artefact_token(slot)),
+            check=False,
+            timeout=_UNIT_STOP_TIMEOUT_S,
+        )
 
     def image_present(self, image: str) -> bool | None:
         """Is ``image`` in the container image store slots use? Tri-state.
@@ -3179,10 +3228,15 @@ class ContainerProvider(Provider):
             )
             return None
         try:
+            # #1869: bounded like the sibling ``inspect`` probes below —
+            # ``TimeoutExpired`` is a ``SubprocessError`` subclass, so the
+            # except clause here already degrades it to image_status=unknown;
+            # it just never fired without a bound to expire.
             result = subprocess.run(
                 [runtime, "image", "exists", image],
                 capture_output=True,
                 check=False,
+                timeout=5,
             )
         except (OSError, subprocess.SubprocessError) as exc:
             log.warning(

--- a/src/hal0/slot_lifecycle_budget.py
+++ b/src/hal0/slot_lifecycle_budget.py
@@ -34,6 +34,30 @@ HEALTH_TIMEOUT_S = 180.0
 #: ``hal0.slots.manager.SlotManager._terminate_timeout_s``.
 TERMINATE_TIMEOUT_S = 30.0
 
+#: Wall-clock bound on the ``systemctl restart`` that actually (re)spawns a
+#: slot's Quadlet-generated unit (#1869/#1870) — the client-observable job
+#: window BEFORE the post-spawn ``/health`` poll even begins. Mirrored by
+#: ``hal0.providers.container._UNIT_START_TIMEOUT_S``.
+#:
+#: Before #1869 this call had NO bound at all: a ``systemctl restart`` that
+#: never returns (crossed with a wedged podman/netavark call) blocked the
+#: calling thread — and every client budget derived from this module —
+#: forever, with nothing printed (#1870). Set equal to
+#: :data:`HEALTH_TIMEOUT_S`: a wedged restart gets no more patience than the
+#: phase that follows it.
+UNIT_START_TIMEOUT_S = HEALTH_TIMEOUT_S
+
+#: Wall-clock bound on the three fast, should-be-sub-second seam calls that
+#: precede ``systemctl restart`` in the unit-start sequence: the Quadlet
+#: write, ``daemon-reload``, and ``reset-failed`` (#1869). Mirrors
+#: ``hal0.providers.container._UNIT_STOP_TIMEOUT_S`` x 3 — like
+#: :data:`EVICTION_UNLOAD_ALLOWANCE`, this is a policy allowance rather than a
+#: value container.py imports FROM here: none of the three legitimately needs
+#: more than an instant (a local file write, a systemd unit-cache reload, a
+#: state-clear), so the bound exists purely to turn "wedged forever" into
+#: "wedged for at most 20s each", not to give real work room.
+UNIT_ADMIN_CALLS_ALLOWANCE_S = 60.0
+
 #: Wall-clock bound on the RAW ``/completion`` output-sanity probe — the one a
 #: ``type=llm`` load runs after ``/health`` converges (#1922 — the gate that
 #: turns "the port answers" into "the model produces language"). Consumed by
@@ -119,6 +143,11 @@ EVICTION_UNLOAD_ALLOWANCE = 3
 #:          before re-spawning
 #:     90   3 x 30, ``preload_evict.admit`` unloading eviction candidates in
 #:          series (EVICTION_UNLOAD_ALLOWANCE)
+#:     60   the Quadlet write + daemon-reload + reset-failed that precede the
+#:          spawn (UNIT_ADMIN_CALLS_ALLOWANCE_S, #1869) — bounded seam calls
+#:          now that (before #1869) had no bound at all
+#:    180   the ``systemctl restart`` that spawns the unit (UNIT_START_TIMEOUT_S,
+#:          #1869/#1870) — likewise unbounded before this fix
 #:    180   the post-spawn ``/health`` poll (HEALTH_TIMEOUT_S)
 #:    360   the output-sanity gate (#1922), at its CPU-lane budget: 180 raw
 #:          probe + 180 chat fallback (OUTPUT_SANITY_LOAD_ALLOWANCE_S = 2 x
@@ -127,10 +156,12 @@ EVICTION_UNLOAD_ALLOWANCE = 3
 #:     30   the failed gate's teardown, which runs before the ERROR stamp and
 #:          therefore still inside the lock
 #:    ---
-#:    690
+#:    930
 LOAD_LOCK_HOLD_S = (
     TERMINATE_TIMEOUT_S
     + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S
+    + UNIT_ADMIN_CALLS_ALLOWANCE_S
+    + UNIT_START_TIMEOUT_S
     + HEALTH_TIMEOUT_S
     + OUTPUT_SANITY_LOAD_ALLOWANCE_S
     + TERMINATE_TIMEOUT_S

--- a/src/hal0/system/seam.py
+++ b/src/hal0/system/seam.py
@@ -36,8 +36,10 @@ import os
 import pwd
 import re
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
+
+from hal0.errors import Hal0Error
 
 #: The wrapper's installed path (``installer/wrappers/hal0-systemctl`` ->
 #: ``${LIB_DIR}/bin/hal0-systemctl`` at install time).
@@ -112,6 +114,72 @@ class Hal0SeamMissing(RuntimeError):
     caller (``hal0 doctor``) can give a precise remediation instead of a raw
     traceback.
     """
+
+
+class SeamTimeout(Hal0Error):
+    """A bounded systemctl/podman seam call did not return within its budget
+    (#1869/#1870).
+
+    Raised by :func:`bounded_call` in place of the bare
+    :class:`subprocess.TimeoutExpired` every direct ``_run`` caller used to
+    let escape (or, worse, never bounded at all): a ``Hal0Error`` subclass
+    carries a stable ``code`` the API error-envelope middleware renders
+    uniformly, and a message an operator (or the CLI's own timeout handler)
+    can act on without reading a Python traceback.
+
+    ``details`` carries the three facts #1869 asked for: the ``command`` that
+    wedged, the ``budget_s`` it was given, and ``last_state`` — whatever the
+    child had already written to stdout/stderr at the moment it was killed
+    (``subprocess.TimeoutExpired.stdout``/``.stderr`` when the call captured
+    output, which every :class:`SystemCtlSeam` route does). ``None`` when the
+    child produced no output before the kill — a wedge that never got as far
+    as writing anything, which is itself informative (it did not even reach
+    the point of talking to systemd/podman).
+    """
+
+    code = "slot.seam_timeout"
+    status = 504
+
+    def __init__(self, command: Sequence[str], budget_s: float, last_state: str | None) -> None:
+        cmd = " ".join(command)
+        message = f"`{cmd}` did not return within {budget_s:g}s"
+        if last_state:
+            message += f" — last observed: {last_state}"
+        super().__init__(
+            message,
+            details={"command": list(command), "budget_s": budget_s, "last_state": last_state},
+        )
+
+
+def bounded_call(
+    argv: Sequence[str],
+    *,
+    timeout: float | None,
+    run: Callable[..., subprocess.CompletedProcess[str]],
+    **kwargs: object,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``argv`` through ``run``, turning a timeout into :class:`SeamTimeout`.
+
+    THE one place a ``systemctl``/``podman`` child's ``subprocess.TimeoutExpired``
+    becomes the typed error the rest of hal0 (the slot state machine, the API
+    error envelope, the CLI) knows how to handle — every :class:`SystemCtlSeam`
+    route calls this instead of ``run`` directly (#1869).
+
+    ``timeout=None`` is a deliberate passthrough (no bound applied, matching
+    ``subprocess.run``'s own default) rather than a special case: callers that
+    have not been given a budget yet keep today's unbounded wait instead of
+    silently gaining a bogus one.
+    """
+    try:
+        return run(list(argv), timeout=timeout, **kwargs)
+    except subprocess.TimeoutExpired as exc:
+        raw_state = exc.stdout or exc.stderr or None
+        last_state: str | None
+        if isinstance(raw_state, bytes):
+            last_state = raw_state.decode("utf-8", errors="replace").strip() or None
+        else:
+            last_state = raw_state.strip() or None if raw_state else None
+        raise SeamTimeout(list(argv), float(timeout or 0.0), last_state) from exc
 
 
 def is_hal0_service_user() -> bool:
@@ -268,8 +336,14 @@ class SystemCtlSeam:
     # written via :meth:`write_quadlet`. ``remove_unit`` stays for legacy
     # pre-quadlet ``.service`` cleanup.
 
-    def remove_unit(self, unit_path: Path) -> None:
-        """Delete a ``hal0-slot@<id>.service`` unit file (no-op if absent)."""
+    def remove_unit(self, unit_path: Path, *, timeout: float | None = None) -> None:
+        """Delete a ``hal0-slot@<id>.service`` unit file (no-op if absent).
+
+        ``timeout`` (seconds, ``None`` = unbounded) bounds the seam child on
+        the hal0-service-user route, like :meth:`systemctl`'s (#1869) — a
+        wedged sudo/root-side ``rm`` on this path is otherwise indistinguishable
+        from a slow one.
+        """
         if not self._is_hal0_user():
             unit_path.unlink(missing_ok=True)
             return
@@ -278,9 +352,16 @@ class SystemCtlSeam:
             raise ValueError(f"not a hal0-slot@ unit: {unit_path.name!r}")
         # Mirrors the direct path's tolerance of "already gone" (missing_ok):
         # the wrapper's remove-unit is idempotent (rm -f semantics).
-        self._run(self._seam_argv("remove-unit", slot_id), check=False)
+        bounded_call(
+            self._seam_argv("remove-unit", slot_id),
+            timeout=timeout,
+            run=self._run,
+            check=False,
+        )
 
-    def write_quadlet(self, quadlet_path: Path, unit_text: str) -> None:
+    def write_quadlet(
+        self, quadlet_path: Path, unit_text: str, *, timeout: float | None = None
+    ) -> None:
         """Write a ``hal0-slot@<token>.container`` Quadlet source file (P3-quadlet).
 
         The declarative Quadlet replacement for the removed ``write_unit``:
@@ -296,6 +377,11 @@ class SystemCtlSeam:
         can no longer carry a host-side ``[Service] ExecStartPre=``. Rendering
         here is a convenience, never the control — see the wrapper's HONEST
         BOUNDARY note for what the allow-list does and does not claim.
+
+        ``timeout`` (seconds, ``None`` = unbounded) bounds the seam child
+        (#1869): this write is the first of three seam calls every slot load
+        makes before the container ever spawns, so a wedge here is just as
+        capable of hanging the CLI/API as the ``systemctl restart`` after it.
         """
         if not self._is_hal0_user():
             quadlet_path.parent.mkdir(parents=True, exist_ok=True)
@@ -304,22 +390,32 @@ class SystemCtlSeam:
         token = _slot_id_from_quadlet(quadlet_path.name)
         if token is None:
             raise ValueError(f"not a hal0-slot@ quadlet file: {quadlet_path.name!r}")
-        self._run(
+        bounded_call(
             self._seam_argv("write-quadlet", token),
+            timeout=timeout,
+            run=self._run,
             input=unit_text,
             text=True,
             check=True,
         )
 
-    def remove_quadlet(self, quadlet_path: Path) -> None:
-        """Delete a ``hal0-slot@<token>.container`` Quadlet file (no-op if absent)."""
+    def remove_quadlet(self, quadlet_path: Path, *, timeout: float | None = None) -> None:
+        """Delete a ``hal0-slot@<token>.container`` Quadlet file (no-op if absent).
+
+        ``timeout`` bounds the seam child, like :meth:`write_quadlet`'s (#1869).
+        """
         if not self._is_hal0_user():
             quadlet_path.unlink(missing_ok=True)
             return
         token = _slot_id_from_quadlet(quadlet_path.name)
         if token is None:
             raise ValueError(f"not a hal0-slot@ quadlet file: {quadlet_path.name!r}")
-        self._run(self._seam_argv("remove-quadlet", token), check=False)
+        bounded_call(
+            self._seam_argv("remove-quadlet", token),
+            timeout=timeout,
+            run=self._run,
+            check=False,
+        )
 
     def write_hindsight_dropin(
         self,
@@ -433,60 +529,42 @@ class SystemCtlSeam:
         behaviour) bounds the child process. Callers that must not be able to
         wedge — notably the slot ``systemctl stop`` on a unit systemd has
         already parked in ``failed`` (#1224) — pass an explicit bound and
-        handle :class:`subprocess.TimeoutExpired`.
+        handle :class:`SeamTimeout` (#1869: raised by :func:`bounded_call` in
+        place of the bare ``subprocess.TimeoutExpired`` this used to let
+        escape uncaught).
         """
-        if not self._is_hal0_user() or not args or args[0] != "systemctl":
-            return self._run(
-                list(args), capture_output=True, text=True, check=check, timeout=timeout
+
+        def _exec(argv: list[str]) -> subprocess.CompletedProcess[str]:
+            return bounded_call(
+                argv, timeout=timeout, run=self._run, capture_output=True, text=True, check=check
             )
+
+        if not self._is_hal0_user() or not args or args[0] != "systemctl":
+            return _exec(list(args))
 
         verb = args[1] if len(args) > 1 else ""
         if verb == "daemon-reload":
-            return self._run(
-                self._seam_argv("daemon-reload"),
-                capture_output=True,
-                text=True,
-                check=check,
-                timeout=timeout,
-            )
+            return _exec(self._seam_argv("daemon-reload"))
         if verb in _UNIT_VERBS and len(args) > 2:
             slot_id = _slot_id_from_unit(args[2])
             if slot_id is not None:
-                return self._run(
-                    self._seam_argv(verb, slot_id),
-                    capture_output=True,
-                    text=True,
-                    check=check,
-                    timeout=timeout,
-                )
+                return _exec(self._seam_argv(verb, slot_id))
             # Bundled-agent unit (hal0-agent@<id>.service) — route through the
             # wrapper's <verb>-agent arms (#1590). Same shape as the slot
             # family: the seam takes the bare id and rebuilds the unit name
             # root-side.
             agent_id = _agent_id_from_unit(args[2])
             if agent_id is not None and verb in AGENT_UNIT_VERBS:
-                return self._run(
-                    self._seam_argv(AGENT_UNIT_VERBS[verb], agent_id),
-                    capture_output=True,
-                    text=True,
-                    check=check,
-                    timeout=timeout,
-                )
+                return _exec(self._seam_argv(AGENT_UNIT_VERBS[verb], agent_id))
             # Companion-service unit (openwebui / hindsight) — the wrapper's
             # svc-<verb> family takes a service KEY from a closed map, never a
             # unit string (#1590).
             svc_key = COMPANION_SERVICE_UNITS.get(args[2])
             if svc_key is not None and verb != "reset-failed":
-                return self._run(
-                    self._seam_argv(f"svc-{verb}", svc_key),
-                    capture_output=True,
-                    text=True,
-                    check=check,
-                    timeout=timeout,
-                )
+                return _exec(self._seam_argv(f"svc-{verb}", svc_key))
         # Not a routable hal0-managed op (e.g. is-active, or a foreign unit) —
         # pass through unprivileged; systemctl read-only queries never need root.
-        return self._run(list(args), capture_output=True, text=True, check=check, timeout=timeout)
+        return _exec(list(args))
 
     def restart_self(self) -> subprocess.CompletedProcess[str]:
         """``systemctl restart hal0-api.service`` — the self-update path."""
@@ -510,9 +588,11 @@ __all__ = [
     "HINDSIGHT_DROPIN_PATH",
     "SEAM_BIN",
     "Hal0SeamMissing",
+    "SeamTimeout",
     "SystemCtlSeam",
     "agent_unit_argv",
     "agent_unit_name",
+    "bounded_call",
     "is_hal0_service_user",
     "privileged_systemctl",
 ]

--- a/tests/cli/test_slot_lifecycle_progress.py
+++ b/tests/cli/test_slot_lifecycle_progress.py
@@ -1,0 +1,202 @@
+"""``hal0 slot load|unload|restart|swap`` progress + timeout UX (#1869/#1870).
+
+Before this, every mutating lifecycle verb made one blocking ``api_post``
+with a multi-minute read timeout and printed nothing until it returned — an
+operator staring at a silent terminal for up to ~2400s had no way to tell
+"still working" from "hung", and a timeout produced a generic error with no
+remedy.
+
+Covers ``hal0.cli._shared.run_with_progress`` (the shared elapsed+state
+renderer, on and off a TTY) and ``slot_commands._run_lifecycle_call``'s
+timeout handling (the typed-error message plus the remedy lines).
+"""
+
+from __future__ import annotations
+
+import io
+import time
+from typing import Any
+
+import pytest
+from rich.console import Console
+from typer.testing import CliRunner
+
+from hal0.cli import slot_commands
+from hal0.cli._shared import CliApiError, CliApiTimeout, run_with_progress
+
+runner = CliRunner()
+
+
+def _capturing_console(*, interactive: bool) -> tuple[Console, io.StringIO]:
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=interactive, width=120)
+    return console, buf
+
+
+# ── run_with_progress ─────────────────────────────────────────────────────
+
+
+def test_run_with_progress_non_interactive_prints_one_summary_line_and_calls_directly() -> None:
+    console, buf = _capturing_console(interactive=False)
+    calls: list[str] = []
+
+    def call() -> str:
+        calls.append("ran")
+        return "done"
+
+    result = run_with_progress(call, console=console, label="Loading primary", timeout_s=90.0)
+
+    assert result == "done"
+    assert calls == ["ran"]
+    out = buf.getvalue()
+    assert "Loading primary" in out
+    assert "up to 90s" in out
+
+
+def test_run_with_progress_json_out_suppresses_all_output() -> None:
+    console, buf = _capturing_console(interactive=False)
+
+    result = run_with_progress(
+        lambda: "done", console=console, label="Loading primary", timeout_s=90.0, json_out=True
+    )
+
+    assert result == "done"
+    assert buf.getvalue() == ""
+
+
+def test_run_with_progress_interactive_shows_elapsed_and_polled_state() -> None:
+    console, buf = _capturing_console(interactive=True)
+    poll_calls: list[int] = []
+
+    def poll_state() -> str:
+        poll_calls.append(1)
+        return "starting"
+
+    def call() -> str:
+        time.sleep(0.05)
+        return "done"
+
+    result = run_with_progress(
+        call,
+        console=console,
+        label="Loading primary",
+        timeout_s=90.0,
+        poll_state=poll_state,
+        poll_interval_s=0.01,
+    )
+
+    assert result == "done"
+    assert poll_calls, "poll_state was never called while waiting"
+    assert "starting" in buf.getvalue()
+
+
+def test_run_with_progress_interactive_reraises_call_error() -> None:
+    console, _buf = _capturing_console(interactive=True)
+
+    def call() -> str:
+        raise CliApiTimeout("POST ... did not respond within 90s")
+
+    with pytest.raises(CliApiTimeout):
+        run_with_progress(
+            call, console=console, label="Loading primary", timeout_s=90.0, poll_interval_s=0.01
+        )
+
+
+def test_run_with_progress_poll_state_failure_is_swallowed() -> None:
+    """A status-line probe must never abort the wait it is only decorating."""
+    console, _buf = _capturing_console(interactive=True)
+
+    def poll_state() -> str:
+        raise RuntimeError("boom")
+
+    result = run_with_progress(
+        lambda: "done",
+        console=console,
+        label="Loading primary",
+        timeout_s=90.0,
+        poll_state=poll_state,
+        poll_interval_s=0.01,
+    )
+
+    assert result == "done"
+
+
+# ── slot_commands._run_lifecycle_call / CliApiTimeout remedy ───────────────
+
+
+@pytest.fixture(autouse=True)
+def _api_reachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(slot_commands, "_api_unreachable", lambda _url: False)
+
+
+def test_slot_load_prints_timeout_remedy_and_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(path: str, **_kw: Any) -> Any:
+        raise CliApiTimeout(f"POST {path} did not respond within 90s")
+
+    monkeypatch.setattr(slot_commands, "api_post", fake_post)
+
+    result = runner.invoke(slot_commands.app, ["load", "primary"])
+    output = " ".join(result.output.split())  # CliRunner's narrow width wraps lines
+
+    assert result.exit_code == 1
+    assert "did not respond within 90s" in output
+    assert "hal0 slot logs primary" in output
+    assert "journalctl -u hal0-slot@primary" in output
+
+
+def test_slot_load_plain_api_error_has_no_timeout_remedy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real 4xx/5xx (not a timeout) gets the ordinary ``die()`` treatment —
+    no "still converging?" remedy, which would be misleading for a request
+    the server flatly rejected."""
+
+    def fake_post(path: str, **_kw: Any) -> Any:
+        raise CliApiError(f"POST {path} -> HTTP 404: slot not found")
+
+    monkeypatch.setattr(slot_commands, "api_post", fake_post)
+
+    result = runner.invoke(slot_commands.app, ["load", "primary"])
+
+    assert result.exit_code == 1
+    assert "slot not found" in result.output
+    assert "still converging" not in result.output
+
+
+def test_slot_load_json_flag_suppresses_progress_and_emits_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_post(path: str, **_kw: Any) -> Any:
+        return {"state": "serving", "model_id": "demo"}
+
+    monkeypatch.setattr(slot_commands, "api_post", fake_post)
+
+    result = runner.invoke(slot_commands.app, ["load", "primary", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "Loading primary" not in result.output
+    assert '"state": "serving"' in result.output
+
+
+def test_slot_unload_timeout_remedy_names_the_slot(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(path: str, **_kw: Any) -> Any:
+        raise CliApiTimeout(f"POST {path} did not respond within 60s")
+
+    monkeypatch.setattr(slot_commands, "api_post", fake_post)
+
+    result = runner.invoke(slot_commands.app, ["unload", "chat"])
+    output = " ".join(result.output.split())
+
+    assert result.exit_code == 1
+    assert "hal0 slot logs chat" in output
+    assert "journalctl -u hal0-slot@chat" in output
+
+
+def test_poll_slot_state_is_none_on_api_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The progress line's state probe is best-effort — GET failing must
+    never surface as an error (the lifecycle call is the one that matters)."""
+
+    def fake_get(path: str, **_kw: Any) -> Any:
+        raise CliApiError(f"GET {path} -> HTTP 503")
+
+    monkeypatch.setattr(slot_commands, "api_get", fake_get)
+
+    assert slot_commands._poll_slot_state("primary") is None

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -39,6 +39,7 @@ from hal0.providers.container import (
     _CTX_DENSE_CAP,
     _CTX_SAFE_FALLBACK,
     _MODEL_STORE_MOUNT,
+    _UNIT_START_TIMEOUT_S,
     _UNIT_STOP_TIMEOUT_S,
     ContainerProvider,
     _best_effort_model_info,
@@ -55,6 +56,7 @@ from hal0.providers.container import (
 )
 from hal0.registry.model import Model
 from hal0.slots.argv import resolve_argv
+from hal0.system.seam import SeamTimeout
 
 # Podman is the only supported runtime under Quadlet; the shims below ignore
 # ``runtime_bin`` (Quadlet doesn't put the runtime binary in the unit), but the
@@ -798,7 +800,7 @@ class TestLoadSync:
 
         calls_made: list[list[str]] = []
 
-        def fake_run(*args: str, check: bool = True) -> MagicMock:
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
             calls_made.append(list(args))
             m = MagicMock()
             m.returncode = 0
@@ -819,6 +821,74 @@ class TestLoadSync:
         assert any("restart" in c for c in cmds), f"restart not in {cmds}"
         assert (tmp_path / "test.service").exists()
 
+    def test_load_sync_bounds_every_systemctl_call(self, tmp_path: Path) -> None:
+        """#1869: no ``_run`` call in the load path may go through with
+        ``timeout=None`` — a wedged ``daemon-reload``/``restart`` used to block
+        the load path forever. ``restart`` gets the wider spawn budget
+        (``_UNIT_START_TIMEOUT_S``); the fast admin calls around it get
+        ``_UNIT_STOP_TIMEOUT_S``."""
+        profile = _moe_profile()
+        provider = ContainerProvider()
+
+        calls: list[tuple[list[str], float | None]] = []
+
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
+            calls.append((list(args), timeout))
+            m = MagicMock()
+            m.returncode = 0
+            return m
+
+        with (
+            patch("hal0.providers.container._resolve_profile", return_value=profile),
+            patch.object(provider, "_run", side_effect=fake_run),
+            patch.object(provider, "_unit_path", return_value=tmp_path / "test.service"),
+        ):
+            provider.load_sync(
+                {"name": "test-container", "port": 8095, "profile": "rocm"},
+                {"path": "/mnt/ai-models/model.gguf", "_model_key": "model"},
+            )
+
+        assert calls, "load_sync made no _run calls"
+        assert all(timeout is not None for _args, timeout in calls), calls
+        for args, timeout in calls:
+            if "restart" in args:
+                assert timeout == _UNIT_START_TIMEOUT_S, (args, timeout)
+            else:
+                assert timeout == _UNIT_STOP_TIMEOUT_S, (args, timeout)
+
+    def test_load_sync_lets_a_seam_timeout_on_restart_propagate_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        """A wedged ``systemctl restart`` raises :class:`SeamTimeout` (#1869) —
+        a distinct failure mode from ``CalledProcessError`` (#1424's
+        ``SlotSpawnFailed`` wrap), so ``_write_and_start_unit`` must NOT catch
+        it: it propagates with its own ``slot.seam_timeout`` code straight
+        through to ``SlotManager.load``'s generic ``except Exception -> ERROR``
+        handling."""
+        profile = _moe_profile()
+        provider = ContainerProvider()
+
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
+            if "restart" in args:
+                raise SeamTimeout(list(args), timeout or 0.0, "activating")
+            m = MagicMock()
+            m.returncode = 0
+            return m
+
+        with (
+            patch("hal0.providers.container._resolve_profile", return_value=profile),
+            patch.object(provider, "_run", side_effect=fake_run),
+            patch.object(provider, "_unit_path", return_value=tmp_path / "test.service"),
+            pytest.raises(SeamTimeout) as excinfo,
+        ):
+            provider.load_sync(
+                {"name": "test-container", "port": 8095, "profile": "rocm"},
+                {"path": "/mnt/ai-models/model.gguf", "_model_key": "model"},
+            )
+
+        assert excinfo.value.code == "slot.seam_timeout"
+        assert "activating" in str(excinfo.value)
+
     def test_load_sync_threads_ctx_size_and_model_tune(self, tmp_path: Path) -> None:
         """load_sync bakes the resolved context window (base --ctx-size) AND the
         MODEL's materialized ``defaults.extra_args`` into the rendered unit.
@@ -833,7 +903,7 @@ class TestLoadSync:
         provider = ContainerProvider()
         unit_file = tmp_path / "test.service"
 
-        def fake_run(*args: str, check: bool = True) -> MagicMock:
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
             m = MagicMock()
             m.returncode = 0
             return m
@@ -877,7 +947,7 @@ class TestLoadSync:
         provider = ContainerProvider()
         unit_file = tmp_path / "test.service"
 
-        def fake_run(*args: str, check: bool = True) -> MagicMock:
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
             m = MagicMock()
             m.returncode = 0
             return m
@@ -929,7 +999,7 @@ class TestLoadSync:
         # paths must honour it identically.
         monkeypatch.setattr("hal0.providers.container._slot_publish_host", lambda: "0.0.0.0")
 
-        def fake_run(*args: str, check: bool = True) -> MagicMock:
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
             m = MagicMock()
             m.returncode = 0
             return m
@@ -1056,6 +1126,34 @@ class TestLoadSync:
             calls_made.append(list(args))
             if "stop" in args:
                 raise subprocess.TimeoutExpired(cmd=list(args), timeout=timeout or 0)
+            m = MagicMock()
+            m.returncode = 0
+            return m
+
+        with (
+            patch.object(provider, "_run", side_effect=fake_run),
+            patch.object(provider, "_unit_path", return_value=unit_file),
+        ):
+            provider.unload_sync({"name": "test-container"})
+
+        assert not unit_file.exists(), "quadlet source must still be removed"
+        assert any("daemon-reload" in c for c in calls_made), calls_made
+
+    def test_unload_sync_survives_a_stop_that_raises_seam_timeout(self, tmp_path: Path) -> None:
+        """Same best-effort teardown as above, but for the REAL (unmocked seam)
+        failure mode (#1869): ``SystemCtlSeam.systemctl`` now raises
+        :class:`SeamTimeout`, not the bare ``subprocess.TimeoutExpired`` the
+        sibling test above stubs directly at ``provider._run``."""
+        provider = ContainerProvider()
+        unit_file = tmp_path / "hal0-slot@test-container.container"
+        unit_file.write_text("[Container]\n")
+
+        calls_made: list[list[str]] = []
+
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
+            calls_made.append(list(args))
+            if "stop" in args:
+                raise SeamTimeout(list(args), timeout or 0.0, "deactivating")
             m = MagicMock()
             m.returncode = 0
             return m

--- a/tests/providers/test_container_chat_template.py
+++ b/tests/providers/test_container_chat_template.py
@@ -217,7 +217,7 @@ class TestLoadSyncChatTemplate:
 
         from unittest.mock import MagicMock
 
-        def fake_run(*args: str, check: bool = True) -> MagicMock:
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
             m = MagicMock()
             m.returncode = 0
             return m
@@ -271,7 +271,7 @@ class TestLoadSyncChatTemplate:
 
         from unittest.mock import MagicMock
 
-        def fake_run(*args: str, check: bool = True) -> MagicMock:
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
             m = MagicMock()
             m.returncode = 0
             return m

--- a/tests/providers/test_container_dropin_cleanup.py
+++ b/tests/providers/test_container_dropin_cleanup.py
@@ -24,7 +24,7 @@ def _make_provider_with_tmp_unit(
     unit_path = tmp_path / f"hal0-slot@{slot_name}.service"
     calls_made: list[list[str]] = []
 
-    def fake_run(*args: str, check: bool = True) -> MagicMock:
+    def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
         calls_made.append(list(args))
         m = MagicMock()
         m.returncode = 0
@@ -48,7 +48,7 @@ def test_stale_dropin_dir_removed_before_start(tmp_path: Path) -> None:
 
     calls_made: list[list[str]] = []
 
-    def fake_run(*args: str, check: bool = True) -> MagicMock:
+    def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
         calls_made.append(list(args))
         m = MagicMock()
         m.returncode = 0
@@ -82,7 +82,7 @@ def test_no_dropin_clean_start(tmp_path: Path) -> None:
 
     calls_made: list[list[str]] = []
 
-    def fake_run(*args: str, check: bool = True) -> MagicMock:
+    def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
         calls_made.append(list(args))
         m = MagicMock()
         m.returncode = 0
@@ -113,7 +113,7 @@ def test_dropin_removal_logged(tmp_path: Path, caplog) -> None:
     dropin_dir.mkdir()
     (dropin_dir / "override.conf").write_text("[Service]\nEnvironmentFile=/dead/path\n")
 
-    def fake_run(*args: str, check: bool = True) -> MagicMock:
+    def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
         m = MagicMock()
         m.returncode = 0
         return m

--- a/tests/providers/test_container_mmproj.py
+++ b/tests/providers/test_container_mmproj.py
@@ -154,7 +154,7 @@ class TestLoadSyncMmproj:
         provider = ContainerProvider()
         unit_file = tmp_path / "test.service"
 
-        def fake_run(*args: str, check: bool = True) -> MagicMock:
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
             m = MagicMock()
             m.returncode = 0
             return m

--- a/tests/providers/test_container_npu.py
+++ b/tests/providers/test_container_npu.py
@@ -138,7 +138,7 @@ class TestLoadSyncNpuBranch:
 
         calls_made: list[list[str]] = []
 
-        def fake_run(*args: str, check: bool = True) -> MagicMock:
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
             calls_made.append(list(args))
             m = MagicMock()
             m.returncode = 0
@@ -172,7 +172,7 @@ class TestLoadSyncNpuBranch:
         unit_file = tmp_path / "hal0-slot@npu.service"
         calls_made: list[list[str]] = []
 
-        def fake_run(*args: str, check: bool = True) -> MagicMock:
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
             calls_made.append(list(args))
             m = MagicMock()
             m.returncode = 0
@@ -215,7 +215,7 @@ class TestLoadSyncNpuBranch:
         )
         unit_file = tmp_path / "hal0-slot@chat.service"
 
-        def fake_run(*args: str, check: bool = True) -> MagicMock:
+        def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
             m = MagicMock()
             m.returncode = 0
             return m

--- a/tests/providers/test_container_spec_dispatch.py
+++ b/tests/providers/test_container_spec_dispatch.py
@@ -245,7 +245,7 @@ def test_gpu_slot_unaffected_still_takes_llama_path(tmp_path: Any) -> None:
     )
     unit_file = tmp_path / "hal0-slot@chat.service"
 
-    def fake_run(*args: str, check: bool = True) -> MagicMock:
+    def fake_run(*args: str, check: bool = True, timeout: float | None = None) -> MagicMock:
         m = MagicMock()
         m.returncode = 0
         return m

--- a/tests/providers/test_container_unit_failure.py
+++ b/tests/providers/test_container_unit_failure.py
@@ -315,7 +315,7 @@ def test_the_start_path_clears_a_start_limited_unit_before_restarting(
     monkeypatch.setattr(ContainerProvider, "_run", _run)
     monkeypatch.setattr(
         "hal0.providers.container._SYSTEMCTL_SEAM.write_quadlet",
-        lambda path, text: None,
+        lambda path, text, timeout=None: None,
     )
 
     provider._write_and_start_unit("chat", "[Container]\n")
@@ -355,7 +355,7 @@ def test_a_failed_restart_raises_slot_spawn_failed_with_the_systemd_reason(
     monkeypatch.setattr(ContainerProvider, "_run", _run)
     monkeypatch.setattr(
         "hal0.providers.container._SYSTEMCTL_SEAM.write_quadlet",
-        lambda path, text: None,
+        lambda path, text, timeout=None: None,
     )
 
     with pytest.raises(SlotSpawnFailed) as excinfo:
@@ -393,7 +393,7 @@ def test_a_failed_restart_is_typed_even_when_the_probe_has_no_reason(
     monkeypatch.setattr(ContainerProvider, "_run", _run)
     monkeypatch.setattr(
         "hal0.providers.container._SYSTEMCTL_SEAM.write_quadlet",
-        lambda path, text: None,
+        lambda path, text, timeout=None: None,
     )
 
     with pytest.raises(SlotSpawnFailed) as excinfo:

--- a/tests/slots/test_seam_timeout_lands_error.py
+++ b/tests/slots/test_seam_timeout_lands_error.py
@@ -1,0 +1,68 @@
+"""A bounded seam call that times out must land the slot in ERROR (#1869/#1870).
+
+Before #1869, ``providers/container.py`` issued several ``systemctl``/podman
+calls with no bound at all (``timeout=None``), so a wedged child hung the
+executor thread forever — the load never resolved, and the operator saw no
+error at all (#1870). Now every such call goes through
+``hal0.system.seam.bounded_call`` and raises the typed
+:class:`hal0.system.seam.SeamTimeout` on expiry. This module checks that
+error reaches the slot state machine exactly like any other load failure:
+stamped onto the record as ``ERROR`` with a readable message, re-raised to
+the caller, and counted against the crash-loop breaker.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.slots.manager import SlotManager
+from hal0.slots.state import SlotState
+from hal0.system.seam import SeamTimeout
+from tests.slots.conftest import FakeContainerProvider
+
+
+async def test_seam_timeout_on_load_lands_error_with_the_seam_message(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """``load()`` re-raises the typed SeamTimeout and stamps ERROR with its
+    message — the same "never swallow" contract every other load failure
+    (SlotSpawnFailed, SlotOutputSanityFailed, ...) already gets."""
+    sm = SlotManager()
+    seam_error = SeamTimeout(
+        ["systemctl", "restart", "hal0-slot@chat.service"], 180.0, "activating"
+    )
+    container_stub.fail_load = seam_error
+
+    with pytest.raises(SeamTimeout) as excinfo:
+        await sm.load("chat")
+
+    assert excinfo.value.code == "slot.seam_timeout"
+    assert sm._current_state("chat") == SlotState.ERROR
+
+    slot = await sm.status("chat")
+    message = slot.metadata.get("message") or ""
+    assert "did not return within 180s" in message
+    assert "activating" in message
+    # Counted like any other load failure — the crash-loop breaker must see it.
+    assert slot.metadata.get("load_failures") == 1
+
+
+async def test_seam_timeout_on_load_is_a_hal0_error_with_a_504_status(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """The typed error carries the status the API error-envelope middleware
+    (``hal0.api.middleware.error_codes``) needs to render a 504, not a bare
+    500 ``system.internal`` (#1424's original complaint, extended to timeouts)."""
+    sm = SlotManager()
+    container_stub.fail_load = SeamTimeout(["systemctl", "daemon-reload"], 20.0, None)
+
+    with pytest.raises(SeamTimeout) as excinfo:
+        await sm.load("chat")
+
+    assert excinfo.value.status == 504
+    assert excinfo.value.details["budget_s"] == 20.0
+    assert excinfo.value.details["last_state"] is None

--- a/tests/system/test_seam.py
+++ b/tests/system/test_seam.py
@@ -16,13 +16,14 @@ real ``hal0`` user, or a privileged filesystem.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
 from hal0.system import seam as seam_mod
-from hal0.system.seam import SEAM_BIN, SystemCtlSeam
+from hal0.system.seam import SEAM_BIN, SeamTimeout, SystemCtlSeam, bounded_call
 
 
 def _completed(returncode: int = 0) -> MagicMock:
@@ -391,3 +392,92 @@ def test_is_hal0_service_user_false_when_euid_differs(monkeypatch: pytest.Monkey
     monkeypatch.setattr(seam_mod.pwd, "getpwnam", lambda _name: _Ent())
     monkeypatch.setattr(seam_mod.os, "geteuid", lambda: 1000)
     assert seam_mod.is_hal0_service_user() is False
+
+
+# ── bounded_call / SeamTimeout (#1869/#1870) ─────────────────────────────────
+
+
+def _timing_out_run(argv: list[str], **kw: object) -> MagicMock:
+    raise subprocess.TimeoutExpired(cmd=argv, timeout=kw.get("timeout") or 0)
+
+
+def test_bounded_call_converts_timeout_expired_to_seam_timeout() -> None:
+    with pytest.raises(SeamTimeout) as excinfo:
+        bounded_call(
+            ["systemctl", "restart", "hal0-slot@chat.service"], timeout=5.0, run=_timing_out_run
+        )
+
+    assert excinfo.value.code == "slot.seam_timeout"
+    assert excinfo.value.status == 504
+    assert isinstance(excinfo.value.__cause__, subprocess.TimeoutExpired)
+
+
+def test_seam_timeout_details_carry_command_budget_and_last_state() -> None:
+    def _run(argv: list[str], **kw: object) -> MagicMock:
+        raise subprocess.TimeoutExpired(
+            cmd=argv, timeout=kw.get("timeout") or 0, output="Starting hal0-slot@chat.service...\n"
+        )
+
+    with pytest.raises(SeamTimeout) as excinfo:
+        bounded_call(["systemctl", "restart", "hal0-slot@chat.service"], timeout=42.0, run=_run)
+
+    exc = excinfo.value
+    assert exc.details["command"] == ["systemctl", "restart", "hal0-slot@chat.service"]
+    assert exc.details["budget_s"] == 42.0
+    assert exc.details["last_state"] == "Starting hal0-slot@chat.service..."
+    assert "42s" in str(exc)
+    assert "Starting hal0-slot@chat.service" in str(exc)
+
+
+def test_seam_timeout_last_state_is_none_when_child_produced_no_output() -> None:
+    with pytest.raises(SeamTimeout) as excinfo:
+        bounded_call(["systemctl", "daemon-reload"], timeout=5.0, run=_timing_out_run)
+
+    assert excinfo.value.details["last_state"] is None
+
+
+def test_bounded_call_passthrough_on_success() -> None:
+    calls, run = _recorder()
+    result = bounded_call(["systemctl", "is-active", "chat"], timeout=5.0, run=run)
+
+    assert calls == [["systemctl", "is-active", "chat"]]
+    assert result.returncode == 0
+
+
+def test_bounded_call_none_timeout_never_raises_seam_timeout() -> None:
+    """``timeout=None`` is a deliberate passthrough — subprocess.run itself
+    never raises TimeoutExpired without a bound, so bounded_call has nothing
+    to convert."""
+    calls, run = _recorder()
+
+    bounded_call(["systemctl", "daemon-reload"], timeout=None, run=run)
+
+    assert calls == [["systemctl", "daemon-reload"]]
+
+
+def test_systemctl_wedged_seam_call_raises_seam_timeout_not_bare_timeout_expired() -> None:
+    """#1869: every ``systemctl()`` route (direct AND seamed) now bounds
+    through :func:`bounded_call` — a wedged child raises the typed error the
+    slot state machine and the CLI know how to handle, not the bare stdlib
+    exception every prior caller would have had to catch individually."""
+    seam = SystemCtlSeam(run=_timing_out_run, is_hal0_user=lambda: True)
+
+    with pytest.raises(SeamTimeout) as excinfo:
+        seam.systemctl("systemctl", "stop", "hal0-slot@chat.service", timeout=7.5)
+
+    assert excinfo.value.details["command"] == [
+        "sudo",
+        "-n",
+        SEAM_BIN,
+        "stop",
+        "chat",
+    ]
+    assert excinfo.value.details["budget_s"] == 7.5
+
+
+def test_write_quadlet_wedged_seam_call_raises_seam_timeout(tmp_path: Path) -> None:
+    seam = SystemCtlSeam(run=_timing_out_run, is_hal0_user=lambda: True)
+    quadlet = tmp_path / "hal0-slot@chat.container"
+
+    with pytest.raises(SeamTimeout):
+        seam.write_quadlet(quadlet, "[Container]\n", timeout=15.0)


### PR DESCRIPTION
Every systemctl/podman seam call a slot load/unload/restart makes is now
bounded. ContainerProvider._run's callers — the Quadlet write,
daemon-reload, reset-failed, and the one that actually wedged in the field,
systemctl restart, which spawns the container — passed no timeout at all, so
a stuck sudo hal0-systemctl or a wedged podman/netavark call blocked the
executor thread forever with nothing bounding it server-side.

hal0.system.seam.bounded_call() wraps every such call and turns a
subprocess.TimeoutExpired into a typed SeamTimeout (slot.seam_timeout,
HTTP 504) carrying the command, its budget, and whatever the child had
already printed before being killed. The error propagates to the slot state
machine as error with that message, same as any other load failure. (#1869)

hal0 slot load|unload|restart|swap and hal0 update --restart-slots now show
an elapsed counter and the slot's live state while they wait (refreshed
every ~2s on a TTY; one summary line otherwise), print the seam-timeout
remedy (hal0 slot logs <name>, journalctl -u hal0-slot@<name>) instead of a
bare read-timeout error, and gained a --json flag — instead of blocking
silently for up to ~40 minutes with no output. (#1870)

The provider tests' _run / write_quadlet stubs are widened to accept the
timeout keyword the real signatures now carry.

Signed-off-by: thinmintdev <alexander@awideweb.com>


## Verification

`ruff check src tests` clean. Full α unit suite (12808 tests) green apart from
three failures that also fail on a clean `main` checkout
(`tests/providers/test_moonshine_server.py` ×2, needs `ffmpeg`, and
`tests/slots/test_pressure_eviction.py::test_pressure_evict_noop_when_probe_fails`).
Integration β not run locally (needs root + a live `hal0-lemonade.service`); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzkumtSWnm3AxixzHG38UG
