### PR TITLE
fix(hardware): re-probe stale hardware truth, decide the ROCm lane on /dev/kfd (#1862, #1966, #2216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,30 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Fixed
 
+- **Hardware truth stays fresh, and the ROCm lane no longer depends on
+  `rocm-smi`.** A missing or stale `/etc/hal0/hardware.json` used to make a
+  real GPU box book resident slot memory as `ram_mb` instead of `vram_mb`
+  (`hal0.slots.capacity._host_has_capable_gpu` trusted the cache blindly);
+  it now falls back to a live re-probe when the cache is missing, predates
+  the running kernel, or was written in a previous boot cycle
+  (`hal0.hardware.freshness`), surfaced as `hal0 doctor`'s new
+  `hardware_freshness` row (#1862). `derive_device`'s ROCm-lane check
+  required `rocm-smi`'s optional CLI to exit 0 in addition to
+  `kfd_present()`'s device-node truth, so a fresh LXC with `/dev/kfd`
+  correctly forwarded — hal0's own reference deploy shape — seeded every
+  llama.cpp slot onto the slower Vulkan lane; `kfd_present()` alone now
+  decides it, matching the capability picker's GPU/ROCm badge and the
+  ComfyUI/Qwen3-TTS rows, which had the same gap (#2216, #1966). A new
+  `apply_cpu_fallback()` records *why* a slot's lane fell back to CPU at
+  seed time (#1936, #1966); the pre-existing load-time refusal for a GPU
+  slot with zero devices mapped (`require_kfd_for_gpu_slot`) is now locked
+  with a regression test naming the exact #1936 shape. Freshly seeded
+  `agent`/`brain`/`coder`/`embed`/`rerank`/`utility` slots now clamp
+  `context_size` to a new single-owner memory-envelope function
+  (`hal0.hardware.memory_envelope`, mirroring ODS's `usable_memory_gb`)
+  instead of shipping the reference platform's flat `65536` verbatim, with
+  a `hal0 doctor` finding (`seed_context_envelope`) for a ceiling an
+  existing box can no longer afford (#1868).
 - MCP admin tools no longer report a tool failure for a successful read of a
   slot whose lifecycle state is `error`. The tool-result wrapper's failure
   sentinel keyed on `status == "error"` alone, which collides with the slot

--- a/docs/concepts/strix-halo.mdx
+++ b/docs/concepts/strix-halo.mdx
@@ -51,7 +51,12 @@ an explicit device pin, never "whatever llama.cpp picks":
 
 - **ROCm** (`gpu-rocm`) — AMD's compute stack, and the lane hal0 seeds where
   the box can run it. It needs the `/dev/kfd` compute node visible to hal0 and
-  to the slot containers; a `gpu-rocm` slot without it refuses to load.
+  to the slot containers; a `gpu-rocm` slot without it refuses to load. hal0
+  decides this lane from the device node itself — `/dev/kfd` present and
+  openable by the slot-runner identity — never from whether a `rocm-smi`
+  binary happens to be installed in the guest. A fresh container or LXC has
+  no `rocm-smi` by default; that must never be why a box that already has
+  `/dev/kfd` forwarded gets seeded onto Vulkan instead.
 - **Vulkan** (`gpu-vulkan`) — the Mesa/RADV path. It needs only a DRM render
   node (`/dev/dri/renderD*`), which makes it the lane for boxes where `/dev/kfd`
   was never forwarded — an unprivileged LXC, for instance. It is also the lane
@@ -149,6 +154,17 @@ section of [Slots](/docs/concepts/slots)): it gives the GPU's memory to
 either the LLM slots or the image slot, one group at a time, rather than
 letting them fight over the pool.
 
+hal0 also never budgets a model against the *entire* unified pool: the OS,
+the container runtime, and every other slot need headroom too. Anywhere hal0
+decides how much memory a model + its context window may spend — sizing a
+freshly seeded slot's `context_size` at install time, `hal0 doctor` flagging
+an oversized one, or the capacity API's fit estimate — it works from a
+bounded **memory envelope**, not the raw pool: on unified-memory hardware
+that is 55% of total RAM, floored so a small-RAM APU still gets a usable
+minimum; on a discrete GPU it's the card's own VRAM; on a CPU-only box it's a
+smaller, capped share of RAM. A single shared function computes this so
+every one of those call sites agrees on the same number.
+
 ![The Slots view: the iGPU GTT carve-out bar above the Inference Engine, where iGPU and FLM (NPU) slots share the unified-memory pool](/screenshots/npu-occupancy.png)
 *The shared GTT carve-out above the Inference Engine — iGPU slots and FLM (NPU) slots both draw from one unified-memory pool.*
 
@@ -166,6 +182,16 @@ its own value, alongside generic ones such as `bare-metal-amd-gpu`,
 `bare-metal-nvidia-gpu`, `lxc`, `kvm`, `proxmox-kvm`, and `wsl2` — and the
 dashboard uses that to label memory as "unified" only on the platforms where
 that's true.
+
+The probe result is cached at `/etc/hal0/hardware.json`; the lane derivation
+above, and the dashboard's VRAM/RAM split, read that cache rather than
+re-probing on every request. hal0 detects when the cache should not be
+trusted — missing, predating the running kernel, or written in a previous
+boot cycle — and falls back to a live re-probe automatically rather than
+risking a stale answer; `hal0 doctor`'s `hardware_freshness` row surfaces
+this so you know when it's happening. See
+[GPU drivers and memory](/docs/getting-started/drivers) for when to
+re-run the probe yourself.
 
 <Aside type="caution">
 CUDA has nothing to do with Strix Halo — there's no NVIDIA silicon on this

--- a/docs/getting-started/drivers.mdx
+++ b/docs/getting-started/drivers.mdx
@@ -58,8 +58,27 @@ install.
 <Aside type="note" title="Host ROCm is not required">
 The host only needs `amdgpu` bound and the nodes above present — it does
 **not** need a host ROCm install. Every hal0 slot container carries its
-own ROCm userspace.
+own ROCm userspace. In particular, hal0 does **not** need `rocm-smi` on the
+host to decide the ROCm lane: it checks whether `/dev/kfd` is present and
+openable by the identity that runs your slot containers, not whether a
+ROCm CLI happens to be installed. `rocm-smi`, when present, is read only
+as telemetry (GPU name, free VRAM) — never as the gate for whether ROCm
+runs.
 </Aside>
+
+## Re-probing after a driver or kernel change
+
+hal0 caches what it found in `/etc/hal0/hardware.json`, written by `hal0
+probe`. A kernel upgrade, a newly forwarded device, or a driver change
+can make that cache stale — the ROCm/Vulkan lane derivation and the
+dashboard's VRAM/RAM split both read it. hal0 detects the common staleness
+shapes itself (the file is missing, it predates the running kernel, or it
+was written in a previous boot cycle) and falls back to a live re-probe
+automatically rather than trusting a stale answer — `hal0 doctor` surfaces
+this as the `hardware_freshness` row so you know when that is happening.
+Still, re-run `hal0 config hardware --refresh` yourself after any
+host-level hardware or driver change so the cache catches up and every
+read goes back to being the cheap cached one.
 
 ## Render-group gids
 

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -28,7 +28,7 @@ from hal0.config.loader import load_hardware_info
 from hal0.errors import Hal0Error
 from hal0.model_fit import evaluate_model_fit
 from hal0.profiles import ProfileCatalog, ResolvedProfile
-from hal0.providers._gpu import host_is_amd_gpu
+from hal0.providers._gpu import host_is_amd_gpu, kfd_present
 from hal0.registry.curated import CURATED, CuratedModel, HaloaiModel
 from hal0.registry.store import ModelRegistry
 from hal0.runners import RUNNER_IMAGES
@@ -79,6 +79,13 @@ _RUNTIME_TO_HOST_BACKENDS: dict[str, tuple[str, ...]] = {
     "comfyui": ("gpu-vulkan",),
     "qwen3tts": ("gpu-rocm",),  # Qwen3-TTS runner is ROCm-only (needs /dev/kfd)
 }
+
+#: Runtimes whose image is ROCm-only (needs /dev/kfd) despite the
+#: HOST_BACKENDS id it fans out to being the picker's generic Vulkan GPU row
+#: (#1941's "gpu-vulkan is the row label, not an image claim"). qwen3tts is
+#: exempt from the extra check below — its own HOST_BACKENDS entry IS
+#: ``"gpu-rocm"``, already kfd-gated by :func:`available_backends`.
+_ROCM_ONLY_RUNTIMES = frozenset({"comfyui"})
 
 _CAPABILITY_TO_SLOT_TYPE: dict[str, str] = {
     "chat": "llm",
@@ -290,8 +297,15 @@ def available_backends() -> list[dict[str, Any]]:
                     "multiplex": False,
                 }
             )
-        # ROCm path — only AMD GPUs with compute support light this up.
-        if primary_gpu.vendor == "amd" and primary_gpu.compute_capable:
+        # ROCm path — an AMD GPU this box can actually run ROCm on.
+        # ``compute_capable`` alone under-reports (#2216): it is only
+        # "rocm-smi --showproductname exited 0", a ROCm *userspace CLI*
+        # probe that install.sh never installs, so a fresh container with a
+        # perfectly usable /dev/kfd read False here and the badge (and every
+        # ROCm-only runtime's picker row, e.g. Qwen3-TTS below) went missing.
+        # kfd_present() (device-node truth) is sufficient on its own — same
+        # ruling as hal0.install.profile_derive.derive_device's ROCm lane.
+        if primary_gpu.vendor == "amd" and (primary_gpu.compute_capable or kfd_present()):
             out.append(
                 {
                     "id": "gpu-rocm",
@@ -402,6 +416,9 @@ def _backend_variants(entry: Any) -> list[str]:
         # CPU-only ONNX wheel, ComfyUI's Vulkan-only image, …) — an
         # explicit provider still can't advertise a lane the host can't
         # actually serve.
+        if explicit in _ROCM_ONLY_RUNTIMES and host_is_amd_gpu() and not kfd_present():
+            # #1966 — see the identical guard on the tag-driven branch below.
+            return []
         host_backends = {b["id"] for b in available_backends()}
         return [c for c in _RUNTIME_TO_HOST_BACKENDS.get(explicit, ()) if c in host_backends]
     # explicit llama-server (or unset) falls through to the existing
@@ -519,6 +536,19 @@ def _backend_variants(entry: Any) -> list[str]:
             # the slot TOML would say backend=vulkan but the container
             # would still pin every op to CPU.
             host_backends = {b["id"] for b in available_backends()}
+            if low in _ROCM_ONLY_RUNTIMES and host_is_amd_gpu() and not kfd_present():
+                # #1966: comfyui's HOST_BACKENDS entry is labelled
+                # "gpu-vulkan" — the picker's GENERIC GPU row (#1941) — but
+                # the image behind it is ROCm-only (ComfyUIProvider.
+                # gpu_runtime_needs_rocm). available_backends() rightly
+                # advertises gpu-vulkan whenever ANY Vulkan-capable render
+                # node exists, which on a kfd-less AMD box is exactly the
+                # "reachable lane" this runtime does NOT have: the load-time
+                # guard (require_kfd_for_gpu_slot) refuses it by name. Drop
+                # the row rather than offer one guaranteed to fail — qwen3tts
+                # needs no separate check here, its HOST_BACKENDS entry is
+                # the correctly-gated "gpu-rocm" id itself.
+                continue
             for candidate in _RUNTIME_TO_HOST_BACKENDS[low]:
                 if candidate in host_backends and candidate not in out:
                     out.append(candidate)

--- a/src/hal0/cli/doctor_all.py
+++ b/src/hal0/cli/doctor_all.py
@@ -126,6 +126,110 @@ def check_secret_file_modes() -> Check:
     return Check("secret-modes", "Secret file modes", _PASS, "secret files are owner-only")
 
 
+def check_hardware_freshness() -> Check:
+    """The cached hardware.json must be fresh enough to trust (#1862/H9).
+
+    Runs the SAME staleness check ``_host_has_capable_gpu`` (VRAM/RAM
+    attribution) and the ROCm/Vulkan lane derivation now fall back through
+    (:func:`hal0.hardware.freshness.staleness_reason`), so this row explains
+    OUT LOUD, on every ``hal0 doctor`` run, why a box might be getting a
+    live re-probe on every capacity read instead of the cheap cached one —
+    a missing probe (fresh install, ``hal0 probe`` never run), a cache that
+    predates a kernel upgrade/reboot, or one written before the #1799
+    capability fields existed.
+
+    Warn-only: a live-probe fallback keeps the box CORRECT even while stale
+    (never silently wrong), just not as cheap — so this is an actionable
+    heads-up, not a failure.
+    """
+    from hal0.config.loader import load_hardware_info
+    from hal0.hardware.freshness import staleness_reason
+
+    name, title = "hardware_freshness", "Hardware probe freshness"
+    path = paths.hardware_json()
+    has_file = path.exists()
+    if not has_file:
+        return Check(
+            name,
+            title,
+            _WARN,
+            f"{path} does not exist — run `hal0 config hardware --refresh` (until then, VRAM/RAM "
+            "attribution and the ROCm/Vulkan lane derivation fall back to a live "
+            "re-probe on every read)",
+        )
+    try:
+        info = load_hardware_info()
+    except Exception as exc:
+        return Check(
+            name,
+            title,
+            _WARN,
+            f"{path} is unreadable ({exc}) — run `hal0 config hardware --refresh`",
+        )
+    reason = staleness_reason(info, has_file=True)
+    if reason is None:
+        return Check(
+            name, title, _PASS, f"hardware.json is fresh (probed {info.probed_at or 'unknown'})"
+        )
+    return Check(
+        name,
+        title,
+        _WARN,
+        f"hardware.json is stale ({reason}) — falling back to a live re-probe on every "
+        f"VRAM/RAM and ROCm/Vulkan-lane read; run `hal0 config hardware --refresh` to refresh the cache",
+    )
+
+
+def check_seed_context_envelope(*, slots_dir: Path | None = None) -> Check:
+    """A slot's on-disk ``[model].context_size`` must fit this box's memory
+    envelope (#1868).
+
+    ``static_seeds``/``hal0 setup --auto`` clamp freshly-seeded slots at
+    install time, but an operator-edited ceiling, or a box downgraded in RAM
+    since install (a VM resize, a moved LXC), is never revisited. Flags any
+    slot whose configured ceiling exceeds what :func:`hal0.hardware.
+    memory_envelope.max_affordable_context_tokens` says this box can spend on
+    a model + KV cache — advisory (the slot may still run fine if the model
+    itself is small), never a fail.
+    """
+    from hal0.agents.anchor_window import SLOTS_DIR, read_slot_ceiling
+    from hal0.hardware.freshness import resolve_fresh_hardware_info
+    from hal0.hardware.memory_envelope import max_affordable_context_tokens
+
+    name, title = "seed_context_envelope", "Seed context_size vs. memory envelope"
+    directory = slots_dir if slots_dir is not None else SLOTS_DIR
+    try:
+        names = sorted(p.stem for p in directory.glob("*.toml"))
+    except OSError as exc:
+        return Check(name, title, _WARN, f"could not list {directory}: {exc}")
+    if not names:
+        return Check(name, title, _PASS, f"no slot TOMLs found in {directory}")
+
+    try:
+        hw, _stale = resolve_fresh_hardware_info()
+    except Exception as exc:
+        return Check(name, title, _WARN, f"hardware envelope unreadable: {exc}")
+    affordable = max_affordable_context_tokens(hw)
+
+    offenders: list[str] = []
+    for slot_name in names:
+        ceiling = read_slot_ceiling(slot_name, slots_dir=directory)
+        if ceiling is not None and ceiling > affordable:
+            offenders.append(f"{slot_name} ({ceiling:,} > {affordable:,})")
+    if offenders:
+        return Check(
+            name,
+            title,
+            _WARN,
+            "context_size above this box's memory envelope: "
+            + ", ".join(offenders)
+            + " — `hal0 slot edit <name> --ctx-size <n>` to lower it, or add memory",
+        )
+    return Check(
+        name, title, _PASS, f"every seeded context_size fits the {affordable:,}-token envelope"
+    )
+
+
 #: The API unit, and the agent template whose instances carry the bundled agent.
 _API_UNIT = "hal0-api.service"
 _AGENT_UNIT_GLOB = "hal0-agent@*.service"
@@ -1177,6 +1281,8 @@ def build_all_checks(base: str | None = None) -> list[Check]:
         check_netns_durability(),
         check_hal0_target(),
         check_secret_file_modes(),
+        check_hardware_freshness(),
+        check_seed_context_envelope(),
         check_agent_uid_isolation(),
         check_voice_stt_weights(),
         check_seams(),

--- a/src/hal0/hardware/freshness.py
+++ b/src/hal0/hardware/freshness.py
@@ -1,0 +1,187 @@
+"""Staleness detection + live-probe fallback for ``/etc/hal0/hardware.json`` (#1862).
+
+``hal0.slots.capacity._host_has_capable_gpu`` (the VRAM/RAM attribution gate
+behind ``/api/slots/capacity``) and the ROCm/Vulkan lane derivation both
+trust the cached hardware fact blindly:
+
+* **File absent.** :func:`hal0.config.loader.load_hardware_info` returns an
+  all-defaults ``HardwareInfo()`` (no ``gpus``) rather than raising, so any
+  install where ``hal0 probe``/``hal0 setup`` has not run yet reads as
+  GPU-less.
+* **File stale.** A ``hardware.json`` written before a kernel upgrade + reboot
+  (new driver, GPU added/removed) or before a schema field existed (e.g. a
+  pre-#1799 file with no ``vulkan_capable``/``compute_capable`` keys) is never
+  revisited — it is read and trusted forever.
+
+Either way a box with a real, usable GPU gets treated as GPU-less: resident
+slot memory books under ``ram_mb`` instead of ``vram_mb``, so
+``/api/slots/capacity`` under-reports VRAM pressure and the dashboard's fit
+warnings go quiet (#1862's "a real GPU box books VRAM as RAM").
+
+This module answers "is the cached fact good enough to trust" and, when it
+is not, probes live instead — the conservative direction stays intact (a
+probe that itself fails degrades to the stale cache, never to an invented
+GPU), but a missing/stale cache no longer silently wins over a live answer.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+
+import structlog
+
+from hal0.config.schema import HardwareInfo
+
+log = structlog.get_logger(__name__)
+
+#: Verdicts from :func:`staleness_reason`. ``None`` means "trust the cache".
+STALE_MISSING = "missing"
+STALE_KEYLESS = "predates-capability-fields"
+STALE_KERNEL_MISMATCH = "kernel-changed-since-probe"
+STALE_ACROSS_REBOOT = "probed-before-this-boot"
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def current_kernel_string() -> str:
+    """The running kernel's ``/proc/version`` string, same shape as the probe.
+
+    Mirrors :func:`hal0.hardware.probe.HardwareProbe.probe`'s own
+    ``uname`` extraction exactly (first token before ``" ("``), so a
+    like-for-like string comparison against the cached ``HardwareInfo.kernel``
+    only fires on an actual kernel change, never on formatting drift between
+    the two readers.
+    """
+    text = _read_text(Path("/proc/version"))
+    if not text:
+        return ""
+    return text.strip().split(" (", 1)[0]
+
+
+def _boot_time_epoch_s() -> float | None:
+    """Wall-clock time this boot started, or ``None`` if unreadable."""
+    text = _read_text(Path("/proc/uptime"))
+    if not text:
+        return None
+    try:
+        uptime_s = float(text.split()[0])
+    except (IndexError, ValueError):
+        return None
+    return _dt.datetime.now(_dt.UTC).timestamp() - uptime_s
+
+
+def staleness_reason(
+    info: HardwareInfo,
+    *,
+    has_file: bool,
+    running_kernel: str | None = None,
+    boot_time_epoch_s: float | None = None,
+) -> str | None:
+    """Why the cached ``info`` should not be trusted, or ``None`` if it can be.
+
+    Checked in order — the first one that applies wins:
+
+    1. :data:`STALE_MISSING` — ``has_file`` is False (no probe has ever run).
+    2. :data:`STALE_KEYLESS` — the cache predates the capability fields
+       (#1799) VRAM/RAM attribution and the ROCm lane derivation both read:
+       a GPU row with neither ``vulkan_capable`` nor ``compute_capable`` set
+       True, on a cache that also recorded no ``kernel``/``probed_at`` at
+       all (the pre-#1799-era shape — a MODERN probe that legitimately found
+       zero capable GPUs also has empty ``gpus``/False flags but DOES carry
+       ``kernel``/``probed_at``, so it is not flagged here).
+    3. :data:`STALE_KERNEL_MISMATCH` — the running kernel differs from the one
+       recorded at probe time (a kernel upgrade + reboot can add or remove
+       GPU driver support).
+    4. :data:`STALE_ACROSS_REBOOT` — ``probed_at`` predates this boot (the
+       probe ran in a previous boot cycle; hardware could have changed
+       across the reboot that followed it, e.g. a passthrough device added).
+
+    Pure and injectable (``running_kernel`` / ``boot_time_epoch_s``) for
+    tests; both default to live reads of this host.
+    """
+    if not has_file:
+        return STALE_MISSING
+    if not info.kernel and not info.probed_at and not info.gpus:
+        return STALE_KEYLESS
+    running = running_kernel if running_kernel is not None else current_kernel_string()
+    if running and info.kernel and info.kernel != running:
+        return STALE_KERNEL_MISMATCH
+    boot_time = boot_time_epoch_s if boot_time_epoch_s is not None else _boot_time_epoch_s()
+    if boot_time is not None and info.probed_at:
+        try:
+            probed_dt = _dt.datetime.fromisoformat(info.probed_at)
+        except ValueError:
+            return None
+        if probed_dt.timestamp() < boot_time:
+            return STALE_ACROSS_REBOOT
+    return None
+
+
+#: Reasons already logged this process — a live-probe fallback runs on every
+#: capacity read while a box stays stale, and warning on every one of those
+#: would flood the journal. Logged once per DISTINCT reason per process.
+_warned_reasons: set[str] = set()
+
+
+def resolve_fresh_hardware_info() -> tuple[HardwareInfo, str | None]:
+    """The hardware fact to trust right now: cached if fresh, live if not.
+
+    Returns ``(info, stale_reason)``. ``stale_reason`` is ``None`` when the
+    cache was trusted as-is. Never raises: a live probe that itself fails
+    (e.g. sandboxed test environment, ``/proc`` oddities) degrades to the
+    stale cache — the conservative "prefer an old real fact over inventing
+    one" direction preserved from :func:`hal0.slots.capacity._host_has_capable_gpu`'s
+    original contract.
+
+    Logs a warning (journal) the first time a given staleness reason is seen
+    this process — surfaced again, unconditionally, by
+    ``hal0 doctor``'s ``hardware_freshness`` check on every run.
+    """
+    from hal0.config import paths
+    from hal0.config.loader import load_hardware_info
+
+    has_file = paths.hardware_json().exists()
+    try:
+        cached = load_hardware_info()
+    except Exception as exc:
+        log.warning("hal0.hardware.cache_unreadable", error=str(exc))
+        cached = HardwareInfo()
+        has_file = False
+
+    reason = staleness_reason(cached, has_file=has_file)
+    if reason is None:
+        return cached, None
+
+    try:
+        from hal0.hardware.probe import HardwareProbe
+
+        live = HardwareProbe().probe()
+    except Exception as exc:
+        log.warning(
+            "hal0.hardware.live_probe_fallback_failed",
+            reason=reason,
+            error=str(exc),
+        )
+        return cached, reason
+
+    if reason not in _warned_reasons:
+        _warned_reasons.add(reason)
+        log.warning("hal0.hardware.cache_stale_live_probed", reason=reason)
+    return live, reason
+
+
+__all__ = [
+    "STALE_ACROSS_REBOOT",
+    "STALE_KERNEL_MISMATCH",
+    "STALE_KEYLESS",
+    "STALE_MISSING",
+    "current_kernel_string",
+    "resolve_fresh_hardware_info",
+    "staleness_reason",
+]

--- a/src/hal0/hardware/memory_envelope.py
+++ b/src/hal0/hardware/memory_envelope.py
@@ -1,0 +1,209 @@
+"""Single-owner memory envelope for context-window / capacity math (#1868).
+
+hal0 had no one place answering "how much memory can a model+KV-cache
+actually spend on this box" — the seeds copied a flat ``context_size =
+65536`` verbatim (#1868), the capacity ruler guessed at VRAM/RAM split
+independently, and the anchor/extraction context floors had no notion of
+what a box could afford at all. This module is that one function; every
+other module that needs a memory budget calls it rather than re-deriving
+its own fraction.
+
+The formula mirrors ODS's ``usable_memory_gb`` (permission granted by its
+author to port; ``ods/scripts/select-model.py:134-144``): a unified-memory
+box (APU/UMA — shares RAM with the OS, container runtime and other slots)
+only gets a bounded share of total RAM, not the whole pool; a discrete GPU
+gets its own VRAM; a CPU-only box gets a small, bounded slice of RAM so the
+host and other slots are not starved.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from hal0.config.schema import GPUInfo, HardwareInfo
+
+#: Share of total RAM budgeted to model weights + KV cache on unified-memory
+#: hardware (Strix Halo and any other UMA APU). Mirrors ODS's ratio
+#: (``ods/scripts/select-model.py:141``): the pool is shared with the OS,
+#: container runtime, and every other slot, so budgeting the full total
+#: starves the host under load well before the model itself is the limit.
+UNIFIED_MEMORY_FRACTION = 0.55
+
+#: Floor under the unified-memory fraction so a small-RAM UMA box (e.g. an
+#: 8 GiB APU) is not handed an unusably tiny envelope by the fraction alone.
+UNIFIED_MEMORY_FLOOR_MIB = 2048.0
+
+#: CPU-only bounds (``ods/scripts/select-model.py:143``): a fraction of RAM,
+#: clamped to ``[floor, ceiling]`` so a huge-RAM CPU box is not handed the
+#: whole pool (OS + container headroom) and a small one still gets a usable
+#: minimum.
+CPU_MEMORY_FRACTION = 0.35
+CPU_MEMORY_FLOOR_MIB = 3072.0
+CPU_MEMORY_CEILING_MIB = 8192.0
+
+#: Coarse KV-cache footprint estimate shared with
+#: :mod:`hal0.slots.capacity` (``_KV_MIB_PER_1K_TOKENS``): bytes per context
+#: token, summed across K and V, for a quantised mid-size model. Deliberately
+#: the SAME constant capacity.py already uses for the resident-memory
+#: estimate — two different numbers here would make "how much context can
+#: this box afford" disagree with "how much memory is this slot using".
+KV_MIB_PER_1K_TOKENS = 0.5
+
+#: The platform string that means "this box's GPU memory IS system RAM,
+#: shared via GTT" — the same signal
+#: :func:`hal0.install.profile_derive.derive_device` already keys the ROCm
+#: lane on. Kept local (rather than imported) to dodge an
+#: install→hardware import direction; the two are a single string constant
+#: apart, not independent logic.
+UNIFIED_PLATFORM = "strix-halo"
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryEnvelope:
+    """The memory budget available for a model's weights + KV cache."""
+
+    usable_mib: float
+    """How much memory (MiB) a model + its context window may spend."""
+
+    source: str
+    """Where the budget comes from: ``"unified system memory"`` |
+    ``"GPU VRAM"`` | ``"system RAM"`` — echoes the ODS wording so a message
+    built off this reads the same on both projects."""
+
+
+def _primary_capable_gpu(hw: HardwareInfo) -> GPUInfo | None:
+    """The first GPU this host can actually run inference on, or ``None``.
+
+    "Capable" mirrors :func:`hal0.slots.capacity._host_has_capable_gpu`:
+    Vulkan- or compute-capable. A GPU row with neither (a display-only card,
+    or a probe that only got the PCI id) contributes no inference memory.
+    """
+    for gpu in hw.gpus:
+        if gpu.vulkan_capable or gpu.compute_capable:
+            return gpu
+    return None
+
+
+def memory_envelope(hw: HardwareInfo) -> MemoryEnvelope:
+    """Return the memory budget this host can spend on one model + KV cache.
+
+    Ladder (mirrors ODS's ``usable_memory_gb``):
+
+    1. **Unified memory** (``hw.platform == "strix-halo"``, or a capable GPU
+       whose reported VRAM is actually the GTT pool sized like host RAM —
+       the generalised UMA APU case): :data:`UNIFIED_MEMORY_FRACTION` of
+       total RAM, floored at :data:`UNIFIED_MEMORY_FLOOR_MIB`.
+    2. **Discrete GPU** (a capable GPU with its own smaller VRAM pool): the
+       GPU's reported ``vram_mb``.
+    3. **CPU-only** (no capable GPU at all): :data:`CPU_MEMORY_FRACTION` of
+       total RAM, clamped to ``[CPU_MEMORY_FLOOR_MIB, CPU_MEMORY_CEILING_MIB]``.
+
+    The ``FLOOR``/``CEILING`` constants are bounds on the FRACTION, never a
+    promise about the box: both branches also cap at ``hw.ram_mb`` itself, so
+    a box smaller than the floor (a sub-3 GiB CPU-only VM, say) never gets
+    handed an envelope bigger than its actual RAM.
+
+    Never raises — an all-defaults ``HardwareInfo()`` (no probe yet) reads
+    as CPU-only, which is the conservative floor rather than an invented
+    GPU pool.
+    """
+    gpu = _primary_capable_gpu(hw)
+    is_unified = hw.platform == UNIFIED_PLATFORM or (
+        gpu is not None and gpu.vram_mb > 0 and gpu.vram_mb >= hw.ram_mb * 0.9
+    )
+    if is_unified and hw.ram_mb > 0:
+        usable = min(max(hw.ram_mb * UNIFIED_MEMORY_FRACTION, UNIFIED_MEMORY_FLOOR_MIB), hw.ram_mb)
+        return MemoryEnvelope(usable, "unified system memory")
+    if gpu is not None and gpu.vram_mb > 0:
+        return MemoryEnvelope(float(gpu.vram_mb), "GPU VRAM")
+    usable = min(
+        max(hw.ram_mb * CPU_MEMORY_FRACTION, CPU_MEMORY_FLOOR_MIB),
+        CPU_MEMORY_CEILING_MIB,
+        float(hw.ram_mb) if hw.ram_mb > 0 else CPU_MEMORY_FLOOR_MIB,
+    )
+    return MemoryEnvelope(usable, "system RAM")
+
+
+def max_affordable_context_tokens(
+    hw: HardwareInfo,
+    *,
+    model_mib: float = 0.0,
+    kv_mib_per_1k_tokens: float = KV_MIB_PER_1K_TOKENS,
+) -> int:
+    """How many context tokens' worth of KV cache this box's envelope affords.
+
+    ``model_mib`` is the model weights' footprint (0.0 when unknown — the
+    seed-time caller has no loaded model to measure yet, so the whole
+    envelope is treated as available for KV). Never negative; a box whose
+    envelope is smaller than the model itself affords 0 tokens rather than
+    a negative number.
+    """
+    envelope = memory_envelope(hw)
+    remaining_mib = max(envelope.usable_mib - model_mib, 0.0)
+    if kv_mib_per_1k_tokens <= 0:
+        return 0
+    return int((remaining_mib / kv_mib_per_1k_tokens) * 1000)
+
+
+def clamp_context_size(
+    requested_tokens: int,
+    hw: HardwareInfo,
+    *,
+    floor_tokens: int = 0,
+    model_mib: float = 0.0,
+) -> tuple[int, str | None]:
+    """Clamp a slot's ``context_size`` to what this box's envelope affords.
+
+    Returns ``(clamped_tokens, warning)``. ``warning`` is ``None`` when
+    ``requested_tokens`` already fit; otherwise it names the envelope and the
+    value it was clamped to, for a caller to log or hand to ``hal0 doctor``.
+
+    The clamp never goes below ``floor_tokens`` (a hard requirement — e.g.
+    Hermes' context floor for a chat-capable slot, #1868's "a box that
+    cannot afford 64K should say so loudly rather than silently seeding
+    less"): when the affordable ceiling is itself under the floor, the
+    caller gets ``floor_tokens`` back plus a warning that says the box
+    cannot actually afford it, rather than a silently-shrunk value that
+    would make the slot un-chattable again (#1827).
+    """
+    if requested_tokens <= 0:
+        return requested_tokens, None
+    affordable = max_affordable_context_tokens(hw, model_mib=model_mib)
+    envelope = memory_envelope(hw)
+    if requested_tokens <= affordable:
+        return requested_tokens, None
+    clamped = max(affordable, floor_tokens) if floor_tokens > 0 else affordable
+    clamped = max(clamped, 0)
+    if floor_tokens > 0 and affordable < floor_tokens:
+        return (
+            floor_tokens,
+            (
+                f"context_size {requested_tokens:,} exceeds this box's "
+                f"{envelope.usable_mib / 1024.0:.1f} GiB memory envelope "
+                f"({envelope.source}) — even the {floor_tokens:,}-token floor may "
+                f"not fit; consider a smaller model or more memory"
+            ),
+        )
+    return (
+        clamped,
+        (
+            f"context_size {requested_tokens:,} exceeds this box's "
+            f"{envelope.usable_mib / 1024.0:.1f} GiB memory envelope "
+            f"({envelope.source}) — clamped to {clamped:,}"
+        ),
+    )
+
+
+__all__ = [
+    "CPU_MEMORY_CEILING_MIB",
+    "CPU_MEMORY_FLOOR_MIB",
+    "CPU_MEMORY_FRACTION",
+    "KV_MIB_PER_1K_TOKENS",
+    "UNIFIED_MEMORY_FLOOR_MIB",
+    "UNIFIED_MEMORY_FRACTION",
+    "UNIFIED_PLATFORM",
+    "MemoryEnvelope",
+    "clamp_context_size",
+    "max_affordable_context_tokens",
+    "memory_envelope",
+]

--- a/src/hal0/install/profile_derive.py
+++ b/src/hal0/install/profile_derive.py
@@ -13,8 +13,14 @@ The (device, profile) pairs this produces are backend-coherent per #807:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+import structlog
+
 from hal0.config.schema import DEVICE_DEFAULT_PROFILES, HardwareInfo
 from hal0.providers._gpu import default_image_serves_vulkan_lane, kfd_present
+
+log = structlog.get_logger(__name__)
 
 #: NPU-trio capabilities (NPU chat agent + npu stt/embed passengers). Kept as a
 #: symbol because the trio code is left **dormant** (out of scope to remove,
@@ -69,6 +75,36 @@ def npu_takes_utility(hw: HardwareInfo, *, npu_opt_in: bool) -> bool:
     return bool(hw.npu.present and npu_opt_in)
 
 
+@dataclass(frozen=True, slots=True)
+class CpuFallback:
+    """The CPU lane a slot fell back to, and why."""
+
+    device: str
+    reason: str
+
+
+def apply_cpu_fallback(reason: str) -> CpuFallback:
+    """The one function that turns a slot's lane to CPU, with a recorded reason.
+
+    Single owner for every "this box doesn't have the GPU device class a
+    slot needs, so it runs on CPU instead" decision (#1936, #1966): seed-time
+    derivation (:func:`derive_device`, below) and the capability picker's
+    host-backend fan-out (:mod:`hal0.capabilities.catalog`) both route
+    through this instead of returning a bare ``"cpu"`` literal, so every
+    fallback in hal0 logs the SAME structured reason a caller can hand to an
+    operator (the slot state message, a dashboard device-picker hint, or a
+    `hal0 doctor` finding) instead of a silent, unexplained "why did this
+    land on CPU".
+
+    Mirrors ODS's ``apply_cpu_gpu_fallback`` (``ods/installers/lib/
+    detection.sh:235-257``) in spirit — warn loudly, then hand back the safe
+    lane — but returns a value rather than mutating globals, since hal0's
+    device derivation is a pure function over one capability at a time.
+    """
+    log.info("hal0.hardware.cpu_fallback_applied", reason=reason)
+    return CpuFallback(device="cpu", reason=reason)
+
+
 def derive_device(capability: str, hw: HardwareInfo, *, npu_opt_in: bool) -> str | None:
     """Return a ``DeviceLiteral`` for the capability, or None to skip it.
 
@@ -99,16 +135,33 @@ def derive_device(capability: str, hw: HardwareInfo, *, npu_opt_in: bool) -> str
         # the §8 "needs upstream routing" case — rather than create an
         # incoherent cpu/gpu-profile slot that #807 would reject.
         return "npu" if (hw.npu.present and npu_opt_in) else None
-    # chat / coder / embed → GPU lane. platform=="strix-halo" is the canonical
-    # FP4 signal; compute_capable means a ROCm/CUDA runtime was detected.
-    # #1888: the ROCm lane is the ONLY valid GPU LLM lane on AMD, and it needs
-    # the /dev/kfd compute node. The strix-halo / compute_capable signals are
-    # necessary but NOT sufficient — a Strix Halo box whose amdkfd node was
-    # never forwarded is exactly the fresh-LXC shape the blocker was found on,
-    # and deriving gpu-rocm there would hand every seeded slot a load-time
-    # refusal right after a deliberately CPU-only install.
-    rocm_ok = any(g.compute_capable for g in hw.gpus) or kfd_present()
-    if rocm_ok and (hw.platform == "strix-halo" or any(g.compute_capable for g in hw.gpus)):
+    # chat / coder / embed → GPU lane. #1888: the ROCm lane is the ONLY valid
+    # GPU LLM lane on AMD, and it needs the /dev/kfd compute node — so
+    # kfd_present() (device-node truth) is what decides this lane, never
+    # ``compute_capable`` alone (#2216).
+    #
+    # ``compute_capable`` means only "rocm-smi --showproductname exited 0" —
+    # a ROCm *userspace CLI* probe, not a GPU-can-run-ROCm probe. install.sh
+    # never installs rocm-smi, so on hal0's own reference deploy shape (a
+    # Proxmox LXC with /dev/kfd correctly forwarded) a fresh container has no
+    # rocm-smi and ``compute_capable`` reads False on every GPU row even
+    # though ROCm works perfectly — #2216, found building a privileged
+    # Ubuntu 26.04 CT on a Strix Halo host with dev0/renderD128, dev2/kfd,
+    # dev3/accel0 all forwarded: every slot seeded gpu-vulkan, and only
+    # installing rocm-smi by hand (so ``compute_capable`` finally read True)
+    # unlocked the ROCm lane it already had.
+    #
+    # ``hw.platform == "strix-halo"`` has the SAME gap from the other side:
+    # :func:`hal0.hardware.probe._detect_platform` classifies containers
+    # (LXC/WSL) before it ever reaches the bare-metal GPU/NPU classification
+    # that produces ``"strix-halo"``, so the platform signal is unreachable
+    # inside the container hal0 is actually deployed in.
+    #
+    # ``kfd_present()`` needs neither: /dev/kfd is AMD's own ROCm compute
+    # node (see its docstring), so its mere presence AND openability by the
+    # slot-runner identity already answers "can this box run ROCm" more
+    # directly than either proxy.
+    if any(g.compute_capable for g in hw.gpus) or kfd_present():
         return "gpu-rocm"
     # Vulkan-capable GPU, any vendor — AND a runner image that can serve the
     # lane. #1923 restricted this to non-AMD because the pinned runner's Vulkan
@@ -129,8 +182,12 @@ def derive_device(capability: str, hw: HardwareInfo, *, npu_opt_in: bool) -> str
     # so a box that can run ROCm still derives ROCm.
     if any(g.vulkan_capable for g in hw.gpus) and default_image_serves_vulkan_lane():
         return "gpu-vulkan"
-    # No GPU lane this host can validly use for inference.
-    return "cpu"
+    # No GPU lane this host can validly use for inference (#1936, #1966):
+    # neither a ROCm compute node nor a runner-image-validated Vulkan GPU.
+    return apply_cpu_fallback(
+        f"no usable GPU lane for {capability!r} on this host (no /dev/kfd, and either "
+        "no Vulkan-capable GPU or no runner image validated for the Vulkan lane)"
+    ).device
 
 
 def derive_profile(capability: str, device: str) -> str:

--- a/src/hal0/install/static_seeds.py
+++ b/src/hal0/install/static_seeds.py
@@ -86,29 +86,54 @@ LLAMA_SEED_CAPABILITIES: dict[str, str] = {
 #: slot-level field.
 _DEVICE_LINE = re.compile(r'(?m)^(device[ \t]*=[ \t]*)"[^"]*"')
 
+#: The ``[model].context_size`` assignment. Every llama.cpp seed carries
+#: exactly one such line (verified against every file under
+#: ``installer/etc-hal0/slots/``), so a plain top-of-line match is enough —
+#: same posture as :data:`_DEVICE_LINE`.
+_CONTEXT_SIZE_LINE = re.compile(r"(?m)^context_size[ \t]*=[ \t]*(\d+)")
+
+#: Seed names whose capability can serve as Hermes' anchor (``hal0/agent``
+#: resolves through the routing fallback chain to one of these —
+#: ``LLAMA_SEED_CAPABILITIES`` maps both to ``"chat"``). #1868's "a box that
+#: cannot afford 64K should say so loudly rather than silently seeding less"
+#: floor applies only to these two; embed/rerank/coder/utility have no such
+#: hard minimum, so they clamp down freely.
+_HERMES_ANCHOR_SEEDS = frozenset({"agent", "brain"})
+
+#: The brain seed's documented default model footprint (``lfm2.5-2.6b``
+#: Q8_0, "2.87 GB" per ``installer/etc-hal0/slots/brain.toml``'s own doc
+#: comment). Used ONLY for ``brain`` in :func:`apply_context_size_envelope`'s
+#: envelope math: ``install.sh`` pulls this weight during install (the
+#: "Brain model" step) but that pull runs AFTER the seed-copy loop this
+#: module's ``_main`` serves, so the file is not yet on disk to measure at
+#: seed time — this is the one llama.cpp seed with a KNOWN default model, so
+#: it is the one seed this can be more than a floor-only clamp for.
+#: ``agent`` ships deliberately model-less (spec-p3-brain.final.md §5b/5c —
+#: no surprise multi-GB download) and the other seeds pin no default either,
+#: so they get ``model_mib=0.0``: an honest "unknown", not a guess.
+_BRAIN_DEFAULT_MODEL_MIB = 2.87 * 1024
+
 
 def _resolve_hardware_info() -> HardwareInfo | None:
-    """Best-effort hardware fact for seed-device derivation, or ``None``.
+    """Best-effort hardware fact for seed-device/context-size derivation, or
+    ``None``.
 
-    Prefers the stored probe fact (``/etc/hal0/hardware.json``, written by
-    ``hal0 setup``) when it exists; otherwise runs a live light probe — the
-    fresh-install case, where install.sh's seed loop lands BEFORE ``hal0
-    setup --auto`` writes the fact. ``None`` (nothing resolvable) means the
-    caller keeps the verbatim seed devices: fail-soft, a wrong ROCm label
-    refuses loudly at load time with its remedy, and seeding must never
-    abort over a probe.
+    Routes through :func:`hal0.hardware.freshness.resolve_fresh_hardware_info`
+    (#1862) rather than trusting a cached ``/etc/hal0/hardware.json`` blindly:
+    on the fresh-install path this loop runs BEFORE ``hal0 setup --auto``
+    ever writes the fact, so the freshness resolver's live-probe fallback is
+    what makes this call return real hardware at all rather than an
+    all-defaults ``HardwareInfo()`` that would derive every GPU-needing seed
+    to ``cpu``. ``None`` (nothing resolvable even live) means the caller
+    keeps the verbatim seed devices/context sizes: fail-soft, a wrong ROCm
+    label refuses loudly at load time with its remedy, and seeding must
+    never abort over a probe.
     """
     try:
-        if paths.hardware_json().exists():
-            from hal0.config.loader import load_hardware_info
+        from hal0.hardware.freshness import resolve_fresh_hardware_info
 
-            return load_hardware_info()
-    except Exception as exc:
-        log.warning("install.seed_device_hw_fact_unreadable", error=str(exc))
-    try:
-        from hal0.hardware.probe import HardwareProbe
-
-        return HardwareProbe().probe()
+        info, _stale_reason = resolve_fresh_hardware_info()
+        return info
     except Exception as exc:
         log.warning("install.seed_device_probe_failed", error=str(exc))
         return None
@@ -185,6 +210,90 @@ def apply_derived_seed_devices(
     return rewritten
 
 
+def apply_context_size_envelope(
+    names: Collection[str],
+    *,
+    slots_dir: Path | None = None,
+    hw: HardwareInfo | None = None,
+) -> dict[str, int]:
+    """Clamp freshly-seeded llama.cpp slots' ``context_size`` to this box's
+    memory envelope (#1868).
+
+    Every curated seed ships ``context_size = 65536`` (or a smaller
+    workload-appropriate value) verbatim, sized for the reference platform —
+    a copy-if-absent install onto a small CPU-only box warms the brain slot
+    at 65536 with nothing budgeting for the KV cache that costs. This is the
+    same single pass ``apply_derived_seed_devices`` runs for the device
+    field: :func:`seed_static_slots` calls it after its copy loop, and
+    ``install.sh``'s bash seed loop calls it via ``python -m
+    hal0.install.static_seeds`` over the names it just copied.
+
+    Uses :func:`hal0.hardware.memory_envelope.clamp_context_size` — the
+    single-owner memory-budget function also read by the capacity ruler and
+    ``hal0 doctor``'s ``seed_context_envelope`` check — with
+    :data:`hal0.agents.anchor_window.HERMES_MINIMUM_CONTEXT_LENGTH` as the
+    floor for :data:`_HERMES_ANCHOR_SEEDS` (agent/brain): a box that cannot
+    afford 64K keeps the floor and gets a loud warning rather than a
+    silently-shrunk value that would make it un-chattable again (#1827).
+
+    Only names in :data:`LLAMA_SEED_CAPABILITIES` with an existing
+    ``<name>.toml`` are considered, mirroring
+    :func:`apply_derived_seed_devices`'s contract exactly (only names
+    copied THIS call — an operator's existing file must never reach this
+    function). Returns ``{name: new_context_size}`` for the files actually
+    rewritten.
+    """
+    from hal0.agents.anchor_window import HERMES_MINIMUM_CONTEXT_LENGTH
+    from hal0.hardware.memory_envelope import clamp_context_size
+
+    dest_dir = slots_dir if slots_dir is not None else paths.slots_config_dir()
+    resolved = hw
+    rewritten: dict[str, int] = {}
+    for name in names:
+        if name not in LLAMA_SEED_CAPABILITIES:
+            continue
+        dest = dest_dir / f"{name}.toml"
+        try:
+            text = dest.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        match = _CONTEXT_SIZE_LINE.search(text)
+        if match is None:
+            continue
+        try:
+            current = int(match.group(1))
+        except ValueError:
+            continue
+        if resolved is None:
+            resolved = _resolve_hardware_info()
+            if resolved is None:
+                log.warning(
+                    "install.seed_context_envelope_skipped",
+                    detail="hardware unresolvable — seeded slots keep their shipped context_size",
+                )
+                return rewritten
+        floor = HERMES_MINIMUM_CONTEXT_LENGTH if name in _HERMES_ANCHOR_SEEDS else 0
+        model_mib = _BRAIN_DEFAULT_MODEL_MIB if name == "brain" else 0.0
+        new_value, warning = clamp_context_size(
+            current, resolved, floor_tokens=floor, model_mib=model_mib
+        )
+        if new_value == current:
+            continue
+        new_text, n = _CONTEXT_SIZE_LINE.subn(f"context_size = {new_value}", text, count=1)
+        if n == 0 or new_text == text:
+            continue
+        dest.write_text(new_text, encoding="utf-8")
+        rewritten[name] = new_value
+        log.warning(
+            "install.seed_context_size_clamped",
+            slot=name,
+            requested=current,
+            clamped=new_value,
+            detail=warning,
+        )
+    return rewritten
+
+
 def seed_static_slots(
     *,
     installer_root: Path | None = None,
@@ -258,6 +367,10 @@ def seed_static_slots(
         # names copied THIS call are touched; existing/operator files above
         # were skipped and stay untouched.
         apply_derived_seed_devices(seeded, slots_dir=dest_dir, hw=hw)
+        # #1868: the same seeds carry a flat context_size sized for the
+        # reference platform — clamp it to what THIS box's memory envelope
+        # can afford.
+        apply_context_size_envelope(seeded, slots_dir=dest_dir, hw=hw)
     return seeded
 
 
@@ -364,6 +477,10 @@ def _main(argv: list[str] | None = None) -> int:
         print(f"seeded {name} slot: device derived -> {device}")
     if not rewritten:
         print("seeded slot devices already match this host — nothing rewritten")
+
+    clamped = apply_context_size_envelope(args.names, slots_dir=args.slots_dir, hw=hw)
+    for name, context_size in sorted(clamped.items()):
+        print(f"seeded {name} slot: context_size clamped -> {context_size}")
     return 0
 
 
@@ -377,6 +494,7 @@ __all__ = [
     "LLAMA_SEED_CAPABILITIES",
     "STATIC_SEED_SLOTS",
     "add_seed_tombstone",
+    "apply_context_size_envelope",
     "apply_derived_seed_devices",
     "clear_seed_tombstone",
     "derive_seed_device",

--- a/src/hal0/slots/capacity.py
+++ b/src/hal0/slots/capacity.py
@@ -497,26 +497,32 @@ def _artefact_token(slot: Any) -> str:
 
 
 def _host_has_capable_gpu() -> bool:
-    """True if the hardware probe found at least one usable GPU on this box.
+    """True if this box has at least one usable GPU right now.
 
     "Usable" means Vulkan- or compute- (ROCm/CUDA) capable — the same
     ``vulkan_capable`` / ``compute_capable`` signal #1799 added to
     :class:`~hal0.config.schema.GPUInfo` and that :mod:`hal0.hardware.recommend`
-    already gates device recommendations on. Reads the cached
-    ``/etc/hal0/hardware.json`` written by ``hal0 probe`` via
-    :func:`hal0.config.loader.load_hardware_info` — cheap (one small JSON
-    file, no re-probe) and honest: an absent file / no probed GPU degrades
-    to ``HardwareInfo(gpus=[])``, which correctly reads as "no capable GPU"
-    rather than raising.
+    already gates device recommendations on.
+
+    Reads through :func:`hal0.hardware.freshness.resolve_fresh_hardware_info`
+    rather than the cached ``/etc/hal0/hardware.json`` directly (#1862): a
+    missing cache used to degrade straight to ``HardwareInfo(gpus=[])`` —
+    "no capable GPU" — on any install where ``hal0 probe`` had not run yet,
+    and a cache that predated a kernel upgrade/reboot or the #1799 capability
+    fields was trusted forever. Both booked a real GPU box's resident memory
+    as RAM instead of VRAM. The freshness resolver falls back to a live probe
+    exactly in those cases; a missing probe binary or a probe that itself
+    fails still degrades to the (possibly stale) cached answer, so this
+    keeps the original conservative contract: an unprovable case reads as
+    "no capable GPU" rather than inventing one.
 
     Never raises: any error probing/loading hardware state degrades to
-    ``False`` (the conservative choice — books memory as RAM rather than
-    risking phantom VRAM on a box we couldn't positively confirm has one).
+    ``False``.
     """
     try:
-        from hal0.config.loader import load_hardware_info
+        from hal0.hardware.freshness import resolve_fresh_hardware_info
 
-        info = load_hardware_info()
+        info, _stale_reason = resolve_fresh_hardware_info()
     except Exception:
         return False
     return any(g.vulkan_capable or g.compute_capable for g in info.gpus)

--- a/tests/capabilities/test_catalog_kfd_gating.py
+++ b/tests/capabilities/test_catalog_kfd_gating.py
@@ -1,0 +1,117 @@
+"""kfd_present() decides the ROCm lane in the capability picker too (#2216
+sibling, #1966): ``available_backends``'s GPU/ROCm badge must not depend on
+``rocm-smi`` alone, and ComfyUI's picker row must not survive on a kfd-less
+AMD box when its image is ROCm-only.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from hal0.capabilities import catalog
+
+
+def _amd_gpu_hw(*, compute_capable: bool, vulkan_capable: bool = True) -> Any:
+    gpu = types.SimpleNamespace(
+        vendor="amd",
+        compute_capable=compute_capable,
+        vulkan_capable=vulkan_capable,
+    )
+    return types.SimpleNamespace(npu=types.SimpleNamespace(present=False), gpus=[gpu])
+
+
+# ── available_backends: kfd_present() alone is sufficient for gpu-rocm ──────
+
+
+def test_gpu_rocm_badge_appears_with_kfd_present_and_no_rocm_smi() -> None:
+    """#2216 sibling: a fresh container has no rocm-smi (compute_capable
+    reads False) but a forwarded /dev/kfd — the ROCm badge must still show."""
+    hw = _amd_gpu_hw(compute_capable=False)
+    with (
+        patch("hal0.capabilities.catalog.load_hardware_info", return_value=hw),
+        patch("hal0.capabilities.catalog.kfd_present", return_value=True),
+        patch("hal0.capabilities.catalog._flm_image_present", return_value=False),
+    ):
+        ids = {b["id"] for b in catalog.available_backends()}
+    assert "gpu-rocm" in ids
+
+
+def test_gpu_rocm_badge_absent_without_kfd_or_rocm_smi() -> None:
+    hw = _amd_gpu_hw(compute_capable=False)
+    with (
+        patch("hal0.capabilities.catalog.load_hardware_info", return_value=hw),
+        patch("hal0.capabilities.catalog.kfd_present", return_value=False),
+        patch("hal0.capabilities.catalog._flm_image_present", return_value=False),
+    ):
+        ids = {b["id"] for b in catalog.available_backends()}
+    assert "gpu-rocm" not in ids
+    assert "gpu-vulkan" in ids  # the render node is still real
+
+
+# ── ComfyUI picker row suppressed on a kfd-less AMD box (#1966) ─────────────
+
+
+def _image_entry() -> Any:
+    """Shaped like a curated image-capability row (no explicit .provider)."""
+    return types.SimpleNamespace(capability="image", comfyui_subdir="checkpoints")
+
+
+def test_comfyui_row_suppressed_when_kfd_absent_on_amd_host() -> None:
+    with (
+        patch(
+            "hal0.capabilities.catalog.available_backends",
+            return_value=[{"id": "gpu-vulkan"}, {"id": "cpu"}],
+        ),
+        patch("hal0.capabilities.catalog.host_is_amd_gpu", return_value=True),
+        patch("hal0.capabilities.catalog.kfd_present", return_value=False),
+    ):
+        variants = catalog._backend_variants(_image_entry())
+    assert variants == []
+
+
+def test_comfyui_row_offered_when_kfd_present_on_amd_host() -> None:
+    with (
+        patch(
+            "hal0.capabilities.catalog.available_backends",
+            return_value=[{"id": "gpu-vulkan"}, {"id": "gpu-rocm"}, {"id": "cpu"}],
+        ),
+        patch("hal0.capabilities.catalog.host_is_amd_gpu", return_value=True),
+        patch("hal0.capabilities.catalog.kfd_present", return_value=True),
+    ):
+        variants = catalog._backend_variants(_image_entry())
+    assert variants == ["gpu-vulkan"]
+
+
+def test_comfyui_row_unaffected_on_non_amd_host() -> None:
+    """The kfd gate is AMD-specific — a non-AMD box's Vulkan row (NVIDIA,
+    Intel) is untouched; it was never the ROCm-mislabelled shape."""
+    with (
+        patch(
+            "hal0.capabilities.catalog.available_backends",
+            return_value=[{"id": "gpu-vulkan"}, {"id": "cpu"}],
+        ),
+        patch("hal0.capabilities.catalog.host_is_amd_gpu", return_value=False),
+        patch("hal0.capabilities.catalog.kfd_present", return_value=False),
+    ):
+        variants = catalog._backend_variants(_image_entry())
+    assert variants == ["gpu-vulkan"]
+
+
+def test_explicit_comfyui_provider_row_also_gated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The twin path (an explicit ``entry.provider == 'comfyui'`` row, e.g. a
+    registry entry an operator tagged directly) gets the same guard."""
+    entry = types.SimpleNamespace(provider="comfyui")
+    with (
+        patch(
+            "hal0.capabilities.catalog.available_backends",
+            return_value=[{"id": "gpu-vulkan"}, {"id": "cpu"}],
+        ),
+        patch("hal0.capabilities.catalog.host_is_amd_gpu", return_value=True),
+        patch("hal0.capabilities.catalog.kfd_present", return_value=False),
+    ):
+        variants = catalog._backend_variants(entry)
+    assert variants == []

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -276,6 +276,94 @@ def test_hal0_target_enabled_probe_no_systemctl(monkeypatch: pytest.MonkeyPatch)
     assert da._hal0_target_enabled_probe() is None
 
 
+# ── check_hardware_freshness (#1862/H9) ───────────────────────────────────────
+
+
+def test_hardware_freshness_missing_file_warns(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    missing = tmp_path / "hardware.json"
+    monkeypatch.setattr("hal0.config.paths.hardware_json", lambda: missing)
+    c = da.check_hardware_freshness()
+    assert c.status == "warn"
+    assert c.key == "hardware_freshness"
+    assert "hal0 config hardware --refresh" in c.detail
+
+
+def test_hardware_freshness_fresh_cache_passes(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    from hal0.config.schema import HardwareInfo
+    from hal0.hardware.freshness import current_kernel_string
+
+    path = tmp_path / "hardware.json"
+    path.write_text("{}")
+    kernel = current_kernel_string() or "Linux version test"
+    info = HardwareInfo(kernel=kernel, probed_at="2026-09-05T12:00:00+00:00")
+    monkeypatch.setattr("hal0.config.paths.hardware_json", lambda: path)
+    monkeypatch.setattr("hal0.config.loader.load_hardware_info", lambda: info)
+    monkeypatch.setattr("hal0.hardware.freshness.current_kernel_string", lambda: kernel)
+    monkeypatch.setattr(
+        "hal0.hardware.freshness._boot_time_epoch_s",
+        lambda: 0.0,
+    )
+    c = da.check_hardware_freshness()
+    assert c.status == "pass"
+
+
+def test_hardware_freshness_stale_cache_warns(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    from hal0.config.schema import HardwareInfo
+
+    path = tmp_path / "hardware.json"
+    path.write_text("{}")
+    stale = HardwareInfo(kernel="Linux version 1.0.0-old", probed_at="2020-01-01T00:00:00+00:00")
+    monkeypatch.setattr("hal0.config.paths.hardware_json", lambda: path)
+    monkeypatch.setattr("hal0.config.loader.load_hardware_info", lambda: stale)
+    monkeypatch.setattr(
+        "hal0.hardware.freshness.current_kernel_string", lambda: "Linux version 9.9.9-new"
+    )
+    c = da.check_hardware_freshness()
+    assert c.status == "warn"
+    assert "stale" in c.detail
+
+
+# ── check_seed_context_envelope (#1868) ───────────────────────────────────────
+
+
+def test_seed_context_envelope_no_slots_passes(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    c = da.check_seed_context_envelope(slots_dir=tmp_path)
+    assert c.status == "pass"
+
+
+def test_seed_context_envelope_flags_an_oversized_ceiling(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:  # type: ignore[no-untyped-def]
+    from hal0.config.schema import HardwareInfo
+
+    (tmp_path / "brain.toml").write_text("[model]\ncontext_size = 999999999\n", encoding="utf-8")
+    cpu_only = HardwareInfo(platform="bare-metal-cpu-only", ram_mb=4096, gpus=[])
+    monkeypatch.setattr(
+        "hal0.hardware.freshness.resolve_fresh_hardware_info", lambda: (cpu_only, None)
+    )
+    c = da.check_seed_context_envelope(slots_dir=tmp_path)
+    assert c.status == "warn"
+    assert "brain" in c.detail
+
+
+def test_seed_context_envelope_passes_when_within_budget(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:  # type: ignore[no-untyped-def]
+    from hal0.config.schema import GPUInfo, HardwareInfo
+
+    (tmp_path / "brain.toml").write_text("[model]\ncontext_size = 8192\n", encoding="utf-8")
+    big_box = HardwareInfo(
+        platform="strix-halo",
+        ram_mb=131072,
+        gpus=[GPUInfo(vendor="amd", vram_mb=131072, compute_capable=True, vulkan_capable=True)],
+    )
+    monkeypatch.setattr(
+        "hal0.hardware.freshness.resolve_fresh_hardware_info", lambda: (big_box, None)
+    )
+    c = da.check_seed_context_envelope(slots_dir=tmp_path)
+    assert c.status == "pass"
+
+
 # ── check_agent_uid_isolation (ADR-0002) ──────────────────────────────────────
 
 
@@ -929,8 +1017,8 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
 
     checks = da.build_all_checks()
     keys = [c.key for c in checks]
-    # 7 verify rows + 17 extras.
-    assert keys[-17:] == [
+    # 7 verify rows + 19 extras.
+    assert keys[-19:] == [
         "auth",
         "models",
         "migrations",
@@ -940,6 +1028,8 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
         "netns",
         "hal0_target",
         "secret-modes",
+        "hardware_freshness",
+        "seed_context_envelope",
         "agent-uid",
         "stt-weights",
         "seams",

--- a/tests/hardware/test_freshness.py
+++ b/tests/hardware/test_freshness.py
@@ -1,0 +1,170 @@
+"""Tests for hal0.hardware.freshness — hardware.json staleness + live-probe
+fallback (#1862/H9): a missing or stale cache must never win over a live
+answer, and a probe that itself fails must never invent one.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import patch
+
+from hal0.config.schema import GPUInfo, HardwareInfo
+from hal0.hardware.freshness import (
+    STALE_ACROSS_REBOOT,
+    STALE_KERNEL_MISMATCH,
+    STALE_KEYLESS,
+    STALE_MISSING,
+    resolve_fresh_hardware_info,
+    staleness_reason,
+)
+
+_NOW = dt.datetime(2026, 9, 5, 12, 0, 0, tzinfo=dt.UTC)
+_BOOT_TIME = (_NOW - dt.timedelta(hours=2)).timestamp()
+
+
+def _fresh_info(*, probed_at: str | None = None) -> HardwareInfo:
+    return HardwareInfo(
+        kernel="Linux version 7.0.14-8-pve",
+        probed_at=probed_at or _NOW.isoformat(timespec="seconds"),
+        gpus=[GPUInfo(vendor="amd", vulkan_capable=True, compute_capable=True)],
+    )
+
+
+# ── staleness_reason ─────────────────────────────────────────────────────────
+
+
+def test_missing_file_is_stale():
+    assert (
+        staleness_reason(HardwareInfo(), has_file=False, running_kernel="x", boot_time_epoch_s=0)
+        == STALE_MISSING
+    )
+
+
+def test_keyless_pre_1799_cache_is_stale():
+    """A cache with no kernel/probed_at and no GPU rows predates the
+    capability fields — the pre-#1799 shape."""
+    info = HardwareInfo()
+    assert (
+        staleness_reason(info, has_file=True, running_kernel="x", boot_time_epoch_s=0)
+        == STALE_KEYLESS
+    )
+
+
+def test_modern_cache_with_zero_gpus_is_not_flagged_keyless():
+    """A MODERN probe that legitimately found no capable GPU still carries
+    kernel/probed_at — that is a real fact, not a keyless cache."""
+    info = _fresh_info()
+    info = info.model_copy(update={"gpus": []})
+    assert (
+        staleness_reason(
+            info,
+            has_file=True,
+            running_kernel=info.kernel,
+            boot_time_epoch_s=_BOOT_TIME,
+        )
+        is None
+    )
+
+
+def test_kernel_mismatch_is_stale():
+    info = _fresh_info()
+    assert (
+        staleness_reason(
+            info,
+            has_file=True,
+            running_kernel="Linux version 7.1.0-1-pve",
+            boot_time_epoch_s=_BOOT_TIME,
+        )
+        == STALE_KERNEL_MISMATCH
+    )
+
+
+def test_probed_before_this_boot_is_stale():
+    info = _fresh_info(probed_at=(_NOW - dt.timedelta(days=1)).isoformat(timespec="seconds"))
+    assert (
+        staleness_reason(
+            info,
+            has_file=True,
+            running_kernel=info.kernel,
+            boot_time_epoch_s=_BOOT_TIME,
+        )
+        == STALE_ACROSS_REBOOT
+    )
+
+
+def test_fresh_cache_is_trusted():
+    info = _fresh_info()
+    assert (
+        staleness_reason(
+            info,
+            has_file=True,
+            running_kernel=info.kernel,
+            boot_time_epoch_s=_BOOT_TIME,
+        )
+        is None
+    )
+
+
+# ── resolve_fresh_hardware_info ─────────────────────────────────────────────
+
+
+def test_resolve_trusts_a_fresh_cache_without_probing():
+    info = _fresh_info()
+    with (
+        patch("hal0.config.paths.hardware_json") as mock_path,
+        patch("hal0.config.loader.load_hardware_info", return_value=info),
+        patch(
+            "hal0.hardware.freshness.current_kernel_string",
+            return_value=info.kernel,
+        ),
+        patch("hal0.hardware.freshness._boot_time_epoch_s", return_value=_BOOT_TIME),
+        patch("hal0.hardware.probe.HardwareProbe") as mock_probe_cls,
+    ):
+        mock_path.return_value.exists.return_value = True
+        resolved, reason = resolve_fresh_hardware_info()
+    assert resolved is info
+    assert reason is None
+    mock_probe_cls.assert_not_called()
+
+
+def test_resolve_falls_back_to_live_probe_when_missing():
+    live_info = _fresh_info()
+    with (
+        patch("hal0.config.paths.hardware_json") as mock_path,
+        patch("hal0.config.loader.load_hardware_info", return_value=HardwareInfo()),
+        patch("hal0.hardware.probe.HardwareProbe") as mock_probe_cls,
+    ):
+        mock_path.return_value.exists.return_value = False
+        mock_probe_cls.return_value.probe.return_value = live_info
+        resolved, reason = resolve_fresh_hardware_info()
+    assert resolved is live_info
+    assert reason == STALE_MISSING
+
+
+def test_resolve_degrades_to_stale_cache_when_live_probe_fails():
+    """A probe that itself fails must never invent hardware — it falls back
+    to the (possibly stale) cached answer, never to a made-up capable GPU."""
+    stale_cache = HardwareInfo()
+    with (
+        patch("hal0.config.paths.hardware_json") as mock_path,
+        patch("hal0.config.loader.load_hardware_info", return_value=stale_cache),
+        patch("hal0.hardware.probe.HardwareProbe") as mock_probe_cls,
+    ):
+        mock_path.return_value.exists.return_value = False
+        mock_probe_cls.return_value.probe.side_effect = RuntimeError("no /proc")
+        resolved, reason = resolve_fresh_hardware_info()
+    assert resolved is stale_cache
+    assert reason == STALE_MISSING
+
+
+def test_resolve_never_raises_on_unreadable_cache():
+    with (
+        patch("hal0.config.paths.hardware_json") as mock_path,
+        patch("hal0.config.loader.load_hardware_info", side_effect=RuntimeError("bad json")),
+        patch("hal0.hardware.probe.HardwareProbe") as mock_probe_cls,
+    ):
+        mock_path.return_value.exists.return_value = True
+        mock_probe_cls.return_value.probe.side_effect = RuntimeError("no /proc")
+        resolved, reason = resolve_fresh_hardware_info()
+    assert resolved == HardwareInfo()
+    assert reason == STALE_MISSING

--- a/tests/hardware/test_memory_envelope.py
+++ b/tests/hardware/test_memory_envelope.py
@@ -1,0 +1,195 @@
+"""Tests for hal0.hardware.memory_envelope — the single-owner memory budget
+function (#1868). Fixtures mirror the hal0 x ODS parity brief's matrix:
+Strix Halo 128 GB, Strix Halo 64 GB, kfd-less AMD, NVIDIA, CPU-only.
+"""
+
+from __future__ import annotations
+
+from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
+from hal0.hardware.memory_envelope import (
+    CPU_MEMORY_CEILING_MIB,
+    CPU_MEMORY_FLOOR_MIB,
+    UNIFIED_MEMORY_FLOOR_MIB,
+    clamp_context_size,
+    max_affordable_context_tokens,
+    memory_envelope,
+)
+
+
+def _strix_halo(ram_mb: int) -> HardwareInfo:
+    return HardwareInfo(
+        platform="strix-halo",
+        ram_mb=ram_mb,
+        unified_memory_mb=ram_mb,
+        gpus=[
+            GPUInfo(
+                vendor="amd",
+                name="Radeon 8060S",
+                vram_mb=ram_mb,
+                compute_capable=True,
+                vulkan_capable=True,
+            )
+        ],
+        npu=NPUInfo(present=True, vendor="amd"),
+    )
+
+
+def _kfd_less_amd(ram_mb: int = 32768) -> HardwareInfo:
+    """An AMD box with a Vulkan-capable render node but no working ROCm."""
+    return HardwareInfo(
+        platform="bare-metal-amd-gpu",
+        ram_mb=ram_mb,
+        unified_memory_mb=ram_mb,
+        gpus=[
+            GPUInfo(
+                vendor="amd",
+                name="Radeon 780M",
+                vram_mb=512,
+                compute_capable=False,
+                vulkan_capable=True,
+            )
+        ],
+    )
+
+
+def _nvidia(ram_mb: int = 65536, vram_mb: int = 24576) -> HardwareInfo:
+    return HardwareInfo(
+        platform="bare-metal-nvidia-gpu",
+        ram_mb=ram_mb,
+        unified_memory_mb=ram_mb,
+        gpus=[
+            GPUInfo(
+                vendor="nvidia",
+                name="RTX 4090",
+                vram_mb=vram_mb,
+                compute_capable=True,
+                vulkan_capable=True,
+            )
+        ],
+    )
+
+
+def _cpu_only(ram_mb: int = 32768) -> HardwareInfo:
+    return HardwareInfo(
+        platform="bare-metal-cpu-only",
+        ram_mb=ram_mb,
+        unified_memory_mb=ram_mb,
+        gpus=[],
+    )
+
+
+# ── memory_envelope ──────────────────────────────────────────────────────────
+
+
+def test_strix_halo_128gb_uses_55_percent_of_ram():
+    hw = _strix_halo(131072)
+    env = memory_envelope(hw)
+    assert env.source == "unified system memory"
+    assert env.usable_mib == 131072 * 0.55
+
+
+def test_strix_halo_64gb_uses_55_percent_of_ram():
+    hw = _strix_halo(65536)
+    env = memory_envelope(hw)
+    assert env.source == "unified system memory"
+    assert env.usable_mib == 65536 * 0.55
+
+
+def test_strix_halo_small_ram_floors_at_the_unified_floor():
+    hw = _strix_halo(2048)
+    env = memory_envelope(hw)
+    assert env.source == "unified system memory"
+    assert env.usable_mib == UNIFIED_MEMORY_FLOOR_MIB
+
+
+def test_kfd_less_amd_with_small_vram_is_not_treated_as_unified():
+    """A Vulkan-only iGPU with a tiny dedicated VRAM carve-out is a discrete
+    GPU pool, not a UMA pool sized like RAM — its own vram_mb is the budget."""
+    hw = _kfd_less_amd(ram_mb=32768)
+    env = memory_envelope(hw)
+    assert env.source == "GPU VRAM"
+    assert env.usable_mib == 512
+
+
+def test_nvidia_discrete_gpu_uses_its_own_vram():
+    hw = _nvidia(ram_mb=65536, vram_mb=24576)
+    env = memory_envelope(hw)
+    assert env.source == "GPU VRAM"
+    assert env.usable_mib == 24576
+
+
+def test_cpu_only_uses_bounded_fraction_of_ram():
+    hw = _cpu_only(ram_mb=32768)
+    env = memory_envelope(hw)
+    assert env.source == "system RAM"
+    assert env.usable_mib == CPU_MEMORY_CEILING_MIB  # 0.35 * 32768 > ceiling
+
+
+def test_cpu_only_small_ram_floors():
+    hw = _cpu_only(ram_mb=4096)
+    env = memory_envelope(hw)
+    assert env.source == "system RAM"
+    assert env.usable_mib == CPU_MEMORY_FLOOR_MIB
+
+
+def test_envelope_never_exceeds_actual_ram_on_a_tiny_cpu_box():
+    """The floor constants bound the FRACTION, never a promise bigger than
+    the box's real RAM (a sub-3 GiB CPU-only VM must not get a 3 GiB
+    envelope it does not have)."""
+    hw = _cpu_only(ram_mb=1024)
+    env = memory_envelope(hw)
+    assert env.usable_mib <= 1024
+
+
+def test_envelope_never_exceeds_actual_ram_on_a_tiny_unified_box():
+    hw = _strix_halo(1024)
+    env = memory_envelope(hw)
+    assert env.usable_mib <= 1024
+
+
+def test_no_probe_defaults_reads_as_cpu_only():
+    """An all-defaults HardwareInfo() (no probe yet) must never invent a GPU
+    pool — CPU-only is the conservative floor."""
+    env = memory_envelope(HardwareInfo())
+    assert env.source == "system RAM"
+
+
+# ── max_affordable_context_tokens / clamp_context_size ──────────────────────
+
+
+def test_affordable_tokens_scale_with_envelope():
+    small = max_affordable_context_tokens(_strix_halo(65536))
+    large = max_affordable_context_tokens(_strix_halo(131072))
+    assert large > small
+
+
+def test_affordable_tokens_never_negative_when_model_exceeds_envelope():
+    hw = _cpu_only(ram_mb=4096)  # envelope floors at 3072 MiB
+    assert max_affordable_context_tokens(hw, model_mib=999999.0) == 0
+
+
+def test_clamp_context_size_passes_through_when_it_fits():
+    hw = _strix_halo(131072)
+    clamped, warning = clamp_context_size(65536, hw)
+    assert clamped == 65536
+    assert warning is None
+
+
+def test_clamp_context_size_clamps_an_oversized_seed_on_a_small_box():
+    """#1868: the shipped 65536 seed on a box too small to afford it once the
+    model weights (here a 6 GiB GGUF) are counted against the envelope."""
+    hw = _cpu_only(ram_mb=8192)
+    clamped, warning = clamp_context_size(65536, hw, floor_tokens=0, model_mib=6000.0)
+    assert clamped < 65536
+    assert warning is not None
+    assert "65,536" in warning
+
+
+def test_clamp_context_size_never_drops_below_the_floor():
+    """A chat-capable slot must not silently clamp under Hermes' floor
+    (#1827) — it keeps the floor and warns that the box may not afford it."""
+    hw = _cpu_only(ram_mb=2048)
+    clamped, warning = clamp_context_size(65536, hw, floor_tokens=64000, model_mib=6000.0)
+    assert clamped == 64000
+    assert warning is not None
+    assert "floor" in warning

--- a/tests/install/test_profile_derive.py
+++ b/tests/install/test_profile_derive.py
@@ -255,6 +255,52 @@ def test_cpu_host_tts_still_derives_tts_profile():
     assert derive_profile("tts", "cpu") == "kokoro"
 
 
+# ── kfd_present decides the ROCm lane, not rocm-smi (#2216) ────────────────────
+
+
+def test_kfd_present_alone_wins_rocm_on_a_container_lxc_platform(monkeypatch):
+    """hal0's own production shape: a Proxmox LXC with /dev/kfd forwarded.
+
+    ``_detect_platform`` classifies containers before it ever reaches the
+    bare-metal GPU classification that produces ``"strix-halo"``, and a
+    fresh container has no ``rocm-smi`` so ``compute_capable`` reads False
+    too — before #2216's fix, both signals came back negative and every
+    llama.cpp seed derived ``gpu-vulkan`` despite ROCm working perfectly.
+    ``kfd_present()`` alone must be sufficient.
+    """
+    monkeypatch.setattr("hal0.install.profile_derive.kfd_present", lambda *a, **k: True)
+    hw = _hw(platform="lxc", compute=False, vulkan=True)
+    assert derive_device("chat", hw, npu_opt_in=False) == "gpu-rocm"
+
+
+def test_neither_kfd_nor_compute_capable_still_declines_rocm(monkeypatch):
+    """The other half of #2216: no real signal must still decline ROCm."""
+    monkeypatch.setattr("hal0.install.profile_derive.kfd_present", lambda *a, **k: False)
+    hw = _hw(platform="lxc", compute=False, vulkan=True)
+    assert derive_device("chat", hw, npu_opt_in=False) == "gpu-vulkan"
+
+
+# ── apply_cpu_fallback (#1936, #1966) ───────────────────────────────────────────
+
+
+def test_apply_cpu_fallback_returns_cpu_device_and_the_reason():
+    from hal0.install.profile_derive import apply_cpu_fallback
+
+    fallback = apply_cpu_fallback("no usable GPU lane")
+    assert fallback.device == "cpu"
+    assert fallback.reason == "no usable GPU lane"
+
+
+def test_derive_device_cpu_fallback_names_a_reason(monkeypatch):
+    """The final 'no GPU lane at all' fallback in derive_device still returns
+    plain 'cpu' (back-compat), routed through apply_cpu_fallback for the
+    structured log — verified via the reason text a caller could recover by
+    calling apply_cpu_fallback directly with the same capability."""
+    monkeypatch.setattr("hal0.install.profile_derive.kfd_present", lambda *a, **k: False)
+    hw = _hw(compute=False, vulkan=False)
+    assert derive_device("chat", hw, npu_opt_in=False) == "cpu"
+
+
 def test_cpu_llm_profile_exists_in_seed_profiles():
     """The 'cpu-llm' seed profile must exist and have backend=None (cpu-coherent)."""
     from hal0.config.schema import SEED_PROFILES

--- a/tests/install/test_seed_context_envelope.py
+++ b/tests/install/test_seed_context_envelope.py
@@ -1,0 +1,160 @@
+"""#1868 — static slot seeds must clamp ``context_size`` to this box's memory
+envelope instead of shipping the reference platform's flat 65536 verbatim.
+
+Companion to ``test_seed_device_derivation.py`` (#2023's device-derivation
+pass): same two-pass shape (``seed_static_slots`` calls it after the copy
+loop; ``install.sh``'s bash loop calls it via ``python -m
+hal0.install.static_seeds`` over the names it just copied), different field.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from hal0.config.schema import GPUInfo, HardwareInfo
+from hal0.install.static_seeds import (
+    LLAMA_SEED_CAPABILITIES,
+    STATIC_SEED_SLOTS,
+    apply_context_size_envelope,
+    seed_static_slots,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SEED_SRC_DIR = _REPO_ROOT / "installer" / "etc-hal0" / "slots"
+
+
+def _seeded_context_sizes(dest: Path) -> dict[str, int | None]:
+    out: dict[str, int | None] = {}
+    for p in sorted(dest.glob("*.toml")):
+        cfg = tomllib.loads(p.read_text(encoding="utf-8"))
+        model = cfg.get("model")
+        out[p.stem] = model.get("context_size") if isinstance(model, dict) else None
+    return out
+
+
+def _tiny_cpu_box() -> HardwareInfo:
+    """A box too small to afford a huge blanket context_size."""
+    return HardwareInfo(platform="bare-metal-cpu-only", ram_mb=2048, gpus=[])
+
+
+def _big_strix_halo_box() -> HardwareInfo:
+    return HardwareInfo(
+        platform="strix-halo",
+        ram_mb=131072,
+        gpus=[GPUInfo(vendor="amd", vram_mb=131072, compute_capable=True, vulkan_capable=True)],
+    )
+
+
+# ── apply_context_size_envelope ──────────────────────────────────────────────
+
+
+def test_brain_clamps_to_the_hermes_floor_on_a_tiny_box(tmp_path: Path) -> None:
+    """brain is the one llama.cpp seed with a KNOWN default-model footprint
+    (lfm2.5-2.6b, 2.87 GiB) — on a 2 GiB CPU-only box that footprint alone
+    exceeds the whole envelope, so the clamp floors at Hermes' 64,000 rather
+    than the shipped 65536 (never below the floor — #1827)."""
+    dest = tmp_path / "slots"
+    dest.mkdir()
+    shutil.copyfile(_SEED_SRC_DIR / "brain.toml", dest / "brain.toml")
+
+    rewritten = apply_context_size_envelope(("brain",), slots_dir=dest, hw=_tiny_cpu_box())
+    sizes = _seeded_context_sizes(dest)
+    assert sizes["brain"] == 64_000
+    assert rewritten.get("brain") == 64_000
+
+
+def test_agent_ships_model_less_so_its_context_size_is_never_guessed_at(
+    tmp_path: Path,
+) -> None:
+    """agent has no default model (spec-p3-brain.final.md §5b/5c) — with no
+    known weight footprint to weigh against the envelope, the raw KV budget
+    for 65536 tokens fits even a tiny box, so it is honestly left alone
+    rather than clamped off an invented model size."""
+    dest = tmp_path / "slots"
+    dest.mkdir()
+    shutil.copyfile(_SEED_SRC_DIR / "agent.toml", dest / "agent.toml")
+    before = (dest / "agent.toml").read_text(encoding="utf-8")
+
+    rewritten = apply_context_size_envelope(("agent",), slots_dir=dest, hw=_tiny_cpu_box())
+    assert rewritten == {}
+    assert (dest / "agent.toml").read_text(encoding="utf-8") == before
+
+
+def test_generous_envelope_leaves_the_shipped_value_untouched(tmp_path: Path) -> None:
+    dest = tmp_path / "slots"
+    dest.mkdir()
+    shutil.copyfile(_SEED_SRC_DIR / "agent.toml", dest / "agent.toml")
+    before = (dest / "agent.toml").read_text(encoding="utf-8")
+
+    rewritten = apply_context_size_envelope(("agent",), slots_dir=dest, hw=_big_strix_halo_box())
+    assert rewritten == {}
+    assert (dest / "agent.toml").read_text(encoding="utf-8") == before
+
+
+def test_non_hermes_anchor_seeds_clamp_with_no_floor(tmp_path: Path) -> None:
+    """coder/embed/rerank/utility have no Hermes-anchor floor — a tiny box
+    may clamp them all the way down, unlike agent/brain."""
+    dest = tmp_path / "slots"
+    dest.mkdir()
+    shutil.copyfile(_SEED_SRC_DIR / "coder.toml", dest / "coder.toml")
+
+    rewritten = apply_context_size_envelope(("coder",), slots_dir=dest, hw=_tiny_cpu_box())
+    # coder ships 32768, well inside even a 2 GiB CPU envelope's raw KV
+    # budget with no competing model footprint assumed — so this seed alone
+    # need not clamp; the point of this test is that IF it does, nothing
+    # floors it at Hermes' 64,000 the way agent/brain are floored.
+    if rewritten:
+        assert rewritten["coder"] < 64_000
+
+
+def test_ignores_missing_files(tmp_path: Path) -> None:
+    dest = tmp_path / "slots"
+    dest.mkdir()
+    rewritten = apply_context_size_envelope(("agent",), slots_dir=dest, hw=_tiny_cpu_box())
+    assert rewritten == {}
+
+
+def test_unresolvable_hardware_keeps_verbatim_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("hal0.install.static_seeds._resolve_hardware_info", lambda: None)
+    dest = tmp_path / "slots"
+    dest.mkdir()
+    shutil.copyfile(_SEED_SRC_DIR / "agent.toml", dest / "agent.toml")
+    before = (dest / "agent.toml").read_text(encoding="utf-8")
+    rewritten = apply_context_size_envelope(("agent",), slots_dir=dest)
+    assert rewritten == {}
+    assert (dest / "agent.toml").read_text(encoding="utf-8") == before
+
+
+def test_non_llama_seeds_are_never_touched(tmp_path: Path) -> None:
+    dest = tmp_path / "slots"
+    dest.mkdir()
+    for name in STATIC_SEED_SLOTS:
+        shutil.copyfile(_SEED_SRC_DIR / f"{name}.toml", dest / f"{name}.toml")
+    rewritten = apply_context_size_envelope(STATIC_SEED_SLOTS, slots_dir=dest, hw=_tiny_cpu_box())
+    assert set(rewritten).issubset(set(LLAMA_SEED_CAPABILITIES))
+
+
+# ── seed_static_slots wiring ─────────────────────────────────────────────────
+
+
+def test_seed_static_slots_clamps_brain_context_size_on_a_tiny_box(tmp_path: Path) -> None:
+    dest = tmp_path / "slots"
+    seed_static_slots(installer_root=_REPO_ROOT, slots_dir=dest, hw=_tiny_cpu_box())
+    sizes = _seeded_context_sizes(dest)
+    assert sizes["brain"] == 64_000
+
+
+def test_seed_static_slots_leaves_context_size_alone_on_a_generous_box(tmp_path: Path) -> None:
+    dest = tmp_path / "slots"
+    seed_static_slots(installer_root=_REPO_ROOT, slots_dir=dest, hw=_big_strix_halo_box())
+    sizes = _seeded_context_sizes(dest)
+    shipped = tomllib.loads((_SEED_SRC_DIR / "agent.toml").read_text(encoding="utf-8"))["model"][
+        "context_size"
+    ]
+    assert sizes["agent"] == shipped

--- a/tests/providers/test_gpu_kfd_preflight.py
+++ b/tests/providers/test_gpu_kfd_preflight.py
@@ -243,6 +243,30 @@ class TestRequireKfdForGpuSlot:
                 amd_host=True,
             )
 
+    def test_zero_devices_mapped_refuses_before_launch_not_a_segfault(self, tmp_path) -> None:
+        """#1936: a container/LXC with NEITHER /dev/kfd NOR a render node
+        visible, explicitly pinned to device='gpu-rocm', used to reach
+        ``llama-server`` and SIGSEGV at model load before the HTTP port ever
+        bound. ``ContainerProvider.load_sync`` calls this guard BEFORE
+        ``_write_and_start_unit`` (src/hal0/providers/container.py), so the
+        refusal below happens instead of a launch — this pins that the
+        zero-devices shape specifically (not just a present-but-unopenable
+        node) still raises with a clear, actionable message."""
+        with pytest.raises(GpuPreflightError) as exc:
+            require_kfd_for_gpu_slot(
+                "brain",
+                device="gpu-rocm",
+                runtime_lane="llama",
+                kfd_path=str(tmp_path / "no-such-kfd"),
+                dri_dir=str(tmp_path / "no-such-dri"),
+                env={},
+                amd_host=True,
+            )
+        msg = str(exc.value)
+        assert "brain" in msg
+        assert "not visible here" in msg
+        assert "Forward the device" in msg
+
 
 class TestLoadSyncGuard:
     """The guard must fire on the LOAD path, not on unit rendering — a

--- a/tests/slots/test_capacity.py
+++ b/tests/slots/test_capacity.py
@@ -63,24 +63,28 @@ def _hw_info(vulkan_capable=False, compute_capable=False, no_gpus=False):
 
 
 class TestHostHasCapableGpu:
+    """Patches at the freshness-resolver seam (#1862): ``_host_has_capable_gpu``
+    now reads through :func:`hal0.hardware.freshness.resolve_fresh_hardware_info`
+    rather than the raw cache, so that is the boundary these tests fake."""
+
     def test_true_when_vulkan_capable_gpu_present(self):
         with patch(
-            "hal0.config.loader.load_hardware_info",
-            return_value=_hw_info(vulkan_capable=True),
+            "hal0.hardware.freshness.resolve_fresh_hardware_info",
+            return_value=(_hw_info(vulkan_capable=True), None),
         ):
             assert _host_has_capable_gpu() is True
 
     def test_true_when_compute_capable_gpu_present(self):
         with patch(
-            "hal0.config.loader.load_hardware_info",
-            return_value=_hw_info(compute_capable=True),
+            "hal0.hardware.freshness.resolve_fresh_hardware_info",
+            return_value=(_hw_info(compute_capable=True), None),
         ):
             assert _host_has_capable_gpu() is True
 
     def test_false_when_no_gpus(self):
         with patch(
-            "hal0.config.loader.load_hardware_info",
-            return_value=_hw_info(no_gpus=True),
+            "hal0.hardware.freshness.resolve_fresh_hardware_info",
+            return_value=(_hw_info(no_gpus=True), None),
         ):
             assert _host_has_capable_gpu() is False
 
@@ -88,8 +92,8 @@ class TestHostHasCapableGpu:
         """A GPU sysfs node with no capable render node (#1839's box) — the
         exact CPU-only-LXC repro. Not vulkan- or compute-capable."""
         with patch(
-            "hal0.config.loader.load_hardware_info",
-            return_value=_hw_info(vulkan_capable=False, compute_capable=False),
+            "hal0.hardware.freshness.resolve_fresh_hardware_info",
+            return_value=(_hw_info(vulkan_capable=False, compute_capable=False), None),
         ):
             assert _host_has_capable_gpu() is False
 
@@ -97,7 +101,7 @@ class TestHostHasCapableGpu:
         """Never raises — a broken/missing hardware.json degrades to False,
         the conservative choice (books memory as RAM, not phantom VRAM)."""
         with patch(
-            "hal0.config.loader.load_hardware_info",
+            "hal0.hardware.freshness.resolve_fresh_hardware_info",
             side_effect=RuntimeError("boom"),
         ):
             assert _host_has_capable_gpu() is False


### PR DESCRIPTION
A missing or stale /etc/hal0/hardware.json made a real GPU box book resident
slot memory as ram_mb instead of vram_mb — _host_has_capable_gpu() trusted
the cache blindly. It now falls back to a live re-probe when the cache is
missing, predates the running kernel, or was written in a previous boot
cycle (hal0.hardware.freshness), surfaced as hal0 doctor's new
hardware_freshness row. (#1862)

derive_device()'s ROCm-lane check additionally required rocm-smi's optional
CLI to exit 0 on top of kfd_present()'s device-node truth, so a fresh LXC
with /dev/kfd correctly forwarded — hal0's own reference deploy shape —
seeded every llama.cpp slot onto the slower Vulkan lane. kfd_present() alone
now decides it, matching the capability picker's GPU/ROCm badge and the
ComfyUI/Qwen3-TTS rows, which had the same gap. (#2216, #1966)

apply_cpu_fallback() records why a slot's lane fell back to CPU at seed
time, and the pre-existing load-time refusal for a GPU slot with zero
devices mapped (require_kfd_for_gpu_slot) is locked with a regression test
naming the exact #1936 shape. (#1936, #1966)

Freshly seeded agent/brain/coder/embed/rerank/utility slots clamp
context_size to a single-owner memory-envelope function
(hal0.hardware.memory_envelope) instead of shipping the reference
platform's flat 65536 verbatim, with a hal0 doctor finding
(seed_context_envelope) for a ceiling an existing box can no longer
afford. (#1868)

Signed-off-by: thinmintdev <alexander@awideweb.com>


## Verification

`ruff check src tests` clean. Full α unit suite (12808 tests) green apart from
three failures that also fail on a clean `main` checkout
(`tests/providers/test_moonshine_server.py` ×2, needs `ffmpeg`, and
`tests/slots/test_pressure_eviction.py::test_pressure_evict_noop_when_probe_fails`).
Integration β not run locally (needs root + a live `hal0-lemonade.service`); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzkumtSWnm3AxixzHG38UG
