### PR TITLE
feat(services): serve /api/services/health from the typed catalog (#2028, #2192, #1859)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,36 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Fixed
 
+- **`GET /api/services/health` (the Overview card's stable feed) now includes
+  Hindsight and iterates the same typed service catalog the full Services
+  page already used**, instead of a hardcoded three-branch construction that
+  could never surface a fourth service or a Hindsight outage. A service with
+  no wired probe reports `up:false, detail:"unmonitored"` — never a
+  fabricated up — via `asyncio.gather(return_exceptions=True)` so one hung
+  probe can't drop the rest. (#2028)
+- **The installer now writes the base `/etc/avahi/services/hal0.service`
+  mDNS announcement it always documented** — the Services page's Discovery
+  card and `services/mdns.py`'s own docstring both promised "the installer
+  writes it when avahi is present," but nothing ever did, so
+  `base_advertised` was permanently false. (H13)
+- **A pulled model's runtime family and pooling type now reach the model
+  registry**, not just `detect()`'s in-memory result — a fresh Kokoro/
+  Moonshine/Qwen3-TTS pull registered with an empty `backends` list, and a
+  GGUF embedding/reranking pull registered with no `metadata.pooling_type`,
+  so `hal0.model_meta.modality.derive_modalities_from_model_info` could
+  never recognise the model. A bound tts/transcription/embedding slot's
+  `LoadedSlot.modalities` stayed empty, so OmniRouter's tool eligibility
+  (`resolve_for_request`) silently never routed to those slots on a real
+  deployment, even though the routing logic itself was correct. An
+  FLM-pulled model's `backends=["npu"]` (a hardware-lane label, not a
+  runtime family) is now `["flm"]`, the string the modality derivation
+  actually recognises. (#2192)
+- **The llama-only effective-context resolver no longer runs against
+  embedding/reranking/transcription/tts/image slots** (FLM, Kokoro,
+  Moonshine, Qwen3-TTS, ComfyUI) on `GET /api/slots` and
+  `GET /api/slots/{name}`. Those slot kinds have no context window; calling
+  the resolver anyway fabricated an 8192-token "window" (its safe fallback
+  for an unrecognised model) that the slot never runs with. (#1859)
 - MCP admin tools no longer report a tool failure for a successful read of a
   slot whose lifecycle state is `error`. The tool-result wrapper's failure
   sentinel keyed on `status == "error"` alone, which collides with the slot
@@ -148,6 +178,16 @@ applying. Add those subsections to a version's section to surface them; see
   `releases_url_override` field (null when no override is set) so API
   consumers and the dashboard's Settings → Updates page see it too. Which
   URL is consulted is unchanged — the override still wins.
+
+### Changed
+
+- `hal0.services.registry.ServiceDef` gains `category`, `source`
+  (`builtin`/`extension`), `modalities`, and a `probe_tcp` field for a future
+  `"tcp"` probe kind — additive, no builtin service's behavior changes. This
+  is the one shape a future extension-manifest-provided service row is meant
+  to reuse, so the registry never grows a second, parallel service shape.
+  (#2028)
+
 ### Removed
 
 - **The v1.3.0 sunset tranche (#2168) is executed** — three internal compat

--- a/docs/guides/dashboard-and-settings.mdx
+++ b/docs/guides/dashboard-and-settings.mdx
@@ -82,6 +82,42 @@ zone pinned to the bottom of the sidebar with quick external launchers:
 **OpenWebUI**, and **Hermes Dash** — the latter two only appear when the
 backend reports them reachable.
 
+### Services
+
+The **Services** page is the management surface for hal0's companion
+processes — OpenWebUI, ComfyUI, Hermes, and Hindsight — all four sourced
+from one server-side catalog (`hal0.services.registry.SERVICES`), so the
+page and the footer's services pip group can never disagree about which
+services exist. Each card shows:
+
+- a real up/down state (never a placeholder) — ComfyUI via its own
+  `/system_stats` + `/queue` probe, OpenWebUI via a loopback `GET /health`,
+  and Hermes/Hindsight via their systemd unit state, distinguishing a
+  deliberate stop (grey, "stopped — starts on demand") from a crash (red,
+  "crashed — systemd unit failed");
+- the systemd unit, browser URL (when one exists — Hermes and Hindsight are
+  loopback-only), and mDNS `.local` URL when advertised;
+- lifecycle buttons (Restart/Start/Stop) limited to the verbs that service
+  actually permits — ComfyUI exposes Start/Restart only, since a raw
+  `systemctl start` would bypass the GPU-arbiter switchover that hands the
+  iGPU back from inference mode;
+- a journald logs drawer, and, for ComfyUI, an inline live job queue.
+
+A service the backend has no real probe for (nothing in the current
+catalog, but a future extension-provided service could arrive this way)
+reports honestly as unmonitored rather than a fabricated "up" — the same
+rule the Overview card's services pip group and the footer's ready count
+follow.
+
+The **Discovery (mDNS)** card at the top shows whether `avahi-daemon` is
+active, the dashboard's own `<hostname>.local` announcement, and lets you
+advertise or withdraw the addon services (ComfyUI, OpenWebUI) as their own
+`<name>.local` entries. The installer writes the base `hal0.service` avahi
+file itself when avahi is present, alongside the same permission fix-up
+that lets the daemon (running as the unprivileged `hal0` user) write the
+addon files — so both announcements come up out of the box, not just the
+addons.
+
 ### Footer
 
 The footer is always visible as a thin strip and expands into a pane when

--- a/docs/reference/api/rest-api.mdx
+++ b/docs/reference/api/rest-api.mdx
@@ -117,7 +117,7 @@ silently paper over.
 | `/api/config` | Mixed | `GET /api/config/urls` (dashboard bootstrap hostnames) is OPEN; the rest of this prefix is ADMIN (may hold config-derived secrets). |
 | `/api/meta` | CLIENT (GET) / ADMIN (else) | `GET /api/meta/enums` — the canonical device/backend/capability vocabulary from `hal0.model_meta`. |
 | `/api/hf` | CLIENT (GET) / ADMIN (else) | HuggingFace Hub search proxy backing the dashboard's "Search HF" button. |
-| `/api/services` | ADMIN | `services_health.router` (`GET /api/services/health`, 3-service overview) and `services_routes.router` (full per-service detail + lifecycle actions + mDNS) share this prefix. |
+| `/api/services` | ADMIN | `services_health.router` (`GET /api/services/health`, stable overview iterating `hal0.services.registry.SERVICES` — comfyui, hermes, hindsight, openwebui) and `services_routes.router` (full per-service detail + lifecycle actions + mDNS) share this prefix. |
 | `/api/dashboard/plugins` | ADMIN | Hermes dashboard-plugin manifest (kanban plugin discovery for `<AgentView>`). |
 | `/api/openrouter` | ADMIN | OpenRouter OAuth callback scaffold — only mounted when `HAL0_OPENROUTER_OAUTH_ENABLED` is truthy; 501 placeholder otherwise absent from the route table entirely. |
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -851,6 +851,45 @@ if [[ "${DEV_MODE}" -eq 0 && -d /etc/avahi/services ]] \
     chgrp hal0 /etc/avahi/services/hal0-addon-*.service 2>/dev/null || true
 fi
 
+# H13: the base dashboard announcement (services/mdns.py's docstring and the
+# Services page caption both promised "the installer writes
+# /etc/avahi/services/hal0.service when avahi is present" — nothing ever did,
+# so ``base_advertised`` (GET /api/services/mdns) was permanently false and
+# the caption was always the fallback "no base file" wording. Written here,
+# root-owned, alongside the addon-dir permission grant above; avahi fills the
+# %h host wildcard itself so this needs no hostname derivation. tmp+rename
+# for atomicity; avahi-daemon inotify-watches the dir, no reload needed.
+# A factored function (not inlined) so it can be extracted and driven in
+# isolation the same way tests/installer/test_avahi_hostname.py already
+# does for sync_avahi_hostname.
+write_avahi_base_service() {
+    local services_dir="${1:?services_dir required}" port="${2:?port required}"
+    local tmp
+    tmp="$(mktemp "${services_dir}/hal0.service.XXXXXX" 2>/dev/null)" || return 0
+    cat > "${tmp}" <<EOF
+<?xml version="1.0" standalone='no'?>
+<!-- Written by the hal0 installer (base dashboard mDNS announcement) — do
+     not edit by hand. Addon services are managed separately via the
+     dashboard Services page / POST /api/services/mdns. -->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">hal0 on %h</name>
+  <service>
+    <type>_http._tcp</type>
+    <port>${port}</port>
+    <txt-record>path=/</txt-record>
+    <txt-record>name=hal0</txt-record>
+  </service>
+</service-group>
+EOF
+    chmod 0644 "${tmp}" 2>/dev/null || true
+    mv -f "${tmp}" "${services_dir}/hal0.service" 2>/dev/null || rm -f "${tmp}"
+}
+
+if [[ "${DEV_MODE}" -eq 0 && -d /etc/avahi/services ]]; then
+    write_avahi_base_service /etc/avahi/services "${HAL0_PORT}"
+fi
+
 # Production (FHS, #495) ships the source tree into the versioned dir
 # ${PREFIX} (=${FHS_ROOT}/hal0-<version>) and points `current` at it, so
 # `hal0 update` can atomically swap `current` to a new versioned tree.

--- a/src/hal0/api/routes/services_health.py
+++ b/src/hal0/api/routes/services_health.py
@@ -1,11 +1,19 @@
 """GET /api/services/health — dashboard services health aggregator.
 
-Returns a stable list of three well-known services (comfyui, hermes,
-openwebui) with honest up/down state.  Every source degrades
-gracefully — a probe failure yields up=false, never a 500.
+Returns one entry per row of ``hal0.services.registry.SERVICES`` — the ONE
+service catalog (#2028) also consumed by the richer ``GET /api/services``
+management page — with honest up/down state. Every source degrades
+gracefully — a probe failure yields up=false, never a 500, and a row is
+never dropped because ONE probe misbehaved: the whole pass runs through
+``asyncio.gather(return_exceptions=True)``.
 
-Real probes: comfyui (in-process /system_stats+/queue), hermes
-(systemd unit state), openwebui (loopback GET /health — SpikeB §5.4).
+Real probes: comfyui (in-process /system_stats+/queue), hermes + hindsight
+(systemd unit state), openwebui (loopback GET /health — SpikeB §5.4). A
+service the table carries but this module has no bespoke probe for reports
+up=false, detail="unmonitored" — the same honest-unwired posture the richer
+page's generic ``_probe()`` dispatcher already uses, so a future extension
+row (w2b) that lands in the table before this module learns to probe it
+degrades safely instead of silently vanishing or reporting a fake "up".
 
 HARD RULE: up=true requires a real signal.  Services with no wired probe
 report up=false, detail="unmonitored" — never a fabricated "up".
@@ -16,6 +24,7 @@ src/hal0/api/__init__.py — do NOT edit that file here.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import Any
 
@@ -31,6 +40,7 @@ from hal0.api.routes.comfyui import (
     _queue_counts,
     _systemd_active,
 )
+from hal0.services.registry import SERVICES, ServiceDef
 
 log = structlog.get_logger(__name__)
 
@@ -106,6 +116,7 @@ def _down_state(unit_state: str, fallback_detail: str) -> tuple[str, str]:
 
 _IMG_SLOT_UNIT = "hal0-slot@img.service"
 _OPENWEBUI_UNIT = "hal0-openwebui.service"
+_HINDSIGHT_UNIT = "hindsight-api.service"
 
 
 async def _img_unit_state(request: Request) -> str:
@@ -174,6 +185,19 @@ async def _probe_hermes() -> tuple[bool, str]:
     return False, "systemd unit inactive or absent"
 
 
+async def _probe_hindsight() -> tuple[bool, str]:
+    """Probe Hindsight via systemd unit state — #2028.
+
+    Same shape as :func:`_probe_hermes`: hindsight is loopback-only with no
+    HTTP health surface this module can reach without a self-call, so the
+    unit's own active/inactive/failed state IS the real signal.
+    """
+    active = await _systemd_active(_HINDSIGHT_UNIT)
+    if active:
+        return True, "systemd unit active"
+    return False, "systemd unit inactive or absent"
+
+
 async def _probe_openwebui() -> tuple[bool, str]:
     """Real reachability probe — GET <loopback>/health on OpenWebUI.
 
@@ -194,36 +218,7 @@ async def _probe_openwebui() -> tuple[bool, str]:
 # ── route ─────────────────────────────────────────────────────────────────────
 
 
-@router.get("/health")
-async def services_health(request: Request) -> dict[str, Any]:
-    """Aggregate health of the known hal0 companion services.
-
-    Response shape::
-
-        {
-          "services": [
-            {
-              "id":     "comfyui"|"hermes"|"openwebui",
-              "name":   str,
-              "up":     bool,
-              "state":  "up"|"stopped"|"down",
-              "detail": str,
-              "url":    str | null,
-              "stat":   {"label": str, "value": str} | null
-            },
-            ...
-          ]
-        }
-
-    ``state`` splits not-up into ``stopped`` (deliberate — unit inactive,
-    comes back on demand, renders grey) and ``down`` (unit failed /
-    unknown — renders red). ``up`` stays for older consumers.
-
-    Never returns 500 — every probe failure degrades to up=false.
-    """
-    services: list[dict[str, Any]] = []
-
-    # ── comfyui ──────────────────────────────────────────────────────────────
+async def _health_comfyui(request: Request) -> dict[str, Any]:
     try:
         cu_up, cu_detail, cu_stat, cu_url = await _probe_comfyui()
     except Exception as exc:
@@ -241,19 +236,18 @@ async def services_health(request: Request) -> dict[str, Any]:
         else:
             cu_state = "down"
 
-    services.append(
-        {
-            "id": "comfyui",
-            "name": "ComfyUI",
-            "up": cu_up,
-            "state": cu_state,
-            "detail": cu_detail,
-            "url": cu_url,
-            "stat": cu_stat,
-        }
-    )
+    return {
+        "id": "comfyui",
+        "name": "ComfyUI",
+        "up": cu_up,
+        "state": cu_state,
+        "detail": cu_detail,
+        "url": cu_url,
+        "stat": cu_stat,
+    }
 
-    # ── hermes ───────────────────────────────────────────────────────────────
+
+async def _health_hermes() -> dict[str, Any]:
     try:
         h_up, h_detail = await _probe_hermes()
     except Exception as exc:
@@ -264,19 +258,43 @@ async def services_health(request: Request) -> dict[str, Any]:
     if not h_up:
         h_state, h_detail = _down_state(await _unit_active_state(_HERMES_UNIT), h_detail)
 
-    services.append(
-        {
-            "id": "hermes",
-            "name": "Hermes",
-            "up": h_up,
-            "state": h_state,
-            "detail": h_detail,
-            "url": None,  # loopback-only, no browser-reachable URL
-            "stat": None,
-        }
-    )
+    return {
+        "id": "hermes",
+        "name": "Hermes",
+        "up": h_up,
+        "state": h_state,
+        "detail": h_detail,
+        "url": None,  # loopback-only, no browser-reachable URL
+        "stat": None,
+    }
 
-    # ── openwebui ─────────────────────────────────────────────────────────────
+
+async def _health_hindsight() -> dict[str, Any]:
+    try:
+        hs_up, hs_detail = await _probe_hindsight()
+    except Exception as exc:
+        log.warning("services_health.hindsight_probe_error", exc=repr(exc))
+        hs_up, hs_detail = False, type(exc).__name__
+
+    hs_state = "up"
+    if not hs_up:
+        # Same posture as hermes: hindsight has no HTTP surface this module
+        # calls, so systemd IS the probe — "inactive" (not-yet-started /
+        # deliberately stopped) is not the same as "failed" (crashed).
+        hs_state, hs_detail = _down_state(await _unit_active_state(_HINDSIGHT_UNIT), hs_detail)
+
+    return {
+        "id": "hindsight",
+        "name": "Hindsight",
+        "up": hs_up,
+        "state": hs_state,
+        "detail": hs_detail,
+        "url": None,  # loopback-only, no browser-reachable URL
+        "stat": None,
+    }
+
+
+async def _health_openwebui() -> dict[str, Any]:
     try:
         ow_up, ow_detail = await _probe_openwebui()
     except Exception as exc:
@@ -292,17 +310,106 @@ async def services_health(request: Request) -> dict[str, Any]:
         else:
             ow_state = "down"
 
-    services.append(
+    return {
+        "id": "openwebui",
+        "name": "OpenWebUI",
+        "up": ow_up,
+        "state": ow_state,
+        "detail": ow_detail,
+        "url": _openwebui_url(),
+        "stat": None,
+    }
+
+
+async def _health_unmonitored(sdef: ServiceDef) -> dict[str, Any]:
+    """Honest default for a table row this module has no bespoke probe for.
+
+    #2028: a service reaching ``SERVICES`` (a builtin added above, or —
+    eventually — an extension manifest row, w2b) with no wiring here MUST
+    NOT be silently dropped or reported up — it shows as down/unmonitored
+    until a probe is written for it, matching the richer ``/api/services``
+    page's own ``_probe()`` fallback.
+    """
+    return {
+        "id": sdef.id,
+        "name": sdef.name,
+        "up": False,
+        "state": "down",
+        "detail": "unmonitored",
+        "url": None,
+        "stat": None,
+    }
+
+
+#: Bespoke per-id health coroutine factories. Anything in ``SERVICES`` not
+#: listed here (a future builtin, or an extension-manifest row) degrades to
+#: :func:`_health_unmonitored` — the table drives WHICH ids appear; this map
+#: only decides HOW WELL each one is currently probed.
+_HEALTH_FACTORIES: dict[str, Any] = {
+    "comfyui": lambda request: _health_comfyui(request),
+    "hermes": lambda request: _health_hermes(),
+    "hindsight": lambda request: _health_hindsight(),
+    "openwebui": lambda request: _health_openwebui(),
+}
+
+
+@router.get("/health")
+async def services_health(request: Request) -> dict[str, Any]:
+    """Aggregate health of every service in ``hal0.services.registry.SERVICES``.
+
+    Response shape::
+
         {
-            "id": "openwebui",
-            "name": "OpenWebUI",
-            "up": ow_up,
-            "state": ow_state,
-            "detail": ow_detail,
-            "url": _openwebui_url(),
-            "stat": None,
+          "services": [
+            {
+              "id":     str,
+              "name":   str,
+              "up":     bool,
+              "state":  "up"|"stopped"|"down",
+              "detail": str,
+              "url":    str | null,
+              "stat":   {"label": str, "value": str} | null
+            },
+            ...
+          ]
         }
-    )
+
+    ``state`` splits not-up into ``stopped`` (deliberate — unit inactive,
+    comes back on demand, renders grey) and ``down`` (unit failed / unknown /
+    unmonitored — renders red). ``up`` stays for older consumers.
+
+    Iterates the registry table (not a hardcoded id list, #2028) so a new
+    row — hindsight included — appears automatically, and runs every
+    service's probe concurrently via ``asyncio.gather(return_exceptions=True)``
+    so one hung/raising probe can't block or drop the rest. Never returns
+    500 — every probe failure (caught here, or already caught inside the
+    per-service coroutine) degrades to up=false.
+    """
+    coros = [
+        _HEALTH_FACTORIES.get(sdef.id, lambda request, sdef=sdef: _health_unmonitored(sdef))(
+            request
+        )
+        for sdef in SERVICES
+    ]
+    results = await asyncio.gather(*coros, return_exceptions=True)
+
+    services: list[dict[str, Any]] = []
+    for sdef, result in zip(SERVICES, results, strict=True):
+        if isinstance(result, BaseException):
+            log.warning("services_health.entry_error", service=sdef.id, exc=repr(result))
+            services.append(
+                {
+                    "id": sdef.id,
+                    "name": sdef.name,
+                    "up": False,
+                    "state": "down",
+                    "detail": type(result).__name__,
+                    "url": None,
+                    "stat": None,
+                }
+            )
+        else:
+            services.append(result)
 
     return {"services": services}
 

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1234,7 +1234,11 @@ async def get_slot(name: str, request: Request) -> dict[str, object]:
         # ``resolved_command``. Mirror the list route's re-resolution here.
         raw_ctx_max = out.get("ctx_max")
         model_id = str(out.get("model_default") or "")
-        if model_id or isinstance(raw_ctx_max, int):
+        # #1859: mirror the list route's llm-only gate (slot_view.snapshot) —
+        # a non-llm slot (embedding/reranking/transcription/tts/image) has no
+        # context window to resolve; see the comment there for the full
+        # rationale.
+        if out.get("type") == "llm" and (model_id or isinstance(raw_ctx_max, int)):
             # #1946/I2: hand this slot's own TOML down so a DEGRADED specialty
             # slot advertises the plain-model window it actually launches with,
             # instead of the card's 262144 — and so this body agrees with the

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -1230,6 +1230,8 @@ def _register_pulled(
     ctx_len: int | None = None
     detected_quant: str | None = None
     detected_arch: str | None = None
+    detected_backends: list[str] = []
+    detected_pooling_type: int | None = None
     try:
         detection = detect(Path(path))
         ctx_len = detection.context_length
@@ -1239,6 +1241,21 @@ def _register_pulled(
         # authoritative; the curated catalogue backfills an unreadable one
         # (same tiering as context_length above).
         detected_arch = detected_architecture(detection)
+        # #2192: detect() already classifies the runtime family
+        # (suggested_backends: ["moonshine"]/["kokoro"]/["flm"]/…) and, for
+        # GGUF embedding/reranking models, the header's pooling_type
+        # (raw_hints["pooling_type"]) — but neither ever reached the
+        # registry row below, which is the ONLY registration a pulled
+        # model's bytes ever get. Without a populated ``backends``/
+        # ``metadata.pooling_type``, hal0.model_meta.modality.
+        # derive_modalities_from_model_info() can't recognise the model, so
+        # a bound tts/transcription/embedding slot's LoadedSlot.modalities
+        # stayed empty and OmniRouter's tool eligibility (resolve_for_request)
+        # never saw those slots on a real deployment — despite the routing
+        # logic itself being correct and unit-tested against a hand-built
+        # model_info that happened to already carry the right shape.
+        detected_backends = list(detection.suggested_backends)
+        detected_pooling_type = detection.raw_hints.get("pooling_type")
     except Exception:  # header parse must never fail a completed pull
         ctx_len = None
     # #1890: capability-grouped installs (``_final_path_for_entry``) rename the
@@ -1262,6 +1279,10 @@ def _register_pulled(
         # backfill) so a LATER re-pull can tell it apart from an operator's
         # explicit metadata edit — see the merge below.
         fresh_meta["context_length_detected"] = True
+    if detected_pooling_type is not None:
+        # Header-derived fact, same standing as context_length/quant above —
+        # re-stamped fresh on every pull, never operator-editable.
+        fresh_meta["pooling_type"] = detected_pooling_type
     # #1890: stamp the detected quant on the row itself — the pull path is the
     # ONLY registration a pull-installed model ever gets, and a null ``quant``
     # left the #1790 FPX-on-wrong-runner guard inert (it reads the raw
@@ -1293,7 +1314,10 @@ def _register_pulled(
         is_comfyui = bool(comfyui_subdir)
         cap = (capability or "").strip()
         caps = [cap] if cap else (["image"] if is_comfyui else ["chat"])
-        backends = ["comfyui"] if is_comfyui else []
+        # #2192: comfyui already special-cased its own backend; every other
+        # kind detect() classified (moonshine/kokoro/flm/llama's vulkan-rocm-
+        # cuda-cpu quartet/…) was dropped on the floor before this fix.
+        backends = ["comfyui"] if is_comfyui else detected_backends
         # #1773: default defaults.tokenizer_repo from hf_repo when the pull
         # path already knows the source HF repo (the ONLY linkage a chat
         # cell's GuideLLM tokenizer resolution can trust without new pull
@@ -1350,6 +1374,12 @@ def _register_pulled(
         merged_meta["context_length"] = existing.metadata["context_length"]
         merged_meta.pop("context_length_detected", None)
     updates["metadata"] = merged_meta
+    # #2192: same "fill only if unset" rule as tokenizer_repo below — backfill
+    # an empty backends list (the pre-fix state every non-comfyui pulled row
+    # has) with this pull's detection, but never clobber an operator's own
+    # edit (registry PATCH surface) or an already-tagged row.
+    if detected_backends and not existing.backends:
+        updates["backends"] = detected_backends
     # #1773: same "fill only if unset" rule as chat_template — a re-pull
     # backfills defaults.tokenizer_repo from hf_repo for a row that never
     # got one (pre-#1773 registration, or a hand-added row), but never
@@ -2133,10 +2163,18 @@ def _register_flm_pulled(
                 path=path,
                 size_bytes=size_bytes,
                 capabilities=caps,
-                backends=["npu"],
+                # #2192: "npu" is a hardware-lane label, not a runtime family —
+                # hal0.model_meta.modality.derive_modalities_from_model_info's
+                # ``_family_runners`` set only recognises "flm" (matching
+                # metadata.runtime above), so an FLM-routed stt/embed shadow
+                # slot's model never resolved a modality and OmniRouter could
+                # never route to it. derive_model_provider("npu") already
+                # mapped to "flm" either way (_PROVIDER_TAGS), so this only
+                # fixes the modality side, not provider derivation.
+                backends=["flm"],
                 # Task 3: stamp provider alongside the tag-era backends tag on
                 # a NEW row — see the matching comment in ``_register_pulled``.
-                provider=derive_model_provider(["npu"]),
+                provider=derive_model_provider(["flm"]),
                 metadata={"runtime": "flm"},
             )
         )
@@ -2144,6 +2182,11 @@ def _register_flm_pulled(
     merged_meta = dict(existing.metadata)
     merged_meta["runtime"] = "flm"
     updates["metadata"] = merged_meta
+    # #2192: backfill a pre-fix row's wrong ["npu"] (or a never-set empty
+    # list) the same "fill only if unset/wrong" way ``_register_pulled``
+    # backfills backends — never clobbers an operator's own edit.
+    if existing.backends in ([], ["npu"]):
+        updates["backends"] = ["flm"]
     registry.update(tag, updates)
 
 

--- a/src/hal0/services/registry.py
+++ b/src/hal0/services/registry.py
@@ -32,7 +32,17 @@ _FULL = LIFECYCLE_ACTIONS
 
 @dataclass(frozen=True)
 class ServiceDef:
-    """One companion service as the management layer sees it."""
+    """One companion service as the management layer sees it.
+
+    #2028: this table is the ONE place a service is declared — both
+    ``GET /api/services`` (services.py) and ``GET /api/services/health``
+    (services_health.py, the Overview card's stable feed) iterate it, so a
+    service added here (hindsight included) appears on both without either
+    route hand-listing ids. ``category``/``source``/``modalities`` are
+    additive fields with no builtin consumer yet: they exist so a future
+    extension-manifest-driven row (w2b's extension loader) can describe
+    itself the same way a builtin does, without a second, parallel shape.
+    """
 
     id: str
     name: str
@@ -44,11 +54,17 @@ class ServiceDef:
     port: int | None = None
     #: Env var carrying an operator-declared public URL (reverse proxy).
     public_url_env: str | None = None
-    #: Probe strategy: "http" | "systemd" | "comfyui" | "none".
+    #: Probe strategy: "http" | "systemd" | "comfyui" | "tcp" | "none".
+    #: "none" is honest-by-construction: services_health/_probe never
+    #: fabricates an "up" for it — it reports up=False, detail="unmonitored".
     probe: str = "none"
     #: Default URL for http probes (loopback), overridable via probe_url_env.
     probe_url: str | None = None
     probe_url_env: str | None = None
+    #: "tcp" probe target when probe="tcp"; ("host", port). Unused by any
+    #: builtin today (all four have an http/systemd/comfyui probe already) —
+    #: present for a future extension whose only signal is "port open".
+    probe_tcp: tuple[str, int] | None = None
     #: Lifecycle verbs the API may run for this service (subset of
     #: LIFECYCLE_ACTIONS). Empty = read-only.
     actions: tuple[str, ...] = ()
@@ -60,6 +76,18 @@ class ServiceDef:
     loopback_port: int | None = None
     #: Extra UI hints (e.g. where deeper controls live).
     hints: tuple[str, ...] = field(default=())
+    #: Grouping for a future Services page section header / filter chip.
+    category: str = "companion"
+    #: Where this row came from — a hand-declared builtin (below) or a
+    #: parsed extension manifest (w2b). Every builtin is "builtin"; nothing
+    #: in this repo produces "extension" rows yet.
+    source: str = "builtin"
+    #: Modality facts this service serves (closed taxonomy in
+    #: :mod:`hal0.model_meta.modality` — "image"/"tts"/"transcription"/
+    #: "embeddings"/"reranking"/"vision"), for a future surface that groups
+    #: services by what they can do rather than by identity. Empty for a
+    #: service with no single modality (hermes/hindsight are general-purpose).
+    modalities: tuple[str, ...] = field(default=())
 
 
 SERVICES: tuple[ServiceDef, ...] = (
@@ -75,6 +103,7 @@ SERVICES: tuple[ServiceDef, ...] = (
         probe_url_env="HAL0_OPENWEBUI_PROBE_URL",
         actions=_FULL,
         mdns=True,
+        category="chat",
     ),
     ServiceDef(
         id="comfyui",
@@ -91,6 +120,8 @@ SERVICES: tuple[ServiceDef, ...] = (
         actions=("start", "restart"),
         mdns=True,
         hints=("stop is GPU-arbiter managed — switch back to inference in the Image-Gen pane",),
+        category="image",
+        modalities=("image",),
     ),
     ServiceDef(
         id="hermes",
@@ -101,6 +132,7 @@ SERVICES: tuple[ServiceDef, ...] = (
         probe="systemd",
         actions=_FULL,
         loopback_port=9119,
+        category="agent",
     ),
     ServiceDef(
         id="hindsight",
@@ -109,6 +141,7 @@ SERVICES: tuple[ServiceDef, ...] = (
         unit="hindsight-api.service",
         probe="systemd",
         actions=_FULL,
+        category="memory",
         loopback_port=9177,
     ),
 )

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -1113,7 +1113,15 @@ class SlotViewAggregator:
             # a model-less slot with neither has nothing to resolve).
             raw_ctx_max = payload.get("ctx_max")
             model_id = str(payload.get("model_default") or "")
-            if model_id or isinstance(raw_ctx_max, int):
+            # #1859: only an "llm" slot runs llama-server with a resolvable
+            # context window. Every other kind (embedding/reranking/
+            # transcription/tts/image — FLM, Kokoro, Moonshine, Qwen3-TTS,
+            # ComfyUI) has no such concept; calling the llama-only resolver
+            # for them fabricated an 8192 "window" (resolve_effective_
+            # context_size's safe fallback for an unrecognised model) that
+            # slot never runs with. Non-llm slots keep whatever raw ctx_max
+            # config_enrichment lifted (usually absent — key stays omitted).
+            if payload.get("type") == "llm" and (model_id or isinstance(raw_ctx_max, int)):
                 # NO ``slot_cfg`` on this path, deliberately (#1946/I2). This
                 # is the ~2s dashboard poll: handing the cfg down would make
                 # every specialty-model slot resolve a preview bundle — and

--- a/tests/api/test_services_health.py
+++ b/tests/api/test_services_health.py
@@ -6,11 +6,17 @@ minimal FastAPI app with the router mounted under the canonical prefix
 so the endpoint is reachable without touching the real app factory.
 
 Covers:
-  1. Endpoint returns 200 with all 3 service ids present.
+  1. Endpoint returns 200 with all 4 registry service ids present
+     (comfyui, hermes, hindsight, openwebui — #2028).
   2. With comfyui probe mocked reachable -> up=true, stat populated.
   3. comfyui probe raising -> comfyui up=false, endpoint still 200.
   4. openwebui /health 2xx -> up=true (SpikeB §5.4 real probe).
   5. openwebui unreachable / non-2xx -> up=false, honest detail.
+  6. hindsight up/down via systemd unit state (#2028 — it used to be
+     entirely absent from this endpoint).
+  7. A registry row with no bespoke probe (a stand-in for a future
+     extension-manifest service) reports up=false, detail="unmonitored" —
+     never dropped, never a fabricated up.
 """
 
 from __future__ import annotations
@@ -24,9 +30,10 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hal0.api.routes.services_health import router as services_router
+from hal0.services.registry import ServiceDef
 
 _BASE = "hal0.api.routes.services_health"
-_EXPECTED_IDS = {"comfyui", "hermes", "openwebui"}
+_EXPECTED_IDS = {"comfyui", "hermes", "hindsight", "openwebui"}
 
 
 @pytest.fixture
@@ -42,10 +49,10 @@ def _services_by_id(body: dict) -> dict:
 
 
 def _stub_other_probes() -> list:
-    """Patch comfyui/hermes/openwebui to neutral down states so a test can
-    isolate ONE service without real network/systemd calls. Returns a list
-    of started patchers the caller closes via an ExitStack, OR use as a
-    context-manager group. Default: everything down/unmonitored.
+    """Patch comfyui/hermes/hindsight/openwebui to neutral down states so a
+    test can isolate ONE service without real network/systemd calls. Returns
+    a list of started patchers the caller closes via an ExitStack, OR use as
+    a context-manager group. Default: everything down/unmonitored.
     """
     return [
         patch(
@@ -55,6 +62,11 @@ def _stub_other_probes() -> list:
         ),
         patch(
             f"{_BASE}._probe_hermes",
+            new_callable=AsyncMock,
+            return_value=(False, "systemd unit inactive or absent"),
+        ),
+        patch(
+            f"{_BASE}._probe_hindsight",
             new_callable=AsyncMock,
             return_value=(False, "systemd unit inactive or absent"),
         ),
@@ -78,7 +90,7 @@ def test_services_health_200_all_ids(svc_client: TestClient) -> None:
     assert r.status_code == 200, r.text
     body = r.json()
     assert "services" in body
-    assert len(body["services"]) == 3
+    assert len(body["services"]) == 4
     ids = {s["id"] for s in body["services"]}
     assert ids == _EXPECTED_IDS
 
@@ -306,6 +318,11 @@ def test_up_services_report_state_up(svc_client: TestClient) -> None:
             return_value=(True, "systemd unit active"),
         ),
         patch(
+            f"{_BASE}._probe_hindsight",
+            new_callable=AsyncMock,
+            return_value=(True, "systemd unit active"),
+        ),
+        patch(
             f"{_BASE}._probe_openwebui",
             new_callable=AsyncMock,
             return_value=(True, "reachable — /health ok"),
@@ -316,3 +333,105 @@ def test_up_services_report_state_up(svc_client: TestClient) -> None:
     assert r.status_code == 200
     for svc in r.json()["services"]:
         assert svc["state"] == "up"
+
+
+# ── 6. hindsight (#2028 — used to be entirely absent from this endpoint) ─────
+
+
+def test_hindsight_up_via_systemd(svc_client: TestClient) -> None:
+    with contextlib.ExitStack() as stack:
+        for p in _stub_other_probes():
+            stack.enter_context(p)
+        stack.enter_context(
+            patch(
+                f"{_BASE}._probe_hindsight",
+                new_callable=AsyncMock,
+                return_value=(True, "systemd unit active"),
+            )
+        )
+        r = svc_client.get("/api/services/health")
+
+    assert r.status_code == 200
+    hs = _services_by_id(r.json())["hindsight"]
+    assert hs["up"] is True
+    assert hs["state"] == "up"
+    assert hs["url"] is None  # loopback-only
+
+
+def test_hindsight_down_reports_honest_detail() -> None:
+    """A hindsight outage must be visible — never masked as absent or up.
+
+    Direct coroutine call (no TestClient) so this asserts the exact
+    down-state mapping without also depending on every other probe.
+    """
+    import asyncio
+
+    from hal0.api.routes import services_health as mod
+
+    with (
+        patch(f"{_BASE}._probe_hindsight", new_callable=AsyncMock, return_value=(False, "x")),
+        patch(f"{_BASE}._unit_active_state", new_callable=AsyncMock, return_value="failed"),
+    ):
+        result = asyncio.run(mod._health_hindsight())
+
+    assert result["id"] == "hindsight"
+    assert result["up"] is False
+    assert result["state"] == "down"
+    assert result["detail"] == "crashed — systemd unit failed"
+
+
+# ── 7. registry row with no bespoke probe -> unmonitored, never dropped ──────
+
+
+def test_unmonitored_row_reports_honest_default() -> None:
+    """A service the table carries but this module hasn't wired a probe for.
+
+    Stands in for a future extension-manifest row (w2b): #2028's hard rule
+    is that such a row is NEVER dropped and NEVER reports a fabricated up.
+    """
+    import asyncio
+
+    from hal0.api.routes.services_health import _health_unmonitored
+
+    sdef = ServiceDef(
+        id="future-extension",
+        name="Future Extension",
+        description="stand-in for an unwired extension-manifest row",
+        source="extension",
+    )
+    result = asyncio.run(_health_unmonitored(sdef))
+    assert result == {
+        "id": "future-extension",
+        "name": "Future Extension",
+        "up": False,
+        "state": "down",
+        "detail": "unmonitored",
+        "url": None,
+        "stat": None,
+    }
+
+
+def test_unwired_registry_row_surfaces_through_the_route(svc_client: TestClient) -> None:
+    """The route iterates the table, not a hardcoded id list (#2028) — a row
+    with no entry in ``_HEALTH_FACTORIES`` must still appear, unmonitored,
+    alongside every service this module DOES know how to probe."""
+    from hal0.api.routes import services_health as mod
+
+    extra = ServiceDef(
+        id="future-extension",
+        name="Future Extension",
+        description="stand-in for an unwired extension-manifest row",
+        source="extension",
+    )
+    with contextlib.ExitStack() as stack:
+        for p in _stub_other_probes():
+            stack.enter_context(p)
+        stack.enter_context(patch.object(mod, "SERVICES", (*mod.SERVICES, extra)))
+        r = svc_client.get("/api/services/health")
+
+    assert r.status_code == 200
+    svcs = _services_by_id(r.json())
+    assert set(svcs) == _EXPECTED_IDS | {"future-extension"}
+    fx = svcs["future-extension"]
+    assert fx["up"] is False
+    assert fx["detail"] == "unmonitored"

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -2251,6 +2251,43 @@ def test_get_slot_resolves_ctx_max_to_effective_window(
     )
 
 
+def test_get_slot_skips_ctx_max_resolution_for_non_llm_slot(
+    tmp_hal0_home: str,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+    isolated_app: FastAPI,
+) -> None:
+    """#1859: mirror of the effective-window test above, but for a "tts"
+    slot — a kind with no real context-window concept. The raw TOML
+    ceiling (65536) must pass through untouched, not get re-resolved down
+    to the registry model's declared window (8000) the way an "llm" slot's
+    would — proving the llama-only resolver is skipped, not coincidentally
+    matching."""
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "voice",
+        [
+            'name = "voice"',
+            "port = 8083",
+            'device = "cpu"',
+            'provider = "kokoro"',
+            'runtime = "container"',
+            'type = "tts"',
+            "[model]",
+            'default = "kokoro-v1"',
+            "context_size = 65536",
+        ],
+    )
+    isolated_app.state.model_registry = _FakeCtxRegistry({"kokoro-v1": _FakeCtxModel(8000)})
+
+    r = isolated_client.get("/api/slots/voice")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ctx_max"] == 65536, (
+        f"a non-llm slot's raw ctx ceiling must not be re-resolved; got {body['ctx_max']!r}"
+    )
+
+
 def test_get_slot_includes_config_drift_when_requested(
     slot_root: Path,
     container_stub: dict[str, Any],

--- a/tests/installer/test_avahi_base_service.py
+++ b/tests/installer/test_avahi_base_service.py
@@ -1,0 +1,94 @@
+"""H13: the installer must write the base avahi announcement it promises.
+
+``services/mdns.py``'s ``status()`` docstring and the Services page's
+Discovery card caption both said "the installer writes
+/etc/avahi/services/hal0.service when avahi is present" — nothing in
+install.sh ever did, so ``base_advertised`` (``GET /api/services/mdns``)
+was permanently ``False`` and the caption always rendered its fallback
+"no base file" wording, regardless of the real box state.
+
+``write_avahi_base_service()`` in install.sh closes that gap. Driven here
+by extracting the function body and running it against a tmp directory —
+the same technique ``test_avahi_hostname.py`` uses for
+``sync_avahi_hostname`` (real avahi/systemd aren't available in CI).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+INSTALL_SH = Path(__file__).resolve().parents[2] / "installer" / "install.sh"
+
+
+def _extract_func() -> str:
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    start = text.index("write_avahi_base_service()")
+    end = text.index("\n}\n", start) + 3
+    return text[start:end]
+
+
+def _drive(tmp_path: Path, *, port: str = "8080") -> Path:
+    """Run ``write_avahi_base_service <services_dir> <port>``; return the dir."""
+    services_dir = tmp_path / "avahi-services"
+    services_dir.mkdir(exist_ok=True)
+    script = tmp_path / "drive.sh"
+    script.write_text(
+        f"#!/usr/bin/env bash\nset -euo pipefail\n{_extract_func()}\n"
+        f'write_avahi_base_service "{services_dir}" "{port}"\n',
+        encoding="utf-8",
+    )
+    proc = subprocess.run(["bash", str(script)], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, proc.stderr
+    return services_dir
+
+
+def test_writes_base_service_file(tmp_path: Path) -> None:
+    services_dir = _drive(tmp_path, port="8080")
+    written = (services_dir / "hal0.service").read_text(encoding="utf-8")
+    assert "<port>8080</port>" in written
+    assert 'name replace-wildcards="yes">hal0 on %h<' in written
+    assert "_http._tcp" in written
+    # Never touches the addon-file surface (services/mdns.py owns that).
+    assert not list(services_dir.glob("hal0-addon-*.service"))
+
+
+def test_never_leaves_a_stray_tmp_file(tmp_path: Path) -> None:
+    services_dir = _drive(tmp_path)
+    assert [p.name for p in services_dir.iterdir()] == ["hal0.service"]
+
+
+def test_custom_port_reflected(tmp_path: Path) -> None:
+    services_dir = _drive(tmp_path, port="9090")
+    written = (services_dir / "hal0.service").read_text(encoding="utf-8")
+    assert "<port>9090</port>" in written
+
+
+def test_rerun_converges_on_a_new_port(tmp_path: Path) -> None:
+    """Re-running the installer with a different HAL0_PORT must update the
+    file in place, not leave a stale port from a first install."""
+    services_dir = _drive(tmp_path, port="8080")
+    _drive(tmp_path, port="9090")
+    written = (services_dir / "hal0.service").read_text(encoding="utf-8")
+    assert "<port>9090</port>" in written
+    assert "8080" not in written
+
+
+def test_unwritable_dir_degrades_without_raising(tmp_path: Path) -> None:
+    """A read-only services dir (permission issue, RO mount) must not abort
+    the install — same fail-soft posture as sync_avahi_hostname."""
+    services_dir = tmp_path / "ro-avahi-services"
+    services_dir.mkdir()
+    services_dir.chmod(0o500)
+    try:
+        script = tmp_path / "drive.sh"
+        script.write_text(
+            f"#!/usr/bin/env bash\nset -euo pipefail\n{_extract_func()}\n"
+            f'write_avahi_base_service "{services_dir}" "8080"\n',
+            encoding="utf-8",
+        )
+        proc = subprocess.run(["bash", str(script)], capture_output=True, text=True, timeout=30)
+        assert proc.returncode == 0, proc.stderr
+        assert not (services_dir / "hal0.service").exists()
+    finally:
+        services_dir.chmod(0o700)

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -23,6 +23,7 @@ from hal0.registry.pull import (
     _CHUNK_BYTES,
     _pull_root,
     _register_flm_pulled,
+    _register_pulled,
     _sanitise_id,
     _tmp_dir,
     hf_download_url,
@@ -1794,6 +1795,121 @@ async def test_run_pull_expected_hash_captured_from_redirect_hop(
     assert job.files[0].expected_sha256 == wrong
 
 
+# ── _register_pulled: backends + pooling_type propagation (#2192) ───────────
+#
+# hal0.model_meta.modality.derive_modalities_from_model_info() needs
+# model_info["backends"] (a runtime-family string: moonshine/kokoro/flm/…)
+# or model_info["metadata"]["pooling_type"] to recognise a non-chat model.
+# _register_pulled already calls detect() for context_length/quant/arch —
+# before this fix, detect()'s own suggested_backends/pooling_type were
+# computed and then dropped on the floor, so a real Kokoro/Moonshine/
+# embedding pull registered with backends=[] and no pooling_type. Every
+# tts/transcription/embedding slot bound to such a model then had an empty
+# LoadedSlot.modalities, and OmniRouter's resolve_for_request() could never
+# route those tools to it — despite the routing logic itself being correct.
+
+
+def test_register_pulled_new_row_gets_detected_backends(tmp_hal0_home: str) -> None:
+    """A brand-new row for a moonshine-named pull gets backends=["moonshine"]
+    from detect()'s filename classification — not the pre-fix backends=[]."""
+    registry = ModelRegistry()
+    root = Path(tmp_hal0_home) / "models"
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / "moonshine-small-streaming-en.bin"
+    path.write_bytes(b"not-a-gguf-asr-blob")
+
+    _register_pulled(
+        registry,
+        model_id="moonshine-small-streaming-en",
+        path=str(path),
+        size_bytes=path.stat().st_size,
+        sha256="deadbeef",
+        hf_repo="org/moonshine",
+        hf_filename=path.name,
+    )
+    entry = registry.get("moonshine-small-streaming-en")
+    assert entry.backends == ["moonshine"]
+
+
+def test_register_pulled_new_row_gets_pooling_type_metadata(tmp_hal0_home: str) -> None:
+    """A GGUF embedding pull's header-derived pooling_type reaches
+    ``metadata.pooling_type`` — the fact derive_modalities_from_model_info
+    reads for the embed/rerank branch of the closed modality taxonomy."""
+    registry = ModelRegistry()
+    root = Path(tmp_hal0_home) / "models"
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / "some-embedder.gguf"
+    path.write_bytes(_payload(2048))
+
+    import sys
+
+    from hal0.registry.detect import DetectionResult
+
+    detect_mod = sys.modules["hal0.registry.detect"]
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            detect_mod,
+            "detect",
+            lambda p: DetectionResult(
+                suggested_backends=[],
+                suggested_capabilities=["embed"],
+                kind="llama",
+                raw_hints={"pooling_type": 2},
+            ),
+        )
+        _register_pulled(
+            registry,
+            model_id="some-embedder",
+            path=str(path),
+            size_bytes=path.stat().st_size,
+            sha256="deadbeef",
+            hf_repo="org/some-embedder",
+            hf_filename=path.name,
+        )
+    entry = registry.get("some-embedder")
+    assert entry.metadata.get("pooling_type") == 2
+
+
+def test_register_pulled_backfills_backends_on_repull_only_when_unset(
+    tmp_hal0_home: str,
+) -> None:
+    """A re-pull backfills an EMPTY backends list from this pull's detection
+    (healing a pre-fix row) but never clobbers an operator-set/prior value —
+    same "fill only if unset" rule the tokenizer_repo backfill uses."""
+    from hal0.registry.model import Model
+
+    registry = ModelRegistry()
+    root = Path(tmp_hal0_home) / "models"
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / "kokoro-v1.bin"
+    path.write_bytes(b"not-a-gguf-tts-blob")
+
+    def _register(model_id: str) -> None:
+        _register_pulled(
+            registry,
+            model_id=model_id,
+            path=str(path),
+            size_bytes=path.stat().st_size,
+            sha256="deadbeef",
+            hf_repo="org/kokoro",
+            hf_filename=path.name,
+        )
+
+    # Pre-fix row: registered with no backends at all.
+    registry.add(
+        Model(id="kokoro-empty", name="kokoro-empty", path=str(path), backends=[]),
+    )
+    _register("kokoro-empty")
+    assert registry.get("kokoro-empty").backends == ["kokoro"]
+
+    # Operator/previously-tagged row: a re-pull must not override it.
+    registry.add(
+        Model(id="kokoro-custom", name="kokoro-custom", path=str(path), backends=["custom"]),
+    )
+    _register("kokoro-custom")
+    assert registry.get("kokoro-custom").backends == ["custom"]
+
+
 # ── _register_flm_pulled: capability classification (#1647) ──────────────────
 
 
@@ -1861,7 +1977,16 @@ def test_register_flm_pulled_re_pull_corrects_stale_capabilities(
 
 def test_register_flm_pulled_stamps_provider_on_new_row(tmp_hal0_home: str) -> None:
     """A brand-new FLM-pulled row gets ``provider="flm"`` stamped alongside
-    the legacy ``backends=["npu"]`` tag — not left for lazy derivation."""
+    the ``backends=["flm"]`` tag — not left for lazy derivation.
+
+    #2192: this used to write the hardware-lane label ``"npu"`` here, which
+    ``derive_modalities_from_model_info``'s runtime-family set doesn't
+    recognise (only "flm" does) — an FLM-routed stt/embed shadow slot's
+    model info never resolved a modality, so OmniRouter's tool eligibility
+    could never route to it. ``derive_model_provider`` already mapped both
+    strings to "flm" (that half was never broken); only the modality side
+    needed the literal fixed.
+    """
     registry = ModelRegistry()
     _register_flm_pulled(
         registry,
@@ -1872,7 +1997,7 @@ def test_register_flm_pulled_stamps_provider_on_new_row(tmp_hal0_home: str) -> N
     )
     entry = registry.get("qwen3-embed:4b")
     assert entry.provider == "flm"
-    assert entry.backends == ["npu"]  # tag still written — vestigial lane hint
+    assert entry.backends == ["flm"]
 
 
 @pytest.mark.asyncio

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -1088,6 +1088,26 @@ class TestCtxMaxEffectiveResolution:
         views = await agg.snapshot()
         assert views[0].to_dict()["ctx_max"] == 65536
 
+    async def test_ctx_max_resolution_skipped_for_non_llm_slot_kind(self, no_mem: None) -> None:
+        """#1859: only an "llm" slot runs llama-server with a resolvable
+        context window. A tts/transcription/embedding/image slot's raw
+        ``[model].context_size`` (a legacy/misconfigured value — these kinds
+        have no real notion of one) must pass through UNTOUCHED, never
+        re-resolved through the llama-only resolver. Same numbers as
+        ``test_ctx_max_downgraded_to_model_window`` above — where the "llm"
+        case DOES resolve down to 8000 — so an unchanged 65536 here proves
+        this is a skip, not a coincidental match."""
+        cfg = _llm_cfg(
+            name="voice", type="tts", model={"default": "kokoro-v1", "context_size": 65536}
+        )
+        registry = _FakeCtxRegistry({"kokoro-v1": _FakeCtxModel(8000)})
+        agg = _agg(
+            FakeSlotManager(slots=[_slot(name="voice", model_id="kokoro-v1")], configs=[cfg]),
+            registry=registry,
+        )
+        views = await agg.snapshot()
+        assert views[0].to_dict()["ctx_max"] == 65536
+
 
 # ── concern 5: metric injection ─────────────────────────────────────────────
 

--- a/tests/slots/test_loaded_slot.py
+++ b/tests/slots/test_loaded_slot.py
@@ -167,6 +167,41 @@ async def test_resolve_for_request_label_overlay_falls_back_to_derived_embed_mod
 
 
 @pytest.mark.asyncio
+async def test_resolve_for_request_label_overlay_falls_back_to_derived_tts_modality(
+    slot_root: Path, tmp_hal0_home: str
+) -> None:
+    """#2192: text_to_speech's required label is "tts", derived from a
+    Kokoro-backed model's ``backends=["kokoro"]`` — the exact fact
+    ``_register_pulled`` now propagates from ``detect()`` at pull time."""
+    ModelRegistry().add(Model(id="kokoro-v1", path="/tmp/kokoro-v1.bin", backends=["kokoro"]))
+    _write_slot(slot_root, "voice", slot_type="tts", model="kokoro-v1")
+
+    slot = await SlotManager().resolve_for_request("tts", required_labels=("tts",))
+
+    assert slot is not None
+    assert slot.name == "voice"
+
+
+@pytest.mark.asyncio
+async def test_resolve_for_request_label_overlay_falls_back_to_derived_transcription_modality(
+    slot_root: Path, tmp_hal0_home: str
+) -> None:
+    """#2192: transcribe_audio's required label is "transcription", derived
+    from a Moonshine-backed model's ``backends=["moonshine"]``."""
+    ModelRegistry().add(
+        Model(id="moonshine-small", path="/tmp/moonshine-small.bin", backends=["moonshine"])
+    )
+    _write_slot(slot_root, "asr", slot_type="transcription", model="moonshine-small")
+
+    slot = await SlotManager().resolve_for_request(
+        "transcription", required_labels=("transcription",)
+    )
+
+    assert slot is not None
+    assert slot.name == "asr"
+
+
+@pytest.mark.asyncio
 async def test_resolve_for_request_label_overlay_has_no_fallback_for_edit(
     slot_root: Path, tmp_hal0_home: str
 ) -> None:

--- a/ui/tests/e2e/specs/services-v3.spec.ts
+++ b/ui/tests/e2e/specs/services-v3.spec.ts
@@ -80,9 +80,34 @@ const SERVICES_PAYLOAD = {
       hints: [],
     },
     {
-      id: 'n8n',
-      name: 'n8n',
-      description: 'Workflow automation (external — not deployed by hal0).',
+      // #2028: hindsight used to be entirely absent from this table.
+      id: 'hindsight',
+      name: 'Hindsight',
+      description: 'Memory engine (native daemon, loopback :9177).',
+      managed: true,
+      unit: 'hindsight-api.service',
+      unit_state: {
+        active_state: 'active',
+        sub_state: 'running',
+        unit_file_state: 'enabled',
+        since: 'Fri 2026-07-03 09:12:01 UTC',
+      },
+      up: true,
+      detail: 'systemd unit active',
+      stat: null,
+      url: null,
+      mdns_url: null,
+      loopback_port: 9177,
+      actions: ['start', 'stop', 'restart', 'enable', 'disable'],
+      mdns_capable: false,
+      hints: [],
+    },
+    {
+      // Stand-in for a future extension-manifest row (w2b) the backend
+      // carries but has no bespoke probe for yet — #2028's honest default.
+      id: 'future-extension',
+      name: 'Future Extension',
+      description: 'Example companion service (external — not deployed by hal0).',
       managed: false,
       unit: null,
       unit_state: null,
@@ -119,12 +144,18 @@ test.describe('Services v3 (/services)', () => {
 
     await expect(page.locator('.view .vh h1')).toHaveText('Services')
     await expect(page.getByTestId('svcp-mdns-toggle')).toBeVisible()
-    for (const id of ['openwebui', 'comfyui', 'hermes', 'n8n']) {
+    for (const id of ['openwebui', 'comfyui', 'hermes', 'hindsight', 'future-extension']) {
       await expect(page.getByTestId(`svcp-card-${id}`)).toBeVisible()
     }
-    // Up service shows an "up" pill; unmanaged shows the external note.
+    // Up service shows an "up" pill; a real, previously-invisible service
+    // (#2028) renders too; an unwired/unmanaged one shows the honest
+    // "unmonitored" detail + external note, never a fabricated up.
     await expect(page.getByTestId('svcp-card-openwebui')).toContainText('up')
-    await expect(page.getByTestId('svcp-card-n8n')).toContainText('external — not managed by hal0')
+    await expect(page.getByTestId('svcp-card-hindsight')).toContainText('up')
+    await expect(page.getByTestId('svcp-card-future-extension')).toContainText('unmonitored')
+    await expect(page.getByTestId('svcp-card-future-extension')).toContainText(
+      'external — not managed by hal0',
+    )
   })
 
   test('action buttons follow the backend allow-list', async ({ page }) => {
@@ -139,8 +170,8 @@ test.describe('Services v3 (/services)', () => {
     await expect(page.getByTestId('svcp-restart-comfyui')).toBeVisible()
     await expect(page.getByTestId('svcp-start-comfyui')).toHaveCount(0)
     await expect(page.getByTestId('svcp-stop-comfyui')).toHaveCount(0)
-    // n8n: no lifecycle buttons at all.
-    await expect(page.getByTestId('svcp-restart-n8n')).toHaveCount(0)
+    // future-extension: no lifecycle buttons at all.
+    await expect(page.getByTestId('svcp-restart-future-extension')).toHaveCount(0)
   })
 
   test('restart posts to /api/services/{id}/action and surfaces the result', async ({ page }) => {


### PR DESCRIPTION
GET /api/services/health — the Overview card's stable feed — now includes
Hindsight and iterates the same typed service catalog the full Services page
already used, instead of a hardcoded three-branch construction that could
never surface a fourth service or a Hindsight outage. A service with no
wired probe reports up:false, detail:"unmonitored" — never a fabricated up —
via asyncio.gather(return_exceptions=True) so one hung probe can't drop the
rest. ServiceDef gains category, source (builtin/extension), modalities and
a probe_tcp field for a future "tcp" probe kind: additive, and the one shape
an extension-manifest service row is meant to reuse so the registry never
grows a second parallel service shape. (#2028)

The installer now writes the base /etc/avahi/services/hal0.service mDNS
announcement it always documented — the Discovery card and services/mdns.py's
own docstring both promised "the installer writes it when avahi is present",
but nothing ever did, so base_advertised was permanently false. (H13)

A pulled model's runtime family and pooling type now reach the model
registry, not just detect()'s in-memory result. A fresh Kokoro/Moonshine/
Qwen3-TTS pull registered with an empty backends list, and a GGUF embedding/
reranking pull with no metadata.pooling_type, so
derive_modalities_from_model_info could never recognise the model: a bound
tts/transcription/embedding slot's LoadedSlot.modalities stayed empty and
OmniRouter silently never routed to those slots on a real deployment, even
though the routing logic itself was correct. An FLM-pulled model's
backends=["npu"] (a hardware-lane label, not a runtime family) is now
["flm"], the string the modality derivation actually recognises. (#2192)

The llama-only effective-context resolver no longer runs against embedding/
reranking/transcription/tts/image slots on GET /api/slots and
GET /api/slots/{name}. Those slot kinds have no context window; calling it
anyway fabricated an 8192-token "window" — its safe fallback for an
unrecognised model — that the slot never runs with. (#1859)

Signed-off-by: thinmintdev <alexander@awideweb.com>


## Verification

`ruff check src tests` clean. Full α unit suite (12808 tests) green apart from
three failures that also fail on a clean `main` checkout
(`tests/providers/test_moonshine_server.py` ×2, needs `ffmpeg`, and
`tests/slots/test_pressure_eviction.py::test_pressure_evict_noop_when_probe_fails`).
Integration β not run locally (needs root + a live `hal0-lemonade.service`); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzkumtSWnm3AxixzHG38UG
