### PR TITLE
feat(openwebui): wire RAG and ComfyUI image generation from live capability state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+
+- **Open WebUI is now fully pre-wired**, not just chat + voice: document
+  uploads route through RAG the moment an embed-capable slot is bound
+  (`RAG_EMBEDDING_ENGINE`/`RAG_OPENAI_API_BASE_URL`/`RAG_EMBEDDING_MODEL`
+  point at hal0's own `/v1`), and the image button generates through
+  ComfyUI the moment the `img` slot is bound (`ENABLE_IMAGE_GENERATION`,
+  `COMFYUI_BASE_URL`, and a `COMFYUI_WORKFLOW`/`COMFYUI_WORKFLOW_NODES`
+  pair baked from the SAME translator `/v1/images/generations` uses, keyed
+  to whichever checkpoint the slot is actually bound to). Both blocks are
+  gated on live capability state and explicitly cleared the moment that
+  state stops being true — never a stale claim of a capability that isn't
+  really there. A seam is left for a future search-provider extension
+  (`ENABLE_WEB_SEARCH` stays off; no search service ships today). The env
+  file re-renders — and the companion restarts only when the render
+  actually changed — on capability apply, `embed`/`img` slot create or
+  delete, and every regular component-convergence pass. The Services
+  page's Open WebUI card now shows a wired chip per feature (Chat, Voice,
+  Documents, Images, Web search), exposed via `GET /api/services`.
+
 ### Fixed
 
 - MCP admin tools no longer report a tool failure for a successful read of a

--- a/docs/guides/open-webui.mdx
+++ b/docs/guides/open-webui.mdx
@@ -1,0 +1,133 @@
+---
+title: Open WebUI — chat companion wiring
+description: What hal0 pre-wires into the Open WebUI companion — chat, voice, retrieval-augmented document uploads, image generation, web search — and how to check what's actually connected before you click a button that has nothing behind it.
+sidebar:
+  order: 75
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+hal0 ships **Open WebUI** as a companion container (`hal0-openwebui.service`,
+LAN `:3001`) and writes its environment file
+(`/etc/hal0/openwebui.env`) for you — there is nothing to configure inside
+Open WebUI's own settings for any of this to work. What gets wired depends
+on what you have actually enabled through hal0's own capability slots:
+
+| Open WebUI feature | Wired when | Always on? |
+| --- | --- | --- |
+| Chat | — | Yes — points at hal0's own `/v1` |
+| Voice (Call mode) | — | Yes — STT/TTS point at hal0's `/v1/audio/*` |
+| Document uploads (RAG) | An **embed**-capable slot is enabled | No |
+| Image generation | The **img** (ComfyUI) slot is enabled | No |
+| Web search | A search provider is installed | No — none ships today |
+
+<Aside type="note">
+Chat and voice are unconditional because hal0 always exposes a `/v1`
+gateway and voice endpoints — there is no "off" state for those to be
+gated on. Documents and images are real capability slots you turn on
+yourself; hal0 never tells Open WebUI a feature exists unless there is a
+real backend behind it, so an unwired button fails honestly instead of
+silently doing nothing.
+</Aside>
+
+## Chat and voice (always wired)
+
+`OPENAI_API_BASE_URLS` points Open WebUI's chat at hal0's own `/v1`
+gateway, and `AUDIO_STT_*` / `AUDIO_TTS_*` point Call mode's transcription
+and synthesis at hal0's own `/v1/audio/transcriptions` and
+`/v1/audio/speech`. See [Speech to text and text to
+speech](/docs/guides/voice-stt-tts) for the underlying `stt`/`tts` slots
+Call mode actually dispatches to.
+
+## Document uploads (RAG)
+
+Open WebUI's upload button embeds every document you attach through
+whichever model backs its `RAG_EMBEDDING_MODEL` setting. hal0 points that
+at its own `/v1` and the model id bound to the **embed** capability's
+`embed` child — enable it the same way you'd enable any other capability:
+
+```sh
+hal0 capabilities set embed embed --model <your-embed-model>
+```
+
+Until an embed-capable slot is enabled, `RAG_EMBEDDING_ENGINE` and its
+siblings are left unset — Open WebUI falls back to its own bundled
+sentence-transformers model rather than a broken hal0 route. See [Enable
+memory](/docs/guides/enable-memory) and [Choose
+models](/docs/guides/choose-models) for picking an embed model.
+
+## Image generation
+
+The image button in the chat composer generates through hal0's ComfyUI
+slot once it's enabled:
+
+```sh
+hal0 capabilities set img img --model <your-image-model>
+```
+
+hal0 bakes a static `COMFYUI_WORKFLOW` (and its matching
+`COMFYUI_WORKFLOW_NODES` substitution map) from the **same** translator
+`/v1/images/generations` itself uses, keyed to whichever checkpoint your
+`img` slot is actually bound to — never a generic pasted-in workflow for a
+checkpoint hal0 doesn't ship. Rebinding the `img` slot to a different model
+re-bakes the workflow on the next convergence pass (see [Generate
+images](/docs/guides/generate-images) for the underlying capability).
+
+## Web search
+
+No search provider ships with hal0 today, so `ENABLE_WEB_SEARCH` stays
+off — the toggle in Open WebUI has nothing to query. This is a seam for a
+future extension (e.g. a SearXNG addon), not a missing feature you can
+turn on by hand-editing the env file; a hand-added `SEARXNG_QUERY_URL`
+would be silently overwritten the next time anything re-renders the env
+(see below).
+
+## Checking what's actually wired
+
+The Services page's Open WebUI card shows a chip per feature — Chat,
+Voice, Documents, Images, Web search — each lit only when hal0 actually
+has a backend behind it. Hover a chip for the specific slot or model it's
+routed to (or why it isn't wired yet). The same information is available
+over the API:
+
+```sh
+curl http://localhost:8080/api/services | jq '.services[] | select(.id == "openwebui") | .wired'
+```
+
+```json
+{
+  "chat": true,
+  "voice": true,
+  "documents": true,
+  "images": false,
+  "web_search": false,
+  "embed_model": "nomic-embed-text-v1.5",
+  "image_model": null
+}
+```
+
+## When the env file re-renders
+
+`/etc/hal0/openwebui.env` re-renders automatically — you never edit it by
+hand for any of this. It re-renders (and the Open WebUI container restarts
+**only if the rendered file actually changed**) whenever:
+
+- You apply a capability change to `embed` or `img`
+  (`hal0 capabilities set …` or the dashboard's Capabilities page).
+- You create or delete the `embed` or `img` slot directly.
+- hal0 runs its regular component convergence pass: `hal0 update`, the
+  Services page's Retry button on Open WebUI's version row, or the
+  boot-time convergence check.
+
+Hand edits to keys hal0 doesn't manage (or the exposure knobs documented
+in the installer — `HAL0_BIND_HOST`, `HAL0_OWUI_TRUSTED_EMAIL_HEADER`) are
+preserved across every re-render; only the RAG/image-gen/web-search keys
+listed above are hal0-owned and rewritten on every pass.
+
+## See also
+
+- [Generate images](/docs/guides/generate-images) — the `img` capability
+  and ComfyUI engine in depth.
+- [Enable memory](/docs/guides/enable-memory) — the `embed` capability.
+- [Speech to text and text to speech](/docs/guides/voice-stt-tts) — the
+  `stt`/`tts` slots Call mode dispatches to.

--- a/src/hal0/api/routes/capabilities.py
+++ b/src/hal0/api/routes/capabilities.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, BackgroundTasks, Request
 
 from hal0.api._audit import record_action
 from hal0.api.deps import CapabilityOrchestratorDep
@@ -20,6 +20,12 @@ from hal0.capabilities.orchestrator import LEGAL_SLOTS, legal_children
 from hal0.errors import BadRequest
 
 router = APIRouter()
+
+#: Capability slots whose selection feeds OpenWebUI's dynamic env blocks
+#: (RAG embeddings / image generation — see hal0.openwebui.wiring). "voice"
+#: is excluded: STT/TTS are prewired unconditionally in env_writer's static
+#: defaults, so a voice apply never changes what OpenWebUI needs re-rendered.
+_OWUI_WIRED_SLOTS = frozenset({"embed", "img"})
 
 
 @router.get("")
@@ -43,6 +49,7 @@ async def apply_capability(
     child: str,
     request: Request,
     orchestrator: CapabilityOrchestratorDep,
+    background_tasks: BackgroundTasks,
 ) -> dict[str, Any]:
     """Apply a partial selection update to one (slot, child) pair.
 
@@ -99,6 +106,13 @@ async def apply_capability(
             "child": child,
             **{k: body[k] for k in ("backend", "provider", "model", "enabled") if k in body},
         }
+    if slot in _OWUI_WIRED_SLOTS:
+        from hal0.components.openwebui_arm import reconcile_openwebui_env_background
+
+        # Runs after the response is sent — re-rendering OpenWebUI's env
+        # (and restarting it, only if that render actually changed
+        # something) is not this endpoint's own result.
+        background_tasks.add_task(reconcile_openwebui_env_background)
     return {"ok": True, "selection": selection}
 
 

--- a/src/hal0/api/routes/services.py
+++ b/src/hal0/api/routes/services.py
@@ -90,6 +90,21 @@ def _mdns_url(sdef: ServiceDef, hostname: str, advertised: list[str]) -> str | N
     return f"http://{hostname}:{sdef.port}"
 
 
+def _openwebui_wired() -> dict[str, Any] | None:
+    """OpenWebUI's wired-chip truth, from the SAME classifier that renders
+    its env file (:mod:`hal0.openwebui.wiring`) — never re-derived here.
+    Fail-soft: a broken resolver must not turn the whole Services page into
+    a 500 over one card's chips.
+    """
+    try:
+        from hal0.openwebui.wiring import openwebui_wiring_status
+
+        return openwebui_wiring_status()
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("services.owui_wiring_status_failed", exc=repr(exc))
+        return None
+
+
 # ── probes ────────────────────────────────────────────────────────────────────
 
 
@@ -179,6 +194,7 @@ async def list_services(request: Request) -> dict[str, Any]:
                 "actions": list(sdef.actions),
                 "mdns_capable": sdef.mdns,
                 "hints": list(sdef.hints),
+                "wired": _openwebui_wired() if sdef.id == "openwebui" else None,
             }
         )
     return {"services": services, "mdns": disco}

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -815,9 +815,18 @@ def _normalize_create_body(
     return out
 
 
+#: Slot names whose creation/deletion can change what OpenWebUI's dynamic
+#: env blocks claim (RAG embeddings / image generation — see
+#: hal0.openwebui.wiring). These are the fixed system slot names the
+#: capability orchestrator targets for the "embed" and "img" capability
+#: lanes (hal0.capabilities.orchestrator's slot mapping), not
+#: operator-chosen names.
+_OWUI_WIRED_SLOT_NAMES = frozenset({"embed", "img"})
+
+
 @router.post("", status_code=201)
 @_invalidates_snapshot
-async def create_slot(request: Request) -> dict[str, object]:
+async def create_slot(request: Request, background_tasks: BackgroundTasks) -> dict[str, object]:
     """Create a new slot. Body: SlotConfig schema.
 
     Writes /etc/hal0/slots/<name>.toml, the systemd drop-in override, the
@@ -958,6 +967,10 @@ async def create_slot(request: Request) -> dict[str, object]:
                     "reason": str(exc),
                 }
 
+    if name in _OWUI_WIRED_SLOT_NAMES:
+        from hal0.components.openwebui_arm import reconcile_openwebui_env_background
+
+        background_tasks.add_task(reconcile_openwebui_env_background)
     return out
 
 
@@ -1305,7 +1318,9 @@ async def _refresh_composite_catalogue(
 
 @router.delete("/{name}")
 @_invalidates_snapshot
-async def delete_slot(name: str, request: Request, force: bool = False) -> dict[str, object]:
+async def delete_slot(
+    name: str, request: Request, background_tasks: BackgroundTasks, force: bool = False
+) -> dict[str, object]:
     """Delete a slot. If the slot is running, it is stopped first.
 
     #2112: only **pinned** slots are protected — the default-pinned anchors
@@ -1335,6 +1350,10 @@ async def delete_slot(name: str, request: Request, force: bool = False) -> dict[
     # advertised by /v1/models (hard-404ing on dispatch) until an
     # unrelated slot went ready or hal0-api restarted. Evict here.
     await _refresh_composite_catalogue(request, before)
+    if name in _OWUI_WIRED_SLOT_NAMES:
+        from hal0.components.openwebui_arm import reconcile_openwebui_env_background
+
+        background_tasks.add_task(reconcile_openwebui_env_background)
     return {"name": name, "deleted": True, "forced": force}
 
 

--- a/src/hal0/components/openwebui_arm.py
+++ b/src/hal0/components/openwebui_arm.py
@@ -17,6 +17,22 @@ whenever ``target_digest`` is supplied — including when it already
 matches the installed digest, so a subsequent un-targeted converge still
 holds the box at the operator's pin instead of drifting back to the
 release pin the moment nothing needs pulling.
+
+Env re-render (RAG/image-gen/web-search full wiring): every ``apply``
+pass of :func:`converge_openwebui` also re-renders ``openwebui.env``'s
+dynamic blocks from live capability state
+(:func:`hal0.openwebui.wiring.resolve_dynamic_env_overrides`, via
+:func:`_render_dynamic_env`) and restarts the unit when the rendered bytes
+changed. That covers ``hal0 update``/``hal0 app converge`` and the
+boot-time convergence pass (:mod:`hal0.components.runner`), which are the
+only existing callers of this arm — capability apply
+(:mod:`hal0.api.routes.capabilities`) and slot create/delete for the
+``embed``/``img`` slots (:mod:`hal0.api.routes.slots`) call
+:func:`reconcile_openwebui_env` directly instead, since neither goes
+through component convergence today. A ``diagnose_only`` pass
+(``apply=False``, e.g. the boot-time drift check) never renders or
+restarts — matching the read-only contract every other branch of this
+function already gives that flag.
 """
 
 from __future__ import annotations
@@ -44,6 +60,142 @@ Runner = Callable[..., subprocess.CompletedProcess]
 
 def override_path() -> Path:
     return var_lib() / "state" / "openwebui.pin-override"
+
+
+def _restart_openwebui(runner: Runner, is_hal0_user: Callable[[], bool]) -> bool:
+    """Restart the OpenWebUI unit through the same seam every other branch
+    of this module uses. Returns whether the restart command itself
+    succeeded (a process failure never raises — callers treat this as a
+    best-effort signal, same posture as the rest of the arm)."""
+    restart_argv = (
+        ["sudo", "-n", SEAM_BIN, "svc-restart", "openwebui"]
+        if is_hal0_user()
+        else ["systemctl", "restart", image_pin.OPENWEBUI_UNIT_NAME]
+    )
+    try:
+        proc = runner(restart_argv, capture_output=True, text=True, timeout=_CTL_TIMEOUT_S)
+        return proc.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _render_dynamic_env(job_id: str | None) -> tuple[bool, str | None]:
+    """Re-render ``openwebui.env``'s dynamic RAG/image-gen/web-search blocks
+    from live capability state. Returns ``(env_changed, error)`` — never
+    raises; a broken resolver degrades to ``(False, <error>)`` so it can
+    never break whichever caller is piggybacking this render on top of
+    (image-pin convergence, a capability apply, a slot delete).
+    """
+    from hal0.config.paths import openwebui_env
+    from hal0.openwebui.env_writer import write_openwebui_env
+    from hal0.openwebui.wiring import resolve_dynamic_env_overrides
+
+    target = openwebui_env()
+    try:
+        before = target.read_bytes() if target.exists() else None
+    except OSError as exc:
+        return False, f"env read failed: {exc}"
+
+    try:
+        overrides = resolve_dynamic_env_overrides()
+        write_openwebui_env(target, overrides=overrides, preserve_existing=True)
+    except Exception as exc:
+        log.warning("components.owui_env_render_failed", job_id=job_id, error=str(exc))
+        return False, f"env render failed: {exc}"
+
+    try:
+        after = target.read_bytes()
+    except OSError as exc:
+        return False, f"env read-back failed: {exc}"
+
+    return before != after, None
+
+
+def reconcile_openwebui_env(
+    *,
+    job_id: str | None = None,
+    runner: Runner | None = None,
+    is_hal0_user: Callable[[], bool] | None = None,
+) -> dict[str, Any]:
+    """Re-render the dynamic env blocks and restart the unit only when the
+    rendered bytes actually changed.
+
+    The single reconcile point every event that changes that truth calls
+    directly: capability apply (:mod:`hal0.api.routes.capabilities`), slot
+    create/delete for the ``embed``/``img`` slots
+    (:mod:`hal0.api.routes.slots`). :func:`converge_openwebui` calls
+    :func:`_render_dynamic_env` itself instead (see its own restart, which
+    this would otherwise race/duplicate on an image-pin change).
+    """
+    runner = runner if runner is not None else subprocess.run
+    is_hal0_user = is_hal0_user if is_hal0_user is not None else is_hal0_service_user
+
+    if not image_pin.installed_unit_path().is_file():
+        # Mirrors converge_openwebui's own early-exit: a box that never
+        # installed the OpenWebUI companion (HAL0_SKIP_OPENWEBUI=1) has
+        # nothing to restart, and writing an env file for a companion that
+        # isn't provisioned would be a surprising side effect of a
+        # capability apply / slot create/delete on an unrelated feature.
+        return {"status": "skipped", "reason": "openwebui unit not installed"}
+
+    changed, error = _render_dynamic_env(job_id)
+    if error is not None:
+        return {"status": "build_failed", "error": error}
+    if not changed:
+        return {"status": "unchanged", "env_changed": False}
+
+    restarted = _restart_openwebui(runner, is_hal0_user)
+    if not restarted:
+        log.warning(
+            "components.owui_env_restart_failed",
+            job_id=job_id,
+            remedy=f"env rewritten; run 'systemctl restart {image_pin.OPENWEBUI_UNIT_NAME}' by hand",
+        )
+    log.info("components.owui_env_reconciled", job_id=job_id, restarted=restarted)
+    return {"status": "converged", "env_changed": True, "restarted": restarted}
+
+
+def reconcile_openwebui_env_background() -> None:
+    """``reconcile_openwebui_env()``, fire-and-forget.
+
+    The one shared body for every caller that triggers a reconcile as a
+    side effect of its own unrelated response — capability apply
+    (:mod:`hal0.api.routes.capabilities`) and slot create/delete for the
+    ``embed``/``img`` slots (:mod:`hal0.api.routes.slots`) both pass this
+    straight to ``BackgroundTasks.add_task``. Never raises: a broken
+    resolver or a dead unit is this function's own problem (logged), never
+    a failure on the response it's piggybacking on.
+    """
+    try:
+        reconcile_openwebui_env()
+    except Exception as exc:  # pragma: no cover — defensive, arm is fail-soft
+        log.warning("components.owui_reconcile_background_failed", error=str(exc))
+
+
+def _env_reconcile_fields(
+    job_id: str | None, runner: Runner, is_hal0_user: Callable[[], bool]
+) -> dict[str, Any]:
+    """Render the dynamic env blocks and restart-if-changed, as extra fields
+    for ``converge_openwebui``'s own payload (never clobbers its ``status``
+    key — image-pin status and env-reconcile status are reported
+    separately).
+
+    Deliberately does NOT call :func:`reconcile_openwebui_env` — that
+    function re-checks ``image_pin.installed_unit_path()``, but
+    ``converge_openwebui`` already confirmed its (possibly test-injected
+    ``unit_path=``) unit exists before reaching either branch that calls
+    this. Re-deriving the path here would silently diverge from the one
+    the caller already resolved.
+    """
+    changed, error = _render_dynamic_env(job_id)
+    fields: dict[str, Any] = {}
+    if error is not None:
+        fields["env_error"] = error
+        return fields
+    if changed:
+        fields["env_changed"] = True
+        fields["restarted"] = _restart_openwebui(runner, is_hal0_user)
+    return fields
 
 
 def read_pin_override() -> str | None:
@@ -119,8 +271,22 @@ def converge_openwebui(
                 log.warning(
                     "components.owui_override_persist_failed", job_id=job_id, error=str(exc)
                 )
+            # No env render/restart here (unlike the branches below): this
+            # is the operator re-affirming an already-matching --target —
+            # persisting the marker is the only side effect that branch has
+            # ever had, and a runner call here would surprise a caller that
+            # passed --target expecting a pure no-op. The next regular
+            # converge pass reconciles the env as usual.
             return {**result, "status": "override"}
-        return {**result, "status": "override" if overridden else "converged"}
+        status = "override" if overridden else "converged"
+        if not apply:
+            return {**result, "status": status}
+        # Image already matches — the env's dynamic blocks can still be
+        # stale (a capability apply/slot delete happened without an image
+        # change in between), so every apply pass reconciles them here too.
+        payload = {**result, "status": status}
+        payload.update(_env_reconcile_fields(job_id, runner, is_hal0_user))
+        return payload
     if not apply:
         log.warning(
             "components.owui_stale",
@@ -175,7 +341,7 @@ def converge_openwebui(
             return {**result, "status": "build_failed", "error": f"unit write failed: {exc}"}
         runner(["systemctl", "daemon-reload"], capture_output=True, text=True, timeout=30.0)
 
-    # ── Persist / restart ──
+    # ── Persist / render env / restart ──
     if target_digest is not None:
         try:
             override_path().parent.mkdir(parents=True, exist_ok=True)
@@ -183,16 +349,12 @@ def converge_openwebui(
         except OSError as exc:
             log.warning("components.owui_override_persist_failed", job_id=job_id, error=str(exc))
 
-    restart_argv = (
-        ["sudo", "-n", SEAM_BIN, "svc-restart", "openwebui"]
-        if is_hal0_user()
-        else ["systemctl", "restart", image_pin.OPENWEBUI_UNIT_NAME]
-    )
-    try:
-        proc = runner(restart_argv, capture_output=True, text=True, timeout=_CTL_TIMEOUT_S)
-        restarted = proc.returncode == 0
-    except (OSError, subprocess.SubprocessError):
-        restarted = False
+    # Render before the restart below so it's the new image AND the new env
+    # that come up together — one restart covers both (a second,
+    # env-triggered restart would just be wasted churn here).
+    env_changed, env_error = _render_dynamic_env(job_id)
+
+    restarted = _restart_openwebui(runner, is_hal0_user)
     if not restarted:
         log.warning(
             "components.owui_restart_failed",
@@ -200,4 +362,15 @@ def converge_openwebui(
             remedy=f"repinned; run 'systemctl restart {image_pin.OPENWEBUI_UNIT_NAME}' and check its journal",
         )
     log.info("components.owui_repinned", job_id=job_id, from_=current, to=desired)
-    return {**result, "status": "upgraded", "from": current, "to": desired, "restarted": restarted}
+    payload = {
+        **result,
+        "status": "upgraded",
+        "from": current,
+        "to": desired,
+        "restarted": restarted,
+    }
+    if env_changed:
+        payload["env_changed"] = True
+    if env_error is not None:
+        payload["env_error"] = env_error
+    return payload

--- a/src/hal0/openwebui/__init__.py
+++ b/src/hal0/openwebui/__init__.py
@@ -1,8 +1,12 @@
 """hal0.openwebui — OpenWebUI companion service configuration.
 
 Writes /etc/hal0/openwebui.env with the prewired variables that configure
-OpenWebUI to use the hal0 API as its backend.  Called by the installer at
-install time and by the Settings API route when the hal0 API port changes.
+OpenWebUI to use the hal0 API as its backend. Called by the installer at
+install time (``python -m hal0.openwebui.env_writer``, static defaults
+only) and by the OpenWebUI component's converge arm
+(:func:`hal0.components.openwebui_arm.converge_openwebui`) on every
+convergence pass, which additionally renders the RAG/image-gen/web-search
+blocks from live capability state via :mod:`hal0.openwebui.wiring`.
 
 Uses the same atomic write primitive as slot env files (hal0.config.env).
 
@@ -10,13 +14,17 @@ New module (no haloai equivalent).
 See PLAN.md §8 (OpenWebUI integration) and §5 Tier 1 (atomic writes).
 
 Key exports:
-    write_openwebui_env — write the OpenWebUI env file atomically.
+    write_openwebui_env  — write the OpenWebUI env file atomically.
+    dynamic_env_overrides — render the RAG/image-gen/web-search blocks
+                             (pure; see hal0.openwebui.wiring for the
+                             live-truth resolver that feeds it).
 """
 
 from __future__ import annotations
 
-from hal0.openwebui.env_writer import write_openwebui_env
+from hal0.openwebui.env_writer import dynamic_env_overrides, write_openwebui_env
 
 __all__ = [
+    "dynamic_env_overrides",
     "write_openwebui_env",
 ]

--- a/src/hal0/openwebui/env_writer.py
+++ b/src/hal0/openwebui/env_writer.py
@@ -2,8 +2,11 @@
 
 write_openwebui_env() produces /etc/hal0/openwebui.env with the variables
 required to prewire OpenWebUI to the hal0 API.  Called by the installer
-(`python -m hal0.openwebui.env_writer`, via :func:`main`); there is no
-settings route for it today.
+(`python -m hal0.openwebui.env_writer`, via :func:`main`) with no
+overrides, and by hal0.components.openwebui_arm's converge/reconcile
+functions with the RAG/image-gen/web-search overrides from
+hal0.openwebui.wiring (see the "Dynamic wiring" section below). There is
+still no settings route that calls this directly.
 
 Uses hal0.config.env.write_env_atomic() — the same atomic write primitive
 used for slot env files (PLAN.md §5 Tier 1).
@@ -52,6 +55,35 @@ Both also survive a re-run: since #1514 the installer path merges rather
 than replaces, so editing /etc/hal0/openwebui.env by hand is a supported
 way to set them. The previous instruction here — "pass them via the
 `overrides` parameter" — named a parameter no shipped caller ever passed.
+
+Dynamic wiring (RAG / image-gen / web-search). Beyond the fixed defaults
+above, three more blocks are rendered — but only when there is a real
+backend to point at, never a claim OpenWebUI can't cash:
+
+    RAG_EMBEDDING_ENGINE=openai              — an embed-capable slot is bound
+    RAG_OPENAI_API_BASE_URL / _MODEL / _KEY
+    ENABLE_IMAGE_GENERATION=True             — a ComfyUI (img) slot is bound
+    IMAGE_GENERATION_ENGINE=comfyui
+    COMFYUI_BASE_URL / _MODEL / COMFYUI_WORKFLOW / _WORKFLOW_NODES
+    ENABLE_WEB_SEARCH=True                   — a search provider is installed
+    WEB_SEARCH_ENGINE / SEARXNG_QUERY_URL / …
+
+:func:`dynamic_env_overrides` renders these as a pure function of already-
+resolved values (model ids, a baked ComfyUI workflow) — it never reads slot
+state itself, so it stays as import-light as the rest of this module. The
+live-truth resolver that gathers those values from ``capabilities.toml`` and
+the registry is :mod:`hal0.openwebui.wiring` (a separate module precisely so
+*that* import weight — ``hal0.capabilities``, ``hal0.registry``,
+``hal0.providers.comfyui_workflows`` — never lands on this module's cold
+``python -m`` path). Every dynamic key is explicitly nulled when its gate is
+false, not merely omitted: ``preserve_existing`` keeps whatever a prior write
+left in the file for any key an override doesn't mention, so a capability
+that WAS wired and got unwired (slot deleted, capability disabled) needs an
+explicit ``None`` to actually disappear on the next render — an omitted key
+would survive as a stale claim (ODS's own Apple footgun — a VRAM fallback
+that "assumes zero current usage" and can over-report what fits,
+``ods/extensions/services/dashboard-api/routers/features.py:27-32`` in the
+ODS reference tree — never claim a capability that isn't there).
 """
 
 from __future__ import annotations
@@ -218,6 +250,120 @@ def default_openwebui_env() -> dict[str, str]:
     return env
 
 
+#: Every env key any dynamic block can emit. Used to explicitly null out a
+#: block's keys when its gate is false — see the module docstring's
+#: "Dynamic wiring" section for why an explicit None (not omission) is
+#: required for a capability to actually stop being claimed.
+_DYNAMIC_ENV_KEYS: tuple[str, ...] = (
+    "RAG_EMBEDDING_ENGINE",
+    "RAG_OPENAI_API_BASE_URL",
+    "RAG_OPENAI_API_KEY",
+    "RAG_EMBEDDING_MODEL",
+    "ENABLE_IMAGE_GENERATION",
+    "IMAGE_GENERATION_ENGINE",
+    "COMFYUI_BASE_URL",
+    "IMAGE_SIZE",
+    "IMAGE_GENERATION_MODEL",
+    "COMFYUI_WORKFLOW",
+    "COMFYUI_WORKFLOW_NODES",
+    "ENABLE_WEB_SEARCH",
+    "ENABLE_SEARCH_QUERY_GENERATION",
+    "WEB_SEARCH_ENGINE",
+    "SEARXNG_QUERY_URL",
+    "WEB_SEARCH_RESULT_COUNT",
+)
+
+
+def _rag_env_block(embed_model_id: str) -> dict[str, str]:
+    """RAG embeddings routed through hal0's own ``/v1`` (not OWUI's default
+    sentence-transformers download, which can block a fresh install's first
+    boot before port 8080 even binds — same rationale as ODS's own
+    ``RAG_EMBEDDING_ENGINE`` comment)."""
+    return {
+        "RAG_EMBEDDING_ENGINE": "openai",
+        "RAG_OPENAI_API_BASE_URL": "http://host.docker.internal:8080/v1",
+        "RAG_OPENAI_API_KEY": "sk-hal0-local",
+        "RAG_EMBEDDING_MODEL": embed_model_id,
+    }
+
+
+def _image_gen_env_block(
+    model_id: str, workflow_json: str, workflow_nodes_json: str
+) -> dict[str, str]:
+    """Image generation routed through the ComfyUI slot on the host.
+
+    ComfyUI runs ``network_mode="host"`` (see
+    ``hal0.providers.comfyui.ComfyUIProvider.container_spec``), so from
+    inside the OpenWebUI container it is reached the same way hal0's own
+    ``/v1`` is: via the host gateway, not a compose-network service name.
+    ``workflow_json`` / ``workflow_nodes_json`` are pre-rendered by the
+    caller (see :mod:`hal0.openwebui.wiring`) from the SAME translator
+    hal0's own ``/v1/images/generations`` route uses, so the baked default
+    never drifts from what the slot actually runs.
+    """
+    return {
+        "ENABLE_IMAGE_GENERATION": "True",
+        "IMAGE_GENERATION_ENGINE": "comfyui",
+        "COMFYUI_BASE_URL": "http://host.docker.internal:8188",
+        "IMAGE_SIZE": "1024x1024",
+        "IMAGE_GENERATION_MODEL": model_id,
+        "COMFYUI_WORKFLOW": workflow_json,
+        "COMFYUI_WORKFLOW_NODES": workflow_nodes_json,
+    }
+
+
+def _web_search_env_block(provider: dict[str, str]) -> dict[str, str]:
+    """Web search routed through an installed provider.
+
+    ``provider`` carries ``{"engine": ..., "query_url": ...}`` — resolved by
+    the caller's registry lookup, never a literal here (no search provider
+    ships with hal0 today; this block only ever fires once an extension
+    registers one — see :mod:`hal0.openwebui.wiring`'s seam).
+    """
+    return {
+        "ENABLE_WEB_SEARCH": "True",
+        "ENABLE_SEARCH_QUERY_GENERATION": "True",
+        "WEB_SEARCH_ENGINE": provider["engine"],
+        "SEARXNG_QUERY_URL": provider["query_url"],
+        "WEB_SEARCH_RESULT_COUNT": "5",
+    }
+
+
+def dynamic_env_overrides(
+    *,
+    embed_model_id: str | None,
+    image_model_id: str | None,
+    image_workflow_json: str | None,
+    image_workflow_nodes_json: str | None,
+    search_provider: dict[str, str] | None,
+) -> dict[str, str | None]:
+    """Render the RAG / image-gen / web-search blocks as a
+    :func:`write_openwebui_env` ``overrides`` dict.
+
+    Pure function of already-resolved values — no I/O, no slot/registry
+    reads (that's :func:`hal0.openwebui.wiring.resolve_dynamic_env_overrides`).
+    Every key in :data:`_DYNAMIC_ENV_KEYS` is present in the result: ``None``
+    for any block whose gate is false, so a converge re-render always
+    deletes a capability's keys the moment it stops being true, rather than
+    leaving them to survive as a stale claim under ``preserve_existing``.
+
+    ``image_model_id`` requires both workflow strings — a caller that
+    resolved a model id but failed to build its workflow (see the
+    ``WorkflowTemplateError`` catch in :mod:`hal0.openwebui.wiring`) must
+    pass ``None`` for all three rather than a half-built block.
+    """
+    merged: dict[str, str | None] = dict.fromkeys(_DYNAMIC_ENV_KEYS, None)
+    if embed_model_id:
+        merged.update(_rag_env_block(embed_model_id))
+    if image_model_id and image_workflow_json and image_workflow_nodes_json:
+        merged.update(
+            _image_gen_env_block(image_model_id, image_workflow_json, image_workflow_nodes_json)
+        )
+    if search_provider:
+        merged.update(_web_search_env_block(search_provider))
+    return merged
+
+
 def _read_existing_env(target: Path) -> dict[str, str]:
     """Parse an existing env file into ``{key: value}``; ``{}`` if absent.
 
@@ -247,7 +393,7 @@ def _read_existing_env(target: Path) -> dict[str, str]:
 
 def write_openwebui_env(
     path: Path | str | None = None,
-    overrides: dict[str, str] | None = None,
+    overrides: dict[str, str | None] | None = None,
     preserve_existing: bool = False,
 ) -> Path:
     """Write the OpenWebUI environment file atomically.

--- a/src/hal0/openwebui/wiring.py
+++ b/src/hal0/openwebui/wiring.py
@@ -1,0 +1,174 @@
+"""Live-truth resolver for OpenWebUI's dynamic env blocks and wired chips.
+
+Reads the actually-bound capability state — an embed-capable slot, a
+ComfyUI (img) slot, a search provider — and turns it into the overrides
+:func:`hal0.openwebui.env_writer.write_openwebui_env` merges on top of its
+defaults. :func:`openwebui_wiring_status` is the SAME classifier the
+Services route exposes for the dashboard's wired chips (one classifier on
+the server — the UI never re-derives "is documents/images wired").
+
+Deliberately a separate module from :mod:`hal0.openwebui.env_writer`: this
+one imports ``hal0.capabilities``, ``hal0.registry`` and
+``hal0.providers.comfyui_workflows`` freely, which is fine because its only
+callers already run inside the full app
+(:func:`hal0.components.openwebui_arm.converge_openwebui`, the services
+route) — never the installer's cold ``python -m hal0.openwebui.env_writer``
+(see that module's docstring for why it avoids this import weight).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from hal0.capabilities.config import CapabilityConfig, load_capabilities_config
+from hal0.openwebui.env_writer import dynamic_env_overrides
+from hal0.registry.curated import get_curated
+
+#: filename_prefix / placeholder prompt baked into the static workflow OWUI
+#: ships with — real requests always overwrite both (see
+#: hal0.providers.comfyui_workflows.build_workflow's node-pointer patching,
+#: which is exactly what COMFYUI_WORKFLOW_NODES tells OWUI to do at request
+#: time).
+_OWUI_REQUEST_TAG = "openwebui"
+_OWUI_PLACEHOLDER_PROMPT = "a placeholder prompt"
+
+#: OWUI's own COMFYUI_WORKFLOW_NODES vocabulary (type, substitution key) →
+#: the translator template's _meta.params pointer key that names the same
+#: node. Generic across every shipped template (sdxl_turbo_simple,
+#: sd15_simple, …) because it walks the template's own pointer map rather
+#: than hardcoding node ids — a new template needs no changes here.
+_OWUI_NODE_TYPES: tuple[tuple[str, str, str], ...] = (
+    ("prompt", "positive_prompt", "text"),
+    ("model", "ckpt_name", "ckpt_name"),
+    ("width", "width", "width"),
+    ("height", "height", "height"),
+    ("steps", "steps", "steps"),
+    ("seed", "seed", "seed"),
+    ("n", "batch_size", "batch_size"),
+)
+
+
+def _selection(cfg: CapabilityConfig, slot: str, child: str) -> Any:
+    return cfg.selections.get(slot, {}).get(child)
+
+
+def openwebui_wiring_status() -> dict[str, Any]:
+    """Live truth behind both the dashboard's wired chips and the dynamic
+    env blocks.
+
+    Chat and voice are unconditionally wired (env_writer's static defaults
+    point them at hal0's own ``/v1`` regardless of capability state — see
+    ``_DEFAULT_OPENWEBUI_ENV``). Documents/images/web-search are gated on a
+    real bound backend: an *enabled* capability selection with a non-empty
+    model, never merely a slot file existing on disk.
+    """
+    cfg = load_capabilities_config()
+    embed_sel = _selection(cfg, "embed", "embed")
+    img_sel = _selection(cfg, "img", "img")
+    embed_model = embed_sel.model.strip() if embed_sel is not None and embed_sel.enabled else ""
+    image_model = img_sel.model.strip() if img_sel is not None and img_sel.enabled else ""
+    return {
+        "chat": True,
+        "voice": True,
+        "documents": bool(embed_model),
+        "images": bool(image_model),
+        "web_search": False,
+        "embed_model": embed_model or None,
+        "image_model": image_model or None,
+    }
+
+
+def _owui_baked_workflow(model_id: str) -> tuple[str, str] | None:
+    """Build the static ``COMFYUI_WORKFLOW`` / ``COMFYUI_WORKFLOW_NODES``
+    pair OWUI needs, from the SAME translator hal0's own
+    ``/v1/images/generations`` route uses (:mod:`hal0.providers.comfyui_workflows`)
+    — so the baked default never drifts from what the img slot actually
+    runs. Never bakes ODS's SDXL-Lightning graph; hal0 doesn't ship that
+    checkpoint by default, and this always reflects the operator's real
+    bound model instead.
+
+    Returns ``None`` when the workflow can't be built (unknown model with
+    no resolvable template/checkpoint) — the caller must then treat images
+    as not wired rather than claim a broken default.
+    """
+    from hal0.providers.comfyui_workflows import (
+        WorkflowTemplateError,
+        build_workflow,
+        template_params_for_model_class,
+    )
+
+    curated = get_curated(model_id)
+    ckpt_filename = curated.hf_file if curated is not None else model_id
+    model_class = curated.model_class if curated is not None else None
+    try:
+        graph, _debug_meta = build_workflow(
+            body={"prompt": _OWUI_PLACEHOLDER_PROMPT},
+            model_class=model_class,
+            ckpt_filename=ckpt_filename,
+            request_tag=_OWUI_REQUEST_TAG,
+        )
+    except WorkflowTemplateError:
+        return None
+
+    params = template_params_for_model_class(model_class)
+    nodes: list[dict[str, Any]] = []
+    for owui_type, param_key, field in _OWUI_NODE_TYPES:
+        pointer = params.get(param_key)
+        if not isinstance(pointer, str) or not pointer.startswith("node:"):
+            continue
+        node_id = pointer[len("node:") :].split(".", 1)[0]
+        nodes.append({"type": owui_type, "key": field, "node_ids": [node_id]})
+
+    return (
+        json.dumps(graph, separators=(",", ":")),
+        json.dumps(nodes, separators=(",", ":")),
+    )
+
+
+def resolve_dynamic_env_overrides() -> dict[str, str | None]:
+    """Live capability state → the overrides dict
+    :func:`~hal0.openwebui.env_writer.write_openwebui_env` merges in.
+    """
+    status = openwebui_wiring_status()
+    image_workflow_json: str | None = None
+    image_nodes_json: str | None = None
+    image_model = status["image_model"]
+    if status["images"] and image_model:
+        built = _owui_baked_workflow(image_model)
+        if built is None:
+            # Curated lookup / template resolution failed — never claim a
+            # capability we can't actually back with a working workflow.
+            image_model = None
+        else:
+            image_workflow_json, image_nodes_json = built
+
+    return dynamic_env_overrides(
+        embed_model_id=status["embed_model"],
+        image_model_id=image_model,
+        image_workflow_json=image_workflow_json,
+        image_workflow_nodes_json=image_nodes_json,
+        search_provider=_search_provider_lookup(),
+    )
+
+
+def _search_provider_lookup() -> dict[str, str] | None:
+    """Seam for a future search-provider extension (e.g. SearXNG).
+
+    No search service ships with hal0 today. An extension would register
+    itself here — a registry lookup this function grows into, e.g. reading
+    an installed-extensions manifest — rather than a hardcoded URL landing
+    in this function. Returns ``None`` until one exists, so
+    ``ENABLE_WEB_SEARCH`` is never rendered against a service that isn't
+    actually there (ODS's own Apple footgun — a VRAM fallback that
+    "assumes zero current usage" and can over-report what fits,
+    ``ods/extensions/services/dashboard-api/routers/features.py:27-32`` in
+    the ODS reference tree).
+    """
+    return None
+
+
+__all__ = [
+    "openwebui_wiring_status",
+    "resolve_dynamic_env_overrides",
+]

--- a/src/hal0/providers/comfyui_workflows.py
+++ b/src/hal0/providers/comfyui_workflows.py
@@ -124,6 +124,21 @@ def _load_template(stem: str) -> dict[str, Any]:
     return data
 
 
+def template_params_for_model_class(model_class: str | None) -> dict[str, Any]:
+    """Return the resolved template's ``_meta.params`` pointer map.
+
+    Lets a caller outside this translator (OpenWebUI's static
+    ``COMFYUI_WORKFLOW_NODES`` export — see
+    :mod:`hal0.openwebui.wiring`) discover which graph node backs each
+    parameter without reaching into :func:`build_workflow`'s private
+    template loader. Empty dict when the template has no ``params`` table.
+    """
+    stem = template_for_model_class(model_class)
+    template = _load_template(stem)
+    params = (template.get("_meta") or {}).get("params")
+    return params if isinstance(params, dict) else {}
+
+
 def template_for_model_class(model_class: str | None) -> str:
     """Resolve a model_class string to a template stem.
 
@@ -312,4 +327,5 @@ __all__ = [
     "WorkflowTemplateNotFound",
     "build_workflow",
     "template_for_model_class",
+    "template_params_for_model_class",
 ]

--- a/tests/api/test_capabilities_owui_reconcile.py
+++ b/tests/api/test_capabilities_owui_reconcile.py
@@ -1,0 +1,64 @@
+"""POST /api/capabilities/{slot}/{child} triggers OpenWebUI's env reconcile
+for the two slots that feed its dynamic env blocks — embed and img —
+and only those two; a voice apply has nothing new for OpenWebUI to render
+(STT/TTS are prewired unconditionally, see hal0.openwebui.env_writer).
+
+Standalone router-only app (mirrors tests/api/test_services_page.py's
+``svc_client`` pattern) — the capabilities router's own dependency is
+overridden with a stub orchestrator so this stays independent of real slot
+lifecycle plumbing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api.deps import get_capability_orchestrator
+from hal0.api.middleware import error_codes
+from hal0.api.routes.capabilities import router as capabilities_router
+
+_RECONCILE = "hal0.components.openwebui_arm.reconcile_openwebui_env"
+
+
+class _FakeOrchestrator:
+    async def apply(self, slot: str, child: str, body: dict) -> dict:
+        return {"device": "", "provider": "", "model": body.get("model", ""), "enabled": True}
+
+
+@pytest.fixture
+def cap_client() -> TestClient:
+    app = FastAPI()
+    error_codes.install(app)
+    app.include_router(capabilities_router, prefix="/api/capabilities")
+    app.dependency_overrides[get_capability_orchestrator] = lambda: _FakeOrchestrator()
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize("slot,child", [("embed", "embed"), ("embed", "rerank"), ("img", "img")])
+def test_apply_triggers_owui_reconcile_for_wired_slots(
+    cap_client: TestClient, slot: str, child: str
+) -> None:
+    with patch(_RECONCILE) as reconcile:
+        r = cap_client.post(f"/api/capabilities/{slot}/{child}", json={"model": "some-model"})
+    assert r.status_code == 200, r.text
+    reconcile.assert_called_once_with()
+
+
+def test_apply_does_not_trigger_owui_reconcile_for_voice(cap_client: TestClient) -> None:
+    with patch(_RECONCILE) as reconcile:
+        r = cap_client.post("/api/capabilities/voice/stt", json={"model": "some-model"})
+    assert r.status_code == 200, r.text
+    reconcile.assert_not_called()
+
+
+def test_apply_reconcile_failure_never_surfaces_on_the_response(cap_client: TestClient) -> None:
+    """A broken resolver is the arm's own problem (logged), never a 5xx on
+    the capability-apply response it's piggybacking on."""
+    with patch(_RECONCILE, side_effect=RuntimeError("boom")):
+        r = cap_client.post("/api/capabilities/embed/embed", json={"model": "some-model"})
+    assert r.status_code == 200, r.text
+    assert r.json()["ok"] is True

--- a/tests/api/test_services_page.py
+++ b/tests/api/test_services_page.py
@@ -134,6 +134,59 @@ def test_list_services_200_all_ids(svc_client: TestClient) -> None:
     assert by_id["openwebui"]["url"] == "http://testserver:3001"
     # loopback-only services expose no URL without a public-URL env.
     assert by_id["hindsight"]["url"] is None
+    # Every entry carries "wired" — non-openwebui rows are honestly null
+    # rather than a re-derived guess (one classifier on the server).
+    assert "wired" in by_id["openwebui"]
+    assert by_id["comfyui"]["wired"] is None
+    assert by_id["hermes"]["wired"] is None
+
+
+# ── 1b. OpenWebUI wired chips ───────────────────────────────────────────────
+
+
+def test_openwebui_wired_reflects_the_shared_classifier(svc_client: TestClient) -> None:
+    """The services route's "wired" block IS
+    hal0.openwebui.wiring.openwebui_wiring_status()'s output — never a
+    client-side re-derivation. Patching the resolver changes the route's
+    answer directly."""
+    status = {
+        "chat": True,
+        "voice": True,
+        "documents": True,
+        "images": False,
+        "web_search": False,
+        "embed_model": "nomic-embed-text-v1.5",
+        "image_model": None,
+    }
+    with contextlib.ExitStack() as stack:
+        for p in _stub_all_down():
+            stack.enter_context(p)
+        stack.enter_context(
+            patch("hal0.openwebui.wiring.openwebui_wiring_status", return_value=status)
+        )
+        r = svc_client.get("/api/services")
+
+    assert r.status_code == 200, r.text
+    by_id = _services_by_id(r.json())
+    assert by_id["openwebui"]["wired"] == status
+
+
+def test_openwebui_wired_degrades_to_none_on_resolver_failure(svc_client: TestClient) -> None:
+    """A broken wiring resolver must not 500 the whole Services page."""
+    with contextlib.ExitStack() as stack:
+        for p in _stub_all_down():
+            stack.enter_context(p)
+        stack.enter_context(
+            patch(
+                "hal0.openwebui.wiring.openwebui_wiring_status",
+                side_effect=RuntimeError("boom"),
+            )
+        )
+        r = svc_client.get("/api/services")
+
+    assert r.status_code == 200, r.text
+    by_id = _services_by_id(r.json())
+    assert by_id["openwebui"]["wired"] is None
 
 
 # ── 2. registry invariants ────────────────────────────────────────────────────

--- a/tests/api/test_slots_owui_reconcile.py
+++ b/tests/api/test_slots_owui_reconcile.py
@@ -1,0 +1,80 @@
+"""POST /api/slots and DELETE /api/slots/{name} trigger OpenWebUI's env
+reconcile for the two fixed system slot names that feed its dynamic
+env blocks — "embed" and "img" — and only those two.
+
+Reuses the isolated_client/slot_root/container_stub fixtures from
+test_slots_routes.py (same app wiring, same container-provider stub).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.api.test_slots_routes import (  # noqa: F401
+    container_stub,
+    isolated_app,
+    isolated_client,
+    slot_root,
+)
+
+_RECONCILE = "hal0.components.openwebui_arm.reconcile_openwebui_env"
+
+_BASE_BODY = {
+    "model": "qwen3-4b-q4_k_m",
+    "device": "gpu-vulkan",
+    "profile": "vulkan-radv",
+}
+
+
+@pytest.mark.parametrize("name", ["embed", "img"])
+def test_create_wired_slot_triggers_owui_reconcile(
+    name: str,
+    slot_root,  # noqa: F811
+    container_stub: dict[str, Any],  # noqa: F811
+    isolated_client: TestClient,  # noqa: F811
+) -> None:
+    with patch(_RECONCILE) as reconcile:
+        r = isolated_client.post("/api/slots", json={"name": name, **_BASE_BODY})
+    assert r.status_code == 201, r.text
+    reconcile.assert_called_once_with()
+
+
+def test_create_unrelated_slot_does_not_trigger_owui_reconcile(
+    slot_root,  # noqa: F811
+    container_stub: dict[str, Any],  # noqa: F811
+    isolated_client: TestClient,  # noqa: F811
+) -> None:
+    with patch(_RECONCILE) as reconcile:
+        r = isolated_client.post("/api/slots", json={"name": "fresh", **_BASE_BODY})
+    assert r.status_code == 201, r.text
+    reconcile.assert_not_called()
+
+
+def test_delete_wired_slot_triggers_owui_reconcile(
+    slot_root,  # noqa: F811
+    container_stub: dict[str, Any],  # noqa: F811
+    isolated_client: TestClient,  # noqa: F811
+) -> None:
+    r = isolated_client.post("/api/slots", json={"name": "img", **_BASE_BODY})
+    assert r.status_code == 201, r.text
+
+    with patch(_RECONCILE) as reconcile:
+        r = isolated_client.delete("/api/slots/img")
+    assert r.status_code == 200, r.text
+    reconcile.assert_called_once_with()
+
+
+def test_delete_unrelated_slot_does_not_trigger_owui_reconcile(
+    slot_root,  # noqa: F811
+    container_stub: dict[str, Any],  # noqa: F811
+    isolated_client: TestClient,  # noqa: F811
+) -> None:
+    # 'chat' comes pre-seeded by the slot_root fixture.
+    with patch(_RECONCILE) as reconcile:
+        r = isolated_client.delete("/api/slots/chat?force=true")
+    assert r.status_code == 200, r.text
+    reconcile.assert_not_called()

--- a/tests/components/test_openwebui_arm.py
+++ b/tests/components/test_openwebui_arm.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -78,6 +78,173 @@ def test_pull_failure_leaves_unit_untouched(tmp_path) -> None:
     )
     assert res["status"] == "build_failed"
     assert OLD in unit.read_text(encoding="utf-8")
+
+
+# ── env re-render / restart-only-on-change ─────────────────────────────────
+
+
+def _restart_calls(runner: MagicMock) -> list:
+    return [c for c in runner.call_args_list if "restart" in c.args[0]]
+
+
+def _installed_unit(tmp_path) -> Path:
+    """Write the unit at the path reconcile_openwebui_env actually resolves
+    (image_pin.installed_unit_path(), HAL0_HOME-aware) — unlike ``_unit()``
+    above, which converge_openwebui tests override via ``unit_path=``."""
+    from hal0.openwebui.image_pin import installed_unit_path
+
+    unit = installed_unit_path()
+    unit.parent.mkdir(parents=True, exist_ok=True)
+    unit.write_text(UNIT.replace(OLD, NEW), encoding="utf-8")
+    return unit
+
+
+def _write_capabilities(tmp_path, model: str) -> None:
+    etc = tmp_path / "etc" / "hal0"
+    etc.mkdir(parents=True, exist_ok=True)
+    (etc / "capabilities.toml").write_text(
+        f"""
+schema_version = 2
+[selections.embed.embed]
+device = "gpu-vulkan"
+provider = "llama-server"
+model = "{model}"
+enabled = true
+""",
+        encoding="utf-8",
+    )
+
+
+def test_converge_first_pass_renders_env_and_restarts(tmp_path) -> None:
+    """Image already pinned + capabilities newly written: the env's first
+    render always differs from "file absent" — it must restart once."""
+    unit = tmp_path / "u.service"
+    unit.write_text(UNIT.replace(OLD, NEW), encoding="utf-8")
+    _write_capabilities(tmp_path, "nomic-embed-text-v1.5")
+    runner = _ok_runner()
+
+    res = openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=runner, is_hal0_user=lambda: False
+    )
+
+    assert res["status"] == "converged"
+    assert res["env_changed"] is True
+    assert res["restarted"] is True
+    assert len(_restart_calls(runner)) == 1
+    env_path = tmp_path / "etc" / "hal0" / "openwebui.env"
+    assert "RAG_EMBEDDING_MODEL=nomic-embed-text-v1.5" in env_path.read_text(encoding="utf-8")
+
+
+def test_converge_second_pass_same_capabilities_does_not_restart(tmp_path) -> None:
+    """Same live truth on the next converge → the rendered bytes are
+    identical → no restart call at all."""
+    unit = tmp_path / "u.service"
+    unit.write_text(UNIT.replace(OLD, NEW), encoding="utf-8")
+    _write_capabilities(tmp_path, "nomic-embed-text-v1.5")
+    runner = _ok_runner()
+
+    first = openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=runner, is_hal0_user=lambda: False
+    )
+    assert first["env_changed"] is True
+    runner.reset_mock()
+
+    second = openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=runner, is_hal0_user=lambda: False
+    )
+    assert "env_changed" not in second
+    assert _restart_calls(runner) == []
+
+
+def test_converge_capability_change_between_passes_restarts_again(tmp_path) -> None:
+    """A capability change between two converge passes must restart on the
+    SECOND pass too — env-driven restarts are not a one-shot."""
+    unit = tmp_path / "u.service"
+    unit.write_text(UNIT.replace(OLD, NEW), encoding="utf-8")
+    _write_capabilities(tmp_path, "nomic-embed-text-v1.5")
+    runner = _ok_runner()
+    openwebui_arm.converge_openwebui(unit_path=unit, runner=runner, is_hal0_user=lambda: False)
+    runner.reset_mock()
+
+    _write_capabilities(tmp_path, "a-different-embed-model")
+    second = openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=runner, is_hal0_user=lambda: False
+    )
+    assert second["env_changed"] is True
+    assert len(_restart_calls(runner)) == 1
+
+
+def test_diagnose_only_pass_never_renders_env(tmp_path) -> None:
+    """apply=False (boot-time drift check) must not mutate openwebui.env —
+    that's the whole point of a diagnose-only pass."""
+    unit = tmp_path / "u.service"
+    unit.write_text(UNIT.replace(OLD, NEW), encoding="utf-8")
+    _write_capabilities(tmp_path, "nomic-embed-text-v1.5")
+    runner = _ok_runner()
+
+    res = openwebui_arm.converge_openwebui(
+        unit_path=unit, apply=False, runner=runner, is_hal0_user=lambda: False
+    )
+    assert res["status"] == "converged"
+    assert "env_changed" not in res
+    env_path = tmp_path / "etc" / "hal0" / "openwebui.env"
+    assert not env_path.exists()
+
+
+def test_pull_repin_pass_renders_env_before_its_single_restart(tmp_path) -> None:
+    """An image upgrade already restarts unconditionally — env must be
+    rendered before that restart (one restart covers both), not trigger a
+    second one."""
+    unit = _unit(tmp_path)
+    _write_capabilities(tmp_path, "nomic-embed-text-v1.5")
+    runner = _ok_runner()
+
+    res = openwebui_arm.converge_openwebui(
+        unit_path=unit, runner=runner, is_hal0_user=lambda: False
+    )
+
+    assert res["status"] == "upgraded"
+    assert res["env_changed"] is True
+    assert len(_restart_calls(runner)) == 1
+    env_path = tmp_path / "etc" / "hal0" / "openwebui.env"
+    assert "RAG_EMBEDDING_MODEL=nomic-embed-text-v1.5" in env_path.read_text(encoding="utf-8")
+
+
+def test_reconcile_openwebui_env_skips_when_unit_not_installed(tmp_path) -> None:
+    res = openwebui_arm.reconcile_openwebui_env(runner=_ok_runner(), is_hal0_user=lambda: False)
+    assert res["status"] == "skipped"
+    env_path = tmp_path / "etc" / "hal0" / "openwebui.env"
+    assert not env_path.exists()
+
+
+def test_reconcile_openwebui_env_restarts_only_when_bytes_change(tmp_path) -> None:
+    _installed_unit(tmp_path)
+    _write_capabilities(tmp_path, "nomic-embed-text-v1.5")
+    runner = _ok_runner()
+
+    first = openwebui_arm.reconcile_openwebui_env(runner=runner, is_hal0_user=lambda: False)
+    assert first["status"] == "converged"
+    assert first["env_changed"] is True
+    assert len(_restart_calls(runner)) == 1
+
+    runner.reset_mock()
+    second = openwebui_arm.reconcile_openwebui_env(runner=runner, is_hal0_user=lambda: False)
+    assert second["status"] == "unchanged"
+    assert second["env_changed"] is False
+    assert _restart_calls(runner) == []
+
+
+def test_reconcile_openwebui_env_resolver_failure_is_fail_soft(tmp_path) -> None:
+    _installed_unit(tmp_path)
+    runner = _ok_runner()
+    with patch(
+        "hal0.openwebui.wiring.resolve_dynamic_env_overrides",
+        side_effect=RuntimeError("boom"),
+    ):
+        res = openwebui_arm.reconcile_openwebui_env(runner=runner, is_hal0_user=lambda: False)
+    assert res["status"] == "build_failed"
+    assert "boom" in res["error"]
+    assert _restart_calls(runner) == []
 
 
 def test_target_digest_writes_override_marker(tmp_path) -> None:

--- a/tests/openwebui/test_dynamic_wiring.py
+++ b/tests/openwebui/test_dynamic_wiring.py
@@ -1,0 +1,284 @@
+"""Tests for the RAG / image-gen / web-search dynamic env blocks.
+
+Two layers:
+
+  * ``hal0.openwebui.env_writer.dynamic_env_overrides`` — pure rendering,
+    already-resolved inputs in, an overrides dict out.
+  * ``hal0.openwebui.wiring`` — the live-truth resolver: reads
+    ``capabilities.toml`` and the curated registry, builds the baked
+    ComfyUI workflow, and calls the renderer above.
+
+The matrix the brief asks for: no embed slot / embed slot / comfyui
+present / both.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hal0.openwebui.env_writer import _DYNAMIC_ENV_KEYS, dynamic_env_overrides
+
+
+def _write_capabilities_toml(home: str, body: str) -> None:
+    etc = Path(home) / "etc" / "hal0"
+    etc.mkdir(parents=True, exist_ok=True)
+    (etc / "capabilities.toml").write_text(body, encoding="utf-8")
+
+
+# ── dynamic_env_overrides (pure renderer) ───────────────────────────────────
+
+
+def test_no_gates_nulls_every_dynamic_key() -> None:
+    """Nothing bound → every dynamic key is explicitly nulled (not merely
+    omitted) so a converge re-render deletes stale keys, never leaves
+    them."""
+    overrides = dynamic_env_overrides(
+        embed_model_id=None,
+        image_model_id=None,
+        image_workflow_json=None,
+        image_workflow_nodes_json=None,
+        search_provider=None,
+    )
+    assert set(overrides) == set(_DYNAMIC_ENV_KEYS)
+    assert all(v is None for v in overrides.values())
+
+
+def test_embed_only_renders_rag_block_and_nulls_the_rest() -> None:
+    overrides = dynamic_env_overrides(
+        embed_model_id="nomic-embed-text-v1.5",
+        image_model_id=None,
+        image_workflow_json=None,
+        image_workflow_nodes_json=None,
+        search_provider=None,
+    )
+    assert overrides["RAG_EMBEDDING_ENGINE"] == "openai"
+    assert overrides["RAG_OPENAI_API_BASE_URL"] == "http://host.docker.internal:8080/v1"
+    assert overrides["RAG_EMBEDDING_MODEL"] == "nomic-embed-text-v1.5"
+    assert overrides["ENABLE_IMAGE_GENERATION"] is None
+    assert overrides["ENABLE_WEB_SEARCH"] is None
+
+
+def test_image_only_renders_comfyui_block_and_nulls_rag() -> None:
+    overrides = dynamic_env_overrides(
+        embed_model_id=None,
+        image_model_id="sdxl-turbo",
+        image_workflow_json='{"3": {}}',
+        image_workflow_nodes_json="[]",
+        search_provider=None,
+    )
+    assert overrides["ENABLE_IMAGE_GENERATION"] == "True"
+    assert overrides["IMAGE_GENERATION_ENGINE"] == "comfyui"
+    assert overrides["COMFYUI_BASE_URL"] == "http://host.docker.internal:8188"
+    assert overrides["IMAGE_GENERATION_MODEL"] == "sdxl-turbo"
+    assert overrides["COMFYUI_WORKFLOW"] == '{"3": {}}'
+    assert overrides["COMFYUI_WORKFLOW_NODES"] == "[]"
+    assert overrides["RAG_EMBEDDING_ENGINE"] is None
+
+
+def test_image_model_without_both_workflow_strings_is_not_rendered() -> None:
+    """A caller that resolved a model id but failed to build its workflow
+    must pass a half-built block through as unrendered, not a partial
+    ENABLE_IMAGE_GENERATION=True with no COMFYUI_WORKFLOW behind it."""
+    overrides = dynamic_env_overrides(
+        embed_model_id=None,
+        image_model_id="sdxl-turbo",
+        image_workflow_json=None,
+        image_workflow_nodes_json=None,
+        search_provider=None,
+    )
+    assert overrides["ENABLE_IMAGE_GENERATION"] is None
+    assert overrides["COMFYUI_WORKFLOW"] is None
+
+
+def test_both_embed_and_image_render_together() -> None:
+    overrides = dynamic_env_overrides(
+        embed_model_id="nomic-embed-text-v1.5",
+        image_model_id="sdxl-turbo",
+        image_workflow_json='{"3": {}}',
+        image_workflow_nodes_json="[]",
+        search_provider=None,
+    )
+    assert overrides["RAG_EMBEDDING_MODEL"] == "nomic-embed-text-v1.5"
+    assert overrides["IMAGE_GENERATION_MODEL"] == "sdxl-turbo"
+
+
+def test_search_provider_renders_web_search_block() -> None:
+    overrides = dynamic_env_overrides(
+        embed_model_id=None,
+        image_model_id=None,
+        image_workflow_json=None,
+        image_workflow_nodes_json=None,
+        search_provider={"engine": "searxng", "query_url": "http://searxng:8080/search?q=<query>"},
+    )
+    assert overrides["ENABLE_WEB_SEARCH"] == "True"
+    assert overrides["WEB_SEARCH_ENGINE"] == "searxng"
+    assert overrides["SEARXNG_QUERY_URL"] == "http://searxng:8080/search?q=<query>"
+
+
+# ── hal0.openwebui.wiring (live-truth resolver) ─────────────────────────────
+
+
+_NO_SELECTIONS = "schema_version = 2\n"
+
+_EMBED_ONLY = """
+schema_version = 2
+[selections.embed.embed]
+device = "gpu-vulkan"
+provider = "llama-server"
+model = "nomic-embed-text-v1.5"
+enabled = true
+"""
+
+_IMG_ONLY = """
+schema_version = 2
+[selections.img.img]
+device = "gpu-vulkan"
+provider = "comfyui"
+model = "sdxl-turbo"
+enabled = true
+"""
+
+_BOTH = """
+schema_version = 2
+[selections.embed.embed]
+device = "gpu-vulkan"
+provider = "llama-server"
+model = "nomic-embed-text-v1.5"
+enabled = true
+
+[selections.img.img]
+device = "gpu-vulkan"
+provider = "comfyui"
+model = "sdxl-turbo"
+enabled = true
+"""
+
+_DISABLED = """
+schema_version = 2
+[selections.embed.embed]
+device = "gpu-vulkan"
+provider = "llama-server"
+model = "nomic-embed-text-v1.5"
+enabled = false
+"""
+
+
+@pytest.mark.parametrize(
+    ("toml_body", "expect_documents", "expect_images"),
+    [
+        (_NO_SELECTIONS, False, False),
+        (_EMBED_ONLY, True, False),
+        (_IMG_ONLY, False, True),
+        (_BOTH, True, True),
+        (_DISABLED, False, False),
+    ],
+    ids=["none", "embed-only", "img-only", "both", "selection-present-but-disabled"],
+)
+def test_wiring_status_matrix(
+    tmp_hal0_home: str, toml_body: str, expect_documents: bool, expect_images: bool
+) -> None:
+    from hal0.openwebui.wiring import openwebui_wiring_status
+
+    _write_capabilities_toml(tmp_hal0_home, toml_body)
+    status = openwebui_wiring_status()
+    # Chat/voice are unconditional (env_writer's static defaults).
+    assert status["chat"] is True
+    assert status["voice"] is True
+    assert status["documents"] is expect_documents
+    assert status["images"] is expect_images
+    assert status["web_search"] is False  # no provider seam wired up yet
+
+
+def test_wiring_no_embed_slot_produces_no_rag_overrides(tmp_hal0_home: str) -> None:
+    from hal0.openwebui.wiring import resolve_dynamic_env_overrides
+
+    _write_capabilities_toml(tmp_hal0_home, _NO_SELECTIONS)
+    overrides = resolve_dynamic_env_overrides()
+    assert overrides["RAG_EMBEDDING_MODEL"] is None
+    assert overrides["ENABLE_IMAGE_GENERATION"] is None
+
+
+def test_wiring_embed_slot_renders_rag_overrides(tmp_hal0_home: str) -> None:
+    from hal0.openwebui.wiring import resolve_dynamic_env_overrides
+
+    _write_capabilities_toml(tmp_hal0_home, _EMBED_ONLY)
+    overrides = resolve_dynamic_env_overrides()
+    assert overrides["RAG_EMBEDDING_MODEL"] == "nomic-embed-text-v1.5"
+    assert overrides["ENABLE_IMAGE_GENERATION"] is None
+
+
+def test_wiring_comfyui_slot_bakes_the_real_translator_workflow(tmp_hal0_home: str) -> None:
+    """The baked COMFYUI_WORKFLOW must match hal0's own translator output for
+    the SAME curated model — never a pasted-in literal (e.g. ODS's SDXL
+    Lightning graph), and never a checkpoint hal0 doesn't actually ship."""
+    from hal0.openwebui.wiring import resolve_dynamic_env_overrides
+    from hal0.providers.comfyui_workflows import build_workflow
+    from hal0.registry.curated import get_curated
+
+    _write_capabilities_toml(tmp_hal0_home, _IMG_ONLY)
+    overrides = resolve_dynamic_env_overrides()
+
+    curated = get_curated("sdxl-turbo")
+    assert curated is not None
+    # A fixed seed so this build is byte-comparable to wiring's own call —
+    # build_workflow() draws a random seed per call otherwise.
+    expected_graph, _meta = build_workflow(
+        body={"prompt": "a placeholder prompt", "extra_body": {"seed": 0}},
+        model_class=curated.model_class,
+        ckpt_filename=curated.hf_file,
+        request_tag="openwebui",
+    )
+    got_graph = json.loads(overrides["COMFYUI_WORKFLOW"])
+    got_graph["3"]["inputs"]["seed"] = 0
+    assert got_graph == expected_graph
+    # The checkpoint filename baked into the graph is the one hal0 actually
+    # ships for this curated id — sdxl-turbo, not ODS's Lightning checkpoint.
+    assert got_graph["4"]["inputs"]["ckpt_name"] == curated.hf_file
+    assert curated.hf_file != "sdxl_lightning_4step.safetensors"
+
+    nodes = json.loads(overrides["COMFYUI_WORKFLOW_NODES"])
+    node_types = {n["type"] for n in nodes}
+    assert {"prompt", "model", "width", "height", "steps", "seed", "n"} <= node_types
+    prompt_node = next(n for n in nodes if n["type"] == "prompt")
+    assert prompt_node["node_ids"] == ["6"]
+    model_node = next(n for n in nodes if n["type"] == "model")
+    assert model_node["node_ids"] == ["4"]
+
+
+def test_wiring_both_slots_renders_both_blocks(tmp_hal0_home: str) -> None:
+    from hal0.openwebui.wiring import resolve_dynamic_env_overrides
+
+    _write_capabilities_toml(tmp_hal0_home, _BOTH)
+    overrides = resolve_dynamic_env_overrides()
+    assert overrides["RAG_EMBEDDING_MODEL"] == "nomic-embed-text-v1.5"
+    assert overrides["IMAGE_GENERATION_MODEL"] == "sdxl-turbo"
+    assert overrides["ENABLE_IMAGE_GENERATION"] == "True"
+
+
+def test_wiring_non_curated_image_model_falls_back_to_raw_id_as_checkpoint(
+    tmp_hal0_home: str,
+) -> None:
+    """An operator-pulled model with no curated registry entry still gets a
+    workflow — the raw model id is used as the checkpoint filename and the
+    template falls back to the generic sdxl_turbo_simple graph (same
+    fallback build_workflow already gives an unknown model_class)."""
+    from hal0.openwebui.wiring import resolve_dynamic_env_overrides
+
+    _write_capabilities_toml(
+        tmp_hal0_home,
+        """
+schema_version = 2
+[selections.img.img]
+device = "gpu-vulkan"
+provider = "comfyui"
+model = "my-custom-checkpoint.safetensors"
+enabled = true
+""",
+    )
+    overrides = resolve_dynamic_env_overrides()
+    assert overrides["ENABLE_IMAGE_GENERATION"] == "True"
+    graph = json.loads(overrides["COMFYUI_WORKFLOW"])
+    assert graph["4"]["inputs"]["ckpt_name"] == "my-custom-checkpoint.safetensors"

--- a/ui/src/dash/services.css
+++ b/ui/src/dash/services.css
@@ -83,6 +83,35 @@
 
 .svcp-unmanaged { color: var(--fg-4); font-style: italic; }
 
+/* Wired chips — mirrors .svc-pill's mono/uppercase/pill vocabulary,
+   one chip per OpenWebUI feature this card renders live from svc.wired. */
+.svcp-wired {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.svcp-wired-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--jbm);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px 6px;
+  border-radius: var(--rad-pill, 999px);
+  border: 1px solid var(--line);
+  color: var(--fg-4);
+  background: transparent;
+}
+
+.svcp-wired-chip.on {
+  color: var(--ok, #6fcf97);
+  border-color: rgba(111, 207, 151, 0.3);
+  background: rgba(111, 207, 151, 0.06);
+}
+
 .svcp-hints {
   font-size: 11px;
   color: var(--fg-4);

--- a/ui/src/dash/services.jsx
+++ b/ui/src/dash/services.jsx
@@ -65,6 +65,58 @@ function uptimeFrom(since) {
   return `up ${Math.round(s / 86400)}d`
 }
 
+// ── OpenWebUI wired chips (RAG/image-gen/web-search full wiring) ─────────────
+// Data comes straight off svc.wired (GET /api/services), which is the SAME
+// classifier hal0.openwebui.wiring renders openwebui.env from — one
+// classifier on the server, never re-derived here. Hint copy is
+// consequence-first per the dashboard's drawer language.
+const _WIRED_CHIPS = [
+  { key: 'chat', label: 'Chat' },
+  { key: 'voice', label: 'Voice' },
+  { key: 'documents', label: 'Documents' },
+  { key: 'images', label: 'Images' },
+  { key: 'web_search', label: 'Web search' },
+]
+
+function _wiredHint(key, on, wired) {
+  switch (key) {
+    case 'chat':
+      return 'Chat in Open WebUI routes through hal0\'s own /v1 — the default llama.cpp-compatible endpoint.'
+    case 'voice':
+      return 'Call mode\'s mic capture and playback route through hal0\'s STT and TTS endpoints.'
+    case 'documents':
+      return on
+        ? `Uploads in Open WebUI are embedded by slot "${wired.embed_model}".`
+        : 'No embed-capable slot is bound — document uploads will fail until one is (Capabilities → embed).'
+    case 'images':
+      return on
+        ? `The image button generates through slot "${wired.image_model}" via ComfyUI.`
+        : 'No ComfyUI slot is bound — the image button has nothing to generate against (Capabilities → img).'
+    case 'web_search':
+      return 'No search provider is installed — the web-search toggle in Open WebUI has nothing to query.'
+    default:
+      return ''
+  }
+}
+
+function WiredChips({ wired }) {
+  if (!wired) return null
+  return (
+    <div className="svcp-wired" data-testid="svcp-wired-openwebui">
+      {_WIRED_CHIPS.map(({ key, label }) => {
+        const on = !!wired[key]
+        return (
+          <span key={key} className={'svcp-wired-chip' + (on ? ' on' : ' off')} data-testid={`svcp-wired-${key}`}>
+            <span className={'sdot ' + (on ? 'serving' : 'offline')} style={{ width: 6, height: 6 }} />
+            {label}
+            <FieldInfoIcon description={_wiredHint(key, on, wired)} />
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
 function StatePill({ svc }) {
   const cls = svc.up ? 'serving' : (svc.unit_state?.active_state === 'failed' ? 'error' : 'offline')
   const label = svc.up ? 'up' : (svc.unit_state?.active_state === 'failed' ? 'failed' : (svc.managed ? 'down' : '—'))
@@ -234,6 +286,7 @@ function ServiceCard({ svc, onAction, busyId, actionMsg, comfyReachable, compone
 
       <div className="svcp-desc">{svc.description}</div>
       <div className="svcp-detail">{svc.detail}{svc.stat ? ` · ${svc.stat.value} ${svc.stat.label}` : ''}</div>
+      {svc.wired && <WiredChips wired={svc.wired} />}
       {component && <ComponentVersionLine component={component} />}
 
       <div className="svcp-meta mono">

--- a/ui/tests/e2e/specs/services-v3.spec.ts
+++ b/ui/tests/e2e/specs/services-v3.spec.ts
@@ -34,6 +34,15 @@ const SERVICES_PAYLOAD = {
       actions: ['start', 'stop', 'restart', 'enable', 'disable'],
       mdns_capable: true,
       hints: [],
+      wired: {
+        chat: true,
+        voice: true,
+        documents: true,
+        images: false,
+        web_search: false,
+        embed_model: 'nomic-embed-text-v1.5',
+        image_model: null,
+      },
     },
     {
       id: 'comfyui',
@@ -125,6 +134,24 @@ test.describe('Services v3 (/services)', () => {
     // Up service shows an "up" pill; unmanaged shows the external note.
     await expect(page.getByTestId('svcp-card-openwebui')).toContainText('up')
     await expect(page.getByTestId('svcp-card-n8n')).toContainText('external — not managed by hal0')
+  })
+
+  test('OpenWebUI card renders wired chips from the services payload', async ({ page }) => {
+    await page.route('**/api/services', (route) => json(route, SERVICES_PAYLOAD))
+    await page.goto('/#services')
+
+    const chips = page.getByTestId('svcp-wired-openwebui')
+    await expect(chips).toBeVisible()
+    // On chips (chat/voice/documents) show the "serving" dot tone.
+    for (const key of ['chat', 'voice', 'documents']) {
+      await expect(page.getByTestId(`svcp-wired-${key}`)).toHaveClass(/\bon\b/)
+    }
+    // Off chips (images/web_search — no ComfyUI slot, no search provider bound).
+    for (const key of ['images', 'web_search']) {
+      await expect(page.getByTestId(`svcp-wired-${key}`)).not.toHaveClass(/\bon\b/)
+    }
+    // Comfyui's card has no `wired` payload — no chips render for it.
+    await expect(page.getByTestId('svcp-card-comfyui').getByTestId(/svcp-wired-/)).toHaveCount(0)
   })
 
   test('action buttons follow the backend allow-list', async ({ page }) => {


### PR DESCRIPTION
Open WebUI is now fully pre-wired, not just chat + voice. Document uploads
route through RAG the moment an embed-capable slot is bound
(RAG_EMBEDDING_ENGINE / RAG_OPENAI_API_BASE_URL / RAG_EMBEDDING_MODEL point
at hal0's own /v1), and the image button generates through ComfyUI the
moment the img slot is bound (ENABLE_IMAGE_GENERATION, COMFYUI_BASE_URL and
a COMFYUI_WORKFLOW / COMFYUI_WORKFLOW_NODES pair baked from the SAME
translator /v1/images/generations uses, keyed to whichever checkpoint the
slot is actually bound to).

Both blocks are gated on live capability state and explicitly cleared the
moment that state stops being true — never a stale claim of a capability
that isn't really there. A seam is left for a future search-provider
extension (ENABLE_WEB_SEARCH stays off; no search service ships today).

The env file re-renders — and the companion restarts only when the render
actually changed — on capability apply, embed/img slot create or delete, and
every regular component-convergence pass. The Services page's Open WebUI
card shows a wired chip per feature (Chat, Voice, Documents, Images, Web
search), exposed via GET /api/services.

Signed-off-by: thinmintdev <alexander@awideweb.com>


## Verification

`ruff check src tests` clean. Full α unit suite (12808 tests) green apart from
three failures that also fail on a clean `main` checkout
(`tests/providers/test_moonshine_server.py` ×2, needs `ffmpeg`, and
`tests/slots/test_pressure_eviction.py::test_pressure_evict_noop_when_probe_fails`).
Integration β not run locally (needs root + a live `hal0-lemonade.service`); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzkumtSWnm3AxixzHG38UG
