### PR TITLE
feat(oauth): agent-driven OAuth passthrough for Hermes skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,24 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+
+- **Agent-driven OAuth passthrough** for Hermes skills that need OAuth
+  (Google Calendar, Spotify, GitHub). A skill is connected by sending the
+  operator a consent link — the provider's redirect lands directly on
+  `GET /api/oauth/{provider}/callback` and hal0 exchanges the code for a
+  token itself (PKCE where the provider supports it), so the operator
+  never copy-pastes an authorization code and the agent never handles a
+  raw code or client secret. New `hal0 oauth {list,connect,disconnect,
+  status,set-client-secret}` CLI, a dashboard Connections page
+  ("Connected accounts"), and a Hermes persona addendum that walks the
+  agent through the connect → poll → confirm flow. The provider registry
+  (`/etc/hal0/oauth-providers.toml`) is seeded from a shipped default
+  covering the common skill providers; tokens are stored through the
+  secrets store, never in TOML, never logged. Ported from ODS's OAuth
+  passthrough (Osmantic/ODS, Apache-2.0; permission to copy granted by its
+  author).
+
 ### Fixed
 
 - MCP admin tools no longer report a tool failure for a successful read of a

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -408,6 +408,20 @@ dashboard/API-only (`/api/profiles`).
 | `auth rotate [tier]` | optional `tier` (default `admin`) | `--force`/`-f` |
 | `auth require <toggle>` | `toggle` (required) | — |
 
+## `hal0 oauth` — connect OAuth providers for Hermes skills
+
+Consent is a link, not a pasted code: the provider redirects straight back to
+`GET /api/oauth/{provider}/callback` and hal0 exchanges the code itself. Poll
+`oauth status <provider>` until `connected` flips true.
+
+| Command | Args | Flags |
+|---|---|---|
+| `oauth list` | — | `--json` |
+| `oauth connect <provider>` | `provider` | — |
+| `oauth disconnect <provider>` | `provider` | `--force`/`-f` |
+| `oauth status <provider>` | `provider` | `--json` |
+| `oauth set-client-secret <provider>` | `provider` | `--value` (required; prompted securely if omitted) |
+
 ## `hal0 board` — operator task board
 
 | Command | Args | Flags |

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -3287,6 +3287,17 @@ def _phase_context_link(ctx: _StepCtx) -> PhaseResult:
             "backend_url": primary_raw["base_url"],
         }
 
+    try:
+        from hal0.oauth.providers import load_providers as _load_oauth_providers
+
+        oauth_providers = [
+            {"id": p.id, "name": p.name, "skill_id": p.skill_id} for p in _load_oauth_providers()
+        ]
+    except Exception:
+        # Best-effort like the slot/context fetches above — a malformed or
+        # unwritable registry should never block persona rendering.
+        oauth_providers = []
+
     vars_ = {
         "env": env_report,
         "hal0_version": _hal0_version_string(),
@@ -3298,6 +3309,7 @@ def _phase_context_link(ctx: _StepCtx) -> PhaseResult:
             "HAL0_DASHBOARD_URL",
             os.environ.get("HAL0_API_URL", "http://hal0.local:8080").rstrip("/"),
         ),
+        "oauth_providers": oauth_providers,
     }
 
     rendered: dict[str, str] = {}
@@ -6224,7 +6236,7 @@ def _write_seed_toml(state: BootstrapState, *, repair: bool) -> tuple[Path, bool
     return path, True
 
 
-def _write_driver_env(state: BootstrapState) -> tuple[Path, bool]:
+def _write_driver_env(state: BootstrapState | None = None) -> tuple[Path, bool]:
     """Write the driver env file at :data:`DRIVER_ENV_PATH`.
 
     Mirrors ``HermesDriver._write_env_file``: the systemd unit's
@@ -6238,6 +6250,19 @@ def _write_driver_env(state: BootstrapState) -> tuple[Path, bool]:
     content and is picked up on the next bootstrap/``--repair`` run, same
     posture as the config.yaml bearer (:func:`_build_config_overlay`).
 
+    Also appends one ``HAL0_OAUTH_<PROVIDER>_TOKEN`` line per skill the
+    operator has connected via ``hal0 oauth`` / the dashboard's Connections
+    page (study 3.3) — :func:`hal0.oauth.store.driver_env_lines` is the one
+    owner of that env-var shape; this function only appends what it
+    returns. Same restart caveat as the MCP token: a running agent picks up
+    a newly connected/rotated OAuth token on its next restart, not live.
+
+    ``state`` is accepted for call-site symmetry with the other bootstrap
+    phase functions but unused — every value below comes from module
+    constants, ``service_identity``, or the secrets store. Optional so
+    :func:`refresh_driver_env` can call this outside the bootstrap
+    pipeline (e.g. right after an OAuth token is stored).
+
     Once this file can carry a live secret, its mode always lands ``0600``
     (root:root — read by pid1 as the unit's EnvironmentFile, never by the
     unprivileged hal0 user directly; see :func:`_build_hermes_env` in
@@ -6246,6 +6271,7 @@ def _write_driver_env(state: BootstrapState) -> tuple[Path, bool]:
     — just without the token line — so a keyless/dev box never fails here.
     Returns ``(path, wrote)``.
     """
+    from hal0.oauth.store import driver_env_lines
     from hal0.service_identity import service_key
 
     api_base = HAL0_API_URL.rstrip("/")
@@ -6258,6 +6284,7 @@ def _write_driver_env(state: BootstrapState) -> tuple[Path, bool]:
     token = service_key(prefer="admin")
     if token:
         lines.append(f"HAL0_MCP_TOKEN={token}")
+    lines.extend(driver_env_lines())
     body = "\n".join(lines) + "\n"
     path = DRIVER_ENV_PATH
     if path.exists():
@@ -6318,6 +6345,19 @@ def _write_driver_env(state: BootstrapState) -> tuple[Path, bool]:
         # pins 0600 — see installer/wrappers/hal0-agentenv `write-driver-env`).
         _privileged_env_write("write-driver-env", body)
     return path, True
+
+
+def refresh_driver_env() -> tuple[Path, bool]:
+    """Public entry point: re-render :data:`DRIVER_ENV_PATH` on its own.
+
+    For callers outside the bootstrap phase pipeline that need the driver
+    env to reflect a change right now — today, ``hal0.api.routes.oauth``
+    after a skill's OAuth token is connected/disconnected — without paying
+    for (or risking a side effect from) the full provision run. Idempotent
+    and side-effect-scoped like :func:`_write_driver_env` itself, which does
+    all the actual work; this just supplies the unused ``state`` argument.
+    """
+    return _write_driver_env()
 
 
 def _write_runtime_json(state: BootstrapState, *, repair: bool) -> tuple[Path, bool]:

--- a/src/hal0/agents/hermes_templates/SOUL.md.j2
+++ b/src/hal0/agents/hermes_templates/SOUL.md.j2
@@ -1,5 +1,7 @@
 {# Hermes-Agent persona — rendered by hal0's context_link phase (#244).
-   Parameters: env (env_report dict), hal0_version, hermes_version.
+   Parameters: env (env_report dict), hal0_version, hermes_version,
+   oauth_providers (list of {id, name, skill_id} — empty when none
+   registered yet).
    Falls back to upstream DEFAULT_SOUL_MD when render fails (caller catches).
 #}# Identity
 
@@ -43,3 +45,36 @@ host{% if env.container.kind %} (container: {{ env.container.kind }}){% endif %}
   `hal0_admin:capability_set` so the orchestrator reconciles.
 - Never run `hermes setup` — it will overwrite your model wiring.
   Use `hal0 agent bootstrap hermes --repair` if config drifts.
+{% if oauth_providers %}
+# Connecting a skill that needs OAuth
+
+Ported from ODS's setup pattern (Osmantic/ODS, Apache-2.0; permission to
+copy granted by its author), adapted to hal0's own passthrough
+(`hal0 oauth`, `/api/oauth/*`) — you drive it with shell commands, not a
+copy-pasted authorization code.
+
+Skills with a registered provider on this box:
+{% for p in oauth_providers %}
+- **{{ p.name }}** (`{{ p.id }}`, skill `{{ p.skill_id }}`)
+{%- endfor %}
+
+When the user asks for something one of these skills covers and it isn't
+connected yet:
+
+1. Run `hal0 oauth status <id>` first — don't assume it needs setup.
+2. If not connected, run `hal0 oauth connect <id>`. It prints a consent
+   URL — send it to the user as a markdown link (`[Authorize
+   Google Calendar](THE-URL)`), never as a wall of raw URL text.
+3. Tell them briefly what happens next: *"tap Allow, and you'll land back
+   here automatically — I don't need a code from you."* Then stop talking
+   and wait; don't ask them to copy anything out of their browser's
+   address bar, hal0's OAuth passthrough (`/api/oauth/{{ '{' }}id{{ '}' }}/callback`)
+   captures it directly.
+4. Poll `hal0 oauth status <id>` every so often until `connected` is
+   true, then confirm in one short sentence and do the thing they asked
+   for.
+5. If a provider needs a client secret and `hal0 oauth list` shows it
+   isn't configured yet, tell the operator to run
+   `hal0 oauth set-client-secret <id>` themselves — that's a real
+   credential and you should not ask them to paste it into chat.
+{% endif %}

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -109,6 +109,9 @@ from hal0.api.routes import (
     meta as meta_routes,
 )
 from hal0.api.routes import (
+    oauth as oauth_routes,
+)
+from hal0.api.routes import (
     ports as ports_routes,
 )
 from hal0.api.routes import (
@@ -2439,6 +2442,13 @@ def create_app() -> FastAPI:
 
     app.state.login_limiter = login_limiter_from_env()
 
+    # OAuth passthrough (study 3.3): single-use state-nonce store for the
+    # start->callback CSRF/replay defense. Process-local like login_limiter
+    # above — one hal0-api instance, no shared store to coordinate.
+    from hal0.oauth.state import OAuthStateStore
+
+    app.state.oauth_state = OAuthStateStore()
+
     # /api/auth: login (mints the admin-equivalent session cookie via the
     # SAME HMAC cookie agents/_auth.py already ships) + status (posture
     # report for the dashboard's own auth gate). Both routes are OPEN in
@@ -2519,6 +2529,17 @@ def create_app() -> FastAPI:
         secrets_routes.router,
         prefix="/api/secrets",
         tags=["secrets"],
+    )
+    # Agent-driven OAuth passthrough (study 3.3): provider registry +
+    # start/callback/status/disconnect for skills that need OAuth (Google
+    # Calendar, Spotify, GitHub, ...). Routes are declared as /oauth/... on
+    # the router (see routes/oauth.py) so the "/api" prefix here composes
+    # to exactly /api/oauth/{provider_id}/callback — the literal path
+    # security/exposure.py's OPEN rule is pinned against.
+    app.include_router(
+        oauth_routes.router,
+        prefix="/api",
+        tags=["oauth"],
     )
     # Proxmox integration sub-router (config file at /etc/hal0/proxmox.json).
     # Mounted as a sibling under /api/settings/proxmox so the dashboard's

--- a/src/hal0/api/routes/oauth.py
+++ b/src/hal0/api/routes/oauth.py
@@ -1,0 +1,412 @@
+"""Agent-driven OAuth passthrough for hal0-bundled skills (study 3.3).
+
+Ports ODS's OAuth passthrough
+(``extensions/services/dashboard-api/routers/oauth_passthrough.py``,
+Osmantic/ODS, Apache-2.0; permission to copy granted by its author): a
+Hermes skill that needs OAuth (Google Calendar, Spotify, GitHub, ...) is
+connected by sending the operator a consent link and having the provider's
+redirect land back on hal0-api directly, instead of the operator having to
+copy an authorization code out of their browser's address bar.
+
+Endpoints::
+
+    GET    /api/oauth/providers                  — registry + connection status
+    POST   /api/oauth/{provider_id}/start         — mint a consent URL
+    GET    /api/oauth/{provider_id}/callback      — provider redirect target (OPEN)
+    GET    /api/oauth/{provider_id}/status        — connected? expiry? (no token)
+    DELETE /api/oauth/{provider_id}                — disconnect (best-effort revoke)
+    POST   /api/oauth/{provider_id}/client-secret — store a provider's client secret
+
+Where hal0 differs from ODS: ODS hands the raw authorization code to the
+agent over a shared file and lets the agent's own ``setup.py`` do the token
+exchange. hal0 does the exchange itself, server-side, and persists the
+result through the secrets store (:mod:`hal0.oauth.store` — never in TOML,
+never logged) — the agent never handles a raw code or a client secret, it
+only ever sees the already-exchanged token via its own env (see
+:func:`hal0.agents.hermes_provision.refresh_driver_env`).
+
+Security model (mirrors ODS's, translated to hal0's exposure model):
+  * Every route except ``callback`` is ADMIN (``security/exposure.py``).
+  * ``callback`` is OPEN (it's a redirect target; a provider carries none
+    of hal0's own auth) but requires a valid, single-use, server-issued
+    ``state`` nonce (:mod:`hal0.oauth.state`) — an unknown, expired, or
+    replayed ``state`` is refused before anything is written.
+  * ``provider_id`` is resolved from the nonce, never trusted from the
+    callback's own query string — closes the "attacker names the
+    provider" class of bug.
+  * Every outbound URL (authorize/token/revoke) is SSRF-guarded via
+    :func:`hal0.mcp.manifest.enforce_safe_url` before hal0 ever makes a
+    request to it — one owner of the deny-list.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import structlog
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel, Field
+
+from hal0.api.middleware.error_codes import Hal0Error
+from hal0.mcp.manifest import enforce_safe_url
+from hal0.oauth import providers as provider_registry
+from hal0.oauth import store as oauth_store
+from hal0.oauth.pkce import generate_pkce_pair
+from hal0.oauth.state import OAuthStateStore
+
+_audit_log = structlog.get_logger("hal0.audit")
+_log = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+# Outbound token-exchange request budget. Mirrors the manifest resolver's
+# fetch timeout (hal0.mcp.manifest._FETCH_TIMEOUT) — short connect, bounded
+# total, so a slow/unresponsive provider can't hang the request handler.
+_TOKEN_EXCHANGE_TIMEOUT = httpx.Timeout(connect=4.0, read=8.0, write=4.0, pool=8.0)
+
+
+class OAuthProviderNotFound(Hal0Error):
+    code = "oauth.provider_not_found"
+    status = 404
+
+
+class OAuthNotConfigured(Hal0Error):
+    """Provider is registered but missing a client_id / required client secret."""
+
+    code = "oauth.not_configured"
+    status = 400
+
+
+class OAuthStateInvalid(Hal0Error):
+    code = "oauth.state_invalid"
+    status = 400
+
+
+class OAuthExchangeFailed(Hal0Error):
+    code = "oauth.exchange_failed"
+    status = 502
+
+
+class OAuthClientSecretInvalid(Hal0Error):
+    code = "oauth.client_secret_invalid"
+    status = 400
+
+
+def _state_store(request: Request) -> OAuthStateStore:
+    return request.app.state.oauth_state
+
+
+def _base_url(request: Request) -> str:
+    """hal0-api's own externally-reachable base URL, for building redirect_uri.
+
+    Mirrors the dashboard_url fallback already used by hermes_provision's
+    context-link phase (HAL0_DASHBOARD_URL, then HAL0_API_URL, then a
+    loopback default) rather than trusting the incoming Host header, which
+    an operator's reverse proxy could rewrite in a way that doesn't match
+    what's actually registered in the provider's developer console.
+    """
+    import os
+
+    return os.environ.get(
+        "HAL0_DASHBOARD_URL", os.environ.get("HAL0_API_URL", "http://hal0.local:8080")
+    ).rstrip("/")
+
+
+def _redirect_uri(request: Request, provider_id: str) -> str:
+    return f"{_base_url(request)}/api/oauth/{provider_id}/callback"
+
+
+def _require_provider(provider_id: str) -> provider_registry.OAuthProvider:
+    provider = provider_registry.get_provider(provider_id)
+    if provider is None:
+        raise OAuthProviderNotFound(f"oauth provider {provider_id!r} not registered", {"provider_id": provider_id})
+    return provider
+
+
+def _serialize_provider(provider: provider_registry.OAuthProvider) -> dict:
+    connected = oauth_store.is_connected(provider.id)
+    token = oauth_store.load_token(provider.id) if connected else None
+    return {
+        "id": provider.id,
+        "name": provider.name,
+        "skill_id": provider.skill_id,
+        "scopes": provider.scopes,
+        "pkce": provider.pkce,
+        "configured": bool(provider.client_id)
+        and (not provider.requires_client_secret or oauth_store.has_client_secret(provider.id)),
+        "requires_client_secret": provider.requires_client_secret,
+        "has_client_secret": oauth_store.has_client_secret(provider.id),
+        "connected": connected,
+        "expires_at": token.expires_at if token else None,
+        "expired": token.is_expired if token else None,
+        "notes": provider.notes,
+    }
+
+
+@router.get("/oauth/providers")
+async def list_oauth_providers() -> dict:
+    """Registry entries + connection status (never a token value)."""
+    return {"providers": [_serialize_provider(p) for p in provider_registry.load_providers()]}
+
+
+class ClientSecretBody(BaseModel):
+    value: str = Field(..., min_length=1)
+
+
+@router.post("/oauth/{provider_id}/client-secret", status_code=204)
+async def set_oauth_client_secret(provider_id: str, body: ClientSecretBody) -> None:
+    """Store a provider's client secret through the secrets store.
+
+    Never returned by any endpoint, never logged — mirrors ``/api/secrets``'s
+    write-only posture.
+    """
+    _require_provider(provider_id)
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in body.value):
+        raise OAuthClientSecretInvalid(
+            "control characters not allowed in a client secret", {"provider_id": provider_id}
+        )
+    oauth_store.save_client_secret(provider_id, body.value)
+    _audit_log.info("oauth.client_secret_set", provider_id=provider_id)
+
+
+@router.post("/oauth/{provider_id}/start")
+async def start_oauth(provider_id: str, request: Request) -> dict:
+    """Mint a consent URL for ``provider_id``.
+
+    The dashboard's Connect button and ``hal0 oauth connect`` both call
+    this and open/print the returned ``authorize_url`` — never construct
+    one client-side (the state nonce + PKCE challenge must come from here).
+    """
+    provider = _require_provider(provider_id)
+    if not provider.client_id:
+        raise OAuthNotConfigured(
+            f"oauth provider {provider_id!r} has no client_id set — edit "
+            f"{provider_registry.registry_path()} or your provider's console registration",
+            {"provider_id": provider_id},
+        )
+    if provider.requires_client_secret and not oauth_store.has_client_secret(provider_id):
+        raise OAuthNotConfigured(
+            f"oauth provider {provider_id!r} requires a client secret — "
+            f"set one with `hal0 oauth set-client-secret {provider_id}` first",
+            {"provider_id": provider_id},
+        )
+
+    enforce_safe_url(provider.authorize_url)
+
+    code_verifier: str | None = None
+    params = {
+        "client_id": provider.client_id,
+        "redirect_uri": _redirect_uri(request, provider_id),
+        "response_type": "code",
+        "scope": " ".join(provider.scopes),
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    if provider.pkce:
+        pair = generate_pkce_pair()
+        code_verifier = pair.verifier
+        params["code_challenge"] = pair.challenge
+        params["code_challenge_method"] = pair.method
+
+    state = _state_store(request).issue(provider_id, code_verifier=code_verifier)
+    params["state"] = state
+
+    authorize_url = f"{provider.authorize_url}?{httpx.QueryParams(params)}"
+    _audit_log.info("oauth.start", provider_id=provider_id)
+    return {"authorize_url": authorize_url, "state": state, "provider_id": provider_id}
+
+
+def _success_page(provider_name: str) -> HTMLResponse:
+    from html import escape
+
+    safe = escape(provider_name)
+    return HTMLResponse(
+        f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>hal0 — connected</title>
+<style>:root{{color-scheme:light dark}}body{{font:16px/1.5 system-ui,sans-serif;
+max-width:32rem;margin:4rem auto;padding:0 1.5rem;text-align:center}}
+.check{{font-size:2.5rem}}</style></head>
+<body><div class="check">&#10003;</div><h1>Connected</h1>
+<p>hal0 just got access to your {safe} account. You can close this tab —
+your agent has picked it up.</p></body></html>"""
+    )
+
+
+def _error_page(reason: str, *, status_code: int) -> HTMLResponse:
+    from html import escape
+
+    return HTMLResponse(
+        f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>hal0 — authorization failed</title>
+<style>body{{font:16px/1.5 system-ui,sans-serif;max-width:32rem;margin:4rem auto;
+padding:0 1.5rem;text-align:center}}</style></head>
+<body><h1>Authorization failed</h1><p>{escape(reason)}</p></body></html>""",
+        status_code=status_code,
+    )
+
+
+async def _exchange_code(
+    provider: provider_registry.OAuthProvider,
+    *,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str | None,
+) -> oauth_store.OAuthToken:
+    enforce_safe_url(provider.token_url)
+    body = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": provider.client_id,
+    }
+    if code_verifier:
+        body["code_verifier"] = code_verifier
+    if provider.requires_client_secret:
+        secret = oauth_store.load_client_secret(provider.id)
+        if not secret:
+            raise OAuthNotConfigured(
+                f"oauth provider {provider.id!r} requires a client secret but none is stored",
+                {"provider_id": provider.id},
+            )
+        body["client_secret"] = secret
+
+    try:
+        async with httpx.AsyncClient(timeout=_TOKEN_EXCHANGE_TIMEOUT) as client:
+            resp = await client.post(
+                provider.token_url, data=body, headers={"Accept": "application/json"}
+            )
+    except httpx.HTTPError as exc:
+        raise OAuthExchangeFailed(
+            f"token exchange request to {provider.id!r} failed: {exc}", {"provider_id": provider.id}
+        ) from exc
+
+    if resp.status_code >= 400:
+        # Never log the response body — a provider's error payload can echo
+        # request parameters back, and we can't rule out a code fragment.
+        raise OAuthExchangeFailed(
+            f"provider {provider.id!r} rejected the token exchange (HTTP {resp.status_code})",
+            {"provider_id": provider.id, "status_code": resp.status_code},
+        )
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        raise OAuthExchangeFailed(
+            f"provider {provider.id!r} returned a non-JSON token response", {"provider_id": provider.id}
+        ) from exc
+
+    access_token = payload.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise OAuthExchangeFailed(
+            f"provider {provider.id!r} token response carried no access_token",
+            {"provider_id": provider.id},
+        )
+    expires_in = payload.get("expires_in")
+    expires_at = time.time() + float(expires_in) if isinstance(expires_in, (int, float)) else None
+    return oauth_store.OAuthToken(
+        access_token=access_token,
+        refresh_token=payload.get("refresh_token"),
+        expires_at=expires_at,
+        scope=payload.get("scope") or " ".join(provider.scopes),
+        token_type=payload.get("token_type") or "Bearer",
+    )
+
+
+def _refresh_hermes_driver_env() -> None:
+    """Best-effort: push the freshly connected token into the agent's env.
+
+    Never raises — a running hal0-agent@hermes doesn't pick up the new
+    token until its next restart regardless (same caveat as `hal0 auth
+    rotate`); a failure here just means that refresh has to happen by hand
+    (`hal0 agent bootstrap hermes --repair`) instead of automatically.
+    """
+    try:
+        from hal0.agents.hermes_provision import refresh_driver_env
+
+        refresh_driver_env()
+    except Exception:  # pragma: no cover — best-effort, see docstring
+        _log.warning("oauth.driver_env_refresh_failed", exc_info=True)
+
+
+@router.get("/oauth/{provider_id}/callback")
+async def oauth_callback(provider_id: str, request: Request) -> HTMLResponse:
+    """Provider redirect target — OPEN (security/exposure.py), state-gated.
+
+    ``provider_id`` in the path is validated against the registry, but the
+    SECURITY boundary is ``state``: it must match a nonce this hal0-api
+    process issued via ``start`` for the SAME provider, and it is consumed
+    (single-use) before anything is written, closing the replay window a
+    race between two callbacks could otherwise open.
+    """
+    params = request.query_params
+    error = params.get("error", "")
+    code = params.get("code", "")
+    state = params.get("state", "")
+
+    nonce = _state_store(request).pop(state) if state else None
+    if error:
+        _log.warning("oauth.callback_provider_error", provider_id=provider_id, error=error[:200])
+        return _error_page(f"The provider sent back an error: {error}", status_code=400)
+    if nonce is None:
+        _log.warning("oauth.callback_bad_state", provider_id=provider_id)
+        return _error_page(
+            "This authorization link is not recognized. It may have already "
+            "been used, or the flow needs to be restarted.",
+            status_code=400,
+        )
+    if nonce.provider_id != provider_id:
+        # The nonce is authoritative; a path/nonce mismatch means the
+        # redirect_uri was reused across providers or tampered with.
+        _log.warning(
+            "oauth.callback_provider_mismatch", path_provider=provider_id, nonce_provider=nonce.provider_id
+        )
+        return _error_page("This authorization link does not match the provider it was issued for.", status_code=400)
+    if not code:
+        return _error_page(
+            "No authorization code was returned. You may have denied the request.",
+            status_code=400,
+        )
+
+    provider = _require_provider(provider_id)
+    token = await _exchange_code(
+        provider,
+        code=code,
+        redirect_uri=_redirect_uri(request, provider_id),
+        code_verifier=nonce.code_verifier,
+    )
+    oauth_store.save_token(provider_id, token)
+    _audit_log.info("oauth.connected", provider_id=provider_id)
+    _refresh_hermes_driver_env()
+    return _success_page(provider.name)
+
+
+@router.get("/oauth/{provider_id}/status")
+async def oauth_status(provider_id: str) -> dict:
+    provider = _require_provider(provider_id)
+    return _serialize_provider(provider)
+
+
+@router.delete("/oauth/{provider_id}", status_code=204)
+async def disconnect_oauth(provider_id: str) -> None:
+    """Disconnect a provider: best-effort revoke, then delete the token.
+
+    Deletion always happens even if the provider's revoke call fails —
+    an operator disconnecting a compromised or unwanted grant should not
+    be blocked by the provider being unreachable; the token is gone from
+    hal0 either way, and the operator can revoke it from the provider's
+    own account settings if the API call didn't land.
+    """
+    provider = _require_provider(provider_id)
+    token = oauth_store.load_token(provider_id)
+    if token is not None and provider.revoke_url:
+        try:
+            enforce_safe_url(provider.revoke_url)
+            async with httpx.AsyncClient(timeout=_TOKEN_EXCHANGE_TIMEOUT) as client:
+                await client.post(provider.revoke_url, data={"token": token.access_token})
+        except httpx.HTTPError:
+            _log.warning("oauth.revoke_failed", provider_id=provider_id, exc_info=True)
+
+    oauth_store.delete_token(provider_id)
+    _audit_log.info("oauth.disconnected", provider_id=provider_id)
+    _refresh_hermes_driver_env()

--- a/src/hal0/api/routes/oauth.py
+++ b/src/hal0/api/routes/oauth.py
@@ -121,7 +121,9 @@ def _redirect_uri(request: Request, provider_id: str) -> str:
 def _require_provider(provider_id: str) -> provider_registry.OAuthProvider:
     provider = provider_registry.get_provider(provider_id)
     if provider is None:
-        raise OAuthProviderNotFound(f"oauth provider {provider_id!r} not registered", {"provider_id": provider_id})
+        raise OAuthProviderNotFound(
+            f"oauth provider {provider_id!r} not registered", {"provider_id": provider_id}
+        )
     return provider
 
 
@@ -293,7 +295,8 @@ async def _exchange_code(
         payload = resp.json()
     except ValueError as exc:
         raise OAuthExchangeFailed(
-            f"provider {provider.id!r} returned a non-JSON token response", {"provider_id": provider.id}
+            f"provider {provider.id!r} returned a non-JSON token response",
+            {"provider_id": provider.id},
         ) from exc
 
     access_token = payload.get("access_token")
@@ -359,9 +362,14 @@ async def oauth_callback(provider_id: str, request: Request) -> HTMLResponse:
         # The nonce is authoritative; a path/nonce mismatch means the
         # redirect_uri was reused across providers or tampered with.
         _log.warning(
-            "oauth.callback_provider_mismatch", path_provider=provider_id, nonce_provider=nonce.provider_id
+            "oauth.callback_provider_mismatch",
+            path_provider=provider_id,
+            nonce_provider=nonce.provider_id,
         )
-        return _error_page("This authorization link does not match the provider it was issued for.", status_code=400)
+        return _error_page(
+            "This authorization link does not match the provider it was issued for.",
+            status_code=400,
+        )
     if not code:
         return _error_page(
             "No authorization code was returned. You may have denied the request.",

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -42,6 +42,7 @@ from hal0.cli.mcp_commands import app as mcp_app
 from hal0.cli.memory_commands import app as memory_app
 from hal0.cli.migrate_commands import app as migrate_app
 from hal0.cli.model_commands import app as model_app
+from hal0.cli.oauth_commands import app as oauth_app
 from hal0.cli.ports_command import ports_cmd
 from hal0.cli.profile_commands import app as profile_app
 from hal0.cli.registry_commands import app as registry_app
@@ -75,6 +76,7 @@ app.add_typer(memory_app, name="memory")
 app.add_typer(config_app, name="config")
 app.add_typer(doctor_app, name="doctor")
 app.add_typer(upstream_app, name="upstream")
+app.add_typer(oauth_app, name="oauth")
 app.add_typer(capabilities_app, name="capabilities")
 # Issue #1199 — ``hal0 comfyui orchestrate-models`` pulls the curated ComfyUI
 # model set in one logged sequence.

--- a/src/hal0/cli/oauth_commands.py
+++ b/src/hal0/cli/oauth_commands.py
@@ -1,0 +1,177 @@
+"""hal0 oauth subcommands — thin HTTP client to the hal0 API.
+
+Provides ``hal0 oauth {list,connect,disconnect,status,set-client-secret}``
+for the agent-driven OAuth passthrough (study 3.3): a Hermes skill that
+needs OAuth (Google Calendar, Spotify, GitHub, ...) is connected by sending
+the operator a consent link rather than having them copy-paste an
+authorization code. This is also the CLI Hermes's persona addendum walks
+the operator through when driving the flow itself (see the OAuth section
+appended to ``src/hal0/agents/hermes_templates/SOUL.md.j2``).
+
+Request/response shapes mirror ``hal0.api.routes.oauth`` exactly — see
+that module's docstring for the full endpoint list.
+"""
+
+from __future__ import annotations
+
+import json as jsonlib
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from hal0.cli._shared import CliApiError, _api_base, _api_unreachable, api_delete, api_get, api_post
+
+app = typer.Typer(help="Connect/disconnect OAuth for Hermes skills (Google Calendar, Spotify, ...).")
+console = Console()
+
+
+def _die(message: str) -> None:
+    console.print(f"[red]✗[/red] {message}")
+
+
+@app.command("list")
+def list_providers(
+    json_out: bool = typer.Option(False, "--json", help="Output raw JSON instead of a table."),
+) -> None:
+    """List every registered OAuth provider and its connection status."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        data = api_get("/api/oauth/providers")
+    except CliApiError as exc:
+        _die(str(exc))
+        raise typer.Exit(1) from None
+
+    providers = data.get("providers", [])
+    if json_out:
+        console.print(jsonlib.dumps(providers, indent=2))
+        return
+    if not providers:
+        console.print("[dim]No OAuth providers registered.[/dim]")
+        return
+
+    table = Table(title="OAuth Providers")
+    table.add_column("Provider", style="bold")
+    table.add_column("Skill")
+    table.add_column("Configured")
+    table.add_column("Connected")
+    table.add_column("Expires")
+
+    for p in providers:
+        expires = p.get("expires_at")
+        expires_str = "—"
+        if expires:
+            import datetime
+
+            expires_str = datetime.datetime.fromtimestamp(expires, tz=datetime.UTC).isoformat()
+            if p.get("expired"):
+                expires_str += " [red](expired)[/red]"
+        table.add_row(
+            p.get("id", "—"),
+            p.get("skill_id", "—"),
+            "✓" if p.get("configured") else "✗ (set client_id / secret)",
+            "✓" if p.get("connected") else "✗",
+            expires_str,
+        )
+    console.print(table)
+
+
+@app.command("connect")
+def connect(
+    provider: str = typer.Argument(..., help="Provider id (see `hal0 oauth list`)."),
+) -> None:
+    """Print the consent URL to authorize a provider.
+
+    Send the printed URL to the operator (a markdown link, if you're the
+    agent). Once they authorize in their browser, the provider redirects
+    straight back to hal0 — poll `hal0 oauth status <provider>` until
+    `connected` flips true rather than asking for a code.
+    """
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        result = api_post(f"/api/oauth/{provider}/start")
+    except CliApiError as exc:
+        _die(str(exc))
+        raise typer.Exit(1) from None
+
+    console.print(f"[green]✓[/green] Authorize [bold]{provider}[/bold] at:")
+    console.print(result.get("authorize_url", ""))
+    console.print(f"[dim]Then check: hal0 oauth status {provider}[/dim]")
+
+
+@app.command("disconnect")
+def disconnect(
+    provider: str = typer.Argument(..., help="Provider id to disconnect."),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation prompt."),
+) -> None:
+    """Disconnect a provider (best-effort revoke at the provider, then forget the token)."""
+    if not force:
+        confirm = typer.confirm(f"Disconnect {provider!r}? The skill will lose access until reconnected.")
+        if not confirm:
+            console.print("Aborted.")
+            raise typer.Exit(0)
+
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        api_delete(f"/api/oauth/{provider}")
+    except CliApiError as exc:
+        _die(str(exc))
+        raise typer.Exit(1) from None
+    console.print(f"[green]✓[/green] Disconnected [bold]{provider}[/bold]")
+
+
+@app.command("status")
+def status(
+    provider: str = typer.Argument(..., help="Provider id."),
+    json_out: bool = typer.Option(False, "--json", help="Output raw JSON."),
+) -> None:
+    """Show one provider's connection status."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        result = api_get(f"/api/oauth/{provider}/status")
+    except CliApiError as exc:
+        _die(str(exc))
+        raise typer.Exit(1) from None
+
+    if json_out:
+        console.print(jsonlib.dumps(result, indent=2))
+        return
+
+    if result.get("connected"):
+        state = "[green]connected[/green]"
+        if result.get("expired"):
+            state += " [red](token expired)[/red]"
+    else:
+        state = "[yellow]not connected[/yellow]"
+    console.print(f"{provider}: {state}")
+
+
+@app.command("set-client-secret")
+def set_client_secret(
+    provider: str = typer.Argument(..., help="Provider id."),
+    value: str = typer.Option(
+        ...,
+        "--value",
+        prompt="Client secret",
+        hide_input=True,
+        help="Client secret VALUE (secret; prompted securely if omitted).",
+    ),
+) -> None:
+    """Store a provider's OAuth client secret (through the secrets store, never in TOML)."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        api_post(f"/api/oauth/{provider}/client-secret", json={"value": value})
+    except CliApiError as exc:
+        _die(str(exc))
+        raise typer.Exit(1) from None
+    console.print(f"[green]✓[/green] Client secret stored for [bold]{provider}[/bold]")

--- a/src/hal0/cli/oauth_commands.py
+++ b/src/hal0/cli/oauth_commands.py
@@ -22,7 +22,9 @@ from rich.table import Table
 
 from hal0.cli._shared import CliApiError, _api_base, _api_unreachable, api_delete, api_get, api_post
 
-app = typer.Typer(help="Connect/disconnect OAuth for Hermes skills (Google Calendar, Spotify, ...).")
+app = typer.Typer(
+    help="Connect/disconnect OAuth for Hermes skills (Google Calendar, Spotify, ...)."
+)
 console = Console()
 
 
@@ -110,7 +112,9 @@ def disconnect(
 ) -> None:
     """Disconnect a provider (best-effort revoke at the provider, then forget the token)."""
     if not force:
-        confirm = typer.confirm(f"Disconnect {provider!r}? The skill will lose access until reconnected.")
+        confirm = typer.confirm(
+            f"Disconnect {provider!r}? The skill will lose access until reconnected."
+        )
         if not confirm:
             console.print("Aborted.")
             raise typer.Exit(0)

--- a/src/hal0/config/data/oauth_providers.toml
+++ b/src/hal0/config/data/oauth_providers.toml
@@ -1,0 +1,54 @@
+# hal0 — shipped default OAuth provider registry.
+#
+# Copied to /etc/hal0/oauth-providers.toml the first time
+# hal0.oauth.providers.load_providers() runs, then never overwritten again
+# — hand-edit the /etc copy to add a provider or point client_id at your
+# own OAuth app. client_secret (when a provider requires one) is never
+# stored in this file; see hal0.oauth.store / `hal0 oauth set-client-secret`.
+#
+# Shape ported from ODS's `extensions/services/hermes/oauth-providers.json`
+# (Osmantic/ODS, Apache-2.0; permission to copy granted by its author) and
+# translated to hal0's TOML-for-config convention and CLI-driven skill flow.
+schema_version = "hal0.oauth-providers.v1"
+
+[[providers]]
+id = "google"
+name = "Google Workspace"
+skill_id = "google-workspace"
+authorize_url = "https://accounts.google.com/o/oauth2/v2/auth"
+token_url = "https://oauth2.googleapis.com/token"
+revoke_url = "https://oauth2.googleapis.com/revoke"
+scopes = [
+  "https://www.googleapis.com/auth/calendar",
+  "https://www.googleapis.com/auth/gmail.readonly",
+]
+pkce = true
+client_id = ""
+requires_client_secret = true
+notes = "Calendar/Gmail scopes may show an unverified-app warning until your OAuth consent screen passes Google verification."
+
+[[providers]]
+id = "spotify"
+name = "Spotify"
+skill_id = "spotify"
+authorize_url = "https://accounts.spotify.com/authorize"
+token_url = "https://accounts.spotify.com/api/token"
+revoke_url = ""
+scopes = ["user-read-playback-state", "user-modify-playback-state"]
+pkce = true
+client_id = ""
+requires_client_secret = false
+notes = "PKCE-only; no client secret needed."
+
+[[providers]]
+id = "github"
+name = "GitHub"
+skill_id = "github"
+authorize_url = "https://github.com/login/oauth/authorize"
+token_url = "https://github.com/login/oauth/access_token"
+revoke_url = ""
+scopes = ["repo", "read:user"]
+pkce = false
+client_id = ""
+requires_client_secret = true
+notes = "GitHub's OAuth app flow does not support PKCE; the client secret is required."

--- a/src/hal0/mcp/manifest.py
+++ b/src/hal0/mcp/manifest.py
@@ -73,6 +73,11 @@ _FETCH_TIMEOUT = httpx.Timeout(connect=4.0, read=6.0, write=2.0, pool=6.0)
 # caller can use hal0 as a blind probe against the LAN, IMDS, and loopback.
 # We enforce a deny-list at the URL/IP layer and refuse to follow redirects
 # (a 30x to a private host would otherwise bypass the pre-flight check).
+#
+# ``is_safe_url`` / ``enforce_safe_url`` are public (not module-private) so
+# ``hal0.api.routes.oauth`` can reuse the same deny-list against a
+# provider's ``authorize_url``/``token_url`` (one owner of the SSRF guard,
+# per COMMON.md rule 2) rather than re-implementing it.
 
 
 class SsrfBlockedError(BadRequest):
@@ -102,7 +107,7 @@ def _ip_is_safe(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     )
 
 
-def _is_safe_url(url: str) -> bool:
+def is_safe_url(url: str) -> bool:
     """Return True only when ``url`` resolves entirely to public addresses.
 
     Steps:
@@ -155,9 +160,9 @@ def _is_safe_url(url: str) -> bool:
     return True
 
 
-def _enforce_safe_url(url: str) -> None:
+def enforce_safe_url(url: str) -> None:
     """Raise :class:`SsrfBlockedError` when the URL fails the SSRF guard."""
-    if not _is_safe_url(url):
+    if not is_safe_url(url):
         raise SsrfBlockedError(
             "refusing to fetch a non-public URL",
             code="mcp.ssrf_blocked",
@@ -376,11 +381,11 @@ async def _default_fetcher(url: str) -> Any:
     """Production fetcher — SSRF-guarded, bounded body, JSON decoded.
 
     Redirects are intentionally NOT followed: a 30x to a private host
-    would bypass the pre-flight :func:`_enforce_safe_url` check. If a
+    would bypass the pre-flight :func:`enforce_safe_url` check. If a
     legitimate manifest sits behind a redirect, the caller can paste the
     final URL directly.
     """
-    _enforce_safe_url(url)
+    enforce_safe_url(url)
     # Stream the body and abort the moment we cross the cap (#381) — a
     # misbehaving server must not be able to make us buffer an unbounded
     # response into memory before we reject it.
@@ -441,7 +446,7 @@ async def resolve(url: str, *, fetcher: HttpFetcher | None = None) -> ResolvedMa
         # pre-flight check. Skipped when the caller injects a fetcher — the
         # test surface relies on synthesised hosts like example.com.
         if fetcher is None:
-            _enforce_safe_url(url)
+            enforce_safe_url(url)
         return await _resolve_http(url, fetcher)
 
     raise BadRequest(

--- a/src/hal0/oauth/__init__.py
+++ b/src/hal0/oauth/__init__.py
@@ -1,0 +1,16 @@
+"""Agent-driven OAuth passthrough for hal0-bundled skills.
+
+Ports ODS's OAuth passthrough (`extensions/services/dashboard-api/routers/
+oauth_passthrough.py`, Osmantic/ODS, Apache-2.0; permission to copy granted
+by its author) so a Hermes skill that needs OAuth (Google Calendar,
+Spotify, ...) can be connected from the dashboard or the CLI without the
+operator ever copy-pasting an authorization code.
+
+Modules:
+  providers — the `/etc/hal0/oauth-providers.toml` registry
+  pkce      — RFC 7636 verifier/challenge generation
+  state     — single-use state-nonce store (CSRF/replay defense)
+  store     — token + client-secret persistence through the secrets store
+"""
+
+from __future__ import annotations

--- a/src/hal0/oauth/pkce.py
+++ b/src/hal0/oauth/pkce.py
@@ -1,0 +1,33 @@
+"""PKCE (RFC 7636) verifier/challenge generation for the OAuth passthrough.
+
+Used by :mod:`hal0.api.routes.oauth` when a provider's registry entry sets
+``pkce = true`` — the code verifier is held server-side in the state nonce
+(:mod:`hal0.oauth.state`) between ``start`` and ``callback`` so no client
+(dashboard tab, CLI, agent) ever needs to see it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from dataclasses import dataclass
+
+# RFC 7636 §4.1: 43..128 chars of [A-Z a-z 0-9 - . _ ~]. token_urlsafe(64)
+# yields 86 base64url chars (no padding), comfortably inside that range.
+_VERIFIER_BYTES = 64
+
+
+@dataclass(frozen=True)
+class PkcePair:
+    verifier: str
+    challenge: str
+    method: str = "S256"
+
+
+def generate_pkce_pair() -> PkcePair:
+    """Generate a fresh (verifier, S256 challenge) pair."""
+    verifier = secrets.token_urlsafe(_VERIFIER_BYTES)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return PkcePair(verifier=verifier, challenge=challenge)

--- a/src/hal0/oauth/providers.py
+++ b/src/hal0/oauth/providers.py
@@ -60,7 +60,9 @@ class OAuthProvider:
                 raise ProviderRegistryError(f"provider entry missing required field {required!r}")
         scopes = data.get("scopes") or []
         if not isinstance(scopes, list) or not all(isinstance(s, str) for s in scopes):
-            raise ProviderRegistryError(f"provider {data.get('id')!r}: scopes must be a list of strings")
+            raise ProviderRegistryError(
+                f"provider {data.get('id')!r}: scopes must be a list of strings"
+            )
         return cls(
             id=data["id"].strip(),
             name=data["name"].strip(),

--- a/src/hal0/oauth/providers.py
+++ b/src/hal0/oauth/providers.py
@@ -1,0 +1,134 @@
+"""OAuth provider registry (`/etc/hal0/oauth-providers.toml`).
+
+Ported from ODS's `extensions/services/hermes/oauth-providers.json`
+(Osmantic/ODS, Apache-2.0; permission to copy granted by its author) — see
+`src/hal0/config/data/oauth_providers.toml` for the shipped provider list
+and the attribution note.
+
+The registry is TOML because it is human config (COMMON.md rule 2): the
+operator can hand-add a provider or point `client_id` at their own OAuth
+app. It never holds a secret value — `client_id` is not treated as
+sensitive (it appears in the browser's address bar during the consent
+redirect regardless), but `client_secret` is a real credential and is
+never written here; see :mod:`hal0.oauth.store` for where it lives.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from importlib.resources import files
+
+import structlog
+
+from hal0.config import paths
+
+log = structlog.get_logger(__name__)
+
+#: Shipped default registry lives under hal0.config.data alongside the
+#: other bundled TOML (seed_profiles.toml, family_defaults.toml, ...) —
+#: read via importlib.resources so it works from an editable checkout AND
+#: an installed wheel identically (mirrors hal0.config.seeds._read_toml).
+_DEFAULT_PACKAGE = "hal0.config.data"
+_DEFAULT_FILENAME = "oauth_providers.toml"
+
+
+class ProviderRegistryError(ValueError):
+    """Raised when the provider registry TOML is malformed."""
+
+
+@dataclass(frozen=True)
+class OAuthProvider:
+    """One entry from `oauth-providers.toml`."""
+
+    id: str
+    name: str
+    skill_id: str
+    authorize_url: str
+    token_url: str
+    revoke_url: str = ""
+    scopes: list[str] = field(default_factory=list)
+    pkce: bool = True
+    client_id: str = ""
+    requires_client_secret: bool = False
+    notes: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict) -> OAuthProvider:
+        for required in ("id", "name", "skill_id", "authorize_url", "token_url"):
+            if not isinstance(data.get(required), str) or not data[required].strip():
+                raise ProviderRegistryError(f"provider entry missing required field {required!r}")
+        scopes = data.get("scopes") or []
+        if not isinstance(scopes, list) or not all(isinstance(s, str) for s in scopes):
+            raise ProviderRegistryError(f"provider {data.get('id')!r}: scopes must be a list of strings")
+        return cls(
+            id=data["id"].strip(),
+            name=data["name"].strip(),
+            skill_id=data["skill_id"].strip(),
+            authorize_url=data["authorize_url"].strip(),
+            token_url=data["token_url"].strip(),
+            revoke_url=str(data.get("revoke_url") or "").strip(),
+            scopes=list(scopes),
+            pkce=bool(data.get("pkce", True)),
+            client_id=str(data.get("client_id") or "").strip(),
+            requires_client_secret=bool(data.get("requires_client_secret", False)),
+            notes=str(data.get("notes") or "").strip(),
+        )
+
+
+def registry_path():
+    """Return `/etc/hal0/oauth-providers.toml` (HAL0_HOME-relative under tests)."""
+    return paths.etc() / "oauth-providers.toml"
+
+
+def _shipped_default_text() -> str:
+    return files(_DEFAULT_PACKAGE).joinpath(_DEFAULT_FILENAME).read_text(encoding="utf-8")
+
+
+def _seed_default(target) -> None:
+    """Copy the shipped default registry to ``target`` (0644, atomic).
+
+    Only ever runs once — on every subsequent load ``target`` already
+    exists and this is skipped, so hand edits are never clobbered.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    body = _shipped_default_text()
+    tmp = target.with_suffix(".toml.tmp")
+    tmp.write_text(body, encoding="utf-8")
+    tmp.chmod(0o644)
+    tmp.replace(target)
+
+
+def load_providers(path=None) -> list[OAuthProvider]:
+    """Load the provider registry, seeding the shipped default if missing.
+
+    Malformed entries are skipped (not fatal) so one bad hand-edit doesn't
+    take down the whole registry — mirrors `personas.list_personas`'s
+    tolerant-load discipline.
+    """
+    target = path if path is not None else registry_path()
+    if not target.exists():
+        _seed_default(target)
+    with open(target, "rb") as f:
+        raw = tomllib.load(f)
+    entries = raw.get("providers")
+    if not isinstance(entries, list):
+        raise ProviderRegistryError(f"{target}: 'providers' must be a list of tables")
+    out: list[OAuthProvider] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            out.append(OAuthProvider.from_dict(entry))
+        except ProviderRegistryError as exc:
+            log.warning("oauth.registry.skip_malformed", path=str(target), error=str(exc))
+            continue
+    return out
+
+
+def get_provider(provider_id: str, *, path=None) -> OAuthProvider | None:
+    """Return the named provider, or None if it isn't registered."""
+    for provider in load_providers(path=path):
+        if provider.id == provider_id:
+            return provider
+    return None

--- a/src/hal0/oauth/state.py
+++ b/src/hal0/oauth/state.py
@@ -41,7 +41,9 @@ class OAuthStateStore:
         self._lock = threading.Lock()
 
     def _prune(self, now: float) -> None:
-        expired = [state for state, nonce in self._nonces.items() if now - nonce.created_at > self._ttl]
+        expired = [
+            state for state, nonce in self._nonces.items() if now - nonce.created_at > self._ttl
+        ]
         for state in expired:
             self._nonces.pop(state, None)
 

--- a/src/hal0/oauth/state.py
+++ b/src/hal0/oauth/state.py
@@ -1,0 +1,69 @@
+"""In-process OAuth state-nonce store.
+
+Mirrors :class:`hal0.security.ratelimit.SlidingWindowRateLimiter`: hal0 is a
+single-node appliance, so there is no shared store to coordinate — one
+hal0-api process owns one :class:`OAuthStateStore` instance, handed out on
+``app.state`` by ``create_app()``. Nonces are the CSRF/replay defense for the
+OAuth ``state`` parameter (RFC 6749 §10.12) and are single-use: a successful
+``pop`` deletes the entry, so a replayed callback with the same ``state``
+finds nothing and is refused.
+
+A nonce additionally carries the PKCE code verifier (when the provider uses
+PKCE) and the provider id, bound at ``start`` time — the callback handler
+resolves both from the nonce rather than trusting anything in the incoming
+redirect's query string, closing the same "attacker picks the provider"
+class of bug ODS's file-based nonce design documents.
+"""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+
+DEFAULT_TTL_SECONDS = 600  # 10 min — comfortably above a provider's own code TTL.
+
+
+@dataclass(frozen=True)
+class OAuthNonce:
+    provider_id: str
+    code_verifier: str | None
+    created_at: float
+
+
+class OAuthStateStore:
+    """Single-use, TTL-bounded state-nonce store. Thread-safe."""
+
+    def __init__(self, *, ttl_seconds: float = DEFAULT_TTL_SECONDS) -> None:
+        self._ttl = ttl_seconds
+        self._nonces: dict[str, OAuthNonce] = {}
+        self._lock = threading.Lock()
+
+    def _prune(self, now: float) -> None:
+        expired = [state for state, nonce in self._nonces.items() if now - nonce.created_at > self._ttl]
+        for state in expired:
+            self._nonces.pop(state, None)
+
+    def issue(self, provider_id: str, *, code_verifier: str | None = None) -> str:
+        """Mint a fresh, single-use ``state`` value bound to ``provider_id``."""
+        now = time.time()
+        with self._lock:
+            self._prune(now)
+            state = secrets.token_urlsafe(32)
+            self._nonces[state] = OAuthNonce(
+                provider_id=provider_id, code_verifier=code_verifier, created_at=now
+            )
+        return state
+
+    def pop(self, state: str) -> OAuthNonce | None:
+        """Consume ``state``, returning its nonce, or None if unknown/expired.
+
+        Single-use: a second call with the same ``state`` always returns
+        None, closing the replay window a race between two callbacks could
+        otherwise open.
+        """
+        now = time.time()
+        with self._lock:
+            self._prune(now)
+            return self._nonces.pop(state, None)

--- a/src/hal0/oauth/store.py
+++ b/src/hal0/oauth/store.py
@@ -1,0 +1,192 @@
+"""OAuth token + client-secret storage — through the secrets store, never
+in TOML, never logged.
+
+Every value this module writes goes through
+:mod:`hal0.api._env_store` — the same atomic, mode-0600 ``api.env`` writer
+the operator secrets router (``/api/secrets``) and the provider-credential
+writer (``/api/providers/{name}/credentials``) already use. Nothing here
+ever logs a token or client-secret value; every log line downstream
+carries the provider id only.
+
+Env-var naming convention (both land in ``/etc/hal0/api.env``, both start
+with ``HAL0_`` and are therefore refused by ``/api/secrets``'s own mutation
+guard — they are managed exclusively through the oauth routes/CLI, not the
+generic Secrets tab):
+
+  ``HAL0_OAUTH_<PROVIDER>_TOKEN``           — JSON blob, see :class:`OAuthToken`
+  ``HAL0_OAUTH_<PROVIDER>_CLIENT_SECRET``   — raw client-secret string
+
+:func:`load_token` and :func:`load_client_secret` read the value back by
+parsing ``api.env`` directly (mirrors
+:func:`hal0.service_identity.keys_from_api_env`'s pattern) rather than
+through :mod:`hal0.api._env_store`, which is deliberately write/list-only
+so the *generic* secrets surface never echoes a value. This module's
+read-back is internal-only: the token exchange/refresh flow and
+:func:`hal0.agents.hermes_provision.refresh_driver_env` are its only
+callers, never a route response body.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from hal0.api._env_store import delete_env_value, list_env_keys, upsert_env_value
+from hal0.config import paths
+
+_TOKEN_KEY_RE = re.compile(r"^HAL0_OAUTH_([A-Z0-9_]+)_TOKEN$")
+
+
+def _normalize(provider_id: str) -> str:
+    return provider_id.upper().replace("-", "_")
+
+
+def _token_env_key(provider_id: str) -> str:
+    return f"HAL0_OAUTH_{_normalize(provider_id)}_TOKEN"
+
+
+def _client_secret_env_key(provider_id: str) -> str:
+    return f"HAL0_OAUTH_{_normalize(provider_id)}_CLIENT_SECRET"
+
+
+@dataclass(frozen=True)
+class OAuthToken:
+    """The token payload persisted for one connected provider."""
+
+    access_token: str
+    refresh_token: str | None
+    expires_at: float | None  # unix epoch seconds; None = provider gave no expiry
+    scope: str
+    token_type: str = "Bearer"
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "access_token": self.access_token,
+                "refresh_token": self.refresh_token,
+                "expires_at": self.expires_at,
+                "scope": self.scope,
+                "token_type": self.token_type,
+            },
+            separators=(",", ":"),
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> OAuthToken:
+        data = json.loads(raw)
+        return cls(
+            access_token=data["access_token"],
+            refresh_token=data.get("refresh_token"),
+            expires_at=data.get("expires_at"),
+            scope=data.get("scope") or "",
+            token_type=data.get("token_type") or "Bearer",
+        )
+
+    @property
+    def is_expired(self) -> bool:
+        return self.expires_at is not None and self.expires_at <= time.time()
+
+
+def _api_env() -> Path:
+    return paths.etc() / "api.env"
+
+
+def _read_quoted_value(api_env: Path, key: str) -> str | None:
+    """Parse one `KEY="value"` line out of an EnvironmentFile-style file.
+
+    Mirrors `hal0.service_identity.keys_from_api_env`'s direct-parse
+    pattern. Returns None on any read failure or if the key isn't set.
+    """
+    try:
+        text = api_env.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        if k.strip() != key:
+            continue
+        value = v.strip()
+        if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+            value = value[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+        return value
+    return None
+
+
+# ── tokens ────────────────────────────────────────────────────────────────
+
+
+def save_token(provider_id: str, token: OAuthToken, *, api_env: Path | None = None) -> None:
+    """Persist ``token`` for ``provider_id``. Never logs the value."""
+    upsert_env_value(api_env or _api_env(), _token_env_key(provider_id), token.to_json())
+
+
+def delete_token(provider_id: str, *, api_env: Path | None = None) -> bool:
+    """Remove the stored token for ``provider_id``. Returns whether one existed."""
+    return delete_env_value(api_env or _api_env(), _token_env_key(provider_id))
+
+
+def is_connected(provider_id: str, *, api_env: Path | None = None) -> bool:
+    """True if a token is stored for ``provider_id`` — the value is never read."""
+    return _token_env_key(provider_id) in list_env_keys(api_env or _api_env())
+
+
+def load_token(provider_id: str, *, api_env: Path | None = None) -> OAuthToken | None:
+    """Read the stored token back. Internal use only — never a route response."""
+    target = api_env or _api_env()
+    raw = _read_quoted_value(target, _token_env_key(provider_id))
+    if raw is None:
+        return None
+    try:
+        return OAuthToken.from_json(raw)
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+def connected_provider_ids(*, api_env: Path | None = None) -> list[str]:
+    """Provider ids with a token currently stored, derived from key names."""
+    out = []
+    for key in list_env_keys(api_env or _api_env()):
+        m = _TOKEN_KEY_RE.match(key)
+        if m:
+            out.append(m.group(1).lower().replace("_", "-"))
+    return sorted(out)
+
+
+def driver_env_lines(*, api_env: Path | None = None) -> list[str]:
+    """``KEY=value`` lines for every connected provider's token.
+
+    Consumed verbatim by :func:`hal0.agents.hermes_provision.refresh_driver_env`
+    so the Hermes agent's own env carries the current OAuth tokens — the
+    ADR-0002-sanctioned env-from-secrets-store delivery path. Re-emits the
+    exact JSON blob this module already stores; no re-encoding, one owner
+    of the token shape.
+    """
+    target = api_env or _api_env()
+    lines = []
+    for provider_id in connected_provider_ids(api_env=target):
+        token = load_token(provider_id, api_env=target)
+        if token is not None:
+            lines.append(f"{_token_env_key(provider_id)}={token.to_json()}")
+    return lines
+
+
+# ── client secrets ───────────────────────────────────────────────────────
+
+
+def save_client_secret(provider_id: str, value: str, *, api_env: Path | None = None) -> None:
+    upsert_env_value(api_env or _api_env(), _client_secret_env_key(provider_id), value)
+
+
+def has_client_secret(provider_id: str, *, api_env: Path | None = None) -> bool:
+    return _client_secret_env_key(provider_id) in list_env_keys(api_env or _api_env())
+
+
+def load_client_secret(provider_id: str, *, api_env: Path | None = None) -> str | None:
+    """Read the stored client secret back. Internal use only (token exchange)."""
+    return _read_quoted_value(api_env or _api_env(), _client_secret_env_key(provider_id))

--- a/src/hal0/security/exposure.py
+++ b/src/hal0/security/exposure.py
@@ -279,6 +279,21 @@ RULES: tuple[_Rule, ...] = (
     _Rule("brain (hal0-brain steward chat)", _prefix("/api/brain"), AuthClass.ADMIN, None),
     _Rule("providers", _prefix("/api/providers"), AuthClass.ADMIN, None),
     _Rule("upstreams", _prefix("/api/upstreams"), AuthClass.ADMIN, None),
+    # OAuth passthrough (agent-driven skill connect, study 3.3). The provider
+    # redirect target MUST be reachable with no session/bearer — a provider's
+    # 302 back to hal0 carries no auth of ours, only its own `state` nonce
+    # (validated inside the route, single-use — see hal0.oauth.state). Pinned
+    # BEFORE the ADMIN catch-all below so it isn't swallowed by the prefix
+    # rule. Every other /api/oauth/* route (start/status/disconnect/registry
+    # edits) is ADMIN — same posture as /api/providers and /api/secrets,
+    # which this feature composes.
+    _Rule(
+        "oauth callback (public redirect target)",
+        _exact("/api/oauth/{provider_id}/callback"),
+        AuthClass.OPEN,
+        _GET,
+    ),
+    _Rule("oauth (start/status/disconnect/registry)", _prefix("/api/oauth"), AuthClass.ADMIN, None),
     _Rule("updates", _prefix("/api/updates"), AuthClass.ADMIN, None),
     _Rule("capabilities", _prefix("/api/capabilities"), AuthClass.ADMIN, None),
     _Rule("stacks", _prefix("/api/stacks"), AuthClass.ADMIN, None),
@@ -371,6 +386,9 @@ OPEN_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
         ("POST", "/api/auth/login"),
         ("GET", "/api/auth/status"),
         ("POST", "/api/auth/logout"),
+        # OAuth passthrough callback — the provider's redirect target, has
+        # no auth of ours to check (see the RULES entry above).
+        ("GET", "/api/oauth/{provider_id}/callback"),
         # Hermes dashboard-plugin static asset proxy (kanban plugin JS/CSS
         # bundles) -- not under /api or /v1, so it hits the same
         # not-api/v1/mcp catch-all the SPA shell itself uses. No secrets:

--- a/tests/api/test_oauth_routes.py
+++ b/tests/api/test_oauth_routes.py
@@ -39,7 +39,9 @@ def _set_client_id(home: str, provider_id: str, client_id: str) -> None:
     # per-block string replace scoped to right after this provider's id.
     marker = f'id = "{provider_id}"'
     idx = text.index(marker)
-    block_end = text.index("[[providers]]", idx + 1) if "[[providers]]" in text[idx + 1 :] else len(text)
+    block_end = (
+        text.index("[[providers]]", idx + 1) if "[[providers]]" in text[idx + 1 :] else len(text)
+    )
     block = text[idx:block_end]
     patched_block = block.replace('client_id = ""', f'client_id = "{client_id}"')
     path.write_text(text[:idx] + patched_block + text[block_end:], encoding="utf-8")
@@ -65,7 +67,13 @@ class _FakeAsyncClient:
 
     calls: ClassVar[list[tuple[str, dict]]] = []
     response: ClassVar[_FakeResponse] = _FakeResponse(
-        200, {"access_token": "at-123", "refresh_token": "rt-456", "expires_in": 3600, "scope": "calendar"}
+        200,
+        {
+            "access_token": "at-123",
+            "refresh_token": "rt-456",
+            "expires_in": 3600,
+            "scope": "calendar",
+        },
     )
 
     def __init__(self, *args, **kwargs) -> None:
@@ -77,7 +85,9 @@ class _FakeAsyncClient:
     async def __aexit__(self, *args) -> bool:
         return False
 
-    async def post(self, url: str, data: dict | None = None, headers: dict | None = None) -> _FakeResponse:
+    async def post(
+        self, url: str, data: dict | None = None, headers: dict | None = None
+    ) -> _FakeResponse:
         type(self).calls.append((url, data or {}))
         return type(self).response
 
@@ -86,7 +96,13 @@ class _FakeAsyncClient:
 def _fake_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
     _FakeAsyncClient.calls = []
     _FakeAsyncClient.response = _FakeResponse(
-        200, {"access_token": "at-123", "refresh_token": "rt-456", "expires_in": 3600, "scope": "calendar"}
+        200,
+        {
+            "access_token": "at-123",
+            "refresh_token": "rt-456",
+            "expires_in": 3600,
+            "scope": "calendar",
+        },
     )
     monkeypatch.setattr("httpx.AsyncClient", _FakeAsyncClient)
     # The driver-env refresh after connect/disconnect shells out to the
@@ -116,7 +132,9 @@ def test_start_unknown_provider_404(client: TestClient) -> None:
     assert r.json()["error"]["code"] == "oauth.provider_not_found"
 
 
-def test_start_returns_authorize_url_with_state_and_pkce(client: TestClient, tmp_hal0_home: str) -> None:
+def test_start_returns_authorize_url_with_state_and_pkce(
+    client: TestClient, tmp_hal0_home: str
+) -> None:
     _set_client_id(tmp_hal0_home, "spotify", "client-abc")  # spotify: pkce=true, no secret required
 
     r = client.post("/api/oauth/spotify/start")
@@ -132,7 +150,9 @@ def test_start_returns_authorize_url_with_state_and_pkce(client: TestClient, tmp
     assert qs["code_challenge_method"] == ["S256"]
 
 
-def test_start_requires_client_secret_when_provider_needs_one(client: TestClient, tmp_hal0_home: str) -> None:
+def test_start_requires_client_secret_when_provider_needs_one(
+    client: TestClient, tmp_hal0_home: str
+) -> None:
     _set_client_id(tmp_hal0_home, "github", "gh-client")  # github requires_client_secret=true
 
     r = client.post("/api/oauth/github/start")
@@ -148,7 +168,9 @@ def test_callback_with_unknown_state_is_rejected(client: TestClient, tmp_hal0_ho
 
 
 def test_callback_provider_error_param_is_reported(client: TestClient) -> None:
-    r = client.get("/api/oauth/google/callback", params={"error": "access_denied", "state": "whatever"})
+    r = client.get(
+        "/api/oauth/google/callback", params={"error": "access_denied", "state": "whatever"}
+    )
     assert r.status_code == 400
     assert "access_denied" in r.text
 
@@ -159,7 +181,9 @@ def test_full_start_to_callback_flow_stores_token(client: TestClient, tmp_hal0_h
     start = client.post("/api/oauth/google/start")
     state = start.json()["state"]
 
-    callback = client.get("/api/oauth/google/callback", params={"code": "auth-code-xyz", "state": state})
+    callback = client.get(
+        "/api/oauth/google/callback", params={"code": "auth-code-xyz", "state": state}
+    )
 
     assert callback.status_code == 200, callback.text
     assert "Connected" in callback.text
@@ -171,19 +195,27 @@ def test_full_start_to_callback_flow_stores_token(client: TestClient, tmp_hal0_h
     assert "auth-code-xyz" not in api_env.read_text(encoding="utf-8")
 
 
-def test_callback_state_is_single_use_replay_rejected(client: TestClient, tmp_hal0_home: str) -> None:
+def test_callback_state_is_single_use_replay_rejected(
+    client: TestClient, tmp_hal0_home: str
+) -> None:
     _configure_google(tmp_hal0_home)
     start = client.post("/api/oauth/google/start")
     state = start.json()["state"]
 
-    first = client.get("/api/oauth/google/callback", params={"code": "auth-code-xyz", "state": state})
-    second = client.get("/api/oauth/google/callback", params={"code": "auth-code-xyz", "state": state})
+    first = client.get(
+        "/api/oauth/google/callback", params={"code": "auth-code-xyz", "state": state}
+    )
+    second = client.get(
+        "/api/oauth/google/callback", params={"code": "auth-code-xyz", "state": state}
+    )
 
     assert first.status_code == 200
     assert second.status_code == 400
 
 
-def test_callback_provider_path_must_match_nonces_provider(client: TestClient, tmp_hal0_home: str) -> None:
+def test_callback_provider_path_must_match_nonces_provider(
+    client: TestClient, tmp_hal0_home: str
+) -> None:
     _configure_google(tmp_hal0_home)
     _set_client_id(tmp_hal0_home, "spotify", "s-client")
     start = client.post("/api/oauth/google/start")

--- a/tests/api/test_oauth_routes.py
+++ b/tests/api/test_oauth_routes.py
@@ -1,0 +1,291 @@
+"""Tests for the /api/oauth router (agent-driven OAuth passthrough, study 3.3).
+
+Covers the registry listing, start (PKCE + state issuance), callback
+(state validation, replay rejection, provider-mismatch rejection, the
+actual token exchange), status, disconnect (+ best-effort revoke), and the
+client-secret write-only surface. Outbound provider HTTP calls are faked
+via a stand-in for ``httpx.AsyncClient`` — no real network access.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.oauth import store as oauth_store
+
+
+def _api_env_path(home: str) -> Path:
+    return Path(home) / "etc" / "hal0" / "api.env"
+
+
+def _registry_path(home: str) -> Path:
+    return Path(home) / "etc" / "hal0" / "oauth-providers.toml"
+
+
+def _set_client_id(home: str, provider_id: str, client_id: str) -> None:
+    """Seed the registry (via a real load) then hand-patch one provider's client_id."""
+    from hal0.oauth.providers import load_providers
+
+    path = _registry_path(home)
+    load_providers(path=path)  # seeds the shipped default if missing
+    text = path.read_text(encoding="utf-8")
+    # Each provider block starts with `id = "<id>"` immediately followed by
+    # its `client_id = ""` line further down; simplest robust edit is a
+    # per-block string replace scoped to right after this provider's id.
+    marker = f'id = "{provider_id}"'
+    idx = text.index(marker)
+    block_end = text.index("[[providers]]", idx + 1) if "[[providers]]" in text[idx + 1 :] else len(text)
+    block = text[idx:block_end]
+    patched_block = block.replace('client_id = ""', f'client_id = "{client_id}"')
+    path.write_text(text[:idx] + patched_block + text[block_end:], encoding="utf-8")
+
+
+def _configure_google(home: str) -> None:
+    """Google requires a client secret too — wire both in one place."""
+    _set_client_id(home, "google", "g-client")
+    oauth_store.save_client_secret("google", "g-secret", api_env=_api_env_path(home))
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, json_data: dict | None = None) -> None:
+        self.status_code = status_code
+        self._json = json_data or {}
+
+    def json(self) -> dict:
+        return self._json
+
+
+class _FakeAsyncClient:
+    """Stand-in for httpx.AsyncClient — records calls, returns a canned token response."""
+
+    calls: ClassVar[list[tuple[str, dict]]] = []
+    response: ClassVar[_FakeResponse] = _FakeResponse(
+        200, {"access_token": "at-123", "refresh_token": "rt-456", "expires_in": 3600, "scope": "calendar"}
+    )
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *args) -> bool:
+        return False
+
+    async def post(self, url: str, data: dict | None = None, headers: dict | None = None) -> _FakeResponse:
+        type(self).calls.append((url, data or {}))
+        return type(self).response
+
+
+@pytest.fixture(autouse=True)
+def _fake_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.response = _FakeResponse(
+        200, {"access_token": "at-123", "refresh_token": "rt-456", "expires_in": 3600, "scope": "calendar"}
+    )
+    monkeypatch.setattr("httpx.AsyncClient", _FakeAsyncClient)
+    # The driver-env refresh after connect/disconnect shells out to the
+    # hal0-agentenv seam when unprivileged; make it a no-op in tests.
+    monkeypatch.setattr("hal0.api.routes.oauth._refresh_hermes_driver_env", lambda: None)
+
+
+def test_list_providers_seeds_default_registry(client: TestClient) -> None:
+    r = client.get("/api/oauth/providers")
+    assert r.status_code == 200, r.text
+    ids = {p["id"] for p in r.json()["providers"]}
+    assert {"google", "spotify", "github"} <= ids
+    google = next(p for p in r.json()["providers"] if p["id"] == "google")
+    assert google["connected"] is False
+    assert google["configured"] is False  # no client_id set yet
+
+
+def test_start_fails_when_not_configured(client: TestClient) -> None:
+    r = client.post("/api/oauth/google/start")
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "oauth.not_configured"
+
+
+def test_start_unknown_provider_404(client: TestClient) -> None:
+    r = client.post("/api/oauth/nope/start")
+    assert r.status_code == 404, r.text
+    assert r.json()["error"]["code"] == "oauth.provider_not_found"
+
+
+def test_start_returns_authorize_url_with_state_and_pkce(client: TestClient, tmp_hal0_home: str) -> None:
+    _set_client_id(tmp_hal0_home, "spotify", "client-abc")  # spotify: pkce=true, no secret required
+
+    r = client.post("/api/oauth/spotify/start")
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["provider_id"] == "spotify"
+    parsed = urlsplit(body["authorize_url"])
+    qs = parse_qs(parsed.query)
+    assert qs["state"] == [body["state"]]
+    assert qs["client_id"] == ["client-abc"]
+    assert "code_challenge" in qs
+    assert qs["code_challenge_method"] == ["S256"]
+
+
+def test_start_requires_client_secret_when_provider_needs_one(client: TestClient, tmp_hal0_home: str) -> None:
+    _set_client_id(tmp_hal0_home, "github", "gh-client")  # github requires_client_secret=true
+
+    r = client.post("/api/oauth/github/start")
+
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "oauth.not_configured"
+
+
+def test_callback_with_unknown_state_is_rejected(client: TestClient, tmp_hal0_home: str) -> None:
+    r = client.get("/api/oauth/google/callback", params={"code": "abc", "state": "never-issued"})
+    assert r.status_code == 400
+    assert not oauth_store.is_connected("google", api_env=_api_env_path(tmp_hal0_home))
+
+
+def test_callback_provider_error_param_is_reported(client: TestClient) -> None:
+    r = client.get("/api/oauth/google/callback", params={"error": "access_denied", "state": "whatever"})
+    assert r.status_code == 400
+    assert "access_denied" in r.text
+
+
+def test_full_start_to_callback_flow_stores_token(client: TestClient, tmp_hal0_home: str) -> None:
+    _configure_google(tmp_hal0_home)
+
+    start = client.post("/api/oauth/google/start")
+    state = start.json()["state"]
+
+    callback = client.get("/api/oauth/google/callback", params={"code": "auth-code-xyz", "state": state})
+
+    assert callback.status_code == 200, callback.text
+    assert "Connected" in callback.text
+    api_env = _api_env_path(tmp_hal0_home)
+    assert oauth_store.is_connected("google", api_env=api_env) is True
+    token = oauth_store.load_token("google", api_env=api_env)
+    assert token.access_token == "at-123"
+    # The exchanged code must never appear stored verbatim anywhere queryable.
+    assert "auth-code-xyz" not in api_env.read_text(encoding="utf-8")
+
+
+def test_callback_state_is_single_use_replay_rejected(client: TestClient, tmp_hal0_home: str) -> None:
+    _configure_google(tmp_hal0_home)
+    start = client.post("/api/oauth/google/start")
+    state = start.json()["state"]
+
+    first = client.get("/api/oauth/google/callback", params={"code": "auth-code-xyz", "state": state})
+    second = client.get("/api/oauth/google/callback", params={"code": "auth-code-xyz", "state": state})
+
+    assert first.status_code == 200
+    assert second.status_code == 400
+
+
+def test_callback_provider_path_must_match_nonces_provider(client: TestClient, tmp_hal0_home: str) -> None:
+    _configure_google(tmp_hal0_home)
+    _set_client_id(tmp_hal0_home, "spotify", "s-client")
+    start = client.post("/api/oauth/google/start")
+    state = start.json()["state"]
+
+    # Same state, but hitting spotify's callback path — must be refused.
+    r = client.get("/api/oauth/spotify/callback", params={"code": "x", "state": state})
+
+    assert r.status_code == 400
+    assert oauth_store.is_connected("spotify", api_env=_api_env_path(tmp_hal0_home)) is False
+
+
+def test_callback_missing_code_is_rejected(client: TestClient, tmp_hal0_home: str) -> None:
+    _configure_google(tmp_hal0_home)
+    start = client.post("/api/oauth/google/start")
+    state = start.json()["state"]
+
+    r = client.get("/api/oauth/google/callback", params={"state": state})
+
+    assert r.status_code == 400
+
+
+def test_exchange_failure_surfaces_502(client: TestClient, tmp_hal0_home: str) -> None:
+    _FakeAsyncClient.response = _FakeResponse(400, {"error": "invalid_grant"})
+    _configure_google(tmp_hal0_home)
+    start = client.post("/api/oauth/google/start")
+    state = start.json()["state"]
+
+    r = client.get("/api/oauth/google/callback", params={"code": "bad-code", "state": state})
+
+    assert r.status_code == 502
+    assert "invalid_grant" not in r.text  # never echo the provider's raw error body
+
+
+def test_status_reflects_connection(client: TestClient, tmp_hal0_home: str) -> None:
+    _configure_google(tmp_hal0_home)
+    start = client.post("/api/oauth/google/start")
+    client.get("/api/oauth/google/callback", params={"code": "c", "state": start.json()["state"]})
+
+    r = client.get("/api/oauth/google/status")
+
+    assert r.status_code == 200
+    assert r.json()["connected"] is True
+    assert r.json()["expired"] is False
+
+
+def test_disconnect_removes_token_and_calls_revoke(client: TestClient, tmp_hal0_home: str) -> None:
+    _configure_google(tmp_hal0_home)
+    start = client.post("/api/oauth/google/start")
+    client.get("/api/oauth/google/callback", params={"code": "c", "state": start.json()["state"]})
+    _FakeAsyncClient.calls = []
+
+    r = client.delete("/api/oauth/google")
+
+    assert r.status_code == 204
+    assert oauth_store.is_connected("google", api_env=_api_env_path(tmp_hal0_home)) is False
+    revoke_calls = [c for c in _FakeAsyncClient.calls if "revoke" in c[0]]
+    assert len(revoke_calls) == 1
+
+
+def test_disconnect_when_never_connected_is_idempotent(client: TestClient) -> None:
+    r = client.delete("/api/oauth/google")
+    assert r.status_code == 204
+
+
+def test_disconnect_unknown_provider_404(client: TestClient) -> None:
+    r = client.delete("/api/oauth/nope")
+    assert r.status_code == 404
+
+
+def test_set_client_secret_never_echoed(client: TestClient, tmp_hal0_home: str) -> None:
+    r = client.post("/api/oauth/github/client-secret", json={"value": "super-secret-value"})
+    assert r.status_code == 204
+    assert "super-secret-value" not in r.text
+
+    listing = client.get("/api/oauth/providers")
+    assert "super-secret-value" not in listing.text
+    github = next(p for p in listing.json()["providers"] if p["id"] == "github")
+    assert github["has_client_secret"] is True
+
+
+def test_set_client_secret_rejects_control_characters(client: TestClient) -> None:
+    r = client.post("/api/oauth/github/client-secret", json={"value": "bad\nvalue"})
+    assert r.status_code == 400
+
+
+def test_ssrf_guard_blocks_private_authorize_url(client: TestClient, tmp_hal0_home: str) -> None:
+    registry = _registry_path(tmp_hal0_home)
+    registry.write_text(
+        'schema_version = "hal0.oauth-providers.v1"\n'
+        "[[providers]]\n"
+        'id = "evil"\n'
+        'name = "Evil"\n'
+        'skill_id = "evil"\n'
+        'authorize_url = "http://127.0.0.1:9999/auth"\n'
+        'token_url = "https://example.com/token"\n'
+        "pkce = false\n"
+        'client_id = "x"\n',
+        encoding="utf-8",
+    )
+
+    r = client.post("/api/oauth/evil/start")
+
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "mcp.ssrf_blocked"

--- a/tests/cli/test_oauth_commands.py
+++ b/tests/cli/test_oauth_commands.py
@@ -1,0 +1,102 @@
+"""Tests for ``hal0 oauth`` command request shapes and output."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import oauth_commands
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def api(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    calls: dict[str, Any] = {"gets": [], "posts": [], "deletes": []}
+    monkeypatch.setattr(oauth_commands, "_api_unreachable", lambda _url: False)
+
+    def fake_get(path: str, **_kw: Any) -> Any:
+        calls["gets"].append(path)
+        return calls.get("get_response", {})
+
+    def fake_post(path: str, *, json: dict[str, Any] | None = None, **_kw: Any) -> Any:
+        calls["posts"].append((path, json))
+        return calls.get("post_response", {})
+
+    def fake_delete(path: str, **_kw: Any) -> Any:
+        calls["deletes"].append(path)
+        return {}
+
+    monkeypatch.setattr(oauth_commands, "api_get", fake_get)
+    monkeypatch.setattr(oauth_commands, "api_post", fake_post)
+    monkeypatch.setattr(oauth_commands, "api_delete", fake_delete)
+    return calls
+
+
+def test_list_hits_providers_endpoint(api: dict[str, Any]) -> None:
+    api["get_response"] = {
+        "providers": [
+            {
+                "id": "google",
+                "skill_id": "google-workspace",
+                "configured": True,
+                "connected": False,
+                "expires_at": None,
+                "expired": None,
+            }
+        ]
+    }
+    result = runner.invoke(oauth_commands.app, ["list"])
+    assert result.exit_code == 0, result.output
+    assert api["gets"] == ["/api/oauth/providers"]
+    assert "google" in result.output
+
+
+def test_list_json_outputs_raw_providers(api: dict[str, Any]) -> None:
+    api["get_response"] = {"providers": [{"id": "spotify"}]}
+    result = runner.invoke(oauth_commands.app, ["list", "--json"])
+    assert result.exit_code == 0, result.output
+    assert '"id": "spotify"' in result.output
+
+
+def test_connect_prints_authorize_url(api: dict[str, Any]) -> None:
+    api["post_response"] = {"authorize_url": "https://accounts.google.com/auth?state=abc", "state": "abc"}
+    result = runner.invoke(oauth_commands.app, ["connect", "google"])
+    assert result.exit_code == 0, result.output
+    assert api["posts"] == [("/api/oauth/google/start", None)]
+    assert "https://accounts.google.com/auth?state=abc" in result.output
+
+
+def test_disconnect_requires_confirmation_without_force(api: dict[str, Any]) -> None:
+    result = runner.invoke(oauth_commands.app, ["disconnect", "google"], input="n\n")
+    assert result.exit_code == 0
+    assert api["deletes"] == []
+
+
+def test_disconnect_force_skips_confirmation(api: dict[str, Any]) -> None:
+    result = runner.invoke(oauth_commands.app, ["disconnect", "google", "--force"])
+    assert result.exit_code == 0, result.output
+    assert api["deletes"] == ["/api/oauth/google"]
+
+
+def test_status_reports_connected(api: dict[str, Any]) -> None:
+    api["get_response"] = {"connected": True, "expired": False}
+    result = runner.invoke(oauth_commands.app, ["status", "google"])
+    assert result.exit_code == 0, result.output
+    assert "connected" in result.output.lower()
+
+
+def test_status_reports_not_connected(api: dict[str, Any]) -> None:
+    api["get_response"] = {"connected": False}
+    result = runner.invoke(oauth_commands.app, ["status", "google"])
+    assert result.exit_code == 0, result.output
+    assert "not connected" in result.output.lower()
+
+
+def test_set_client_secret_sends_value_field(api: dict[str, Any]) -> None:
+    result = runner.invoke(oauth_commands.app, ["set-client-secret", "github", "--value", "s3cr3t"])
+    assert result.exit_code == 0, result.output
+    assert api["posts"] == [("/api/oauth/github/client-secret", {"value": "s3cr3t"})]
+    assert "s3cr3t" not in result.output

--- a/tests/cli/test_oauth_commands.py
+++ b/tests/cli/test_oauth_commands.py
@@ -62,7 +62,10 @@ def test_list_json_outputs_raw_providers(api: dict[str, Any]) -> None:
 
 
 def test_connect_prints_authorize_url(api: dict[str, Any]) -> None:
-    api["post_response"] = {"authorize_url": "https://accounts.google.com/auth?state=abc", "state": "abc"}
+    api["post_response"] = {
+        "authorize_url": "https://accounts.google.com/auth?state=abc",
+        "state": "abc",
+    }
     result = runner.invoke(oauth_commands.app, ["connect", "google"])
     assert result.exit_code == 0, result.output
     assert api["posts"] == [("/api/oauth/google/start", None)]

--- a/tests/mcp/test_manifest.py
+++ b/tests/mcp/test_manifest.py
@@ -215,7 +215,7 @@ async def test_default_fetcher_aborts_oversized_body(monkeypatch: pytest.MonkeyP
     bytes exceed _MAX_MANIFEST_BYTES, rather than buffering it all first."""
     import httpx
 
-    monkeypatch.setattr(manifest, "_enforce_safe_url", lambda url: None)
+    monkeypatch.setattr(manifest, "enforce_safe_url", lambda url: None)
     monkeypatch.setattr(manifest, "_MAX_MANIFEST_BYTES", 32)
 
     class _FakeResp:

--- a/tests/oauth/test_pkce.py
+++ b/tests/oauth/test_pkce.py
@@ -1,0 +1,37 @@
+"""Tests for RFC 7636 PKCE pair generation."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+
+from hal0.oauth.pkce import generate_pkce_pair
+
+_UNRESERVED = re.compile(r"^[A-Za-z0-9\-._~]+$")
+
+
+def test_verifier_matches_rfc7636_charset_and_length() -> None:
+    pair = generate_pkce_pair()
+    assert 43 <= len(pair.verifier) <= 128
+    assert _UNRESERVED.match(pair.verifier)
+
+
+def test_challenge_is_s256_of_verifier() -> None:
+    pair = generate_pkce_pair()
+    expected = base64.urlsafe_b64encode(hashlib.sha256(pair.verifier.encode("ascii")).digest())
+    expected = expected.rstrip(b"=").decode("ascii")
+    assert pair.challenge == expected
+    assert pair.method == "S256"
+
+
+def test_challenge_has_no_padding() -> None:
+    pair = generate_pkce_pair()
+    assert "=" not in pair.challenge
+
+
+def test_pairs_are_unique() -> None:
+    a = generate_pkce_pair()
+    b = generate_pkce_pair()
+    assert a.verifier != b.verifier
+    assert a.challenge != b.challenge

--- a/tests/oauth/test_providers.py
+++ b/tests/oauth/test_providers.py
@@ -1,0 +1,91 @@
+"""Tests for the `/etc/hal0/oauth-providers.toml` registry loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.oauth.providers import (
+    OAuthProvider,
+    ProviderRegistryError,
+    get_provider,
+    load_providers,
+)
+
+
+def test_load_providers_seeds_shipped_default_on_first_read(tmp_path: Path) -> None:
+    target = tmp_path / "oauth-providers.toml"
+    assert not target.exists()
+
+    providers = load_providers(path=target)
+
+    assert target.exists()
+    ids = {p.id for p in providers}
+    assert {"google", "spotify", "github"} <= ids
+
+
+def test_seeded_file_is_never_overwritten_after_hand_edit(tmp_path: Path) -> None:
+    target = tmp_path / "oauth-providers.toml"
+    load_providers(path=target)  # seeds it
+    original = target.read_text(encoding="utf-8")
+    edited = original + '\n[[providers]]\nid = "custom"\nname = "Custom"\nskill_id = "custom"\nauthorize_url = "https://example.com/auth"\ntoken_url = "https://example.com/token"\n'
+    target.write_text(edited, encoding="utf-8")
+
+    providers = load_providers(path=target)
+
+    assert any(p.id == "custom" for p in providers)
+
+
+def test_get_provider_returns_none_for_unknown_id(tmp_path: Path) -> None:
+    target = tmp_path / "oauth-providers.toml"
+    assert get_provider("nonexistent", path=target) is None
+
+
+def test_get_provider_finds_seeded_entry(tmp_path: Path) -> None:
+    target = tmp_path / "oauth-providers.toml"
+    google = get_provider("google", path=target)
+    assert google is not None
+    assert google.name == "Google Workspace"
+    assert google.pkce is True
+    assert google.requires_client_secret is True
+
+
+def test_malformed_entry_is_skipped_not_fatal(tmp_path: Path) -> None:
+    target = tmp_path / "oauth-providers.toml"
+    target.write_text(
+        'schema_version = "hal0.oauth-providers.v1"\n'
+        "[[providers]]\n"
+        'id = "broken"\n'  # missing required fields
+        "\n"
+        "[[providers]]\n"
+        'id = "ok"\n'
+        'name = "OK Provider"\n'
+        'skill_id = "ok"\n'
+        'authorize_url = "https://example.com/auth"\n'
+        'token_url = "https://example.com/token"\n',
+        encoding="utf-8",
+    )
+
+    providers = load_providers(path=target)
+
+    assert [p.id for p in providers] == ["ok"]
+
+
+def test_missing_providers_key_raises() -> None:
+    with pytest.raises(ProviderRegistryError):
+        OAuthProvider.from_dict({"id": "x"})
+
+
+def test_from_dict_rejects_non_list_scopes() -> None:
+    with pytest.raises(ProviderRegistryError):
+        OAuthProvider.from_dict(
+            {
+                "id": "x",
+                "name": "X",
+                "skill_id": "x",
+                "authorize_url": "https://example.com/a",
+                "token_url": "https://example.com/t",
+                "scopes": "not-a-list",
+            }
+        )

--- a/tests/oauth/test_providers.py
+++ b/tests/oauth/test_providers.py
@@ -29,7 +29,10 @@ def test_seeded_file_is_never_overwritten_after_hand_edit(tmp_path: Path) -> Non
     target = tmp_path / "oauth-providers.toml"
     load_providers(path=target)  # seeds it
     original = target.read_text(encoding="utf-8")
-    edited = original + '\n[[providers]]\nid = "custom"\nname = "Custom"\nskill_id = "custom"\nauthorize_url = "https://example.com/auth"\ntoken_url = "https://example.com/token"\n'
+    edited = (
+        original
+        + '\n[[providers]]\nid = "custom"\nname = "Custom"\nskill_id = "custom"\nauthorize_url = "https://example.com/auth"\ntoken_url = "https://example.com/token"\n'
+    )
     target.write_text(edited, encoding="utf-8")
 
     providers = load_providers(path=target)

--- a/tests/oauth/test_state.py
+++ b/tests/oauth/test_state.py
@@ -1,0 +1,56 @@
+"""Tests for the in-process OAuth state-nonce store (CSRF/replay defense)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.oauth.state import OAuthStateStore
+
+
+def test_issue_then_pop_returns_the_bound_nonce() -> None:
+    store = OAuthStateStore()
+    state = store.issue("google", code_verifier="verifier123")
+
+    nonce = store.pop(state)
+
+    assert nonce is not None
+    assert nonce.provider_id == "google"
+    assert nonce.code_verifier == "verifier123"
+
+
+def test_pop_is_single_use() -> None:
+    store = OAuthStateStore()
+    state = store.issue("google")
+
+    first = store.pop(state)
+    second = store.pop(state)
+
+    assert first is not None
+    assert second is None
+
+
+def test_unknown_state_returns_none() -> None:
+    store = OAuthStateStore()
+    assert store.pop("never-issued") is None
+
+
+def test_expired_nonce_is_pruned(monkeypatch: pytest.MonkeyPatch) -> None:
+    import hal0.oauth.state as state_mod
+
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(state_mod.time, "time", lambda: clock["now"])
+    store = OAuthStateStore(ttl_seconds=60)
+
+    state = store.issue("google")
+    clock["now"] += 61
+
+    assert store.pop(state) is None
+
+
+def test_nonces_for_different_providers_are_independent() -> None:
+    store = OAuthStateStore()
+    s1 = store.issue("google")
+    s2 = store.issue("spotify")
+
+    assert store.pop(s1).provider_id == "google"
+    assert store.pop(s2).provider_id == "spotify"

--- a/tests/oauth/test_store.py
+++ b/tests/oauth/test_store.py
@@ -1,0 +1,104 @@
+"""Tests for OAuth token/client-secret storage (through api.env, never logged)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from hal0.oauth import store
+from hal0.oauth.store import OAuthToken
+
+
+def _api_env(tmp_path: Path) -> Path:
+    return tmp_path / "api.env"
+
+
+def _token(**overrides) -> OAuthToken:
+    defaults = dict(
+        access_token="access-xyz",
+        refresh_token="refresh-abc",
+        expires_at=time.time() + 3600,
+        scope="calendar",
+        token_type="Bearer",
+    )
+    defaults.update(overrides)
+    return OAuthToken(**defaults)
+
+
+def test_save_and_load_round_trips(tmp_path: Path) -> None:
+    api_env = _api_env(tmp_path)
+    token = _token()
+
+    store.save_token("google", token, api_env=api_env)
+    loaded = store.load_token("google", api_env=api_env)
+
+    assert loaded == token
+
+
+def test_is_connected_true_after_save_false_after_delete(tmp_path: Path) -> None:
+    api_env = _api_env(tmp_path)
+    store.save_token("google", _token(), api_env=api_env)
+    assert store.is_connected("google", api_env=api_env) is True
+
+    assert store.delete_token("google", api_env=api_env) is True
+    assert store.is_connected("google", api_env=api_env) is False
+
+
+def test_delete_nonexistent_returns_false(tmp_path: Path) -> None:
+    api_env = _api_env(tmp_path)
+    assert store.delete_token("google", api_env=api_env) is False
+
+
+def test_load_returns_none_when_not_set(tmp_path: Path) -> None:
+    api_env = _api_env(tmp_path)
+    assert store.load_token("google", api_env=api_env) is None
+
+
+def test_connected_provider_ids_lists_only_token_keys(tmp_path: Path) -> None:
+    api_env = _api_env(tmp_path)
+    store.save_token("google", _token(), api_env=api_env)
+    store.save_client_secret("github", "shh-secret", api_env=api_env)
+
+    ids = store.connected_provider_ids(api_env=api_env)
+
+    assert ids == ["google"]  # the client-secret-only entry must not appear
+
+
+def test_driver_env_lines_emit_the_stored_json_verbatim(tmp_path: Path) -> None:
+    api_env = _api_env(tmp_path)
+    token = _token(expires_at=1234.5)
+    store.save_token("google", token, api_env=api_env)
+
+    lines = store.driver_env_lines(api_env=api_env)
+
+    assert len(lines) == 1
+    key, _, value = lines[0].partition("=")
+    assert key == "HAL0_OAUTH_GOOGLE_TOKEN"
+    assert OAuthToken.from_json(value) == token
+
+
+def test_provider_id_with_hyphen_normalizes_to_underscore_env_key(tmp_path: Path) -> None:
+    api_env = _api_env(tmp_path)
+    store.save_token("google-workspace", _token(), api_env=api_env)
+
+    assert store.is_connected("google-workspace", api_env=api_env) is True
+    assert "google-workspace" in store.connected_provider_ids(api_env=api_env)
+
+
+def test_client_secret_round_trips_and_is_separate_from_token(tmp_path: Path) -> None:
+    api_env = _api_env(tmp_path)
+    store.save_client_secret("github", "top-secret", api_env=api_env)
+
+    assert store.has_client_secret("github", api_env=api_env) is True
+    assert store.load_client_secret("github", api_env=api_env) == "top-secret"
+    assert store.is_connected("github", api_env=api_env) is False
+
+
+def test_stored_value_never_appears_in_plaintext_on_disk(tmp_path: Path) -> None:
+    """The api.env writer quotes + escapes; sanity-check nothing round-trips
+    to a plain unquoted secret line an operator might mistake for config."""
+    api_env = _api_env(tmp_path)
+    store.save_client_secret("github", "sekrit-value", api_env=api_env)
+
+    content = api_env.read_text(encoding="utf-8")
+    assert 'HAL0_OAUTH_GITHUB_CLIENT_SECRET="sekrit-value"' in content

--- a/tests/security/test_exposure.py
+++ b/tests/security/test_exposure.py
@@ -221,9 +221,26 @@ def test_representative_admin_routes_are_admin() -> None:
         ("POST", "/api/secrets/{name}"),
         ("GET", "/api/secrets"),
         ("POST", "/api/auth/rotate"),
+        ("GET", "/api/oauth/providers"),
+        ("POST", "/api/oauth/{provider_id}/start"),
+        ("GET", "/api/oauth/{provider_id}/status"),
+        ("DELETE", "/api/oauth/{provider_id}"),
+        ("POST", "/api/oauth/{provider_id}/client-secret"),
     ]
     for method, path in admin_examples:
         assert classify(method, path) is AuthClass.ADMIN, f"{method} {path} should be ADMIN"
+
+
+def test_oauth_callback_is_open_but_nothing_else_under_oauth_is() -> None:
+    """The provider redirect target is the one OAuth route with no auth.
+
+    A provider's 302 back to hal0 carries none of hal0's own bearer/cookie
+    — the security boundary there is the single-use state nonce
+    (hal0.oauth.state), not the exposure tier. Everything else under
+    /api/oauth stays ADMIN, same posture as /api/secrets.
+    """
+    assert classify("GET", "/api/oauth/{provider_id}/callback") is AuthClass.OPEN
+    assert classify("POST", "/api/oauth/{provider_id}/callback") is AuthClass.ADMIN
 
 
 def test_representative_client_routes_are_client() -> None:

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -390,6 +390,17 @@ export const ENDPOINTS = {
   providersCatalog: '/api/providers/catalog',
   providerCredentials: (name: string) =>
     `/api/providers/${encodeURIComponent(name)}/credentials`,
+
+  // ── OAuth passthrough (agent-driven skill connect, study 3.3) ─────
+  // GET providers lists the registry + connection status (never a token
+  // value). start mints a consent URL (opens in a new tab); the provider
+  // redirects straight back to GET /api/oauth/{id}/callback (server-side,
+  // never hit from the dashboard). DELETE disconnects.
+  oauthProviders: '/api/oauth/providers',
+  oauthStart: (id: string) => `/api/oauth/${encodeURIComponent(id)}/start`,
+  oauthStatus: (id: string) => `/api/oauth/${encodeURIComponent(id)}/status`,
+  oauthDisconnect: (id: string) => `/api/oauth/${encodeURIComponent(id)}`,
+  oauthClientSecret: (id: string) => `/api/oauth/${encodeURIComponent(id)}/client-secret`,
   // Service URL discovery — the dashboard reads this to resolve the
   // reachable hostnames for sibling services (OpenWebUI, Hermes) from the
   // request host, so links work on any install (localhost / LAN IP /

--- a/ui/src/api/hooks/useOAuth.ts
+++ b/ui/src/api/hooks/useOAuth.ts
@@ -1,0 +1,68 @@
+// hal0 v3 dashboard — OAuth passthrough hooks (Connections → Connected accounts).
+//
+// Backs the agent-driven OAuth passthrough (study 3.3): a Hermes skill
+// that needs OAuth (Google Calendar, Spotify, GitHub) is connected by
+// opening a provider consent link in a new tab; the provider redirects
+// straight back to hal0-api's own callback route, never through the
+// dashboard. This file only ever sees connection STATUS — a token value
+// never round-trips here.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiDelete, apiGet, apiPost } from '../client'
+import { ENDPOINTS } from '../endpoints'
+
+export interface OAuthProviderStatus {
+  id: string
+  name: string
+  skill_id: string
+  scopes: string[]
+  pkce: boolean
+  configured: boolean
+  requires_client_secret: boolean
+  has_client_secret: boolean
+  connected: boolean
+  expires_at: number | null
+  expired: boolean | null
+  notes: string
+}
+
+export interface OAuthStartResult {
+  authorize_url: string
+  state: string
+  provider_id: string
+}
+
+export function useOAuthProviders() {
+  return useQuery({
+    queryKey: ['oauth', 'providers'],
+    queryFn: () => apiGet<{ providers: OAuthProviderStatus[] }>(ENDPOINTS.oauthProviders),
+    select: (data) => data.providers,
+    // Connection state can change out-of-band (the operator authorizes in
+    // another tab, then comes back) — poll gently so the chip catches up
+    // without the operator having to refresh.
+    refetchInterval: 5000,
+  })
+}
+
+export function useOAuthStart() {
+  return useMutation({
+    mutationFn: (id: string) => apiPost<OAuthStartResult>(ENDPOINTS.oauthStart(id)),
+  })
+}
+
+export function useOAuthDisconnect() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => apiDelete(ENDPOINTS.oauthDisconnect(id)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['oauth', 'providers'] }),
+  })
+}
+
+export function useOAuthSetClientSecret() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, value }: { id: string; value: string }) =>
+      apiPost(ENDPOINTS.oauthClientSecret(id), { value }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['oauth', 'providers'] }),
+  })
+}

--- a/ui/src/dash/connections.jsx
+++ b/ui/src/dash/connections.jsx
@@ -39,6 +39,12 @@ import {
   useUpstreamTest,
   useUpstreamUpdate,
 } from '@/api/hooks/useUpstreams'
+import {
+  useOAuthDisconnect,
+  useOAuthProviders,
+  useOAuthSetClientSecret,
+  useOAuthStart,
+} from '@/api/hooks/useOAuth'
 
 const { useState: useCS } = React
 
@@ -1402,6 +1408,217 @@ function AddUpstreamForm({ onClose }) {
   )
 }
 
+// ─── Connected accounts (agent-driven OAuth passthrough, study 3.3) ────────
+//
+// A Hermes skill that needs OAuth (Google Calendar, Spotify, GitHub) is
+// connected here: Connect opens the provider's consent page in a new tab,
+// the provider redirects straight back to hal0-api's own callback route
+// (never through the dashboard), and this panel's poll picks up the new
+// `connected: true` a few seconds later. A token VALUE never reaches the
+// browser — only connection status.
+
+function OAuthStatusChip({ p }) {
+  if (!p.configured) return <span className="chip outlined">not configured</span>
+  if (p.connected && p.expired) return <span className="chip warn">token expired</span>
+  if (p.connected) return <span className="chip ok">connected</span>
+  return <span className="chip outlined">not connected</span>
+}
+
+function SetClientSecretDrawer({ provider, onClose }) {
+  const [value, setValue] = useCS('')
+  const setSecret = useOAuthSetClientSecret()
+
+  function submit() {
+    if (!value) return
+    setSecret.mutate(
+      { id: provider.id, value },
+      {
+        onSuccess: () => {
+          toast(`Client secret stored for ${provider.name}`, 'ok')
+          onClose()
+        },
+        onError: (e) => toast(`Could not store client secret — ${e?.message || 'see logs'}`, 'err'),
+      },
+    )
+  }
+
+  return (
+    <FormDrawer
+      eyebrow="connected accounts"
+      title={`Configure ${provider.name}`}
+      ariaLabel={`Configure ${provider.name} OAuth client secret`}
+      submitting={setSecret.isPending}
+      onClose={onClose}
+      foot={
+        <>
+          <button className="btn sm" onClick={onClose} disabled={setSecret.isPending}>
+            Cancel
+          </button>
+          <button
+            className="btn sm primary"
+            onClick={submit}
+            disabled={!value || setSecret.isPending}
+          >
+            {setSecret.isPending ? 'Saving…' : 'Save'}
+          </button>
+        </>
+      }
+    >
+      <FormRow
+        label="Client secret"
+        sub={`from ${provider.name}'s OAuth app console`}
+      >
+        <input
+          type="password"
+          autoFocus
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="paste the client secret"
+        />
+      </FormRow>
+      <p className="oa-drawer-hint">
+        Stored through hal0's secrets store — never written to
+        oauth-providers.toml, never shown again once saved.
+      </p>
+    </FormDrawer>
+  )
+}
+
+function OAuthAccountRow({ p }) {
+  const [confirmOpen, setConfirmOpen] = useCS(false)
+  const [secretDrawerOpen, setSecretDrawerOpen] = useCS(false)
+  const start = useOAuthStart()
+  const disconnect = useOAuthDisconnect()
+
+  function connect() {
+    start.mutate(p.id, {
+      onSuccess: (result) => {
+        window.open(result.authorize_url, '_blank', 'noopener,noreferrer')
+        toast(`Authorize ${p.name} in the new tab — hal0 picks it up automatically`, 'ok')
+      },
+      onError: (e) => toast(`Could not start ${p.name} connect — ${e?.message || 'see logs'}`, 'err'),
+    })
+  }
+
+  function confirmDisconnect() {
+    disconnect.mutate(p.id, {
+      onSuccess: () => {
+        setConfirmOpen(false)
+        toast(`Disconnected ${p.name}`, 'ok')
+      },
+      onError: (e) => {
+        setConfirmOpen(false)
+        toast(`Could not disconnect ${p.name} — ${e?.message || 'see logs'}`, 'err')
+      },
+    })
+  }
+
+  const needsSecret = p.requires_client_secret && !p.has_client_secret
+  const canConnect = p.configured && !p.connected
+
+  return (
+    <div className="eprow oarow">
+      <div className="eprow-main oa-main">
+        <span className={'ep-dot ' + (p.connected && !p.expired ? 'serving' : 'offline')} />
+        <span className="ep-name">{p.name}</span>
+        <span className="oa-skill mono">{p.skill_id}</span>
+        <span className="oa-chip">
+          <OAuthStatusChip p={p} />
+        </span>
+        <span className="oa-actions">
+          {needsSecret && (
+            <button className="btn sm" onClick={() => setSecretDrawerOpen(true)}>
+              Set client secret
+            </button>
+          )}
+          {!needsSecret && canConnect && (
+            <button className="btn sm primary" onClick={connect} disabled={start.isPending}>
+              {start.isPending ? 'Starting…' : 'Connect'}
+            </button>
+          )}
+          {p.connected && (
+            <button className="btn sm danger" onClick={() => setConfirmOpen(true)}>
+              Disconnect
+            </button>
+          )}
+        </span>
+      </div>
+      {secretDrawerOpen && (
+        <SetClientSecretDrawer provider={p} onClose={() => setSecretDrawerOpen(false)} />
+      )}
+      <ConfirmDialog
+        open={confirmOpen}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={confirmDisconnect}
+        title={`Disconnect ${p.name}?`}
+        message={`hal0's Hermes agent can use your ${p.name} account until you disconnect. This can't be undone from here — you'll need to reconnect to use ${p.skill_id} again.`}
+        confirmLabel={disconnect.isPending ? 'Disconnecting…' : 'Disconnect'}
+        destructive
+        confirmDisabled={disconnect.isPending}
+      />
+    </div>
+  )
+}
+
+function ConnectedAccountsPanel() {
+  const providersQuery = useOAuthProviders()
+  const providers = providersQuery.data ?? []
+  const connectedCount = providers.filter((p) => p.connected).length
+
+  return (
+    <EnginePane
+      glyph="connections"
+      eyebrow={
+        <>
+          <b>oauth</b>
+          <span className="dim">·</span>
+          <span className="meta">agent skills</span>
+          <span className="dim">·</span>
+          <span className="mono" style={{ color: 'var(--fg-3)' }}>
+            {providers.length} registered
+          </span>
+          <span className="grow" />
+          <span className="meta">oauth-providers.toml · agent-driven</span>
+        </>
+      }
+      title="Connected accounts"
+      sub="OAuth for Hermes skills · /api/oauth"
+      pill={{
+        tone: connectedCount ? 'live' : 'off',
+        text: `${connectedCount} connected`,
+      }}
+      foot={
+        <>
+          <span className="k">registry</span>
+          <span className="v">/etc/hal0/oauth-providers.toml</span>
+          <span className="sep">·</span>
+          <span className="k">tokens</span>
+          <span className="v">secrets store · never echoed</span>
+        </>
+      }
+    >
+      <div className="eplist oarowlist">
+        <div className="ep-head oa-head">
+          <span />
+          <span>account</span>
+          <span>skill</span>
+          <span>status</span>
+          <span />
+        </div>
+        {providersQuery.isPending && <div className="cn-empty mono">Loading OAuth providers…</div>}
+        {!providersQuery.isPending && providers.length === 0 && (
+          <div className="cn-empty mono">
+            No OAuth providers registered — hal0 seeds a default registry on first read.
+          </div>
+        )}
+        {providers.map((p) => (
+          <OAuthAccountRow key={p.id} p={p} />
+        ))}
+      </div>
+    </EnginePane>
+  )
+}
+
 function UpstreamProvidersPanel() {
   const upstreamsQuery = useUpstreams()
   const [adding, setAdding] = useCS(false)
@@ -1504,6 +1721,7 @@ function ConnectionsView() {
       </div>
       <div className="conn">
         <LocalEndpointsPanel />
+        <ConnectedAccountsPanel />
         <UpstreamProvidersPanel />
         <McpServersPanel />
       </div>


### PR DESCRIPTION
Hermes skills that need OAuth (Google Calendar, Spotify, GitHub) are now
connected by sending the operator a consent link. The provider's redirect
lands directly on GET /api/oauth/{provider}/callback and hal0 exchanges the
code for a token itself — PKCE where the provider supports it — so the
operator never copy-pastes an authorization code and the agent never handles
a raw code or client secret.

Adds hal0 oauth {list,connect,disconnect,status,set-client-secret}, a
dashboard Connections page ("Connected accounts"), and a Hermes persona
addendum walking the agent through the connect -> poll -> confirm flow. The
provider registry (/etc/hal0/oauth-providers.toml) is seeded from a shipped
default covering the common skill providers; tokens are stored through the
secrets store, never in TOML, never logged.

Ported from ODS's OAuth passthrough (Osmantic/ODS, Apache-2.0; permission to
copy granted by its author).

Signed-off-by: thinmintdev <alexander@awideweb.com>


## Verification

`ruff check src tests` clean. Full α unit suite (12808 tests) green apart from
three failures that also fail on a clean `main` checkout
(`tests/providers/test_moonshine_server.py` ×2, needs `ffmpeg`, and
`tests/slots/test_pressure_eviction.py::test_pressure_evict_noop_when_probe_fails`).
Integration β not run locally (needs root + a live `hal0-lemonade.service`); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzkumtSWnm3AxixzHG38UG
