### PR TITLE
fix(update): verify the served build, re-assert PATH links on activation (#1550, #1844, #1845, #2019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,34 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Fixed
 
+- `scripts/deploy.sh` now verifies the *served* build before printing
+  success, instead of trusting `git rev-parse HEAD` against the checkout's
+  files alone. `/api/status` gained a `build_sha` field — the short git SHA
+  of the tree the running process actually imports `hal0` from
+  (`hal0.build_info.build_sha`, cached once at process start so it reflects
+  what was true when the worker booted, not a live re-read) — and the
+  deploy script's health-check step now polls it after the service restart,
+  failing loudly with a `journalctl` hint on a mismatch rather than
+  reporting a deploy complete that a stuck-on-old-code worker never picked
+  up. (#1550)
+- `hal0 update`'s "Convergence incomplete" panel (and the new Settings ▸
+  Updates dashboard panel) no longer print a `migrate-flags`/`migrate-caps`/
+  `migrate-hw --apply` command that fails outright when `hal0-api` or a
+  `hal0-slot@*` unit is still active — `detect_pending_ownership_migrations`
+  now decides server-side whether `--stop-services` is required (reusing the
+  same live-unit check `hal0 slot migrate-*` itself refuses against,
+  `hal0.cli.slot_commands.active_hal0_units`) and both surfaces render that
+  exact string, never reassembling it client-side. (#1845)
+- `hal0 update` (and `scripts/deploy.sh`'s dev-deploy) now re-assert the
+  `/usr/local/bin/hal0` and `/usr/local/bin/hal0-agent` PATH symlinks on
+  every activation, the same way `refresh_privileged_wrappers` already
+  re-asserts the root-owned sudo wrappers — `install.sh` was previously the
+  only writer of these links, so a box upgraded exclusively through
+  `hal0 update` (or an editable checkout kept current via `deploy.sh`, which
+  never runs an FHS activation at all) could end up with a `hal0` on PATH
+  pointing at a stale or rebuilt venv shim. A new `hal0 doctor wrappers
+  --fix` command exposes the same refresh (wrappers + PATH links) for the
+  editable-install case deploy.sh runs under. (#1844, #2019)
 - MCP admin tools no longer report a tool failure for a successful read of a
   slot whose lifecycle state is `error`. The tool-result wrapper's failure
   sentinel keyed on `status == "error"` alone, which collides with the slot

--- a/docs/guides/manage-slots.mdx
+++ b/docs/guides/manage-slots.mdx
@@ -552,11 +552,13 @@ older on-disk slot config forward through the v1.0 field-ownership
 changes: `migrate-id-keying`, `migrate-hw`, `migrate-caps`,
 `migrate-flags`, `migrate-enabled-removal`. These are **manual, operator-run**
 migrations — `hal0 update` only *detects* which ones a box still needs and
-prints the command to run; it never applies one for you. `hal0 slot
+prints the exact command to run; it never applies one for you. `hal0 slot
 migrate-hw --apply` (and its siblings) also refuse to run while `hal0-api`
 or any `hal0-slot@*` unit is active, since rewriting slot TOML under a live
-runtime risks a split-brain config — stop hal0's services first, then run
-the reported command with `--apply`.
+runtime risks a split-brain config. `hal0 update` already knows whether any
+such unit is up, so the command it prints carries `--stop-services` for you
+when that's the case (stopping those units before proceeding) — copy the
+line verbatim rather than adding the flag yourself.
 
 ## Related
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -266,6 +266,7 @@ Bare `hal0 doctor` (no subcommand) runs `installer/lib/preflight.sh`:
 | `doctor migrations` | `--json` |
 | `doctor profiles` | `--json` |
 | `doctor ports` | `--fix` (delete stale netavark DNAT rules found by the audit; privileged) |
+| `doctor wrappers` | `--fix` (re-install `${LIB_DIR}/bin/hal0-*`, the matching `/etc/sudoers.d` drop-ins, and the `/usr/local/bin/hal0`(`-agent`) PATH links from the active tree; privileged) |
 | `doctor all` | `--json` |
 | `doctor bundle` | `--out`, `--no-rocm-smi`, `--include-logs` (default `auto`; `auto\|yes\|no`) |
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -197,6 +197,23 @@ fi
 step "3. Re-assert group-shared ownership (keeps the tree writable by '${HAL0_GROUP:-hal0}')"
 reassert_group_share "$REPO_ROOT"
 
+# ── 3b. Re-assert privileged wrappers + PATH links ────────────────────────────
+# `hal0 update commit` refreshes /usr/lib/hal0/bin/hal0-*, the /etc/sudoers.d
+# drop-ins and the /usr/local/bin/hal0(-agent) PATH links from the tree it just
+# activated (Updater.activate_release) — but that path only runs for an FHS
+# install; it's refused outright on this editable checkout. Without this step
+# a wrapper or PATH-link change pulled in by the reset above never reaches the
+# running box (#1844/#2019). Best-effort: never fails an otherwise-successful
+# deploy — same policy the updater itself uses for these refreshes.
+step "3b. Refresh privileged wrappers + PATH links"
+if [[ "$(id -u)" -ne 0 ]]; then
+    warn "not running as root — skipping wrapper/PATH-link refresh (sudo hal0 doctor wrappers --fix)"
+elif ! command -v hal0 >/dev/null 2>&1; then
+    warn "hal0 not on PATH — skipping wrapper/PATH-link refresh"
+else
+    hal0 doctor wrappers --fix || warn "wrapper/PATH-link refresh reported a problem — see above"
+fi
+
 # ── 4. Restart service ────────────────────────────────────────────────────────
 if [[ "$DO_RESTART" -eq 1 ]]; then
     step "4. Restart ${SERVICE} (editable install picks up new source on restart)"
@@ -215,15 +232,41 @@ step "5. Health check"
 port="${HAL0_PORT:-8080}"
 url="http://127.0.0.1:${port}"
 ok=0
+status_body=""
 for _ in $(seq 1 15); do
+    status_body="$(curl -s "${url}/api/status" 2>/dev/null || true)"
     code="$(curl -s -o /dev/null -w '%{http_code}' "${url}/api/status" 2>/dev/null || echo 000)"
     if [[ "$code" == "200" ]]; then ok=1; break; fi
     sleep 1
 done
-if [[ "$ok" -eq 1 ]]; then
-    served="$(curl -s "${url}/" 2>/dev/null | grep -oE 'index-[A-Za-z0-9_-]+\.js' | head -1 || true)"
-    info "gateway healthy at ${url} (serving ${served:-?})"
-    info "deploy complete @ $(git rev-parse --short HEAD)"
+[[ "$ok" -eq 1 ]] || die "gateway did not return 200 at ${url}/api/status after restart"
+
+served="$(curl -s "${url}/" 2>/dev/null | grep -oE 'index-[A-Za-z0-9_-]+\.js' | head -1 || true)"
+info "gateway healthy at ${url} (serving ${served:-?})"
+
+# ── 5b. Verify the SERVED build identity, not just that git moved ────────────
+# A 200 above only proves hal0-api's event loop answers — an editable install
+# only picks up new source on restart, and step 4's restart fails SOFT when no
+# systemd unit is found (a warn, not a die). `/api/status.build_sha` is the
+# git SHA the RUNNING process actually loaded (hal0.build_info.build_sha,
+# cached at process start — see src/hal0/build_info.py), so comparing it
+# against what we just checked out catches a stuck-on-old-code worker that a
+# bare `git rev-parse HEAD` (this script's old success message) could never
+# see (#1550/H7).
+if [[ "$DO_RESTART" -ne 1 ]]; then
+    warn "build-identity check skipped (--no-restart) — served code may predate this deploy"
+elif ! command -v jq >/dev/null 2>&1; then
+    warn "jq not found — skipping build-identity check"
 else
-    die "gateway did not return 200 at ${url}/api/status after restart"
+    served_sha="$(printf '%s' "$status_body" | jq -r '.build_sha // empty' 2>/dev/null || true)"
+    expected_sha="$(git rev-parse --short=12 HEAD)"
+    if [[ -z "$served_sha" ]]; then
+        warn "served build reports no build_sha (non-git install?) — cannot verify identity"
+    elif [[ "$served_sha" == "$expected_sha" ]]; then
+        info "served build matches deployed commit (${served_sha})"
+    else
+        die "served build_sha (${served_sha}) != deployed commit (${expected_sha}) — ${SERVICE} did not pick up the new code; check: journalctl -u ${SERVICE} -n 50"
+    fi
 fi
+
+info "deploy complete @ $(git rev-parse --short HEAD)"

--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -26,6 +26,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import Response
 
 from hal0 import __version__
+from hal0.build_info import build_sha
 from hal0.config import paths
 from hal0.slots.state import SlotState
 
@@ -228,6 +229,14 @@ async def get_status(request: Request) -> dict[str, Any]:
     return {
         "name": "hal0",
         "version": __version__,
+        # Short git SHA of the tree THIS PROCESS started from, or None on a
+        # non-git FHS install (#1550/H7). `scripts/deploy.sh` polls this after
+        # restarting hal0-api and fails loudly on a mismatch — a served
+        # version string alone can't catch a worker still running the old
+        # code (an editable install's `__version__` doesn't change between
+        # commits at all). Cached at process start, never re-read live — see
+        # hal0.build_info.build_sha.
+        "build_sha": build_sha(),
         "status": "ok",
         "hardware": None,  # populated by /api/hardware on demand
         "slots": slot_list,

--- a/src/hal0/build_info.py
+++ b/src/hal0/build_info.py
@@ -1,0 +1,51 @@
+"""Git identity of the source tree this process is running from (#1550/H7).
+
+Single owner for "what commit is actually serving right now" — the fact
+`/api/status` exposes and `scripts/deploy.sh` polls after a restart to prove
+the deploy actually took, rather than trusting `git rev-parse HEAD` run
+against the checkout's *files* (which says nothing about whether the running
+process picked them up — the exact gap #1550 reported: an editable install's
+worker only sees new code after a restart, and the old script printed
+success straight from git, never from the served process).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+
+@lru_cache(maxsize=1)
+def build_sha() -> str | None:
+    """Short git SHA of the tree this process imports ``hal0`` from, or ``None``.
+
+    Populated only for a git-tracked checkout (an editable ``pip install -e``,
+    or the maintainer-only git-tracked FHS layout — see
+    :func:`hal0.updater.updater._is_editable_install`) where a ``.git``
+    directory sits above this file. A normal FHS install's site-packages copy
+    carries no ``.git``, so this stays ``None`` there — ``__version__`` is
+    that install's identity instead.
+
+    Cached for the life of the process: the whole point is catching a worker
+    that is STILL running the old tree after a deploy's restart, so this must
+    report what was true when the process STARTED, never re-read live.
+    """
+    here = Path(__file__).resolve().parent
+    for candidate in (here, *here.parents):
+        if (candidate / ".git").exists():
+            try:
+                result = subprocess.run(  # nosec B603 B607 — fixed argv, no caller input
+                    ["git", "-C", str(candidate), "rev-parse", "--short=12", "HEAD"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    check=True,
+                )
+            except (OSError, subprocess.SubprocessError):
+                return None
+            return result.stdout.strip() or None
+    return None
+
+
+__all__ = ["build_sha"]

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -989,6 +989,89 @@ def perms(
     raise typer.Exit(0)
 
 
+# ── hal0 doctor wrappers — privileged wrapper + PATH-link refresh ────────────
+#
+# install.sh writes /usr/lib/hal0/bin/hal0-* (root-owned sudo wrappers), the
+# matching /etc/sudoers.d drop-ins, and the /usr/local/bin/hal0(-agent) PATH
+# links. `hal0 update commit` re-asserts all three from the just-activated
+# release (Updater.activate_release -> refresh_privileged_wrappers /
+# refresh_path_links), but that path is refused outright on an editable/dev
+# install (_raise_if_editable_install) — exactly the shape
+# `scripts/deploy.sh` runs under on an editable /opt/hal0 checkout. Without
+# this command a dev-deploy had no way to pick up a wrapper or PATH-link
+# change at all (#1844/#2019) — this is the same refresh path, callable
+# outside an activation.
+
+
+@app.command("wrappers")
+def wrappers(
+    fix: bool = typer.Option(
+        False,
+        "--fix",
+        help=(
+            "Re-install the wrappers, sudoers drop-ins and PATH links from the "
+            "active tree (needs root)."
+        ),
+    ),
+) -> None:
+    """Refresh the root-owned sudo wrappers + `/usr/local/bin/hal0` PATH links.
+
+    Audit-only by default: reports which tree it would refresh from.
+    ``--fix`` re-installs ``/usr/lib/hal0/bin/hal0-*``, the matching
+    ``/etc/sudoers.d`` drop-ins, and the ``/usr/local/bin/hal0`` +
+    ``hal0-agent`` PATH links from that tree — the exact
+    :func:`hal0.updater.updater.refresh_privileged_wrappers` /
+    :func:`hal0.updater.updater.refresh_path_links` calls
+    ``hal0 update commit`` makes automatically on every FHS activation.
+    Use this on an editable checkout (``scripts/deploy.sh``'s dev-deploy
+    target), which never goes through activation at all.
+    """
+    from hal0.updater.updater import (
+        _editable_install_path,
+        _usr_lib_root,
+        refresh_path_links,
+        refresh_privileged_wrappers,
+    )
+
+    editable = _editable_install_path()
+    target = Path(editable) if editable else (_usr_lib_root() / "current").resolve()
+    console.print(f"[dim]refreshing from {target}[/dim]")
+
+    if not fix:
+        console.print("[dim]audit-only — pass --fix to actually re-install.[/dim]")
+        raise typer.Exit(0)
+    if os.geteuid() != 0:
+        console.print("[red]✗[/red]  --fix needs root — re-run `sudo hal0 doctor wrappers --fix`.")
+        raise typer.Exit(1)
+
+    wrappers_result = refresh_privileged_wrappers(target)
+    links_result = refresh_path_links(target)
+
+    if wrappers_result["refreshed"]:
+        console.print(
+            f"[green]✓[/green]  wrappers refreshed: {', '.join(wrappers_result['refreshed'])}"
+        )
+    else:
+        console.print("[dim]no wrappers changed.[/dim]")
+    if wrappers_result["sudoers_refreshed"]:
+        console.print(
+            f"[green]✓[/green]  sudoers refreshed: {', '.join(wrappers_result['sudoers_refreshed'])}"
+        )
+    for seam, err in wrappers_result["errors"].items():
+        console.print(f"[red]✗[/red]  {seam}: {err}")
+
+    for name, status in links_result.items():
+        if status == "linked":
+            console.print(f"[green]✓[/green]  {name} PATH link refreshed")
+        elif status == "missing":
+            console.print(f"[yellow]![/yellow]  {name}: no shim found in this venv — skipped")
+        else:
+            console.print(f"[red]✗[/red]  {name} PATH link refresh failed")
+
+    if wrappers_result["errors"] or "failed" in links_result.values():
+        raise typer.Exit(1)
+
+
 # ── hal0 doctor models — FLM (NPU) store pure helpers ─────────────────────────
 #
 # The FLM store is the single most reboot-fragile surface on the box: the NPU

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -928,7 +928,7 @@ def slot_capacity(
 # process.
 
 
-def _active_hal0_units(
+def active_hal0_units(
     *, run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run
 ) -> list[str]:
     """Every hal0-owned systemd unit currently active: ``hal0-api.service``
@@ -1120,7 +1120,7 @@ def slot_migrate_id_keying(
         console.print("\n[dim]Re-run with --apply to write (stop hal0 first).[/dim]")
         return
 
-    active = _active_hal0_units()
+    active = active_hal0_units()
     if active:
         console.print(
             "[yellow]![/yellow]  the following hal0 units are still active: " + ", ".join(active)
@@ -1129,7 +1129,7 @@ def slot_migrate_id_keying(
             console.print("[dim]Stopping active units first (--stop-services)...[/dim]")
             for unit in active:
                 subprocess.run(["systemctl", "stop", unit], check=False)
-            active = _active_hal0_units()
+            active = active_hal0_units()
         if active:
             console.print(
                 "[red]✗[/red]  refusing to migrate while hal0 is live — flipping artefact "
@@ -1237,7 +1237,7 @@ def slot_migrate_hw(
 
     # --apply: a real deploy-window write. Guard against a live runtime — the
     # fold rewrites slot TOMLs the running process still resolves.
-    active = _active_hal0_units()
+    active = active_hal0_units()
     if active:
         console.print(
             "[yellow]![/yellow]  the following hal0 units are still active: " + ", ".join(active)
@@ -1246,7 +1246,7 @@ def slot_migrate_hw(
             console.print("[dim]Stopping active units first (--stop-services)...[/dim]")
             for unit in active:
                 subprocess.run(["systemctl", "stop", unit], check=False)
-            active = _active_hal0_units()
+            active = active_hal0_units()
         if active:
             console.print(
                 "[red]✗[/red]  refusing to fold while hal0 is live — rewriting slot TOMLs "
@@ -1340,7 +1340,7 @@ def slot_migrate_caps(
 
     # --apply: a real deploy-window write. Guard against a live runtime — the
     # fold rewrites slot TOMLs the running process still resolves.
-    active = _active_hal0_units()
+    active = active_hal0_units()
     if active:
         console.print(
             "[yellow]![/yellow]  the following hal0 units are still active: " + ", ".join(active)
@@ -1349,7 +1349,7 @@ def slot_migrate_caps(
             console.print("[dim]Stopping active units first (--stop-services)...[/dim]")
             for unit in active:
                 subprocess.run(["systemctl", "stop", unit], check=False)
-            active = _active_hal0_units()
+            active = active_hal0_units()
         if active:
             console.print(
                 "[red]✗[/red]  refusing to fold while hal0 is live — rewriting slot TOMLs "
@@ -1467,7 +1467,7 @@ def slot_migrate_flags(
 
     # --apply: a real deploy-window write. Guard against a live runtime — the
     # fold rewrites registry rows the running process still resolves.
-    active = _active_hal0_units()
+    active = active_hal0_units()
     if active:
         console.print(
             "[yellow]![/yellow]  the following hal0 units are still active: " + ", ".join(active)
@@ -1476,7 +1476,7 @@ def slot_migrate_flags(
             console.print("[dim]Stopping active units first (--stop-services)...[/dim]")
             for unit in active:
                 subprocess.run(["systemctl", "stop", unit], check=False)
-            active = _active_hal0_units()
+            active = active_hal0_units()
         if active:
             console.print(
                 "[red]✗[/red]  refusing to fold while hal0 is live — rewriting model "

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -2925,14 +2925,27 @@ def detect_pending_ownership_migrations(*, job_id: str | None = None) -> dict[st
 
     What is NOT acceptable is leaving the box silently half-converged, so this
     runs each fold's *planner* (``dry_run=True``, filesystem- and DB-write-free)
-    and reports precisely what is outstanding, with the command that fixes it.
+    and reports precisely what is outstanding, with the EXACT runnable command
+    that fixes it — including ``--stop-services`` when it is actually required
+    (#1845/H8): every ``migrate-*`` command in :data:`_OWNERSHIP_MIGRATIONS`
+    refuses ``--apply`` while ``hal0-api`` or any ``hal0-slot@*`` unit is
+    active (:func:`hal0.cli.slot_commands.active_hal0_units` is that same
+    live-unit check), and a bare ``... --apply`` printed while units are up
+    fails with no indication the flag exists. Callers (the CLI panel and the
+    dashboard) print this string verbatim — the flag is decided HERE, once,
+    not re-derived client-side.
 
     Returns ``{"pending": [keys], "detail": {key: {...}}, "commands": [...]}``.
     """
     import importlib
 
+    from hal0.cli.slot_commands import active_hal0_units
+
+    stop_services_suffix = " --stop-services" if active_hal0_units() else ""
+
     detail: dict[str, Any] = {}
-    for key, module_name, command in _OWNERSHIP_MIGRATIONS:
+    for key, module_name, base_command in _OWNERSHIP_MIGRATIONS:
+        command = base_command + stop_services_suffix
         entry: dict[str, Any] = {"command": command, "lines": [], "error": None}
         try:
             module = importlib.import_module(module_name)
@@ -4102,6 +4115,73 @@ def refresh_privileged_wrappers(target: Path, *, job_id: str | None = None) -> d
     return {"refreshed": refreshed, "sudoers_refreshed": sudoers_refreshed, "errors": errors}
 
 
+#: Where ``install.sh`` symlinks the CLI onto PATH (installer/install.sh:1078,
+#: env-overridable there via ``HAL0_PATH_LINK``). A module constant for the
+#: same testability reason as :data:`GPU_PERMS_UNIT_DST` — tests redirect it
+#: rather than touching the real ``/usr/local/bin``.
+HAL0_PATH_LINK_DST = Path(os.environ.get("HAL0_PATH_LINK", "/usr/local/bin/hal0"))
+
+
+def refresh_path_links(target: Path, *, job_id: str | None = None) -> dict[str, str]:
+    """Re-assert the ``/usr/local/bin/hal0`` (+ ``hal0-agent``) PATH links (#1844/#2019).
+
+    Same #1689 shape as :func:`refresh_privileged_wrappers`: ``install.sh`` was
+    the ONLY writer of these symlinks (installer/install.sh:1077-1099) —
+    ``hal0 update`` never refreshed them, so a box upgraded exclusively
+    through the updater kept ``/usr/local/bin/hal0`` pointed at whatever venv
+    shim existed at the LAST ``install.sh`` run. A rebuilt or relocated venv
+    (or a `scripts/deploy.sh` dev-deploy that reprovisions one, #2019) then
+    left the PATH entry stale or dangling with nothing to re-assert it.
+
+    Privileged-side ONLY, same guard as its siblings: a no-op unless
+    ``os.geteuid() == 0`` — the unprivileged daemon must never write
+    ``/usr/local/bin``.
+
+    ``target`` names the release tree only for log context; the link SOURCE
+    is always THIS process's actual venv (``sys.prefix`` — the same signal
+    :func:`refresh_gpu_perms_unit` trusts), because the CLI shim lives in the
+    venv's ``bin/``, not the release tree, and by the time this runs
+    :func:`activate_release` has already re-pip'd ``target`` into that venv
+    (a no-op re-pip for an editable install).
+
+    Best-effort per link, using the same atomic swap :func:`activate_release`
+    uses for the release symlink itself (:func:`_atomic_symlink_swap`) so a
+    concurrent ``hal0`` invocation never observes a half-written link. A
+    missing ``hal0-agent`` shim (older release, or a venv still provisioning)
+    is skipped, not fatal — the same "never wedge an otherwise-successful
+    activate" policy as :func:`refresh_privileged_wrappers`.
+
+    Returns ``{"hal0": "linked"|"missing"|"failed", "hal0-agent": ...}``
+    (empty dict when not root).
+    """
+    if os.geteuid() != 0:
+        return {}
+
+    venv_bin = Path(sys.prefix) / "bin"
+    results: dict[str, str] = {}
+    for src_name, dst in (
+        ("hal0", HAL0_PATH_LINK_DST),
+        ("hal0-agent", HAL0_PATH_LINK_DST.with_name("hal0-agent")),
+    ):
+        src = venv_bin / src_name
+        if not src.is_file():
+            results[src_name] = "missing"
+            log.warning(
+                "updater.path_link_source_missing", job_id=job_id, name=src_name, src=str(src)
+            )
+            continue
+        try:
+            _atomic_symlink_swap(src, dst)
+            results[src_name] = "linked"
+        except OSError as exc:
+            results[src_name] = "failed"
+            log.warning(
+                "updater.path_link_refresh_failed", job_id=job_id, name=src_name, error=str(exc)
+            )
+    log.info("updater.path_links_refreshed", job_id=job_id, target=str(target), results=results)
+    return results
+
+
 def activate_release(dir_name: str, *, job_id: str | None = None) -> dict[str, Any]:
     """§9 step 8 + 8b: swap ``current`` to ``<usr_lib>/<dir_name>`` and re-pip it.
 
@@ -4161,6 +4241,7 @@ def activate_release(dir_name: str, *, job_id: str | None = None) -> dict[str, A
     # activate (a wrapper that fails to refresh keeps the OLD one in place,
     # same class of degradation as before this fix, not a new failure mode).
     wrappers = refresh_privileged_wrappers(target, job_id=job_id)
+    path_links = refresh_path_links(target, job_id=job_id)
     gpu_perms_unit = refresh_gpu_perms_unit(target, job_id=job_id)
 
     log.info(
@@ -4173,6 +4254,7 @@ def activate_release(dir_name: str, *, job_id: str | None = None) -> dict[str, A
         "previous": str(prior) if prior else None,
         "target": str(target),
         "wrappers_refreshed": wrappers["refreshed"],
+        "path_links_refreshed": path_links,
         "gpu_perms_unit": gpu_perms_unit,
     }
 
@@ -4994,6 +5076,7 @@ __all__ = [
     "fetch_release_manifest",
     "profile_reset_status",
     "refresh_gpu_perms_unit",
+    "refresh_path_links",
     "refresh_privileged_wrappers",
     "release_dir_name",
     "releases_url",

--- a/tests/agents/conftest.py
+++ b/tests/agents/conftest.py
@@ -16,15 +16,20 @@ default for the duration of that test.
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
 
 from hal0.agents import hermes_provision as hp
 
 
 @pytest.fixture(autouse=True)
-def _euid_root_by_default():
-    """Run hermes-provision tests as if euid == 0 (the direct-write path)."""
-    with patch.object(hp.os, "geteuid", return_value=0):
-        yield
+def _euid_root_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run hermes-provision tests as if euid == 0 (the direct-write path).
+
+    Takes the test's OWN ``monkeypatch`` rather than an independent
+    ``patch.object`` context: ``hp.os`` IS the global :mod:`os` module, and a
+    per-test override set through ``monkeypatch`` would otherwise be undone
+    AFTER this fixture had already restored the real ``geteuid`` — re-installing
+    the euid-0 stub process-wide for every test that followed in the same xdist
+    worker. One monkeypatch instance makes the undo order LIFO and correct.
+    """
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 0)

--- a/tests/api/test_smoke.py
+++ b/tests/api/test_smoke.py
@@ -16,6 +16,10 @@ def test_status_endpoint(client: TestClient) -> None:
     body = response.json()
     assert body["name"] == "hal0", f"Expected name='hal0', got {body.get('name')!r}"
     assert body["version"], f"Expected non-empty version, got {body.get('version')!r}"
+    # #1550/H7: build_sha is present (None or a str) even without a .git dir —
+    # the field must never be missing, only possibly null.
+    assert "build_sha" in body
+    assert body["build_sha"] is None or isinstance(body["build_sha"], str)
 
 
 def test_openapi_loads(client: TestClient) -> None:

--- a/tests/cli/test_doctor_wrappers.py
+++ b/tests/cli/test_doctor_wrappers.py
@@ -1,0 +1,102 @@
+"""Tests for `hal0 doctor wrappers` (#1844/#2019).
+
+`hal0 update commit` refreshes the privileged sudo wrappers + PATH links
+automatically on every FHS activation, but that path is refused outright on
+an editable/dev install — exactly the shape `scripts/deploy.sh`'s dev-deploy
+runs under. `doctor wrappers` exposes the same refresh so a dev-deploy has a
+way to pick one up. Audit-only by default; `--fix` needs root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli.main import app
+
+runner = CliRunner()
+
+
+def test_audit_only_by_default_makes_no_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("hal0.updater.updater._editable_install_path", lambda: "/opt/hal0")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "hal0.updater.updater.refresh_privileged_wrappers",
+        lambda *a, **k: calls.append("wrappers") or {"refreshed": [], "errors": {}},
+    )
+    monkeypatch.setattr(
+        "hal0.updater.updater.refresh_path_links",
+        lambda *a, **k: calls.append("links") or {},
+    )
+
+    result = runner.invoke(app, ["doctor", "wrappers"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == []
+    assert "/opt/hal0" in result.output
+
+
+def test_fix_without_root_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("hal0.updater.updater._editable_install_path", lambda: "/opt/hal0")
+    monkeypatch.setattr("hal0.cli.doctor_commands.os.geteuid", lambda: 1000)
+
+    result = runner.invoke(app, ["doctor", "wrappers", "--fix"])
+
+    assert result.exit_code == 1
+    assert "needs root" in result.output
+
+
+def test_fix_as_root_refreshes_wrappers_and_links(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    editable_root = tmp_path / "opt-hal0"
+    monkeypatch.setattr("hal0.updater.updater._editable_install_path", lambda: str(editable_root))
+    monkeypatch.setattr("hal0.cli.doctor_commands.os.geteuid", lambda: 0)
+
+    seen_targets: list[Path] = []
+    monkeypatch.setattr(
+        "hal0.updater.updater.refresh_privileged_wrappers",
+        lambda target, **k: (
+            seen_targets.append(target)
+            or {"refreshed": ["hal0-systemctl"], "sudoers_refreshed": [], "errors": {}}
+        ),
+    )
+    monkeypatch.setattr(
+        "hal0.updater.updater.refresh_path_links",
+        lambda target, **k: seen_targets.append(target) or {"hal0": "linked"},
+    )
+
+    result = runner.invoke(app, ["doctor", "wrappers", "--fix"])
+
+    assert result.exit_code == 0, result.output
+    assert seen_targets == [editable_root, editable_root]
+    assert "hal0-systemctl" in result.output
+    assert "hal0 PATH link refreshed" in result.output
+
+
+def test_fix_reports_errors_with_nonzero_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "hal0.updater.updater._editable_install_path", lambda: str(tmp_path / "opt-hal0")
+    )
+    monkeypatch.setattr("hal0.cli.doctor_commands.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "hal0.updater.updater.refresh_privileged_wrappers",
+        lambda *a, **k: {
+            "refreshed": [],
+            "sudoers_refreshed": [],
+            "errors": {"hal0-systemctl": "permission denied"},
+        },
+    )
+    monkeypatch.setattr(
+        "hal0.updater.updater.refresh_path_links", lambda *a, **k: {"hal0": "failed"}
+    )
+
+    result = runner.invoke(app, ["doctor", "wrappers", "--fix"])
+
+    assert result.exit_code == 1
+    assert "permission denied" in result.output
+    assert "PATH link refresh failed" in result.output

--- a/tests/cli/test_slot_migrate_caps.py
+++ b/tests/cli/test_slot_migrate_caps.py
@@ -63,7 +63,7 @@ def test_apply_folds_slot_mtp_to_model_and_backs_up(
 
     # Exercise the filesystem fold independently of host systemd state. The
     # safety gate itself retains dedicated coverage in the id-keying tests.
-    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: [])
+    monkeypatch.setattr("hal0.cli.slot_commands.active_hal0_units", lambda: [])
     slot_migrate_caps(apply=True, yes=True, stop_services=False)
 
     raw = tomllib.loads(slot.read_text(encoding="utf-8"))
@@ -91,7 +91,7 @@ def test_apply_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     )
     registry = ModelRegistry()
     registry.add(Model(id="m", path="/models/m.gguf"))
-    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: [])
+    monkeypatch.setattr("hal0.cli.slot_commands.active_hal0_units", lambda: [])
 
     slot_migrate_caps(apply=True, yes=True, stop_services=False)
     first_defaults = registry.get("m").defaults

--- a/tests/cli/test_slot_migrate_flags.py
+++ b/tests/cli/test_slot_migrate_flags.py
@@ -82,7 +82,7 @@ def test_apply_folds_slot_tune_onto_the_model_and_backs_up(
     registry = ModelRegistry()
     registry.add(Model(id="m", path="/models/m.gguf"))
 
-    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: [])
+    monkeypatch.setattr("hal0.cli.slot_commands.active_hal0_units", lambda: [])
     slot_migrate_flags(apply=True, yes=True, stop_services=False)
 
     folded = registry.get("m").defaults
@@ -120,7 +120,7 @@ def test_apply_folds_chat_template_onto_the_model(
     registry = ModelRegistry()
     registry.add(Model(id="m", path="/models/m.gguf"))
 
-    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: [])
+    monkeypatch.setattr("hal0.cli.slot_commands.active_hal0_units", lambda: [])
     slot_migrate_flags(apply=True, yes=True, stop_services=False)
 
     # resolve_chat_template reads ONLY the model now, so the slot's template
@@ -139,7 +139,7 @@ def test_apply_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     )
     registry = ModelRegistry()
     registry.add(Model(id="m", path="/models/m.gguf"))
-    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: [])
+    monkeypatch.setattr("hal0.cli.slot_commands.active_hal0_units", lambda: [])
 
     slot_migrate_flags(apply=True, yes=True, stop_services=False)
     first = registry.get("m").defaults
@@ -170,7 +170,7 @@ def test_divergent_share_refuses_and_writes_nothing(
     )
     registry = ModelRegistry()
     registry.add(Model(id="shared", path="/models/shared.gguf"))
-    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: [])
+    monkeypatch.setattr("hal0.cli.slot_commands.active_hal0_units", lambda: [])
 
     with pytest.raises(typer.Exit) as exc:
         slot_migrate_flags(apply=True, yes=True, stop_services=False)
@@ -225,7 +225,7 @@ def test_apply_refuses_while_hal0_units_are_live(
     )
     registry = ModelRegistry()
     registry.add(Model(id="m", path="/models/m.gguf"))
-    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: ["hal0-api.service"])
+    monkeypatch.setattr("hal0.cli.slot_commands.active_hal0_units", lambda: ["hal0-api.service"])
 
     with pytest.raises(typer.Exit) as exc:
         slot_migrate_flags(apply=True, yes=True, stop_services=False)

--- a/tests/cli/test_slot_migrate_hw.py
+++ b/tests/cli/test_slot_migrate_hw.py
@@ -59,7 +59,7 @@ def test_apply_folds_slot_image_to_image_pin_and_backs_up(
 
     # Exercise the filesystem fold independently of host systemd state. The
     # safety gate itself retains dedicated coverage in the id-keying tests.
-    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: [])
+    monkeypatch.setattr("hal0.cli.slot_commands.active_hal0_units", lambda: [])
     slot_migrate_hw(apply=True, yes=True, stop_services=False)
 
     raw = tomllib.loads(slot.read_text(encoding="utf-8"))

--- a/tests/cli/test_slot_migrate_id_keying.py
+++ b/tests/cli/test_slot_migrate_id_keying.py
@@ -7,7 +7,7 @@ API.
 Covers the three seams the command wires together:
 
   * ``_backup_slot_state``   — pre-flight tar backup (the only rollback path).
-  * ``_active_hal0_units``   — the live-runtime safety gate (halo143 split-brain
+  * ``active_hal0_units``   — the live-runtime safety gate (halo143 split-brain
                                 lesson: never flip under a running API/slot).
   * ``_migrate_id_keying_dry_run_plan`` — the plan a ``--dry-run`` prints
                                 without invoking the real (file-moving) migrator.
@@ -24,9 +24,9 @@ from pathlib import Path
 import pytest
 
 from hal0.cli.slot_commands import (
-    _active_hal0_units,
     _backup_slot_state,
     _migrate_id_keying_dry_run_plan,
+    active_hal0_units,
     slot_migrate_id_keying,
 )
 from hal0.slots.identity import SlotIdentityStore
@@ -79,7 +79,7 @@ def test_backup_tolerates_missing_data_dir(tmp_path: Path) -> None:
     assert any("chat.toml" in n for n in names)
 
 
-# ── _active_hal0_units ───────────────────────────────────────────────────────
+# ── active_hal0_units ───────────────────────────────────────────────────────
 
 
 def _fake_run(active_units: set[str]):
@@ -105,11 +105,11 @@ def _fake_run(active_units: set[str]):
 
 
 def test_active_units_empty_when_nothing_running() -> None:
-    assert _active_hal0_units(run=_fake_run(set())) == []
+    assert active_hal0_units(run=_fake_run(set())) == []
 
 
 def test_active_units_reports_api_and_slots() -> None:
-    active = _active_hal0_units(run=_fake_run({"hal0-api.service", "hal0-slot@143.service"}))
+    active = active_hal0_units(run=_fake_run({"hal0-api.service", "hal0-slot@143.service"}))
     assert "hal0-api.service" in active
     assert "hal0-slot@143.service" in active
 
@@ -118,7 +118,7 @@ def test_active_units_tolerates_missing_systemctl() -> None:
     def run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         raise FileNotFoundError("systemctl not found")
 
-    assert _active_hal0_units(run=run) == []
+    assert active_hal0_units(run=run) == []
 
 
 # ── _migrate_id_keying_dry_run_plan ──────────────────────────────────────────
@@ -180,7 +180,7 @@ def test_command_migrates_tree_and_writes_backup(
 
     # Exercise the filesystem migration independently of host systemd state.
     # The safety gate keeps its dedicated coverage above.
-    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: [])
+    monkeypatch.setattr("hal0.cli.slot_commands.active_hal0_units", lambda: [])
     slot_migrate_id_keying(apply=True, yes=True, stop_services=False, dry_run=False)
 
     remaining = sorted(p.name for p in config_dir.glob("*.toml"))
@@ -207,7 +207,7 @@ def test_apply_false_previews_and_writes_nothing(
     config_dir.mkdir(parents=True, exist_ok=True)
     (config_dir / "chat.toml").write_text('[slot]\nname = "chat"\nport = 8081\n')
 
-    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: [])
+    monkeypatch.setattr("hal0.cli.slot_commands.active_hal0_units", lambda: [])
     # apply defaults to False on the real CLI → dry-run: prints the plan,
     # writes nothing. yes=True so the (skipped, on this path) confirm can't
     # block the assertion under pytest's captured stdin.
@@ -238,7 +238,7 @@ def test_dry_run_flag_is_a_no_op_alias_that_apply_overrides(
     config_dir.mkdir(parents=True, exist_ok=True)
     (config_dir / "chat.toml").write_text('[slot]\nname = "chat"\nport = 8081\n')
 
-    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: [])
+    monkeypatch.setattr("hal0.cli.slot_commands.active_hal0_units", lambda: [])
     slot_migrate_id_keying(apply=True, yes=True, stop_services=False, dry_run=True)
 
     remaining = sorted(p.name for p in config_dir.glob("*.toml"))

--- a/tests/test_build_info.py
+++ b/tests/test_build_info.py
@@ -1,0 +1,71 @@
+"""hal0.build_info.build_sha — #1550/H7.
+
+`scripts/deploy.sh` polls `/api/status`'s `build_sha` after restarting
+hal0-api to prove the RUNNING process picked up the new tree, not merely
+that the checkout's files moved. Two properties matter: it finds the real
+sha for a git-tracked tree, and it degrades to `None` (never raises) when
+there's nothing to find — a broken probe must not take `/api/status` down
+with it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from hal0.build_info import build_sha
+
+
+def test_finds_the_sha_of_this_checkout() -> None:
+    build_sha.cache_clear()
+    repo_root = Path(__file__).resolve().parents[1]
+    expected = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--short=12", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert build_sha() == expected
+
+
+def test_returns_none_outside_any_git_tree(tmp_path, monkeypatch) -> None:
+    build_sha.cache_clear()
+    fake_pkg_file = tmp_path / "nested" / "hal0" / "build_info.py"
+    fake_pkg_file.parent.mkdir(parents=True)
+    fake_pkg_file.write_text("", encoding="utf-8")
+    monkeypatch.setattr("hal0.build_info.__file__", str(fake_pkg_file))
+    assert build_sha() is None
+
+
+def test_never_raises_on_a_broken_git_binary(tmp_path, monkeypatch) -> None:
+    build_sha.cache_clear()
+    tree = tmp_path / "checkout" / "src" / "hal0"
+    tree.mkdir(parents=True)
+    (tmp_path / "checkout" / ".git").mkdir()
+    monkeypatch.setattr("hal0.build_info.__file__", str(tree / "build_info.py"))
+
+    def _boom(*a, **k):
+        raise OSError("git not found")
+
+    monkeypatch.setattr("hal0.build_info.subprocess.run", _boom)
+    assert build_sha() is None
+    build_sha.cache_clear()
+
+
+def test_result_is_cached_for_the_process_lifetime(monkeypatch) -> None:
+    """The whole point (#1550): a deploy's restart must be observable, so a
+    stale worker must never re-read a `.git` HEAD that moved after it started."""
+    build_sha.cache_clear()
+    calls = {"n": 0}
+    real_run = subprocess.run
+
+    def _counting_run(*a, **k):
+        calls["n"] += 1
+        return real_run(*a, **k)
+
+    monkeypatch.setattr("hal0.build_info.subprocess.run", _counting_run)
+    first = build_sha()
+    second = build_sha()
+    assert first == second
+    assert calls["n"] <= 1
+    build_sha.cache_clear()

--- a/tests/updater/test_convergence_report.py
+++ b/tests/updater/test_convergence_report.py
@@ -113,6 +113,43 @@ def test_real_fold_work_is_reported_with_its_command(
     assert report["detail"]["hw"]["lines"][0].startswith("would fold slot 'chat'")
 
 
+def test_pending_command_gains_stop_services_when_units_are_up(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1845/H8: a bare `--apply` printed while hal0 units are live fails —
+    the migrate-* commands all refuse without `--stop-services` in that state
+    (cli/slot_commands.py). The server is the one place that knows whether
+    units are up, so it must be the one to decide the flag, not the CLI panel
+    or the dashboard reprinting a stale static string.
+    """
+    import hal0.cli.slot_commands as slot_commands
+    import hal0.config.migrations.hw_slot_ownership as m
+
+    monkeypatch.setattr(
+        m, "run_migration", lambda **kw: ["would fold slot 'chat': ngl=99 binary='rocmfpx'"]
+    )
+    monkeypatch.setattr(slot_commands, "active_hal0_units", lambda: ["hal0-api.service"])
+    report = U.detect_pending_ownership_migrations()
+    assert report["commands"] == ["hal0 slot migrate-hw --apply --stop-services"]
+    assert report["detail"]["hw"]["command"] == "hal0 slot migrate-hw --apply --stop-services"
+
+
+def test_pending_command_omits_stop_services_when_units_are_down(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The common case: no live units, so the plain `--apply` command is correct
+    and must not carry a flag the operator doesn't need."""
+    import hal0.cli.slot_commands as slot_commands
+    import hal0.config.migrations.hw_slot_ownership as m
+
+    monkeypatch.setattr(
+        m, "run_migration", lambda **kw: ["would fold slot 'chat': ngl=99 binary='rocmfpx'"]
+    )
+    monkeypatch.setattr(slot_commands, "active_hal0_units", lambda: [])
+    report = U.detect_pending_ownership_migrations()
+    assert report["commands"] == ["hal0 slot migrate-hw --apply"]
+
+
 def test_divergent_share_refusal_is_surfaced_not_swallowed(
     tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/updater/test_path_link_refresh.py
+++ b/tests/updater/test_path_link_refresh.py
@@ -1,0 +1,115 @@
+"""#1844/#2019 — `hal0 update` never refreshed the `/usr/local/bin/hal0` PATH
+link (or `hal0-agent`'s sibling), only `install.sh` did.
+
+These tests pin :func:`hal0.updater.updater.refresh_path_links`: privileged-side
+only (a no-op unless euid 0), reads its source shims from the ACTUAL running
+venv (``sys.prefix``) rather than the release tree, and is best-effort per
+link so a missing `hal0-agent` shim never fails an otherwise-successful
+activation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.updater.updater import refresh_path_links
+
+
+def _fake_venv(tmp_path: Path, *, shims: tuple[str, ...]) -> Path:
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    for name in shims:
+        (bin_dir / name).write_text("#!/bin/sh\n", encoding="utf-8")
+    return venv
+
+
+@pytest.fixture
+def link_dst(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    dst = tmp_path / "usr-local-bin" / "hal0"
+    monkeypatch.setattr("hal0.updater.updater.HAL0_PATH_LINK_DST", dst)
+    return dst
+
+
+def test_noop_when_not_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, link_dst: Path
+) -> None:
+    """The unprivileged daemon must never write /usr/local/bin itself."""
+    monkeypatch.setattr("hal0.updater.updater.os.geteuid", lambda: 1000)
+    venv = _fake_venv(tmp_path, shims=("hal0", "hal0-agent"))
+    monkeypatch.setattr("hal0.updater.updater.sys.prefix", str(venv))
+
+    result = refresh_path_links(tmp_path / "release-tree")
+
+    assert result == {}
+    assert not link_dst.exists()
+
+
+def test_root_links_both_shims_from_the_running_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, link_dst: Path
+) -> None:
+    monkeypatch.setattr("hal0.updater.updater.os.geteuid", lambda: 0)
+    venv = _fake_venv(tmp_path, shims=("hal0", "hal0-agent"))
+    monkeypatch.setattr("hal0.updater.updater.sys.prefix", str(venv))
+
+    result = refresh_path_links(tmp_path / "release-tree", job_id="job-1")
+
+    assert result == {"hal0": "linked", "hal0-agent": "linked"}
+    assert link_dst.is_symlink()
+    assert Path(link_dst).resolve() == (venv / "bin" / "hal0").resolve()
+    agent_dst = link_dst.with_name("hal0-agent")
+    assert agent_dst.is_symlink()
+    assert agent_dst.resolve() == (venv / "bin" / "hal0-agent").resolve()
+
+
+def test_missing_agent_shim_is_skipped_not_fatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, link_dst: Path
+) -> None:
+    """An older release / a venv still provisioning may lack hal0-agent —
+    the hal0 link must still succeed."""
+    monkeypatch.setattr("hal0.updater.updater.os.geteuid", lambda: 0)
+    venv = _fake_venv(tmp_path, shims=("hal0",))
+    monkeypatch.setattr("hal0.updater.updater.sys.prefix", str(venv))
+
+    result = refresh_path_links(tmp_path / "release-tree")
+
+    assert result == {"hal0": "linked", "hal0-agent": "missing"}
+    assert link_dst.is_symlink()
+    assert not link_dst.with_name("hal0-agent").exists()
+
+
+def test_re_linking_is_idempotent_and_replaces_a_stale_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, link_dst: Path
+) -> None:
+    """A rebuilt venv (#2019) must overwrite the OLD link, not refuse."""
+    monkeypatch.setattr("hal0.updater.updater.os.geteuid", lambda: 0)
+    old_venv = _fake_venv(tmp_path / "old", shims=("hal0",))
+    link_dst.parent.mkdir(parents=True, exist_ok=True)
+    link_dst.symlink_to(old_venv / "bin" / "hal0")
+
+    new_venv = _fake_venv(tmp_path / "new", shims=("hal0", "hal0-agent"))
+    monkeypatch.setattr("hal0.updater.updater.sys.prefix", str(new_venv))
+
+    result = refresh_path_links(tmp_path / "release-tree")
+
+    assert result["hal0"] == "linked"
+    assert Path(link_dst).resolve() == (new_venv / "bin" / "hal0").resolve()
+
+
+def test_swap_failure_is_recorded_not_raised(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, link_dst: Path
+) -> None:
+    monkeypatch.setattr("hal0.updater.updater.os.geteuid", lambda: 0)
+    venv = _fake_venv(tmp_path, shims=("hal0",))
+    monkeypatch.setattr("hal0.updater.updater.sys.prefix", str(venv))
+
+    def _boom(*a, **k):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr("hal0.updater.updater._atomic_symlink_swap", _boom)
+
+    result = refresh_path_links(tmp_path / "release-tree")
+
+    assert result["hal0"] == "failed"

--- a/tests/updater/test_wrapper_refresh.py
+++ b/tests/updater/test_wrapper_refresh.py
@@ -246,3 +246,4 @@ def test_activate_release_includes_wrappers_refreshed_key(
     result = activate_release("hal0-1.0.0")
 
     assert result["wrappers_refreshed"] == []
+    assert result["path_links_refreshed"] == {}

--- a/ui/src/api/hooks/useUpdates.ts
+++ b/ui/src/api/hooks/useUpdates.ts
@@ -34,6 +34,29 @@ export interface UpdateState {
 
 export type UpdateJobState = 'queued' | 'running' | 'applied' | 'failed'
 
+// One of the three deploy-window ownership folds (spec-flags-ownership /
+// spec-hw-slot-ownership) hal0.updater.updater.detect_pending_ownership_migrations
+// reports on. `command` is the EXACT runnable line — it already carries
+// `--stop-services` when the server determined hal0 units are live
+// (#1845/H8) — render it verbatim; never re-derive or append flags here.
+export interface OwnershipMigrationEntry {
+  command: string
+  lines: string[]
+  error: string | null
+}
+
+export interface OwnershipMigrations {
+  pending: string[]
+  detail: Record<string, OwnershipMigrationEntry>
+  commands: string[]
+}
+
+export interface ConvergenceReport {
+  profile_reset?: { due: boolean; outcome?: string; backup?: string | null }
+  ownership_migrations: OwnershipMigrations
+  converged: boolean
+}
+
 export interface UpdateJob {
   id: string
   state: UpdateJobState
@@ -43,6 +66,9 @@ export interface UpdateJob {
   updated_at: number
   error: string | null
   error_code?: string | null
+  // Attached by /api/updates/status/{id} after a commit — null until the
+  // job reaches a terminal state, or on a daemon too old to send it.
+  convergence?: ConvergenceReport | null
 }
 
 export function useUpdateState() {

--- a/ui/src/dash/settings/pages/diagnostics/UpdatesPage.jsx
+++ b/ui/src/dash/settings/pages/diagnostics/UpdatesPage.jsx
@@ -154,6 +154,25 @@ export function UpdatesPage() {
             <a className="btn ghost sm" href="https://hal0.dev/changelog" target="_blank" rel="noreferrer">Changelog →</a>
           </>}
         />
+        {/* #1845/H8: ownership-fold migrations the update installed but did NOT
+            apply (they refuse to rewrite slot TOMLs under a live runtime — see
+            hal0.updater.updater.detect_pending_ownership_migrations). The
+            command lines are printed EXACTLY as the server returns them —
+            including `--stop-services` when it decided units are up — so
+            this can never drift from what `hal0 update`'s own CLI panel
+            prints for the same job. */}
+        {job?.convergence?.ownership_migrations?.pending?.length > 0 && (
+          <div className="s-row" data-testid="updates-convergence-pending">
+            <div className="k"><span style={{color: "var(--warn)"}}>Migrations not yet applied</span></div>
+            <div className="v mono" style={{color: "var(--fg-3)"}}>
+              The new code is installed and running, but the on-disk slot/model shape is not
+              fully migrated. hal0 refuses to rewrite it while live — stop hal0, then run:
+              {job.convergence.ownership_migrations.commands.map((cmd) => (
+                <div key={cmd} style={{marginTop: 4}}>{cmd}</div>
+              ))}
+            </div>
+          </div>
+        )}
         {u.hal0?.revoked && (
           <SRow
             k="Release notice"

--- a/ui/tests/e2e/specs/updates-convergence-panel-v3.spec.ts
+++ b/ui/tests/e2e/specs/updates-convergence-panel-v3.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * updates-convergence-panel-v3 — Settings ▸ Updates ▸ ownership-migration
+ * banner (#1845/H8).
+ *
+ * `hal0.updater.updater.detect_pending_ownership_migrations` decides,
+ * server-side, whether the pending migrate-* command needs `--stop-services`
+ * (hal0 units live) or not (units down) — see
+ * tests/updater/test_convergence_report.py for the backend cases. This spec
+ * covers the OTHER half of the promise in the brief: the dashboard panel
+ * must print that exact command line, with no client-side reassembly.
+ *
+ * `/api/updates/state` is in `mockFetch`'s FORCED-mock allowlist (not
+ * `networkFirst`), so `page.route` can never see it — same shape
+ * update-banner-v3.spec.ts documents. Override it via
+ * `window.__hal0UpdateStateOverride` instead. `/api/updates/apply` (POST)
+ * and `/api/updates/status/:id` (unrouted GET) aren't allowlisted, so both
+ * reach `page.route` normally.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+const JOB_ID = 'job-convergence-1'
+
+async function mockApplyAndStatus(page: import('@playwright/test').Page, convergence: unknown) {
+  await page.addInitScript(() => {
+    ;(window as any).__hal0UpdateStateOverride = {
+      hal0: { current: '1.1.0', available: '1.2.0', channel: 'stable' },
+      flm: { current: 'v0.9.42', source: 'manual-deb' },
+      autoCheck: true,
+    }
+  })
+  await page.route('**/api/updates/apply', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: JOB_ID,
+        state: 'queued',
+        channel: 'stable',
+        version: '1.2.0',
+        created_at: Date.now() / 1000,
+        updated_at: Date.now() / 1000,
+        error: null,
+      }),
+    }),
+  )
+  await page.route(`**/api/updates/status/${JOB_ID}`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: JOB_ID,
+        state: 'applied',
+        channel: 'stable',
+        version: '1.2.0',
+        created_at: Date.now() / 1000,
+        updated_at: Date.now() / 1000,
+        error: null,
+        convergence,
+      }),
+    }),
+  )
+}
+
+test.describe('Updates page — ownership-migration panel (#1845/H8)', () => {
+  test('prints the server command verbatim, --stop-services included, when units are up', async ({
+    page,
+  }) => {
+    await mockApplyAndStatus(page, {
+      profile_reset: { due: false },
+      ownership_migrations: {
+        pending: ['hw'],
+        detail: {
+          hw: {
+            command: 'hal0 slot migrate-hw --apply --stop-services',
+            lines: ["would fold slot 'chat': ngl=99 binary='rocmfpx'"],
+            error: null,
+          },
+        },
+        commands: ['hal0 slot migrate-hw --apply --stop-services'],
+      },
+      converged: false,
+    })
+    await page.goto('/#settings/updates')
+    await page.locator('[data-testid="updates-hal0-version"]').waitFor()
+    await page.getByRole('button', { name: 'Install update' }).click()
+
+    const panel = page.locator('[data-testid="updates-convergence-pending"]')
+    await expect(panel).toBeVisible()
+    await expect(panel).toContainText('hal0 slot migrate-hw --apply --stop-services')
+  })
+
+  test('prints the plain command with no flag when units are down', async ({ page }) => {
+    await mockApplyAndStatus(page, {
+      profile_reset: { due: false },
+      ownership_migrations: {
+        pending: ['hw'],
+        detail: {
+          hw: {
+            command: 'hal0 slot migrate-hw --apply',
+            lines: ["would fold slot 'chat': ngl=99 binary='rocmfpx'"],
+            error: null,
+          },
+        },
+        commands: ['hal0 slot migrate-hw --apply'],
+      },
+      converged: false,
+    })
+    await page.goto('/#settings/updates')
+    await page.locator('[data-testid="updates-hal0-version"]').waitFor()
+    await page.getByRole('button', { name: 'Install update' }).click()
+
+    const panel = page.locator('[data-testid="updates-convergence-pending"]')
+    await expect(panel).toBeVisible()
+    await expect(panel).toContainText('hal0 slot migrate-hw --apply')
+    await expect(panel).not.toContainText('--stop-services')
+  })
+
+  test('no panel when fully converged', async ({ page }) => {
+    await mockApplyAndStatus(page, {
+      profile_reset: { due: false },
+      ownership_migrations: { pending: [], detail: {}, commands: [] },
+      converged: true,
+    })
+    await page.goto('/#settings/updates')
+    await page.locator('[data-testid="updates-hal0-version"]').waitFor()
+    await page.getByRole('button', { name: 'Install update' }).click()
+    await expect(page.locator('[data-testid="updates-convergence-pending"]')).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
scripts/deploy.sh now verifies the served build before printing success,
instead of trusting git rev-parse HEAD against the checkout's files alone.
/api/status gained a build_sha field — the short git SHA of the tree the
running process actually imports hal0 from (hal0.build_info.build_sha,
cached once at process start so it reflects what was true when the worker
booted, not a live re-read) — and the deploy script's health-check step
polls it after the service restart, failing loudly with a journalctl hint on
a mismatch rather than reporting a deploy complete that a stuck-on-old-code
worker never picked up. (#1550)

hal0 update's "Convergence incomplete" panel (and the new Settings > Updates
dashboard panel) no longer print a migrate-flags/migrate-caps/migrate-hw
--apply command that fails outright when hal0-api or a hal0-slot@* unit is
still active. detect_pending_ownership_migrations now decides server-side
whether --stop-services is required, reusing the same live-unit check
hal0 slot migrate-* itself refuses against (active_hal0_units), and both
surfaces render that exact string, never reassembling it client-side. (#1845)

hal0 update (and deploy.sh's dev-deploy) re-assert the /usr/local/bin/hal0
and /usr/local/bin/hal0-agent PATH symlinks on every activation, the way
refresh_privileged_wrappers already re-asserts the root-owned sudo wrappers.
install.sh was the only writer of these links, so a box upgraded exclusively
through hal0 update — or an editable checkout kept current via deploy.sh,
which never runs an FHS activation at all — could end up with a hal0 on PATH
pointing at a stale or rebuilt venv shim. hal0 doctor wrappers --fix exposes
the same refresh (wrappers + PATH links) for the editable-install case.
(#1844, #2019)

tests/agents/conftest.py's autouse euid fixture now takes the test's own
monkeypatch instead of an independent patch.object context. hp.os IS the
global os module, so a per-test override set through monkeypatch was undone
AFTER that context had already restored the real geteuid, re-installing the
euid-0 stub process-wide for every test that followed in the same xdist
worker — which the euid-gated refresh_path_links is the first code to
notice.

Signed-off-by: thinmintdev <alexander@awideweb.com>


## Verification

`ruff check src tests` clean. Full α unit suite (12808 tests) green apart from
three failures that also fail on a clean `main` checkout
(`tests/providers/test_moonshine_server.py` ×2, needs `ffmpeg`, and
`tests/slots/test_pressure_eviction.py::test_pressure_evict_noop_when_probe_fails`).
Integration β not run locally (needs root + a live `hal0-lemonade.service`); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzkumtSWnm3AxixzHG38UG
