### PR TITLE
feat(mcp): user-installed MCP servers reach an agent — tool policy, exposure, Hermes join (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,31 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+
+- **User-installed MCP servers can now actually reach an agent.** ADR-0015
+  extends `InstalledServer` with `secrets` (a reference into hal0's own
+  `/etc/hal0/api.env` store, never a literal), `tool_policy` (the same
+  `ToolPolicy` allow/gated/blocked scheme bundled agents use, disjoint and
+  empty-by-default), and `exposure` (`hermes`/`brain` honoured; `openwebui`/
+  `opencode` reserved, rejected with `501 mcp.exposure_unsupported`).
+  Flipping `exposure.hermes` on an enabled `streamable-http`/`sse` server
+  joins it into Hermes's `config.yaml` and mirrors its tool policy into the
+  `/etc/hal0/agents/hermes.toml` seed so `classify()` governs it exactly
+  like the two bundled servers — the join recomputes and prunes on every
+  registry mutation, never touching an operator's own hand-added
+  `mcp_servers` block. New CLI: `hal0 mcp test <id>` (probe + per-tool
+  allow/gated/blocked/unknown verdicts), `hal0 mcp allow|gate|block <id>
+  <tool>`, `hal0 mcp expose <id> --hermes/--brain`, and `add`/`remove` as
+  aliases of `install`/`uninstall`. New REST: `POST /api/mcp/{id}/test`,
+  `PATCH /api/mcp/{id}/tools`, `PATCH /api/mcp/{id}/exposure`; `GET
+  /api/mcp/servers` now reports real reachability for installed
+  `streamable-http`/`sse` servers instead of a hard-coded `"stopped"`. A
+  `stdio`-transport server's process supervisor is deferred (see
+  `docs/adr/0015-mcp-supervisor-and-exposure.md`) — install/configure work,
+  `exposure.hermes`/`.brain` reject with `409 mcp.exposure_needs_supervisor`
+  until it ships. (#305)
+
 ### Fixed
 
 - MCP admin tools no longer report a tool failure for a successful read of a

--- a/docs/adr/0015-mcp-supervisor-and-exposure.md
+++ b/docs/adr/0015-mcp-supervisor-and-exposure.md
@@ -1,0 +1,293 @@
+# ADR-0015: MCP process supervisor and Hermes exposure join
+
+## Status
+
+Accepted (http/sse scope). stdio supervision is designed but deferred —
+see "Deferred: stdio supervisor" below.
+
+## Context
+
+`src/hal0/mcp/installed.py` (issue #305) already gives operators a
+per-server TOML registry under `/etc/hal0/mcp-servers/<id>.toml` —
+atomic-written, 0600, lock-protected (`installed.py:211-314`). What it
+does not do:
+
+- An installed server never reaches Hermes. `_default_mcp_servers()`
+  (`src/hal0/agents/hermes_provision.py:1462-1497`) is the sole source of
+  `mcp_servers` entries written into Hermes's `config.yaml`
+  (`hermes_provision.py:2012-2021`) and the sole seed for
+  `/etc/hal0/agents/hermes.toml [mcp.servers.*]`
+  (`hermes_provision.py:6130-6165`) — the file
+  `hal0.agents.mcp_client.AgentMCPClient.classify()` reads
+  (`mcp_client.py:149-180`). Installing a server through the dashboard or
+  `hal0 mcp install` has never given an agent the ability to call it.
+- `InstalledServer` has no `[secrets]`, `[tools]`, or `[exposure]` block,
+  so there is nowhere to record per-tool policy or which consumer should
+  see a server.
+- `POST /api/mcp/{id}/{action}` is a 501 stub (`routes/mcp.py:934-945`)
+  that names this ADR by number; `list_servers` hard-codes
+  `state="stopped"` for every installed record (`routes/mcp.py:565`)
+  regardless of whether an http/sse server is actually reachable.
+- There is no `test` verb — installing a server currently gives an
+  operator no way to see what tools it advertises before deciding what
+  to allow.
+
+This ADR was commissioned by the hal0 × ODS parity field study
+(`06-mcp-memory.md`, section E). The study's conclusion, verified against
+both trees, is that **ODS contributes no code to this feature** — its
+`ape` policy service is unreachable dead infrastructure (see "Rejected"
+below) and its MCP story is thinner than hal0's own `ToolPolicy` +
+`AgentMCPClient.classify()`. The one thing worth porting is a *shape*:
+`ods/scripts/patch-hermes-config.py` patches Hermes's YAML by locating a
+named top-level block via regex over `list[str]` lines and rewriting only
+that span (`_top_level_block`/`_set_key`,
+`patch-hermes-config.py:17-59`), which is how it avoids clobbering an
+operator's hand-edited config on migration. Section "Decision 3" below
+explains why hal0 achieves the same operator-wins-and-converges property
+through a *different, already-precedented* mechanism instead of a literal
+port of that text patcher.
+
+## Decision
+
+### 1. Schema: extend `InstalledServer`, five new fields, all defaulted
+
+Added to `src/hal0/mcp/installed.py`'s `InstalledServer`:
+
+- `command: str = ""`, `args: list[str] = []` — stdio launch, unused
+  until the supervisor (below) ships.
+- `url: str = ""` — the streamable-http/sse connect URL. `transport`
+  gains `"sse"` as a third accepted value (`stdio | streamable-http |
+  sse`).
+- `secrets: dict[str, str] = {}` — maps an env-var name the server
+  expects to the **name of a key** in `/etc/hal0/api.env`, never a
+  literal value. Resolved at call time via `os.environ` (hal0-api keeps
+  `os.environ` in lockstep with `api.env` on every write —
+  `routes/secrets.py:1-10`); this is why the resolution never needs its
+  own read path. Reuses `/api/secrets`'s existing
+  `^[A-Z][A-Z0-9_]{0,63}$` name gate (`routes/secrets.py:63`) rather than
+  inventing a second secrets store, per the field study's recommendation
+  (§G.5) — hal0 already refuses to hold bearer tokens in TOML
+  (`AgentAuthConfig`, `schema.py:2682-2689`); this is the same rule
+  applied to third-party servers.
+- `tools: ToolPolicy` — **reused verbatim** from
+  `src/hal0/config/schema.py:2726` (allow/gated/blocked, disjoint,
+  empty-by-default). A freshly installed server therefore has zero
+  callable tools until an operator promotes some, matching
+  `ToolPolicy`'s own documented intent (`schema.py:2737-2740`). This
+  shadows the existing top-level `tools: int` counter field name — kept
+  as `tool_policy` on the model (`tools` stays the int count for
+  backward-compat with every existing on-disk record and dashboard
+  reader) to avoid a breaking rename; `to_toml_dict()` writes it under
+  the `[tools]` table.
+- `exposure: ExposureConfig` — new small model:
+  `hermes: bool = False`, `brain: bool = False`, `openwebui: bool =
+  False`, `opencode: bool = False`. Only `hermes` is honoured today
+  (Decision 3); `brain` is honoured for http/sse only (Decision 4);
+  setting `openwebui` or `opencode` `true` raises `501
+  mcp.exposure_unsupported` at the route layer — following the
+  `McpNotImplemented` precedent (`routes/mcp.py:57-69`) rather than
+  silently ignoring the field.
+
+Every new field defaults such that `InstalledServer.model_validate()` on
+an existing pre-#305 on-disk record (no `[secrets]`/`[tools]`/`[exposure]`
+table at all) still validates and now carries an empty, zero-tool,
+zero-exposure policy — i.e. install-time behaviour for old records is
+unchanged (still nothing reaches Hermes) until an operator explicitly
+opts in through the new CLI/REST surface.
+
+### 2. Exposure join: recompute, don't hand-patch
+
+On every registry mutation that can change the desired Hermes set
+(install, uninstall, `PATCH /tools`, `PATCH /exposure`, `PATCH /config`
+enabled toggle), `src/hal0/mcp/hermes_join.py` (new) runs
+`sync_hermes_mcp_servers()`:
+
+1. **Desired set** = `_default_mcp_servers()`'s two builtin entries
+   (unchanged, still the sole source for those) **plus** every
+   `InstalledServer` with `enabled=True`, `transport in
+   {"streamable-http", "sse"}`, and `exposure.hermes=True`. `stdio`
+   servers are excluded from the desired set — see "Deferred" below —
+   and a `hal0 mcp expose <id> --hermes` on a stdio server returns `409
+   mcp.exposure_needs_supervisor` rather than silently doing nothing.
+2. **Additive apply**: for each desired user-installed entry, call
+   `hermes config set` for `mcp_servers.<id>.{type,url,timeout}` +
+   `headers.X-hal0-Agent` (+ `Authorization` when a secret named
+   `AUTHORIZATION` or a service bearer is available), reusing the exact
+   pattern already at `hermes_provision.py:2012-2021` (same subprocess
+   invocation via `_hermes_bin`/`_fmt_config_value`, promoted from
+   private helpers in `hermes_provision.py` to a small public
+   `hermes_provision.apply_mcp_server_entries()` this ADR adds — one
+   owner for "how to talk to hermes config set" stays
+   `hermes_provision.py`, `hermes_join.py` only decides *what* the
+   desired user-server entries are).
+3. **Removal — the one thing `hermes config set` cannot express.**
+   `config.yaml` is Hermes-owned and machine-migrated
+   (`hermes config migrate`); hal0 already accepts losing hand
+   formatting/comments on it for exactly this reason —
+   `_merge_config_yaml_layers` (`hermes_provision.py:2131-2176`) and
+   `_phase_brain_profile_mcp_wire` (`hermes_provision.py:4012-4067`)
+   both `yaml.safe_load` → `_deep_merge` → `yaml.safe_dump` the whole
+   file today. Given that precedent, `hermes_join.py` uses the **same**
+   load/merge/dump primitive rather than ODS's line-based text patcher
+   (`patch-hermes-config.py`'s `_top_level_block`/`_set_key` operate on
+   a Jinja-rendered file with no independent owner of "what's inside a
+   block", and depend on comment-line survival hal0's own tooling
+   already doesn't guarantee): it loads `config.yaml`, computes
+   `desired_ids = {installed servers with exposure.hermes}`, drops any
+   `mcp_servers.<id>` key that (a) is not a builtin name, (b) is not in
+   `desired_ids`, and (c) **is present in a small ownership manifest**
+   at `/var/lib/hal0/mcp/hermes-managed.json` — the list of ids
+   `hermes_join` itself wrote on the previous run. Condition (c) is the
+   sentinel-comment idea's functional equivalent for a format that can't
+   carry inline markers through a full re-dump: an operator's hand-added
+   `mcp_servers` block was never in that manifest, so it is never a
+   candidate for removal, matching the field study's "never touch an
+   operator hand-added block" requirement (§E.3 step 3) without
+   depending on YAML comment preservation.
+4. **Mirror `[tools]` into the seed TOML.** `hermes_join.py` merges
+   `{"mcp": {"servers": {id: {"builtin": False, "enabled": record.enabled,
+   "tools": record.tools.model_dump()}}}}` into
+   `/etc/hal0/agents/hermes.toml` using the same deep-merge-preserving
+   write `_write_seed_toml` already uses for the two builtin blocks
+   (`hermes_provision.py:6178-6210`) — never a wholesale rewrite, and it
+   removes a previously-mirrored `[mcp.servers.<id>]` block under the
+   same ownership-manifest rule as step 3 when a server is uninstalled.
+   This is what makes `AgentMCPClient.classify()` (`mcp_client.py:149`)
+   govern user-installed servers on the same two axes (allow-listed at
+   all, then per-tool) as the two builtins — no change needed in
+   `mcp_client.py` itself.
+5. **Targeted re-probe.** After steps 2–4, `hermes_join.py` calls the
+   existing `hermes_provision._probe_mcp_server` **only for the servers
+   whose desired set changed**, so a bad URL surfaces at
+   install/expose-toggle time (`hal0 mcp test` reuses the identical call
+   — Decision 5) rather than at the agent's first turn.
+
+Failure mode: any step 2–5 exception is caught, logged, and returned to
+the caller as a warning field on the install/patch response (`"hermes_sync":
+{"ok": false, "error": ...}`) — never a 500. The registry write (the
+operator-visible source of truth) always succeeds or fails on its own;
+the Hermes join is a best-effort side effect that self-heals on the next
+mutation or the next `hal0 agent reprovision hermes --repair` (which
+still runs the full `_build_config_overlay` and will reconcile any drift).
+
+### 3. Why `hermes` only, unconditionally reachable
+
+`hermes` is the only consumer wired today because it is the only one with
+an existing, working config-write mechanism (`_build_config_overlay`) to
+extend. `brain` reuses `_build_brain_profile_mcp_servers` +
+`_phase_brain_profile_mcp_wire` (`hermes_provision.py:3974-4067`) the same
+way — `hermes_join.py` calls both syncs when a record's `exposure.brain`
+is set, since the brain profile join is a pure deep-merge on its own
+`config.yaml` copy and costs no new mechanism (field study §E.3/§G.4
+option: "ship hermes+brain in v1"). `openwebui`/`opencode` have no
+equivalent write path in this codebase today; wiring either is new
+infrastructure, not a join, and is explicitly out of this ADR's scope —
+setting either flag `true` returns `501 mcp.exposure_unsupported`.
+
+### 4. CLI verbs
+
+`src/hal0/cli/mcp_commands.py` gains:
+
+- `hal0 mcp test <id>` — calls `POST /api/mcp/{id}/test`: probes the
+  server (`_probe_mcp_server` for http/sse; stdio always reports
+  `mcp.supervisor_unavailable`) and prints each advertised tool's
+  `allow`/`gated`/`blocked`/`unknown_tool` verdict via
+  `mcp_client.classify_many` (`mcp_client.py:264-273`) against the
+  seed-TOML mirror written by Decision 2 step 4.
+- `hal0 mcp allow|gate|block <id> <tool>` — `PATCH /{id}/tools`,
+  wrapping `installed.patch_config`'s lock (`installed.py:281-314`,
+  extended to accept a `tools` argument).
+- `hal0 mcp expose <id> --hermes/--no-hermes [--brain/--no-brain]` —
+  `PATCH /{id}/exposure`, triggers Decision 2.
+- `hal0 mcp add`/`hal0 mcp remove` ship as `install`/`uninstall`
+  aliases (same handler, same route) — existing verb names are kept,
+  not renamed.
+
+### 5. REST
+
+`src/hal0/api/routes/mcp.py` gains `POST /{id}/test`, `PATCH
+/{id}/tools`, `PATCH /{id}/exposure`. All three classify as `ADMIN` in
+`src/hal0/security/exposure.py` (new `_Rule` rows next to the existing
+`mcp introspection` rule at `exposure.py:294` — unclassified defaults to
+ADMIN already, so this is belt-and-suspenders, verified by
+`tests/security/test_exposure.py`'s ratchet). `list_servers` replaces the
+hard-coded `state="stopped"` for `transport in {"streamable-http",
+"sse"}` records with a live reachability probe (cheap TCP-connect-class
+check, not the full tools/list handshake `test` does) — `stdio` records
+keep reporting `"stopped"` since there is still no process behind them.
+
+### 6. UI
+
+`ui/src/dash/connections.jsx`'s `McpServerRow` (`:727`) gets a per-tool
+three-state control (allow/gated/blocked) writing `PATCH /{id}/tools`,
+and an exposure row (Hermes toggle; Brain toggle; OpenWebUI/OpenCode
+rendered disabled with the 501 copy) writing `PATCH /{id}/exposure`. A
+new `InstallDrawer` (referenced but never built — `manifest.py:1-6`'s
+docstring has described it since #224) drives paste → `GET
+/api/mcp/resolve` preview → secrets/env rows → exposure toggles →
+`POST /api/mcp/install` → `POST /{id}/test` shown inline as the first
+tool-verdict list the operator sees.
+
+## Deferred: stdio supervisor
+
+`stdio` servers (the majority of the npm/uvx catalog — `filesystem`,
+`playwright`, `sequential-thinking`, …) need a process. The field study
+(§E.2) and hal0's own bundled-agent precedent
+(`ARCHITECTURE.md:395-397` — sandboxed sibling systemd units) both point
+at the same shape: one transient `hal0-mcp@<id>.service` per enabled
+stdio server, `User=hal0`, `ProtectSystem=strict`,
+`LoadCredential=` per `[secrets]` entry (mirroring how
+`AgentAuthConfig`'s `bearer-from-env` tokens already arrive,
+`mcp_client.py:199-231`), `ReadWritePaths=` scoped to a per-server
+scratch dir. `POST /{id}/{start,stop,restart}` would replace the current
+`McpNotImplemented` 501 with `systemctl`-equivalent calls through the
+existing `installer/wrappers/hal0-systemctl` allow-list seam.
+
+This is deferred out of this PR rather than designed further here
+because it needs the `hal0-systemctl` allow-list widened — an
+infrastructure change the field study and `COMMON.md` both flag as
+something to coordinate with the lead rather than land unilaterally in a
+vertical feature PR. Until it ships: `stdio` transport records install
+and configure normally (schema, tools, secrets all work), but `enabled`
+has no runtime effect, `exposure.hermes=true` on a stdio record is
+rejected with `409 mcp.exposure_needs_supervisor`, and
+`POST /{id}/{start,stop,restart}` keeps returning `mcp.supervisor_unavailable`
+pointing at this ADR.
+
+## Rejected
+
+- **ODS's `ape` policy service as a deployed component.** It is a
+  running, port-bound policy engine nothing calls — `config/ape/policy.yaml`
+  was updated for Hermes paths that never route through it (field study
+  §F.1). hal0's policy already lives in the call path
+  (`AgentMCPClient.classify()`); adding an out-of-path service would be
+  strictly worse than what exists.
+- **Literal port of `patch-hermes-config.py`'s line-based text patcher.**
+  Covered in Decision 2 — hal0 already committed to full-parse-merge-dump
+  for `config.yaml` in two existing call sites; a second, different
+  patching strategy for the same file would be a second owner of "how
+  `config.yaml` gets edited," which is exactly what `CLAUDE.md`'s
+  one-owner-per-fact rule forbids.
+- **Sentinel HTML/YAML comments as the ownership marker.** Comments
+  don't survive `yaml.safe_dump`; the ownership manifest (Decision 2
+  step 3) gets the identical "hal0 knows exactly what it can safely
+  remove" property without depending on that survival.
+
+## Consequences
+
+- Installing a server and flipping `exposure.hermes` now actually gives
+  an agent the ability to call it, closing the gap the field study
+  identified as the owner's original ask ("a custom way to add MCP
+  servers rather than just be stuck with the originals").
+- `classify()` governs user-installed tools identically to the two
+  builtins — no new policy code path, no new attack surface on the
+  tool-gating axis.
+- The Hermes/brain join is eventually-consistent and self-healing (best
+  effort now, full reconciliation on the next reprovision) rather than
+  transactional with the registry write — an operator who installs a
+  server and immediately checks Hermes before the join completes may see
+  a one-mutation lag; `hal0 mcp test` and `hal0 mcp status` both report
+  the join's last-known state so this is observable, not silent.
+- `stdio` servers remain registry-only (install/configure but not run)
+  until the supervisor ADR follow-up ships; this PR does not regress
+  anything — `stdio` already had no runtime before it.

--- a/docs/guides/connect-mcp.mdx
+++ b/docs/guides/connect-mcp.mdx
@@ -19,19 +19,22 @@ hal0 mcp install oci://ghcr.io/example/some-mcp-server:latest
 hal0 mcp install npm:@example/some-mcp-server
 hal0 mcp install uvx:some-mcp-server
 hal0 mcp install git+https://github.com/example/some-mcp-server
+hal0 mcp install https://some-mcp-server.example.com/mcp
 ```
 
-`hal0 mcp install` accepts an OCI image ref, an npm/uvx package
-specifier, a git URL, or a manifest URL. Each installed server persists
-as its own file, `/etc/hal0/mcp-servers/<id>.toml`, mode `0600` — secrets
-live in that server's own `env` block, never in a shared file.
+`hal0 mcp install` (alias: `hal0 mcp add`) accepts an OCI image ref, an
+npm/uvx package specifier, a git URL, or a streamable-http/sse manifest
+URL. Each installed server persists as its own file,
+`/etc/hal0/mcp-servers/<id>.toml`, mode `0600`. A **freshly installed
+server has zero callable tools and zero exposure** — see the next two
+sections to actually let an agent use it.
 
 ```sh
 hal0 mcp list                # bundled + installed
 hal0 mcp list --json
 hal0 mcp status <id>         # tools, env, connected clients
 hal0 mcp restart <id>
-hal0 mcp uninstall <id>
+hal0 mcp uninstall <id>      # alias: hal0 mcp remove <id>
 hal0 mcp uninstall <id> --force
 ```
 
@@ -43,6 +46,84 @@ hal0 mcp catalog refresh
 <Aside type="note">
 `hal0-admin` and `hal0-memory` (below) are bundled and cannot be
 uninstalled — `hal0 mcp uninstall hal0-admin` is rejected with a 409.
+</Aside>
+
+### Credentials
+
+Non-secret settings (a base URL, a workspace path) go in a server's
+plain `env` block. Anything credential-shaped is a *reference*, not a
+literal — point it at a name already in hal0's own secrets store
+(`hal0 config secrets set` / the dashboard's Settings → Secrets panel),
+never at a value typed straight into the server's TOML file:
+
+```toml
+# /etc/hal0/mcp-servers/github.toml
+[env]
+GITHUB_HOST = "github.com"
+
+[secrets]
+GITHUB_TOKEN = "GITHUB_MCP_TOKEN"   # name of a key already in /etc/hal0/api.env
+```
+
+This edits through `PATCH /api/mcp/{id}/config` (`env`) — the `secrets`
+block is written the same way a future release exposes on the CLI; today
+edit the record's `[secrets]` table directly, then `hal0 mcp restart <id>`
+(or reinstall) to pick it up.
+
+### Probe an installed server
+
+```sh
+hal0 mcp test github
+```
+
+Connects to the server directly (its own `url` + resolved `env`/`secrets`
+headers — never hal0's own credentials), lists its advertised tools, and
+shows each one's current `allow` / `gated` / `blocked` / `unknown_tool`
+verdict. Run this right after install: a fresh server's tools all show
+`unknown_tool` until you promote some (next section).
+
+### Set the tool policy
+
+A newly installed server can connect, but every one of its tools is
+unreachable until you say otherwise — the same default-deny posture
+hal0's bundled agents use:
+
+```sh
+hal0 mcp allow github search_repositories    # autonomous calls
+hal0 mcp gate github create_pull_request     # each call enqueues an approval
+hal0 mcp block github delete_repository      # hard-rejected at the client
+```
+
+A tool moves between tiers, never sits on two at once — `hal0 mcp allow`
+on a currently-gated tool promotes it and drops the gated entry
+automatically. Re-run `hal0 mcp test <id>` to confirm a verdict changed.
+
+### Expose to an agent
+
+Installing and setting a tool policy is not enough on its own — a server
+only reaches an agent once it is **exposed**:
+
+```sh
+hal0 mcp expose github --hermes           # join into Hermes's own config
+hal0 mcp expose github --no-hermes        # withdraw it
+hal0 mcp expose github --hermes --brain   # also join the hal0-brain profile
+```
+
+Exposing re-runs the join immediately (an idempotent recompute, not a
+one-shot patch) and re-probes the server, so a bad URL surfaces at expose
+time rather than at the agent's first turn. `openwebui`/`opencode` are
+reserved flags with no join yet — setting either returns
+`501 mcp.exposure_unsupported`. A `stdio`-transport server (most
+npm/uvx packages) has no supervisor yet either — `--hermes`/`--brain` on
+one of those returns `409 mcp.exposure_needs_supervisor` until that
+follow-up ships; `streamable-http`/`sse` servers work today.
+
+<Aside type="note">
+Uninstalling, disabling (`PATCH /api/mcp/{id}/config` `enabled: false`),
+or withdrawing exposure all re-run the same join and remove hal0's own
+entry from Hermes's config — an operator's own hand-added
+`mcp_servers.*` block in `config.yaml` is never touched, only entries
+hal0 itself previously wrote.
 </Aside>
 
 ## hal0's own bundled servers

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -388,13 +388,23 @@ dashboard/API-only (`/api/profiles`).
 
 ## `hal0 mcp` — manage MCP servers
 
+`add`/`remove` are aliases of `install`/`uninstall` (ADR-0015) — same
+route, same behaviour, different vocabulary.
+
 | Command | Args | Flags |
 |---|---|---|
 | `mcp list` | — | `--json` |
 | `mcp status <server_id>` | `server_id` | `--json` |
 | `mcp install <url_spec>` | `url_spec` | `--json` |
+| `mcp add <url_spec>` | `url_spec` | `--json` |
 | `mcp uninstall <server_id>` | `server_id` | `--force`/`-f` |
+| `mcp remove <server_id>` | `server_id` | `--force`/`-f` |
 | `mcp restart <server_id>` | `server_id` | — |
+| `mcp test <server_id>` | `server_id` | `--json` |
+| `mcp allow <server_id> <tool>` | `server_id`, `tool` | — |
+| `mcp gate <server_id> <tool>` | `server_id`, `tool` | — |
+| `mcp block <server_id> <tool>` | `server_id`, `tool` | — |
+| `mcp expose <server_id>` | `server_id` | `--hermes`/`--no-hermes`, `--brain`/`--no-brain` |
 | `mcp catalog list` | — | `--json` |
 | `mcp catalog refresh` | — | `--json` |
 

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -47,7 +47,7 @@ import stat
 import subprocess  # nosec B404 — needed to spawn python -m venv + pip
 import sys
 import tempfile
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -2126,6 +2126,163 @@ def _apply_config_set(
         except (subprocess.SubprocessError, OSError) as exc:
             errors.append(f"{key}: {exc}")
     return applied, errors
+
+
+def apply_mcp_server_entries(
+    entries: Mapping[str, dict[str, Any]],
+    *,
+    remove_ids: Iterable[str] = (),
+    hermes_home: Path | str = HERMES_HOME_DEFAULT,
+    venv: Path | str = "/var/lib/hal0/venvs/hermes",
+) -> dict[str, Any]:
+    """Additively write + surgically remove ``mcp_servers.<id>`` entries.
+
+    ADR-0015 §Decision 2 — the sole write path :mod:`hal0.mcp.hermes_join`
+    uses to join user-installed servers into Hermes's ``config.yaml``. This
+    is a public entrypoint (not a provisioning step) so it can run outside
+    the full :class:`BootstrapState` pipeline, on every MCP registry
+    mutation rather than only at ``hal0 agent reprovision`` time.
+
+    ``entries`` maps server id → ``{"type", "url", "timeout", "headers":
+    {...}}`` — the identical shape the two-builtin-server loop in
+    :func:`_build_config_overlay` already applies (``:2012-2021``); this
+    function reuses the same ``hermes config set`` mechanism
+    (:func:`_apply_config_set`) rather than a second one.
+
+    ``remove_ids`` are ids to delete from the ``mcp_servers`` table.
+    ``hermes config set`` cannot express deletion, so removal is a direct
+    load → pop → dump of ``config.yaml`` — the same full-parse-merge-dump
+    strategy :func:`_merge_config_yaml_layers` and
+    :func:`_phase_brain_profile_mcp_wire` already use on this exact file,
+    chosen over a line-based text patch (see ADR-0015 "Rejected") because
+    hal0 already accepts losing hand-formatting on this machine-migrated
+    file at those two call sites. Any id present in BOTH ``entries`` and
+    ``remove_ids`` is treated as a desired entry (removal loses) — callers
+    pass only ids that are no longer desired.
+
+    Best-effort: every failure lands in the returned ``errors`` list rather
+    than raising, so a caller can surface a warning without failing the
+    registry mutation that triggered the sync. Returns
+    ``{"applied": int, "removed": list[str], "errors": list[str]}``.
+    """
+    hermes_home = Path(hermes_home)
+    venv = Path(venv)
+    errors: list[str] = []
+    applied = 0
+
+    if entries:
+        pairs: list[tuple[str, Any]] = []
+        for sid, spec in entries.items():
+            pairs += [
+                (f"mcp_servers.{sid}.type", spec.get("type", "http")),
+                (f"mcp_servers.{sid}.url", spec["url"]),
+                (f"mcp_servers.{sid}.timeout", spec.get("timeout", 60)),
+            ]
+            for hk, hv in (spec.get("headers") or {}).items():
+                pairs.append((f"mcp_servers.{sid}.headers.{hk}", hv))
+        hermes_bin = _hermes_bin(venv)
+        if hermes_bin.exists():
+            applied, set_errors = _apply_config_set(
+                pairs, hermes_bin=hermes_bin, hermes_home=hermes_home, run=subprocess.run
+            )
+            errors.extend(set_errors)
+        else:
+            errors.append(f"hermes binary not found at {hermes_bin}")
+
+    removed: list[str] = []
+    to_remove = [sid for sid in remove_ids if sid not in entries]
+    if to_remove:
+        try:
+            import yaml
+        except ImportError:
+            errors.append("PyYAML unavailable; cannot remove stale mcp_servers entries")
+        else:
+            config_path = hermes_home / "config.yaml"
+            try:
+                data: dict[str, Any] = {}
+                if config_path.exists():
+                    data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+                servers = data.get("mcp_servers")
+                if isinstance(servers, dict):
+                    changed = False
+                    for sid in to_remove:
+                        if servers.pop(sid, None) is not None:
+                            removed.append(sid)
+                            changed = True
+                    if changed:
+                        out = yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
+                        _atomic_write(config_path, out)
+            except (OSError, yaml.YAMLError) as exc:
+                errors.append(f"remove: {exc}")
+
+    return {"applied": applied, "removed": removed, "errors": errors}
+
+
+def apply_brain_profile_mcp_entries(
+    entries: Mapping[str, dict[str, Any]],
+    *,
+    remove_ids: Iterable[str] = (),
+    hermes_home: Path | str = HERMES_HOME_DEFAULT,
+) -> dict[str, Any]:
+    """Join user-installed servers into the hal0-brain profile's config.yaml.
+
+    ADR-0015 §Decision 3. The brain profile is a separate hermes-managed
+    ``config.yaml`` under ``profiles/hal0-brain/`` that ``hermes config
+    set`` cannot target (the CLI only edits the active ``$HERMES_HOME``
+    config) — :func:`_phase_brain_profile_mcp_wire` already handles this by
+    deep-merging directly, so this function does the same for user-installed
+    entries rather than inventing a second mechanism. Skips (returns
+    ``{"wired": False, ...}``) when the profile config doesn't exist yet or
+    PyYAML is unavailable, matching that function's own degrade-to-OK
+    posture — brain wiring is never load-bearing for the registry mutation
+    that triggered it.
+    """
+    path = Path(hermes_home) / "profiles" / _BRAIN_PROFILE_NAME / "config.yaml"
+    if not path.exists():
+        return {"wired": False, "reason": "brain profile config absent", "path": str(path)}
+    try:
+        import yaml
+    except ImportError:
+        return {"wired": False, "reason": "PyYAML unavailable", "path": str(path)}
+
+    try:
+        current = path.read_text(encoding="utf-8")
+        data = yaml.safe_load(current) or {}
+        servers = (
+            data.setdefault("mcp_servers", {})
+            if entries or remove_ids
+            else data.get("mcp_servers", {})
+        )
+        removed: list[str] = []
+        for sid in remove_ids:
+            if (
+                sid not in entries
+                and isinstance(servers, dict)
+                and servers.pop(sid, None) is not None
+            ):
+                removed.append(sid)
+        if isinstance(servers, dict):
+            for sid, spec in entries.items():
+                servers[sid] = {
+                    "type": spec.get("type", "http"),
+                    "url": spec["url"],
+                    "headers": dict(spec.get("headers") or {}),
+                    "timeout": spec.get("timeout", 60),
+                }
+        out = yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
+        changed = out != current
+        if changed:
+            _atomic_write(path, out)
+    except (OSError, yaml.YAMLError) as exc:
+        return {"wired": False, "error": str(exc), "path": str(path)}
+
+    return {
+        "wired": True,
+        "changed": changed,
+        "removed": removed,
+        "path": str(path),
+        "servers": sorted(entries.keys()),
+    }
 
 
 def _merge_config_yaml_layers(

--- a/src/hal0/api/routes/mcp.py
+++ b/src/hal0/api/routes/mcp.py
@@ -48,7 +48,6 @@ from fastapi.responses import StreamingResponse
 from hal0 import __version__
 from hal0.config.schema import ToolPolicy
 from hal0.errors import BadRequest, Conflict, Hal0Error
-from hal0.mcp import hermes_join
 from hal0.mcp import installed as installed_registry
 from hal0.mcp import manifest as manifest_resolver
 from hal0.mcp import probe as mcp_probe
@@ -877,7 +876,16 @@ async def _sync_hermes_join(server_id: str | None) -> dict[str, Any]:
     rather than importing it directly into the async handler body.
     Never raises — :func:`sync_exposure` folds every failure into its own
     ``errors`` list (ADR-0015 §Decision 2).
+
+    Imported HERE, not at module scope: ``hal0.api`` imports every route
+    module eagerly, so a top-level ``from hal0.mcp import hermes_join`` puts
+    a hermes-named module in the core import graph and breaks GP-15
+    ("importing the public core does not drag in a hermes dependency",
+    ``tests/golden_paths/test_gp15_no_hermes.py``). The join is only ever
+    reached from a mutation handler, which is well past import time.
     """
+    from hal0.mcp import hermes_join
+
     return await asyncio.to_thread(hermes_join.sync_exposure, only_server_id=server_id)
 
 

--- a/src/hal0/api/routes/mcp.py
+++ b/src/hal0/api/routes/mcp.py
@@ -19,8 +19,11 @@ Endpoints
     POST   /api/mcp/install            — install from a resolved spec/URL (#305)
     DELETE /api/mcp/{id}               — uninstall a user-installed server (#305)
     PATCH  /api/mcp/{id}/config        — write env / enabled overrides (#305)
+    POST   /api/mcp/{id}/test          — probe + classify advertised tools (ADR-0015)
+    PATCH  /api/mcp/{id}/tools         — write the [tools] allow/gated/blocked policy (ADR-0015)
+    PATCH  /api/mcp/{id}/exposure      — write the [exposure] hermes/brain flags (ADR-0015)
     POST   /api/mcp/{id}/{action}      — start/stop/restart — stubs 501
-                                          pending the supervisor follow-up.
+                                          pending the stdio supervisor (ADR-0015).
 
 Bundled servers (``hal0-admin``, ``hal0-memory``) are uninstall-protected;
 the route returns ``409 mcp.bundled`` rather than letting the registry
@@ -36,17 +39,25 @@ import shutil
 import time
 from collections.abc import AsyncIterator
 from typing import Any
+from urllib.parse import urlsplit
 
 import structlog
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import StreamingResponse
 
 from hal0 import __version__
+from hal0.config.schema import ToolPolicy
 from hal0.errors import BadRequest, Conflict, Hal0Error
+from hal0.mcp import hermes_join
 from hal0.mcp import installed as installed_registry
 from hal0.mcp import manifest as manifest_resolver
+from hal0.mcp import probe as mcp_probe
+from hal0.mcp.installed import ExposureConfig, InstalledServer
 
 log = structlog.get_logger(__name__)
+
+#: ADR-0015 §Decision 3/4 — the only two exposure targets with a join.
+_UNSUPPORTED_EXPOSURE_TARGETS = ("openwebui", "opencode")
 
 router = APIRouter()
 
@@ -441,6 +452,33 @@ def _tool_detail(tool: Any, gated_names: frozenset[str]) -> dict[str, Any]:
     }
 
 
+async def _installed_state(record: InstalledServer) -> str:
+    """Real reachability for ``streamable-http``/``sse``; unchanged for stdio.
+
+    A cheap TCP-connect probe — deliberately NOT the full ``tools/list``
+    JSON-RPC handshake ``POST /{id}/test`` performs (:mod:`hal0.mcp.probe`)
+    — so listing every installed server stays fast regardless of count
+    (ADR-0015 §Decision 5). ``stdio`` still reports ``"stopped"``: there is
+    no process behind it until the supervisor ships (ADR-0015 "Deferred").
+    """
+    if record.transport not in ("streamable-http", "sse") or not record.url:
+        return "stopped"
+    parts = urlsplit(record.url)
+    host = parts.hostname
+    if not host:
+        return "stopped"
+    port = parts.port or (443 if parts.scheme == "https" else 80)
+    try:
+        async with asyncio.timeout(1.5):
+            _reader, writer = await asyncio.open_connection(host, port)
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+        return "reachable" if record.enabled else "disabled"
+    except (OSError, TimeoutError):
+        return "unreachable"
+
+
 def _connect_url(request: Request, mount: str) -> str:
     """Build the connect URL the dashboard renders next to each server.
 
@@ -559,10 +597,9 @@ async def list_servers(request: Request) -> dict[str, Any]:
                 "id": record.id,
                 "name": record.name,
                 "bundled": False,
-                # No supervisor yet → installed servers always start stopped;
-                # ``enabled`` is the operator's intent for when the supervisor
-                # arrives, not the current process state.
-                "state": "stopped",
+                # http/sse: real reachability (ADR-0015). stdio still has no
+                # supervisor, so it always reports "stopped".
+                "state": await _installed_state(record),
                 "transport": record.transport,
                 "connect_url": _connect_url(request, record.id),
                 "pid": None,
@@ -586,6 +623,9 @@ async def list_servers(request: Request) -> dict[str, Any]:
                 "spec": record.spec,
                 "source_url": record.source_url,
                 "env": record.env,
+                "secrets": sorted(record.secrets),
+                "tools_policy": record.tool_policy.model_dump(mode="python"),
+                "exposure": record.exposure.model_dump(mode="python"),
                 "enabled": record.enabled,
                 "installed_at": record.installed_at,
             }
@@ -815,6 +855,18 @@ async def resolve_manifest(
     return resolved.model_dump(mode="python")
 
 
+async def _sync_hermes_join(server_id: str | None) -> dict[str, Any]:
+    """Run :func:`hal0.mcp.hermes_join.sync_exposure` off the event loop.
+
+    Subprocess calls (``hermes config set``) and file I/O make this
+    blocking; every mutation route awaits it via ``asyncio.to_thread``
+    rather than importing it directly into the async handler body.
+    Never raises — :func:`sync_exposure` folds every failure into its own
+    ``errors`` list (ADR-0015 §Decision 2).
+    """
+    return await asyncio.to_thread(hermes_join.sync_exposure, only_server_id=server_id)
+
+
 # ── Install / uninstall / patch (#305) ──────────────────────────────────────
 
 
@@ -859,12 +911,20 @@ async def install_server(request: Request, body: dict[str, Any]) -> dict[str, An
         fetcher = getattr(request.app.state, "mcp_manifest_fetcher", None)
         resolved = await manifest_resolver.resolve(url, fetcher=fetcher)
 
+    # A streamable-http/sse manifest's connect endpoint is the resolved
+    # URL itself (the http(s) branch of manifest.resolve() only reaches
+    # here for a manifest whose declared transport isn't "stdio"); stdio
+    # records have no `url` (ADR-0015 §Decision 1 — `command`/`args`
+    # cover that transport, unused until the supervisor ships).
+    connect_url = resolved.source_url or "" if resolved.transport != "stdio" else ""
+
     record = installed_registry.InstalledServer(
         id=resolved.id,
         name=resolved.name,
         description=resolved.description,
         spec=resolved.spec,
         transport=resolved.transport,
+        url=connect_url,
         tools=resolved.tools,
         resources=resolved.resources,
         prompts=resolved.prompts,
@@ -875,7 +935,8 @@ async def install_server(request: Request, body: dict[str, Any]) -> dict[str, An
         verified=resolved.verified,
     )
     stored = installed_registry.install(record)
-    return {"installed": stored.model_dump(mode="python")}
+    hermes_sync = await _sync_hermes_join(stored.id)
+    return {"installed": stored.model_dump(mode="python"), "hermes_sync": hermes_sync}
 
 
 @router.delete("/{server_id}")
@@ -893,7 +954,8 @@ async def uninstall_server(server_id: str) -> dict[str, Any]:
             details={"server_id": server_id},
         )
     installed_registry.uninstall(server_id)
-    return {"uninstalled": server_id}
+    hermes_sync = await _sync_hermes_join(server_id)
+    return {"uninstalled": server_id, "hermes_sync": hermes_sync}
 
 
 @router.patch("/{server_id}/config")
@@ -925,7 +987,134 @@ async def patch_server_config(server_id: str, body: dict[str, Any]) -> dict[str,
     if enabled is not None and not isinstance(enabled, bool):
         raise BadRequest("'enabled' must be a boolean", code="mcp.enabled_invalid")
     updated = installed_registry.patch_config(server_id, env=env_block, enabled=enabled)
-    return {"server": updated.model_dump(mode="python")}
+    result: dict[str, Any] = {"server": updated.model_dump(mode="python")}
+    if enabled is not None:
+        # enabled gates membership in the Hermes/brain desired set
+        # (hal0.mcp.installed.list_enabled_exposed) — env alone never does.
+        result["hermes_sync"] = await _sync_hermes_join(server_id)
+    return result
+
+
+@router.post("/{server_id}/test")
+async def test_server(server_id: str) -> dict[str, Any]:
+    """Probe an installed server + classify its advertised tools.
+
+    ADR-0015 §Decision 4/5 — the single highest-value new verb: turns "I
+    added a server" into "here is exactly what it can do and what I have
+    permitted". ``stdio`` servers have no supervisor yet, so this always
+    returns the same ``mcp.supervisor_unavailable`` 501 the start/stop/
+    restart stub does. Bundled servers aren't installed-registry records
+    at all — this route 404s for them via :func:`installed_registry.get_installed`.
+    """
+    record = installed_registry.get_installed(server_id)
+    if record.transport == "stdio":
+        raise McpNotImplemented(
+            "stdio servers have no supervisor yet (pending ADR-0015)",
+            details={"server_id": server_id, "action": "test"},
+        )
+    result = await asyncio.to_thread(mcp_probe.probe_installed_server_sync, record)
+    verdicts: dict[str, str] = {}
+    if result.get("ok"):
+        verdicts = _classify_tools(server_id, result.get("tools") or [])
+    return {"server_id": server_id, "probe": result, "verdicts": verdicts}
+
+
+def _classify_tools(server_id: str, tool_names: list[str]) -> dict[str, str]:
+    """Classify each advertised tool against the seed-TOML mirror.
+
+    Reuses :meth:`hal0.agents.mcp_client.AgentMCPClient.classify` — the
+    exact function that governs a live agent's tool calls — against the
+    ``/etc/hal0/agents/hermes.toml`` mirror :mod:`hal0.mcp.hermes_join`
+    writes. Degrades to ``"unknown_server"`` for every tool when the seed
+    TOML doesn't exist yet (fresh install, no agent provisioned) or fails
+    to parse — never a 500 for what is fundamentally a read-only preview.
+    """
+    from hal0.agents.mcp_client import AgentMCPClient, classify_many
+
+    try:
+        client = AgentMCPClient.from_agent_name("hermes")
+    except Exception:
+        return dict.fromkeys(tool_names, "unknown_server")
+    verdicts = classify_many(client, [(server_id, name) for name in tool_names])
+    return {name: verdicts[(server_id, name)] for name in tool_names}
+
+
+@router.patch("/{server_id}/tools")
+async def patch_server_tools(server_id: str, body: dict[str, Any]) -> dict[str, Any]:
+    """Write the ``[tools]`` allow/gated/blocked policy for a server.
+
+    ADR-0015 §Decision 1/4. Reuses :class:`hal0.config.schema.ToolPolicy`
+    verbatim — the same disjointness validator a bundled agent's policy
+    gets — so an overlapping edit 400s here instead of silently deciding
+    "which list wins" at dispatch time. Triggers the Hermes/brain seed-TOML
+    mirror re-sync (the policy axis, not membership, so config.yaml itself
+    is untouched — only the classify() source changes).
+    """
+    if server_id in installed_registry.BUNDLED_SERVER_IDS:
+        raise Conflict(
+            f"server {server_id!r} is bundled — tools are read-only here",
+            code="mcp.bundled",
+            details={"server_id": server_id},
+        )
+    if not isinstance(body, dict):
+        raise BadRequest("patch body must be a JSON object", code="mcp.body_invalid")
+    try:
+        policy = ToolPolicy.model_validate(body)
+    except Exception as exc:
+        raise BadRequest(
+            "invalid tool policy",
+            code="mcp.tools_invalid",
+            details={"reason": str(exc)},
+        ) from exc
+    updated = installed_registry.patch_config(server_id, tool_policy=policy)
+    hermes_sync = await _sync_hermes_join(server_id)
+    return {"server": updated.model_dump(mode="python"), "hermes_sync": hermes_sync}
+
+
+@router.patch("/{server_id}/exposure")
+async def patch_server_exposure(server_id: str, body: dict[str, Any]) -> dict[str, Any]:
+    """Write the ``[exposure]`` hermes/brain/openwebui/opencode flags.
+
+    ADR-0015 §Decision 1/3/4. ``openwebui``/``opencode`` have no join
+    mechanism — setting either ``true`` is rejected with
+    ``501 mcp.exposure_unsupported`` (the field study's explicit
+    recommendation: fail loudly rather than silently ignore an operator's
+    intent). A ``stdio`` record has no supervisor to make it reachable, so
+    ``hermes``/``brain`` reject with ``409 mcp.exposure_needs_supervisor``
+    instead of accepting a flag that would never actually join anything.
+    """
+    if server_id in installed_registry.BUNDLED_SERVER_IDS:
+        raise Conflict(
+            f"server {server_id!r} is bundled — exposure is read-only here",
+            code="mcp.bundled",
+            details={"server_id": server_id},
+        )
+    if not isinstance(body, dict):
+        raise BadRequest("patch body must be a JSON object", code="mcp.body_invalid")
+    for target in _UNSUPPORTED_EXPOSURE_TARGETS:
+        if body.get(target) is True:
+            raise McpNotImplemented(
+                f"{target} exposure has no join mechanism yet (pending ADR-0015)",
+                details={"server_id": server_id, "target": target},
+            )
+    record = installed_registry.get_installed(server_id)
+    current = record.exposure.model_dump(mode="python")
+    current.update({k: v for k, v in body.items() if k in current})
+    try:
+        exposure = ExposureConfig.model_validate(current)
+    except Exception as exc:
+        raise BadRequest(
+            "invalid exposure flags", code="mcp.exposure_invalid", details={"reason": str(exc)}
+        ) from exc
+    if record.transport == "stdio" and (exposure.hermes or exposure.brain):
+        raise Conflict(
+            "stdio servers have no supervisor yet — cannot expose to hermes/brain",
+            code="mcp.exposure_needs_supervisor",
+            details={"server_id": server_id},
+        )
+    updated = installed_registry.patch_config(server_id, exposure=exposure)
+    hermes_sync = await _sync_hermes_join(server_id)
+    return {"server": updated.model_dump(mode="python"), "hermes_sync": hermes_sync}
 
 
 # ── Action stub (start/stop/restart — supervisor follow-up) ─────────────────

--- a/src/hal0/api/routes/mcp.py
+++ b/src/hal0/api/routes/mcp.py
@@ -80,6 +80,20 @@ class McpNotImplemented(Hal0Error):
     status = 501
 
 
+class McpExposureUnsupported(Hal0Error):
+    """``PATCH /{id}/exposure`` rejects ``openwebui``/``opencode`` — no join yet.
+
+    ADR-0015 §Decision 1/3/4: only ``hermes`` and ``brain`` have a join
+    mechanism. A distinct code (rather than reusing
+    ``mcp.supervisor_unavailable``, which names a different gap — the
+    stdio process supervisor) so a client can tell "this target has no
+    join at all" apart from "this server has no process yet".
+    """
+
+    code = "mcp.exposure_unsupported"
+    status = 501
+
+
 # ── Static catalog ──────────────────────────────────────────────────────────
 #
 # A small, hand-checked list of MCP servers an operator can install. It is
@@ -624,7 +638,7 @@ async def list_servers(request: Request) -> dict[str, Any]:
                 "source_url": record.source_url,
                 "env": record.env,
                 "secrets": sorted(record.secrets),
-                "tools_policy": record.tool_policy.model_dump(mode="python"),
+                "tool_policy": record.tool_policy.model_dump(mode="python"),
                 "exposure": record.exposure.model_dump(mode="python"),
                 "enabled": record.enabled,
                 "installed_at": record.installed_at,
@@ -1093,7 +1107,7 @@ async def patch_server_exposure(server_id: str, body: dict[str, Any]) -> dict[st
         raise BadRequest("patch body must be a JSON object", code="mcp.body_invalid")
     for target in _UNSUPPORTED_EXPOSURE_TARGETS:
         if body.get(target) is True:
-            raise McpNotImplemented(
+            raise McpExposureUnsupported(
                 f"{target} exposure has no join mechanism yet (pending ADR-0015)",
                 details={"server_id": server_id, "target": target},
             )

--- a/src/hal0/cli/mcp_commands.py
+++ b/src/hal0/cli/mcp_commands.py
@@ -34,6 +34,7 @@ from hal0.cli._shared import (
     _api_unreachable,
     api_delete,
     api_get,
+    api_patch,
     api_post,
     die,
 )
@@ -233,6 +234,18 @@ def install_cmd(
     )
 
 
+# ── `hal0 mcp add` (ADR-0015 §Decision 4 — alias of install) ────────────────
+
+
+@app.command("add")
+def add_cmd(
+    url_spec: str = typer.Argument(..., help="MCP server URL or spec (oci://…, npm:…, etc.)."),
+    json_out: bool = typer.Option(False, "--json", help="Emit raw JSON instead of the panel."),
+) -> None:
+    """Alias of ``hal0 mcp install``."""
+    install_cmd(url_spec, json_out)
+
+
 # ── `hal0 mcp uninstall` ─────────────────────────────────────────────────────
 
 
@@ -265,6 +278,18 @@ def uninstall_cmd(
     )
 
 
+# ── `hal0 mcp remove` (ADR-0015 §Decision 4 — alias of uninstall) ───────────
+
+
+@app.command("remove")
+def remove_cmd(
+    server_id: str = typer.Argument(..., help="MCP server id to remove."),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation prompt."),
+) -> None:
+    """Alias of ``hal0 mcp uninstall``."""
+    uninstall_cmd(server_id, force)
+
+
 # ── `hal0 mcp restart` ───────────────────────────────────────────────────────
 
 
@@ -284,6 +309,152 @@ def restart_cmd(
 
     # Expecting a 501 for now (supervisor not implemented), but handle gracefully
     console.print(f"[bold yellow]restart {server_id}:[/bold yellow] {result}")
+
+
+# ── `hal0 mcp test` (ADR-0015) ───────────────────────────────────────────────
+
+
+@app.command("test")
+def test_cmd(
+    server_id: str = typer.Argument(..., help="MCP server id to probe."),
+    json_out: bool = typer.Option(False, "--json", help="Emit raw JSON instead of the table."),
+) -> None:
+    """Probe an installed server and show each tool's allow/gated/blocked verdict."""
+    api_url = _api_base()
+    if _api_unreachable(api_url):
+        raise typer.Exit(1)
+    try:
+        result = api_post(f"/api/mcp/{server_id}/test")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    if json_out:
+        typer.echo(jsonlib.dumps(result, indent=2, sort_keys=True))
+        return
+
+    probe = result.get("probe", {})
+    if not probe.get("ok"):
+        console.print(
+            Panel(
+                f"[bold red]✗ unreachable[/bold red]  {probe.get('error', 'unknown error')}",
+                border_style="red",
+            )
+        )
+        return
+
+    verdicts: dict[str, str] = result.get("verdicts", {})
+    verdict_style = {
+        "allow": "[green]allow[/green]",
+        "gated": "[yellow]gated[/yellow]",
+        "blocked": "[red]blocked[/red]",
+        "unknown_tool": "[dim]unknown_tool[/dim]",
+        "unknown_server": "[dim]unknown_server[/dim]",
+    }
+    table = Table(title=f"mcp test · {server_id}")
+    table.add_column("Tool", style="bold")
+    table.add_column("Verdict")
+    for tool in probe.get("tools", []):
+        table.add_row(tool, verdict_style.get(verdicts.get(tool, ""), verdicts.get(tool, "—")))
+    console.print(table)
+
+
+# ── `hal0 mcp allow|gate|block` (ADR-0015) ───────────────────────────────────
+
+
+def _move_tool(server_id: str, tool: str, target: str) -> None:
+    """Fetch the current [tools] policy, move ``tool`` into ``target``, PATCH."""
+    api_url = _api_base()
+    if _api_unreachable(api_url):
+        raise typer.Exit(1)
+    try:
+        servers = api_get("/api/mcp/servers").get("servers", [])
+        server = _find_server(servers, server_id)
+        if server is None:
+            die(f"no MCP server matching '{server_id}'")
+            return
+        policy = dict(server.get("tools_policy") or {"allow": [], "gated": [], "blocked": []})
+        for tier in ("allow", "gated", "blocked"):
+            policy[tier] = [t for t in policy.get(tier, []) if t != tool]
+        policy[target] = [*policy.get(target, []), tool]
+        result = api_patch(f"/api/mcp/{server_id}/tools", json=policy)
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    console.print(
+        Panel(
+            f"[bold]{tool}[/bold] → [bold]{target}[/bold] on {server_id}",
+            border_style="green",
+        )
+    )
+    if not result.get("hermes_sync", {}).get("errors"):
+        return
+    console.print(f"[yellow]![/yellow] [dim]hermes sync: {result['hermes_sync']['errors']}[/dim]")
+
+
+@app.command("allow")
+def allow_cmd(
+    server_id: str = typer.Argument(..., help="MCP server id."),
+    tool: str = typer.Argument(..., help="Tool name to allow autonomously."),
+) -> None:
+    """Move a tool onto the allow list (autonomous calls)."""
+    _move_tool(server_id, tool, "allow")
+
+
+@app.command("gate")
+def gate_cmd(
+    server_id: str = typer.Argument(..., help="MCP server id."),
+    tool: str = typer.Argument(..., help="Tool name to gate behind approval."),
+) -> None:
+    """Move a tool onto the gated list (each call enqueues an approval)."""
+    _move_tool(server_id, tool, "gated")
+
+
+@app.command("block")
+def block_cmd(
+    server_id: str = typer.Argument(..., help="MCP server id."),
+    tool: str = typer.Argument(..., help="Tool name to hard-block."),
+) -> None:
+    """Move a tool onto the blocked list (hard-rejected at the client)."""
+    _move_tool(server_id, tool, "blocked")
+
+
+# ── `hal0 mcp expose` (ADR-0015) ─────────────────────────────────────────────
+
+
+@app.command("expose")
+def expose_cmd(
+    server_id: str = typer.Argument(..., help="MCP server id."),
+    hermes: bool = typer.Option(None, "--hermes/--no-hermes", help="Join into Hermes's config."),
+    brain: bool = typer.Option(
+        None, "--brain/--no-brain", help="Join into the hal0-brain profile."
+    ),
+) -> None:
+    """Flip which consumers can see an installed server."""
+    if hermes is None and brain is None:
+        die("pass at least one of --hermes/--no-hermes or --brain/--no-brain")
+        return
+    api_url = _api_base()
+    if _api_unreachable(api_url):
+        raise typer.Exit(1)
+    body: dict[str, Any] = {}
+    if hermes is not None:
+        body["hermes"] = hermes
+    if brain is not None:
+        body["brain"] = brain
+    try:
+        result = api_patch(f"/api/mcp/{server_id}/exposure", json=body)
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    exposure = result.get("server", {}).get("exposure", {})
+    console.print(
+        Panel(
+            f"[bold]{server_id}[/bold] exposure: "
+            f"hermes={exposure.get('hermes')} brain={exposure.get('brain')}",
+            border_style="green",
+        )
+    )
 
 
 # ── `hal0 mcp catalog list` ──────────────────────────────────────────────────

--- a/src/hal0/cli/mcp_commands.py
+++ b/src/hal0/cli/mcp_commands.py
@@ -373,7 +373,7 @@ def _move_tool(server_id: str, tool: str, target: str) -> None:
         if server is None:
             die(f"no MCP server matching '{server_id}'")
             return
-        policy = dict(server.get("tools_policy") or {"allow": [], "gated": [], "blocked": []})
+        policy = dict(server.get("tool_policy") or {"allow": [], "gated": [], "blocked": []})
         for tier in ("allow", "gated", "blocked"):
             policy[tier] = [t for t in policy.get(tier, []) if t != tool]
         policy[target] = [*policy.get(target, []), tool]

--- a/src/hal0/mcp/hermes_join.py
+++ b/src/hal0/mcp/hermes_join.py
@@ -49,6 +49,7 @@ from typing import Any
 
 import structlog
 
+from hal0.config import paths as cfg_paths
 from hal0.mcp.installed import InstalledServer, list_enabled_exposed
 from hal0.mcp.probe import build_headers
 
@@ -59,36 +60,65 @@ log = structlog.get_logger(__name__)
 #: layer with ``mcp.exposure_unsupported`` before this module ever runs.
 JOIN_TARGETS = ("hermes", "brain")
 
-#: Ownership manifest — the ids this module wrote into Hermes's
-#: ``config.yaml``/seed TOML on its own last run, per target. Only ids
-#: recorded here are ever candidates for removal (see module docstring).
-_MANIFEST_PATH = Path("/var/lib/hal0/mcp/hermes-managed.json")
-
 #: Agent identity tag applied to every user-installed server's headers —
 #: mirrors the tag `_build_config_overlay` applies to the two builtins
 #: (`hermes_provision.py:2017`) so audit rows attribute calls the same way.
 _AGENT_ID = "hermes"
 
 
+def _hermes_home() -> Path:
+    """``/var/lib/hal0/.hermes`` (or its HAL0_HOME sandbox equivalent).
+
+    Mirrors ``hermes_provision.HERMES_HOME_DEFAULT``'s FHS shape exactly,
+    but resolved through :func:`hal0.config.paths.var_lib` (HAL0_HOME-aware)
+    rather than that module's bare constant — this module is called from
+    the request path in tests (``tmp_hal0_home``) where a hardcoded
+    ``/var/lib/hal0`` write would escape the test sandbox.
+    """
+    return cfg_paths.var_lib() / ".hermes"
+
+
+def _hermes_venv() -> Path:
+    """``/var/lib/hal0/venvs/hermes`` (or its HAL0_HOME sandbox equivalent)."""
+    return cfg_paths.var_lib() / "venvs" / "hermes"
+
+
+def _seed_toml_path() -> Path:
+    """``/etc/hal0/agents/hermes.toml`` (or its HAL0_HOME sandbox equivalent).
+
+    Same physical file as ``hermes_provision.INSTALL_SEED_PATH``, resolved
+    through :func:`hal0.config.paths.etc` for the same test-isolation
+    reason as :func:`_hermes_home`.
+    """
+    return cfg_paths.etc() / "agents" / "hermes.toml"
+
+
+def _manifest_path() -> Path:
+    """Ownership manifest path — see module docstring's "Removal ownership"."""
+    return cfg_paths.var_lib() / "mcp" / "hermes-managed.json"
+
+
 def _load_manifest() -> dict[str, list[str]]:
-    if not _MANIFEST_PATH.exists():
+    path = _manifest_path()
+    if not path.exists():
         return {t: [] for t in JOIN_TARGETS}
     try:
-        raw = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+        raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return {t: [] for t in JOIN_TARGETS}
     return {t: sorted({str(x) for x in raw.get(t, [])}) for t in JOIN_TARGETS}
 
 
 def _write_manifest(manifest: dict[str, list[str]]) -> None:
+    path = _manifest_path()
     with contextlib.suppress(OSError):
-        _MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
-        os.chmod(_MANIFEST_PATH.parent, 0o700)
-    tmp = _MANIFEST_PATH.with_suffix(".tmp")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        os.chmod(path.parent, 0o700)
+    tmp = path.with_suffix(".tmp")
     tmp.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
-    tmp.replace(_MANIFEST_PATH)
+    tmp.replace(path)
     with contextlib.suppress(OSError):
-        os.chmod(_MANIFEST_PATH, 0o600)
+        os.chmod(path, 0o600)
 
 
 def _desired_entries(target: str) -> dict[str, dict[str, Any]]:
@@ -160,10 +190,15 @@ def sync_exposure(*, only_server_id: str | None = None) -> dict[str, Any]:
         remove_ids = sorted(previously_owned - set(desired))
         try:
             if target == "hermes":
-                result = hermes_provision.apply_mcp_server_entries(desired, remove_ids=remove_ids)
+                result = hermes_provision.apply_mcp_server_entries(
+                    desired,
+                    remove_ids=remove_ids,
+                    hermes_home=_hermes_home(),
+                    venv=_hermes_venv(),
+                )
             else:
                 result = hermes_provision.apply_brain_profile_mcp_entries(
-                    desired, remove_ids=remove_ids
+                    desired, remove_ids=remove_ids, hermes_home=_hermes_home()
                 )
         except Exception as exc:
             log.warning("hal0.mcp.hermes_join.apply_failed", target=target, error=str(exc))
@@ -214,11 +249,9 @@ def _mirror_seed_toml(
     """
     import tomllib
 
-    import tomli_w
+    from hal0.config.loader import write_toml_atomic
 
-    from hal0.agents.hermes_provision import INSTALL_SEED_PATH
-
-    path = INSTALL_SEED_PATH
+    path = _seed_toml_path()
     existing: dict[str, Any] = {}
     if path.exists():
         try:
@@ -240,11 +273,7 @@ def _mirror_seed_toml(
     merged = dict(existing)
     merged["mcp"] = mcp
 
-    from hal0.agents.hermes_provision import _atomic_write
-
-    _atomic_write(path, tomli_w.dumps(merged))
-    with contextlib.suppress(OSError):
-        os.chmod(path, 0o600)
+    write_toml_atomic(path, merged, mode=0o600)
 
 
 __all__ = ["JOIN_TARGETS", "sync_exposure"]

--- a/src/hal0/mcp/hermes_join.py
+++ b/src/hal0/mcp/hermes_join.py
@@ -178,15 +178,18 @@ def sync_exposure(*, only_server_id: str | None = None) -> dict[str, Any]:
     """
     from hal0.agents import hermes_provision
 
-    manifest = _load_manifest()
+    old_manifest = _load_manifest()
+    new_manifest: dict[str, list[str]] = {}
     report: dict[str, Any] = {"hermes": {}, "brain": {}, "errors": []}
 
     all_records = {r.id: r for r in list_enabled_exposed(target="hermes")}
     all_records.update({r.id: r for r in list_enabled_exposed(target="brain")})
 
+    desired_by_target: dict[str, dict[str, dict[str, Any]]] = {}
     for target in JOIN_TARGETS:
         desired = _desired_entries(target)
-        previously_owned = set(manifest.get(target, []))
+        desired_by_target[target] = desired
+        previously_owned = set(old_manifest.get(target, []))
         remove_ids = sorted(previously_owned - set(desired))
         try:
             if target == "hermes":
@@ -205,18 +208,22 @@ def sync_exposure(*, only_server_id: str | None = None) -> dict[str, Any]:
             result = {"errors": [str(exc)]}
             report["errors"].append(f"{target}: {exc}")
         report[target] = result
-        manifest[target] = sorted(desired.keys())
+        new_manifest[target] = sorted(desired.keys())
 
-    _write_manifest(manifest)
+    _write_manifest(new_manifest)
 
     # Seed TOML mirror (classify() source) always reflects hermes-exposed
     # records — brain has no separate policy axis, it shares the same
-    # per-server ToolPolicy.
+    # per-server ToolPolicy. Pruning uses the PRE-sync "hermes" ownership
+    # set (`old_manifest`, not `new_manifest`) — an id already written to
+    # `new_manifest` above is never a stale entry to prune.
     hermes_desired_records = {
-        sid: rec for sid, rec in all_records.items() if sid in _desired_entries("hermes")
+        sid: rec for sid, rec in all_records.items() if sid in desired_by_target["hermes"]
     }
     try:
-        _mirror_seed_toml(hermes_desired_records, previously_owned=set(manifest.get("hermes", [])))
+        _mirror_seed_toml(
+            hermes_desired_records, previously_owned=set(old_manifest.get("hermes", []))
+        )
     except Exception as exc:
         log.warning("hal0.mcp.hermes_join.seed_mirror_failed", error=str(exc))
         report["errors"].append(f"seed_toml: {exc}")

--- a/src/hal0/mcp/hermes_join.py
+++ b/src/hal0/mcp/hermes_join.py
@@ -1,0 +1,250 @@
+"""The Hermes/brain exposure join for user-installed MCP servers (ADR-0015).
+
+`src/hal0/mcp/installed.py` persists the operator's install/tool/exposure
+choices; this module is what makes an `exposure.hermes` (or `.brain`) flag
+actually reach the agent. It has three jobs, run together as
+:func:`sync_exposure` after every registry mutation that can change the
+desired set (install, uninstall, and the ``PATCH /tools``/``/exposure``/
+``/config`` routes):
+
+1. Recompute the desired ``mcp_servers`` set for Hermes's main config and
+   the hal0-brain profile config, and additively apply / surgically remove
+   entries via :func:`hal0.agents.hermes_provision.apply_mcp_server_entries`
+   / :func:`~hal0.agents.hermes_provision.apply_brain_profile_mcp_entries` —
+   the two functions ADR-0015 added specifically so this module doesn't
+   need a second "how to edit Hermes config" mechanism.
+2. Mirror each exposed record's ``[tools]`` policy into the seed TOML at
+   ``/etc/hal0/agents/hermes.toml`` so
+   :meth:`hal0.agents.mcp_client.AgentMCPClient.classify` governs
+   user-installed tools on the same axes as the two builtins.
+3. Re-probe (via :mod:`hal0.mcp.probe`) exactly the servers whose desired
+   membership changed, so a bad URL surfaces at the mutation that exposed
+   it rather than at an agent's first turn.
+
+Removal ownership: an id is only ever a removal candidate for step 1 when
+it appears in the on-disk ownership manifest
+(``/var/lib/hal0/mcp/hermes-managed.json`` — the ids this module wrote on
+its own previous run). This is the format-agnostic equivalent of the
+sentinel-comment idea in the field study's design note: YAML comments do
+not survive the full parse/dump cycle hal0 already uses for
+``config.yaml`` (see ADR-0015 "Rejected"), but a small side-car manifest
+gives the identical guarantee — hal0 only ever deletes an entry it knows
+it wrote, never an operator's hand-added block, which was never in the
+manifest to begin with.
+
+Every step here is best-effort: a failure is folded into the returned
+report's ``errors`` rather than raised. The registry write that triggered
+a sync has already succeeded by the time this runs (see call sites in
+``routes/mcp.py``); the join self-heals on the next mutation or the next
+``hal0 agent reprovision hermes --repair``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from hal0.mcp.installed import InstalledServer, list_enabled_exposed
+from hal0.mcp.probe import build_headers
+
+log = structlog.get_logger(__name__)
+
+#: hal0's two-consumer scope for v1 (ADR-0015 §Decision 3/4). ``openwebui``
+#: and ``opencode`` have no join mechanism and are rejected at the route
+#: layer with ``mcp.exposure_unsupported`` before this module ever runs.
+JOIN_TARGETS = ("hermes", "brain")
+
+#: Ownership manifest — the ids this module wrote into Hermes's
+#: ``config.yaml``/seed TOML on its own last run, per target. Only ids
+#: recorded here are ever candidates for removal (see module docstring).
+_MANIFEST_PATH = Path("/var/lib/hal0/mcp/hermes-managed.json")
+
+#: Agent identity tag applied to every user-installed server's headers —
+#: mirrors the tag `_build_config_overlay` applies to the two builtins
+#: (`hermes_provision.py:2017`) so audit rows attribute calls the same way.
+_AGENT_ID = "hermes"
+
+
+def _load_manifest() -> dict[str, list[str]]:
+    if not _MANIFEST_PATH.exists():
+        return {t: [] for t in JOIN_TARGETS}
+    try:
+        raw = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {t: [] for t in JOIN_TARGETS}
+    return {t: sorted({str(x) for x in raw.get(t, [])}) for t in JOIN_TARGETS}
+
+
+def _write_manifest(manifest: dict[str, list[str]]) -> None:
+    with contextlib.suppress(OSError):
+        _MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
+        os.chmod(_MANIFEST_PATH.parent, 0o700)
+    tmp = _MANIFEST_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(_MANIFEST_PATH)
+    with contextlib.suppress(OSError):
+        os.chmod(_MANIFEST_PATH, 0o600)
+
+
+def _desired_entries(target: str) -> dict[str, dict[str, Any]]:
+    """Desired ``mcp_servers`` entries for ``target`` from the registry.
+
+    Only ``streamable-http``/``sse`` records qualify — ``stdio`` has no
+    supervisor yet (ADR-0015 "Deferred"), so a stdio record's
+    ``exposure.hermes``/``.brain`` is rejected before it ever reaches
+    here (see ``routes/mcp.py``'s ``PATCH /exposure`` handler).
+    """
+    entries: dict[str, dict[str, Any]] = {}
+    for record in list_enabled_exposed(target=target):
+        if record.transport not in ("streamable-http", "sse"):
+            continue
+        if not record.url:
+            continue
+        entries[record.id] = {
+            "type": "sse" if record.transport == "sse" else "http",
+            "url": record.url,
+            "timeout": 60,
+            "headers": build_headers(record, agent_id=_AGENT_ID),
+        }
+    return entries
+
+
+def _seed_tools_block(records_by_id: dict[str, InstalledServer]) -> dict[str, Any]:
+    """Build the ``[mcp.servers.<id>]`` seed-TOML mirror for classify().
+
+    Shape matches ``hermes_provision._builtin_mcp_seed_servers`` (
+    ``builtin: False`` distinguishes these from the two hal0-owned
+    entries) plus the record's ``tool_policy`` under ``tools`` — the exact
+    key :class:`hal0.config.schema.MCPServerConfig` reads as its
+    ``ToolPolicy``.
+    """
+    return {
+        sid: {
+            "builtin": False,
+            "enabled": True,
+            "tools": record.tool_policy.model_dump(mode="python"),
+        }
+        for sid, record in records_by_id.items()
+    }
+
+
+def sync_exposure(*, only_server_id: str | None = None) -> dict[str, Any]:
+    """Recompute + apply the Hermes/brain join for every exposed server.
+
+    Called after any registry mutation that can change the desired set.
+    ``only_server_id`` narrows the post-sync re-probe to one server (the
+    one that just changed) — the sync itself always recomputes the full
+    desired set, since an uninstall/disable can change what should be
+    *removed* for servers other than the one just mutated.
+
+    Returns a report dict merging both targets' results plus a `probe`
+    key for the re-probed server(s); never raises — every failure is
+    folded into `errors`.
+    """
+    from hal0.agents import hermes_provision
+
+    manifest = _load_manifest()
+    report: dict[str, Any] = {"hermes": {}, "brain": {}, "errors": []}
+
+    all_records = {r.id: r for r in list_enabled_exposed(target="hermes")}
+    all_records.update({r.id: r for r in list_enabled_exposed(target="brain")})
+
+    for target in JOIN_TARGETS:
+        desired = _desired_entries(target)
+        previously_owned = set(manifest.get(target, []))
+        remove_ids = sorted(previously_owned - set(desired))
+        try:
+            if target == "hermes":
+                result = hermes_provision.apply_mcp_server_entries(desired, remove_ids=remove_ids)
+            else:
+                result = hermes_provision.apply_brain_profile_mcp_entries(
+                    desired, remove_ids=remove_ids
+                )
+        except Exception as exc:
+            log.warning("hal0.mcp.hermes_join.apply_failed", target=target, error=str(exc))
+            result = {"errors": [str(exc)]}
+            report["errors"].append(f"{target}: {exc}")
+        report[target] = result
+        manifest[target] = sorted(desired.keys())
+
+    _write_manifest(manifest)
+
+    # Seed TOML mirror (classify() source) always reflects hermes-exposed
+    # records — brain has no separate policy axis, it shares the same
+    # per-server ToolPolicy.
+    hermes_desired_records = {
+        sid: rec for sid, rec in all_records.items() if sid in _desired_entries("hermes")
+    }
+    try:
+        _mirror_seed_toml(hermes_desired_records, previously_owned=set(manifest.get("hermes", [])))
+    except Exception as exc:
+        log.warning("hal0.mcp.hermes_join.seed_mirror_failed", error=str(exc))
+        report["errors"].append(f"seed_toml: {exc}")
+
+    changed_ids = set(report["hermes"].get("removed", [])) | set(report["brain"].get("removed", []))
+    if only_server_id:
+        changed_ids.add(only_server_id)
+    probes: dict[str, Any] = {}
+    for sid in sorted(changed_ids):
+        record = all_records.get(sid)
+        if record is None or record.transport not in ("streamable-http", "sse") or not record.url:
+            continue
+        with contextlib.suppress(Exception):
+            from hal0.mcp.probe import probe_installed_server_sync
+
+            probes[sid] = probe_installed_server_sync(record)
+    report["probe"] = probes
+    return report
+
+
+def _mirror_seed_toml(
+    records_by_id: dict[str, InstalledServer], *, previously_owned: set[str]
+) -> None:
+    """Merge/prune the ``[mcp.servers.<id>]`` seed-TOML mirror in place.
+
+    Uses the same merge-never-clobber write hal0's own seed-TOML writer
+    uses for the two builtin blocks — never a wholesale rewrite of
+    ``/etc/hal0/agents/hermes.toml`` (``hermes_provision._write_seed_toml``,
+    ADR-0015 §Decision 2 step 4).
+    """
+    import tomllib
+
+    import tomli_w
+
+    from hal0.agents.hermes_provision import INSTALL_SEED_PATH
+
+    path = INSTALL_SEED_PATH
+    existing: dict[str, Any] = {}
+    if path.exists():
+        try:
+            existing = tomllib.loads(path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError):
+            existing = {}
+
+    mcp = dict(existing.get("mcp") or {})
+    servers = dict(mcp.get("servers") or {})
+
+    for sid in previously_owned - set(records_by_id):
+        entry = servers.get(sid)
+        if isinstance(entry, dict) and entry.get("builtin") is False:
+            servers.pop(sid, None)
+
+    servers.update(_seed_tools_block(records_by_id))
+
+    mcp["servers"] = servers
+    merged = dict(existing)
+    merged["mcp"] = mcp
+
+    from hal0.agents.hermes_provision import _atomic_write
+
+    _atomic_write(path, tomli_w.dumps(merged))
+    with contextlib.suppress(OSError):
+        os.chmod(path, 0o600)
+
+
+__all__ = ["JOIN_TARGETS", "sync_exposure"]

--- a/src/hal0/mcp/installed.py
+++ b/src/hal0/mcp/installed.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import contextlib
 import fcntl
 import os
+import re
 import tomllib
 from collections.abc import Iterator
 from datetime import UTC, datetime
@@ -36,10 +37,11 @@ from pathlib import Path
 from typing import Any
 
 import structlog
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from hal0.config import paths as cfg_paths
 from hal0.config.loader import write_toml_atomic
+from hal0.config.schema import ToolPolicy
 from hal0.errors import BadRequest, Conflict, NotFound
 
 log = structlog.get_logger(__name__)
@@ -52,6 +54,32 @@ BUNDLED_SERVER_IDS = frozenset({"hal0-admin", "hal0-memory"})
 
 
 # ── Schema ──────────────────────────────────────────────────────────────────
+
+#: Grammar for a ``[secrets]`` reference — the name of a key in
+#: ``/etc/hal0/api.env``. Mirrors ``routes/secrets.py:65`` (the canonical
+#: enforcement point for names actually stored there); duplicated here
+#: rather than imported so this domain module doesn't reach up into the
+#: API route layer for a one-line regex.
+_SECRET_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
+
+
+class ExposureConfig(BaseModel):
+    """``[exposure]`` — which consumers a user-installed server is joined to.
+
+    ADR-0015 §Decision 1/3/4: ``hermes`` and ``brain`` are honoured today
+    (:mod:`hal0.mcp.hermes_join`); ``openwebui``/``opencode`` have no join
+    mechanism in this codebase and setting either raises
+    ``501 mcp.exposure_unsupported`` at the route layer rather than being
+    silently ignored — the field still round-trips so a future join can
+    read an operator's already-expressed intent.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    hermes: bool = Field(default=False)
+    brain: bool = Field(default=False)
+    openwebui: bool = Field(default=False)
+    opencode: bool = Field(default=False)
 
 
 class InstalledServer(BaseModel):
@@ -70,13 +98,36 @@ class InstalledServer(BaseModel):
     a manifest URL. Stored verbatim so a future re-install / upgrade
     path can rerun the resolver."""
     transport: str = Field(default="stdio")
-    """``stdio`` or ``streamable-http``. ``stdio`` covers the most
-    common path (npx/uvx packages) — the supervisor follow-up will
-    actually honour this field."""
+    """``stdio``, ``streamable-http``, or ``sse`` (ADR-0015). ``stdio``
+    covers the most common path (npx/uvx packages) but has no
+    supervisor yet — see ADR-0015's "Deferred: stdio supervisor"."""
+    command: str = Field(default="")
+    """Stdio launch command (e.g. ``npx``, ``uvx``). Unused until the
+    stdio supervisor ships (ADR-0015); recorded now so a record doesn't
+    need a schema migration when it does."""
+    args: list[str] = Field(default_factory=list)
+    """Stdio launch args. Same deferred-use note as ``command``."""
+    url: str = Field(default="")
+    """Connect URL for ``streamable-http``/``sse`` transports. Empty for
+    ``stdio`` records."""
     tools: int = Field(default=0, ge=0, le=4096)
     resources: int = Field(default=0, ge=0)
     prompts: int = Field(default=0, ge=0)
     env: dict[str, str] = Field(default_factory=dict)
+    secrets: dict[str, str] = Field(default_factory=dict)
+    """``env var name`` → ``key in /etc/hal0/api.env``. A *reference*,
+    never a literal value (ADR-0015 §Decision 1) — resolved at call/probe
+    time via ``os.environ``, which hal0-api keeps in lockstep with
+    ``api.env`` on every secrets write (``routes/secrets.py``)."""
+    tool_policy: ToolPolicy = Field(default_factory=ToolPolicy)
+    """Reuses :class:`hal0.config.schema.ToolPolicy` verbatim — same
+    allow/gated/blocked disjointness, same empty-by-default posture.
+    Serialised under the TOML ``[tools]`` table (see
+    :meth:`to_toml_dict`); named ``tool_policy`` on the model, not
+    ``tools``, because the pre-existing ``tools`` field above is the
+    advertised tool *count* every existing on-disk record already
+    carries."""
+    exposure: ExposureConfig = Field(default_factory=ExposureConfig)
     enabled: bool = Field(default=True)
     installed_at: str = Field(default="")
     """ISO-8601 UTC timestamp set on first write."""
@@ -85,10 +136,57 @@ class InstalledServer(BaseModel):
     author: str = Field(default="user")
     verified: bool = Field(default=False)
 
+    @field_validator("secrets")
+    @classmethod
+    def _secrets_reference_valid_names(cls, v: dict[str, str]) -> dict[str, str]:
+        """Both sides of a ``[secrets]`` entry must be env-var-shaped.
+
+        The left side becomes a literal env var name in the eventual
+        process/header env; the right side must match the grammar
+        ``/api/secrets`` enforces for names it will actually store
+        (``routes/secrets.py:63``) — a mismatched reference here would
+        otherwise resolve to ``None`` silently at call time.
+        """
+        bad = {k: val for k, val in v.items() if not _SECRET_KEY_RE.match(val)}
+        if bad:
+            raise ValueError(
+                f"secrets values must reference a valid api.env key name "
+                f"(^[A-Z][A-Z0-9_]{{0,63}}$): {sorted(bad)}"
+            )
+        return v
+
     def to_toml_dict(self) -> dict[str, Any]:
-        """Serialise to a tomli_w-compatible dict (drops None values)."""
+        """Serialise to a tomli_w-compatible dict (drops None values).
+
+        ``tool_policy`` round-trips under the on-disk ``[tools]`` key —
+        the model attribute is named differently only to avoid colliding
+        with the pre-existing ``tools`` int-count field (see its
+        docstring); the TOML shape matches ADR-0015's schema example
+        exactly (``[tools]`` with ``allow``/``gated``/``blocked``).
+        """
         d = self.model_dump(mode="python")
+        tool_policy = d.pop("tool_policy")
+        d["tools_count"] = d.pop("tools")
+        d["tools"] = tool_policy
         return {k: v for k, v in d.items() if v is not None}
+
+    @classmethod
+    def from_toml_dict(cls, raw: dict[str, Any]) -> InstalledServer:
+        """Inverse of :meth:`to_toml_dict` — undoes the ``tools`` rename.
+
+        Tolerates the pre-#N on-disk shape (``tools`` as a bare int,
+        no ``[tools]`` table) so every existing record still validates:
+        that shape has no ``tools_count`` key, so ``tools`` is left as
+        the int count and ``tool_policy`` falls back to its empty default.
+        """
+        raw = dict(raw)
+        if isinstance(raw.get("tools"), dict):
+            raw["tool_policy"] = raw.pop("tools")
+            if "tools_count" in raw:
+                raw["tools"] = raw.pop("tools_count")
+            else:
+                raw["tools"] = 0
+        return cls.model_validate(raw)
 
 
 # ── Registry surface ────────────────────────────────────────────────────────
@@ -176,7 +274,7 @@ def list_installed() -> list[InstalledServer]:
         try:
             with p.open("rb") as f:
                 raw = tomllib.load(f)
-            rows.append(InstalledServer.model_validate(raw))
+            rows.append(InstalledServer.from_toml_dict(raw))
         except (OSError, tomllib.TOMLDecodeError, ValidationError) as exc:
             log.warning(
                 "hal0.mcp.installed.bad_record",
@@ -199,7 +297,7 @@ def get_installed(server_id: str) -> InstalledServer:
     try:
         with path.open("rb") as f:
             raw = tomllib.load(f)
-        return InstalledServer.model_validate(raw)
+        return InstalledServer.from_toml_dict(raw)
     except (OSError, tomllib.TOMLDecodeError, ValidationError) as exc:
         raise BadRequest(
             f"installed-server record at {path} is malformed",
@@ -282,14 +380,21 @@ def patch_config(
     server_id: str,
     *,
     env: dict[str, str] | None = None,
+    secrets: dict[str, str] | None = None,
+    tool_policy: ToolPolicy | None = None,
+    exposure: ExposureConfig | None = None,
     enabled: bool | None = None,
 ) -> InstalledServer:
-    """Merge env / enabled overrides into a registry record.
+    """Merge env / secrets / tools / exposure / enabled overrides into a record.
 
-    Replaces the record's ``env`` dict wholesale when supplied (a TOML
-    file holds a single per-server env block, so the route layer always
-    sends the full intended set, not a delta). ``enabled`` flips the
-    flag without touching anything else.
+    Every dict/model field replaces wholesale when supplied — a TOML
+    file holds a single per-server block for each, so the route layer
+    always sends the full intended set, not a delta (matches the
+    pre-existing ``env`` contract). ``enabled`` flips the flag without
+    touching anything else. Callers that also need the Hermes exposure
+    join re-run (``tool_policy``/``exposure``/``enabled`` changes) are
+    responsible for calling :mod:`hal0.mcp.hermes_join` themselves —
+    this function only owns the on-disk record.
     """
     with _registry_lock(server_id):
         record = get_installed(server_id)
@@ -298,6 +403,12 @@ def patch_config(
             # Coerce values to strings — pydantic validates the type but the
             # FastAPI body is permissive (numbers, bools, etc).
             updates["env"] = {k: str(v) for k, v in env.items()}
+        if secrets is not None:
+            updates["secrets"] = {k: str(v) for k, v in secrets.items()}
+        if tool_policy is not None:
+            updates["tool_policy"] = tool_policy
+        if exposure is not None:
+            updates["exposure"] = exposure
         if enabled is not None:
             updates["enabled"] = bool(enabled)
         if not updates:
@@ -314,11 +425,23 @@ def patch_config(
     return next_record
 
 
+def list_enabled_exposed(*, target: str) -> list[InstalledServer]:
+    """Installed, enabled records with ``exposure.<target>`` set.
+
+    ``target`` is ``"hermes"`` or ``"brain"`` — the two joins ADR-0015
+    wires. Used by :mod:`hal0.mcp.hermes_join` to compute its desired
+    set without duplicating the enabled+exposure filter at each call site.
+    """
+    return [r for r in list_installed() if r.enabled and bool(getattr(r.exposure, target, False))]
+
+
 __all__ = [
     "BUNDLED_SERVER_IDS",
+    "ExposureConfig",
     "InstalledServer",
     "get_installed",
     "install",
+    "list_enabled_exposed",
     "list_installed",
     "patch_config",
     "uninstall",

--- a/src/hal0/mcp/installed.py
+++ b/src/hal0/mcp/installed.py
@@ -210,19 +210,21 @@ def _registry_path(server_id: str) -> Path:
     reaches this before ``patch_config``'s own :func:`get_installed` has
     validated anything, and it opens the returned path's sibling ``.lock`` with
     mode ``"w"`` — a truncating create. :func:`_validate_id`'s charset already
-    makes traversal unrepresentable; the resolved-containment assert states
-    that as a property of the path rather than of the id spelling.
+    makes traversal unrepresentable; the containment check states that as a
+    property of the resolved path rather than of the id spelling, and is
+    written as realpath-then-prefix-compare so the taint analysers reading this
+    file can see the barrier too.
     """
     _validate_id(server_id)
-    root = _registry_dir().resolve()
-    path = (root / f"{server_id}.toml").resolve()
-    if path.parent != root:
+    root = os.path.realpath(_registry_dir())
+    candidate = os.path.realpath(os.path.join(root, f"{server_id}.toml"))
+    if not candidate.startswith(root + os.sep) or os.path.dirname(candidate) != root:
         raise BadRequest(
             "server id does not resolve inside the MCP registry",
             code="mcp.id_invalid",
             details={"id": server_id},
         )
-    return path
+    return Path(candidate)
 
 
 # Restrictive perms: TOML files contain the per-server ``env`` block, which

--- a/src/hal0/mcp/installed.py
+++ b/src/hal0/mcp/installed.py
@@ -203,7 +203,26 @@ def _registry_dir() -> Path:
 
 
 def _registry_path(server_id: str) -> Path:
-    return _registry_dir() / f"{server_id}.toml"
+    """Resolve one server's record path, refusing anything outside the registry.
+
+    THE single place a caller-supplied id becomes a filesystem path, so the
+    barrier belongs here rather than at each entry point: :func:`_registry_lock`
+    reaches this before ``patch_config``'s own :func:`get_installed` has
+    validated anything, and it opens the returned path's sibling ``.lock`` with
+    mode ``"w"`` — a truncating create. :func:`_validate_id`'s charset already
+    makes traversal unrepresentable; the resolved-containment assert states
+    that as a property of the path rather than of the id spelling.
+    """
+    _validate_id(server_id)
+    root = _registry_dir().resolve()
+    path = (root / f"{server_id}.toml").resolve()
+    if path.parent != root:
+        raise BadRequest(
+            "server id does not resolve inside the MCP registry",
+            code="mcp.id_invalid",
+            details={"id": server_id},
+        )
+    return path
 
 
 # Restrictive perms: TOML files contain the per-server ``env`` block, which

--- a/src/hal0/mcp/probe.py
+++ b/src/hal0/mcp/probe.py
@@ -1,0 +1,150 @@
+"""Generic MCP streamable-http/sse probe for user-installed servers.
+
+`hal0.agents.hermes_provision._probe_mcp_server` speaks the same
+JSON-RPC protocol but hard-codes hal0's own mount convention — it always
+appends `/mcp` to the given URL (built for `_default_mcp_servers()`'s
+mount-root entries, see its call site at
+`hermes_provision.py:_phase_mcp_wire`) and only ever sends hal0's own
+`X-hal0-Agent` + box-service bearer. A user-installed server's `url`
+field is already the exact transport endpoint (ADR-0015 §Decision 1), and
+its auth comes from its own `[secrets]`/`[env]` blocks, not hal0's
+service identity — reusing that function as-is would silently
+double-append `/mcp` onto an arbitrary third-party endpoint and send it
+a bearer meant for hal0's own mounts. This module is the generic
+counterpart used by `hal0 mcp test` / `POST /{id}/test` and by
+`hal0.mcp.hermes_join`'s post-mutation re-probe.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from hal0.mcp.installed import InstalledServer
+
+_PROBE_TIMEOUT_S = 5.0
+
+
+def resolve_secret(secret_key: str) -> str | None:
+    """Resolve a ``[secrets]`` reference (a key name in api.env) to its value.
+
+    hal0-api keeps ``os.environ`` in lockstep with ``/etc/hal0/api.env``
+    on every write (``routes/secrets.py``) — an in-process read is always
+    current, no separate file read needed.
+    """
+    return os.environ.get(secret_key)
+
+
+def build_headers(record: InstalledServer, *, agent_id: str = "hermes") -> dict[str, str]:
+    """Headers a probe / Hermes join sends for one installed record.
+
+    ``[secrets]`` entries resolve to live values and are dropped (never
+    sent empty) when unset, so a server missing a required secret still
+    gets probed — the upstream 401/403 is the real signal, not a local
+    skip. ``[env]`` literals are layered too (lower precedence than a
+    same-named secret, since ``[secrets]`` is the more specific override
+    path for anything credential-shaped).
+    """
+    headers: dict[str, str] = {"X-hal0-Agent": agent_id}
+    headers.update(record.env)
+    for env_name, secret_key in record.secrets.items():
+        value = resolve_secret(secret_key)
+        if value:
+            headers[env_name] = value
+    return headers
+
+
+def _parse_jsonrpc(body: str) -> dict[str, Any]:
+    body = (body or "").strip()
+    if not body:
+        return {}
+    if body[0] == "{":
+        parsed: dict[str, Any] = json.loads(body)
+        return parsed
+    for line in body.splitlines():
+        if line.startswith("data: "):
+            try:
+                parsed = json.loads(line[6:])
+            except json.JSONDecodeError:
+                continue
+            return parsed
+    return {}
+
+
+def probe_installed_server_sync(
+    record: InstalledServer, *, timeout: float = _PROBE_TIMEOUT_S
+) -> dict[str, Any]:
+    """Speak MCP streamable-http JSON-RPC against ``record.url`` directly.
+
+    POSTs ``initialize`` then ``tools/list`` at the record's own URL (no
+    path rewriting — unlike ``_probe_mcp_server``, this is the exact
+    endpoint the operator/manifest gave). Returns
+    ``{"ok": bool, "tools": [str, ...], "error": str | None}``. Never
+    raises — every transport failure becomes ``ok=False`` + a message.
+
+    stdlib-only (mirrors ``_probe_mcp_server``'s own rationale): a probe
+    triggered from the API process shouldn't need an extra dependency
+    beyond what's already vendored for the rest of the MCP surface.
+    """
+    if record.transport not in ("streamable-http", "sse"):
+        return {"ok": False, "tools": [], "error": f"transport {record.transport!r} not probeable"}
+    if not record.url:
+        return {"ok": False, "tools": [], "error": "no url configured"}
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        **build_headers(record),
+    }
+
+    def _post(payload: dict[str, Any], session_id: str | None) -> tuple[dict[str, Any], str | None]:
+        req_headers = dict(headers)
+        if session_id:
+            req_headers["Mcp-Session-Id"] = session_id
+        req = Request(
+            record.url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers=req_headers,
+            method="POST",
+        )
+        with urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            new_session = resp.headers.get("Mcp-Session-Id") or session_id
+            return _parse_jsonrpc(body), new_session
+
+    try:
+        init_payload = {
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "hal0-mcp-test", "version": "1"},
+            },
+        }
+        _init_result, session_id = _post(init_payload, None)
+        tools_payload = {
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "method": "tools/list",
+            "params": {},
+        }
+        result, _ = _post(tools_payload, session_id)
+    except (HTTPError, URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+        return {"ok": False, "tools": [], "error": str(exc)}
+
+    if "error" in result:
+        err = result["error"]
+        return {"ok": False, "tools": [], "error": str(err.get("message", err))}
+
+    tools = (result.get("result") or {}).get("tools") or []
+    names = [t.get("name") for t in tools if isinstance(t, dict) and t.get("name")]
+    return {"ok": True, "tools": names, "error": None}
+
+
+__all__ = ["build_headers", "probe_installed_server_sync", "resolve_secret"]

--- a/tests/api/test_mcp_routes.py
+++ b/tests/api/test_mcp_routes.py
@@ -913,3 +913,134 @@ def test_validate_id_rejects_path_traversal(client: TestClient) -> None:
     assert code in {"mcp.id_invalid", "mcp.manifest_invalid"}, (
         f"path traversal must be rejected at validation, got {code}"
     )
+
+
+# ── ADR-0015: POST /{id}/test, PATCH /{id}/tools, PATCH /{id}/exposure ──────
+
+
+def _github_http_manifest_dict() -> dict[str, Any]:
+    """A streamable-http manifest — the shape a real hosted MCP server takes."""
+    return {
+        "id": "github",
+        "name": "github",
+        "description": "GitHub MCP server.",
+        "spec": "https://github.example.com/manifest.json",
+        "transport": "streamable-http",
+        "tools": 3,
+        "resources": 0,
+        "prompts": 0,
+        "env_required": [],
+        "source_kind": "manifest",
+        "source_url": "https://github.example.com/mcp",
+        "author": "user",
+    }
+
+
+def _install_github(client: TestClient) -> dict[str, Any]:
+    response = client.post("/api/mcp/install", json={"manifest": _github_http_manifest_dict()})
+    assert response.status_code == 201, response.text
+    return response.json()["installed"]
+
+
+def test_install_sets_url_for_http_transport(client: TestClient) -> None:
+    installed = _install_github(client)
+    assert installed["url"] == "https://github.example.com/mcp"
+    assert installed["transport"] == "streamable-http"
+
+
+def test_test_endpoint_returns_probe_and_verdicts(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_github(client)
+
+    def fake_probe(record: Any) -> dict[str, Any]:
+        return {"ok": True, "tools": ["search_repositories"], "error": None}
+
+    monkeypatch.setattr(mcp_routes.mcp_probe, "probe_installed_server_sync", fake_probe)
+    response = client.post("/api/mcp/github/test")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["probe"]["ok"] is True
+    # No hermes agent config present under this tmp sandbox -> classify()
+    # degrades to unknown_server rather than 500ing the preview.
+    assert body["verdicts"] == {"search_repositories": "unknown_server"}
+
+
+def test_test_endpoint_stdio_returns_501(client: TestClient) -> None:
+    client.post("/api/mcp/install", json={"manifest": _filesystem_manifest_dict()})
+    response = client.post("/api/mcp/filesystem/test")
+    assert response.status_code == 501
+    assert response.json()["error"]["code"] == "mcp.supervisor_unavailable"
+
+
+def test_test_endpoint_missing_server_404(client: TestClient) -> None:
+    response = client.post("/api/mcp/nope/test")
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "mcp.not_found"
+
+
+def test_patch_tools_writes_policy(client: TestClient) -> None:
+    _install_github(client)
+    response = client.patch(
+        "/api/mcp/github/tools",
+        json={"allow": ["search_repositories"], "gated": ["create_pull_request"], "blocked": []},
+    )
+    assert response.status_code == 200, response.text
+    tools = response.json()["server"]["tool_policy"]
+    assert tools["allow"] == ["search_repositories"]
+    assert tools["gated"] == ["create_pull_request"]
+    assert "hermes_sync" in response.json()
+
+
+def test_patch_tools_rejects_overlap(client: TestClient) -> None:
+    _install_github(client)
+    response = client.patch(
+        "/api/mcp/github/tools",
+        json={"allow": ["x"], "gated": ["x"], "blocked": []},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "mcp.tools_invalid"
+
+
+def test_patch_tools_bundled_rejected(client: TestClient) -> None:
+    response = client.patch(
+        "/api/mcp/hal0-admin/tools", json={"allow": [], "gated": [], "blocked": []}
+    )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "mcp.bundled"
+
+
+def test_patch_exposure_hermes(client: TestClient) -> None:
+    _install_github(client)
+    response = client.patch("/api/mcp/github/exposure", json={"hermes": True})
+    assert response.status_code == 200, response.text
+    exposure = response.json()["server"]["exposure"]
+    assert exposure["hermes"] is True
+    assert exposure["brain"] is False
+    assert "hermes_sync" in response.json()
+
+
+def test_patch_exposure_openwebui_rejected(client: TestClient) -> None:
+    _install_github(client)
+    response = client.patch("/api/mcp/github/exposure", json={"openwebui": True})
+    assert response.status_code == 501
+    assert response.json()["error"]["code"] == "mcp.exposure_unsupported"
+
+
+def test_patch_exposure_stdio_needs_supervisor(client: TestClient) -> None:
+    client.post("/api/mcp/install", json={"manifest": _filesystem_manifest_dict()})
+    response = client.patch("/api/mcp/filesystem/exposure", json={"hermes": True})
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "mcp.exposure_needs_supervisor"
+
+
+def test_patch_exposure_bundled_rejected(client: TestClient) -> None:
+    response = client.patch("/api/mcp/hal0-admin/exposure", json={"hermes": True})
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "mcp.bundled"
+
+
+def test_install_returns_hermes_sync_report(client: TestClient) -> None:
+    response = client.post("/api/mcp/install", json={"manifest": _github_http_manifest_dict()})
+    assert response.status_code == 201, response.text
+    assert "hermes_sync" in response.json()

--- a/tests/api/test_mcp_routes.py
+++ b/tests/api/test_mcp_routes.py
@@ -772,7 +772,10 @@ def test_uninstall_removes_installed_server(client: TestClient) -> None:
     client.post("/api/mcp/install", json={"manifest": _filesystem_manifest_dict()})
     response = client.delete("/api/mcp/filesystem")
     assert response.status_code == 200, response.text
-    assert response.json() == {"uninstalled": "filesystem"}
+    # ADR-0015: the response also carries a best-effort "hermes_sync"
+    # report from re-running the Hermes/brain exposure join.
+    assert response.json()["uninstalled"] == "filesystem"
+    assert "hermes_sync" in response.json()
     # Second uninstall is 404.
     again = client.delete("/api/mcp/filesystem")
     assert again.status_code == 404

--- a/tests/cli/test_mcp_commands.py
+++ b/tests/cli/test_mcp_commands.py
@@ -1,0 +1,185 @@
+"""Tests for the ADR-0015 ``hal0 mcp`` verbs: test/allow/gate/block/expose/add/remove.
+
+Pins each command's request shape (path, method, body) against the API
+surface added in :mod:`hal0.api.routes.mcp` — a mismatched field name
+would 400/422 against the live server and only be caught here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import mcp_commands
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def api(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub the API client surface and capture calls."""
+    calls: dict[str, Any] = {"gets": [], "posts": [], "patches": [], "deletes": []}
+
+    monkeypatch.setattr(mcp_commands, "_api_unreachable", lambda _url: False)
+
+    def fake_get(path: str, **_kw: Any) -> Any:
+        calls["gets"].append(path)
+        return calls.get("get_response", {"servers": []})
+
+    def fake_post(path: str, *, json: dict[str, Any] | None = None, **_kw: Any) -> Any:
+        calls["posts"].append((path, json))
+        return calls.get("post_response", {"ok": True})
+
+    def fake_patch(path: str, *, json: dict[str, Any] | None = None, **_kw: Any) -> Any:
+        calls["patches"].append((path, json))
+        return calls.get("patch_response", {"server": {}, "hermes_sync": {"errors": []}})
+
+    def fake_delete(path: str, **_kw: Any) -> Any:
+        calls["deletes"].append(path)
+        return calls.get("delete_response", {"uninstalled": "x"})
+
+    monkeypatch.setattr(mcp_commands, "api_get", fake_get)
+    monkeypatch.setattr(mcp_commands, "api_post", fake_post)
+    monkeypatch.setattr(mcp_commands, "api_patch", fake_patch)
+    monkeypatch.setattr(mcp_commands, "api_delete", fake_delete)
+    return calls
+
+
+# ── `hal0 mcp test` ───────────────────────────────────────────────────────────
+
+
+def test_test_cmd_posts_to_test_endpoint(api: dict[str, Any]) -> None:
+    api["post_response"] = {
+        "server_id": "github",
+        "probe": {"ok": True, "tools": ["search_repositories", "delete_repository"], "error": None},
+        "verdicts": {"search_repositories": "allow", "delete_repository": "blocked"},
+    }
+    result = runner.invoke(mcp_commands.app, ["test", "github"])
+    assert result.exit_code == 0, result.output
+    assert api["posts"] == [("/api/mcp/github/test", None)]
+    assert "search_repositories" in result.output
+    assert "delete_repository" in result.output
+
+
+def test_test_cmd_reports_unreachable(api: dict[str, Any]) -> None:
+    api["post_response"] = {"probe": {"ok": False, "error": "connection refused"}}
+    result = runner.invoke(mcp_commands.app, ["test", "github"])
+    assert result.exit_code == 0, result.output
+    assert "unreachable" in result.output
+    assert "connection refused" in result.output
+
+
+def test_test_cmd_json_out(api: dict[str, Any]) -> None:
+    api["post_response"] = {"probe": {"ok": True, "tools": []}, "verdicts": {}}
+    result = runner.invoke(mcp_commands.app, ["test", "github", "--json"])
+    assert result.exit_code == 0, result.output
+    assert '"probe"' in result.output
+
+
+# ── `hal0 mcp allow|gate|block` ───────────────────────────────────────────────
+
+
+def test_allow_moves_tool_and_patches_tools(api: dict[str, Any]) -> None:
+    api["get_response"] = {
+        "servers": [
+            {
+                "id": "github",
+                "tools_policy": {
+                    "allow": [],
+                    "gated": ["create_pull_request"],
+                    "blocked": ["delete_repository"],
+                },
+            }
+        ]
+    }
+    result = runner.invoke(mcp_commands.app, ["allow", "github", "create_pull_request"])
+    assert result.exit_code == 0, result.output
+    assert len(api["patches"]) == 1
+    path, body = api["patches"][0]
+    assert path == "/api/mcp/github/tools"
+    assert body == {"allow": ["create_pull_request"], "gated": [], "blocked": ["delete_repository"]}
+
+
+def test_gate_moves_tool(api: dict[str, Any]) -> None:
+    api["get_response"] = {
+        "servers": [
+            {"id": "github", "tools_policy": {"allow": ["search"], "gated": [], "blocked": []}}
+        ]
+    }
+    result = runner.invoke(mcp_commands.app, ["gate", "github", "search"])
+    assert result.exit_code == 0, result.output
+    _path, body = api["patches"][0]
+    assert body == {"allow": [], "gated": ["search"], "blocked": []}
+
+
+def test_block_moves_tool(api: dict[str, Any]) -> None:
+    api["get_response"] = {
+        "servers": [
+            {"id": "github", "tools_policy": {"allow": ["danger"], "gated": [], "blocked": []}}
+        ]
+    }
+    result = runner.invoke(mcp_commands.app, ["block", "github", "danger"])
+    assert result.exit_code == 0, result.output
+    _path, body = api["patches"][0]
+    assert body == {"allow": [], "gated": [], "blocked": ["danger"]}
+
+
+def test_allow_unknown_server_dies(api: dict[str, Any]) -> None:
+    api["get_response"] = {"servers": []}
+    result = runner.invoke(mcp_commands.app, ["allow", "nope", "tool"])
+    assert result.exit_code != 0
+    assert not api["patches"]
+
+
+# ── `hal0 mcp expose` ─────────────────────────────────────────────────────────
+
+
+def test_expose_hermes_patches_exposure(api: dict[str, Any]) -> None:
+    api["patch_response"] = {
+        "server": {"exposure": {"hermes": True, "brain": False}},
+        "hermes_sync": {"errors": []},
+    }
+    result = runner.invoke(mcp_commands.app, ["expose", "github", "--hermes"])
+    assert result.exit_code == 0, result.output
+    path, body = api["patches"][0]
+    assert path == "/api/mcp/github/exposure"
+    assert body == {"hermes": True}
+
+
+def test_expose_both_flags(api: dict[str, Any]) -> None:
+    api["patch_response"] = {
+        "server": {"exposure": {"hermes": True, "brain": True}},
+        "hermes_sync": {"errors": []},
+    }
+    result = runner.invoke(mcp_commands.app, ["expose", "github", "--hermes", "--brain"])
+    assert result.exit_code == 0, result.output
+    _path, body = api["patches"][0]
+    assert body == {"hermes": True, "brain": True}
+
+
+def test_expose_no_flags_dies(api: dict[str, Any]) -> None:
+    result = runner.invoke(mcp_commands.app, ["expose", "github"])
+    assert result.exit_code != 0
+    assert not api["patches"]
+
+
+# ── `hal0 mcp add` / `hal0 mcp remove` (aliases) ─────────────────────────────
+
+
+def test_add_is_install_alias(api: dict[str, Any]) -> None:
+    api["post_response"] = {"installed": {"id": "github", "name": "GitHub", "tools": 3}}
+    result = runner.invoke(mcp_commands.app, ["add", "npm:@modelcontextprotocol/server-github"])
+    assert result.exit_code == 0, result.output
+    assert api["posts"] == [
+        ("/api/mcp/install", {"url": "npm:@modelcontextprotocol/server-github"})
+    ]
+    assert "installed" in result.output
+
+
+def test_remove_is_uninstall_alias(api: dict[str, Any]) -> None:
+    api["delete_response"] = {"uninstalled": "github"}
+    result = runner.invoke(mcp_commands.app, ["remove", "github", "--force"])
+    assert result.exit_code == 0, result.output
+    assert api["deletes"] == ["/api/mcp/github"]

--- a/tests/cli/test_mcp_commands.py
+++ b/tests/cli/test_mcp_commands.py
@@ -86,7 +86,7 @@ def test_allow_moves_tool_and_patches_tools(api: dict[str, Any]) -> None:
         "servers": [
             {
                 "id": "github",
-                "tools_policy": {
+                "tool_policy": {
                     "allow": [],
                     "gated": ["create_pull_request"],
                     "blocked": ["delete_repository"],
@@ -105,7 +105,7 @@ def test_allow_moves_tool_and_patches_tools(api: dict[str, Any]) -> None:
 def test_gate_moves_tool(api: dict[str, Any]) -> None:
     api["get_response"] = {
         "servers": [
-            {"id": "github", "tools_policy": {"allow": ["search"], "gated": [], "blocked": []}}
+            {"id": "github", "tool_policy": {"allow": ["search"], "gated": [], "blocked": []}}
         ]
     }
     result = runner.invoke(mcp_commands.app, ["gate", "github", "search"])
@@ -117,7 +117,7 @@ def test_gate_moves_tool(api: dict[str, Any]) -> None:
 def test_block_moves_tool(api: dict[str, Any]) -> None:
     api["get_response"] = {
         "servers": [
-            {"id": "github", "tools_policy": {"allow": ["danger"], "gated": [], "blocked": []}}
+            {"id": "github", "tool_policy": {"allow": ["danger"], "gated": [], "blocked": []}}
         ]
     }
     result = runner.invoke(mcp_commands.app, ["block", "github", "danger"])

--- a/tests/mcp/test_hermes_join.py
+++ b/tests/mcp/test_hermes_join.py
@@ -8,8 +8,6 @@ would have written to the real filesystem here).
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from hal0.config import paths as cfg_paths
 from hal0.config.schema import ToolPolicy
 from hal0.mcp import hermes_join, installed
@@ -42,7 +40,9 @@ def test_sync_exposure_applies_exposed_server(tmp_hal0_home: str) -> None:
     # hermes binary doesn't exist under the tmp sandbox -> apply degrades to
     # a recorded error rather than a crash, but the manifest still tracks
     # "github" as desired so a later real-hermes sync would apply it.
-    assert "github" in "".join(report["hermes"].get("errors", [])) or report["hermes"]["applied"] == 0
+    assert (
+        "github" in "".join(report["hermes"].get("errors", [])) or report["hermes"]["applied"] == 0
+    )
     manifest_path = cfg_paths.var_lib() / "mcp" / "hermes-managed.json"
     assert manifest_path.exists()
     import json
@@ -79,9 +79,9 @@ def test_sync_exposure_preserves_operator_seed_blocks(tmp_hal0_home: str) -> Non
     seed_path = cfg_paths.etc() / "agents" / "hermes.toml"
     seed_path.parent.mkdir(parents=True, exist_ok=True)
     seed_path.write_text(
-        '[mcp.servers.operator-added]\nbuiltin = false\nenabled = true\n'
+        "[mcp.servers.operator-added]\nbuiltin = false\nenabled = true\n"
         '[mcp.servers.operator-added.tools]\nallow = ["hand_tool"]\n'
-        'gated = []\nblocked = []\n'
+        "gated = []\nblocked = []\n"
     )
     _install("github", exposure=installed.ExposureConfig(hermes=True))
     hermes_join.sync_exposure()
@@ -98,8 +98,8 @@ def test_sync_exposure_removes_only_previously_owned_ids(tmp_hal0_home: str) -> 
     seed_path = cfg_paths.etc() / "agents" / "hermes.toml"
     seed_path.parent.mkdir(parents=True, exist_ok=True)
     seed_path.write_text(
-        '[mcp.servers.operator-added]\nbuiltin = false\nenabled = true\n'
-        '[mcp.servers.operator-added.tools]\nallow = []\ngated = []\nblocked = []\n'
+        "[mcp.servers.operator-added]\nbuiltin = false\nenabled = true\n"
+        "[mcp.servers.operator-added.tools]\nallow = []\ngated = []\nblocked = []\n"
     )
     _install("github", exposure=installed.ExposureConfig(hermes=True))
     hermes_join.sync_exposure()

--- a/tests/mcp/test_hermes_join.py
+++ b/tests/mcp/test_hermes_join.py
@@ -1,0 +1,149 @@
+"""Tests for :mod:`hal0.mcp.hermes_join` — ADR-0015 §Decision 2.
+
+Every test runs under ``tmp_hal0_home`` so real ``/etc/hal0``/``/var/lib/hal0``
+are never touched (see the ``fix(mcp): make hermes_join HAL0_HOME-aware``
+commit — the first cut of this module didn't thread paths through and
+would have written to the real filesystem here).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hal0.config import paths as cfg_paths
+from hal0.config.schema import ToolPolicy
+from hal0.mcp import hermes_join, installed
+
+
+def _install(server_id: str, **overrides: object) -> installed.InstalledServer:
+    defaults: dict[str, object] = {
+        "id": server_id,
+        "name": server_id,
+        "spec": f"https://{server_id}.example.com/manifest.json",
+        "transport": "streamable-http",
+        "url": f"https://{server_id}.example.com/mcp",
+        "enabled": True,
+    }
+    defaults.update(overrides)
+    return installed.install(installed.InstalledServer(**defaults))
+
+
+def test_sync_exposure_noop_when_nothing_exposed(tmp_hal0_home: str) -> None:
+    _install("github")  # exposure defaults to all-False
+    report = hermes_join.sync_exposure()
+    assert report["hermes"]["applied"] == 0
+    assert report["hermes"]["removed"] == []
+    assert report["errors"] == []
+
+
+def test_sync_exposure_applies_exposed_server(tmp_hal0_home: str) -> None:
+    _install("github", exposure=installed.ExposureConfig(hermes=True))
+    report = hermes_join.sync_exposure()
+    # hermes binary doesn't exist under the tmp sandbox -> apply degrades to
+    # a recorded error rather than a crash, but the manifest still tracks
+    # "github" as desired so a later real-hermes sync would apply it.
+    assert "github" in "".join(report["hermes"].get("errors", [])) or report["hermes"]["applied"] == 0
+    manifest_path = cfg_paths.var_lib() / "mcp" / "hermes-managed.json"
+    assert manifest_path.exists()
+    import json
+
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["hermes"] == ["github"]
+
+
+def test_sync_exposure_mirrors_tools_into_seed_toml(tmp_hal0_home: str) -> None:
+    _install(
+        "github",
+        exposure=installed.ExposureConfig(hermes=True),
+        tool_policy=ToolPolicy(allow=["search"], gated=["create_pr"]),
+    )
+    hermes_join.sync_exposure()
+    seed_path = cfg_paths.etc() / "agents" / "hermes.toml"
+    assert seed_path.exists()
+    import tomllib
+
+    data = tomllib.loads(seed_path.read_text())
+    github_entry = data["mcp"]["servers"]["github"]
+    assert github_entry["builtin"] is False
+    assert github_entry["tools"]["allow"] == ["search"]
+    assert github_entry["tools"]["gated"] == ["create_pr"]
+
+
+def test_sync_exposure_preserves_operator_seed_blocks(tmp_hal0_home: str) -> None:
+    """An operator's hand-added [mcp.servers.*] block is never touched.
+
+    Simulates a pre-existing seed TOML with a hand-added server that was
+    never installed through this registry — the sync must leave it intact
+    (it was never in hal0's own ownership manifest).
+    """
+    seed_path = cfg_paths.etc() / "agents" / "hermes.toml"
+    seed_path.parent.mkdir(parents=True, exist_ok=True)
+    seed_path.write_text(
+        '[mcp.servers.operator-added]\nbuiltin = false\nenabled = true\n'
+        '[mcp.servers.operator-added.tools]\nallow = ["hand_tool"]\n'
+        'gated = []\nblocked = []\n'
+    )
+    _install("github", exposure=installed.ExposureConfig(hermes=True))
+    hermes_join.sync_exposure()
+
+    import tomllib
+
+    data = tomllib.loads(seed_path.read_text())
+    assert "operator-added" in data["mcp"]["servers"]
+    assert data["mcp"]["servers"]["operator-added"]["tools"]["allow"] == ["hand_tool"]
+
+
+def test_sync_exposure_removes_only_previously_owned_ids(tmp_hal0_home: str) -> None:
+    """Disabling exposure removes hal0's own seed entry, never an operator's."""
+    seed_path = cfg_paths.etc() / "agents" / "hermes.toml"
+    seed_path.parent.mkdir(parents=True, exist_ok=True)
+    seed_path.write_text(
+        '[mcp.servers.operator-added]\nbuiltin = false\nenabled = true\n'
+        '[mcp.servers.operator-added.tools]\nallow = []\ngated = []\nblocked = []\n'
+    )
+    _install("github", exposure=installed.ExposureConfig(hermes=True))
+    hermes_join.sync_exposure()
+
+    installed.patch_config("github", exposure=installed.ExposureConfig(hermes=False))
+    hermes_join.sync_exposure()
+
+    import tomllib
+
+    data = tomllib.loads(seed_path.read_text())
+    servers = data["mcp"]["servers"]
+    assert "github" not in servers
+    assert "operator-added" in servers
+
+
+def test_stdio_records_excluded_from_desired_set(tmp_hal0_home: str) -> None:
+    _install(
+        "npmserver",
+        transport="stdio",
+        url="",
+        spec="npm:some-mcp",
+        exposure=installed.ExposureConfig(hermes=True),
+    )
+    entries = hermes_join._desired_entries("hermes")
+    assert entries == {}
+
+
+def test_headers_include_resolved_secret(tmp_hal0_home: str, monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_MCP_TOKEN", "shh-secret-value")
+    record = _install(
+        "github",
+        exposure=installed.ExposureConfig(hermes=True),
+        secrets={"Authorization": "GITHUB_MCP_TOKEN"},
+    )
+    entries = hermes_join._desired_entries("hermes")
+    assert entries["github"]["headers"]["Authorization"] == "shh-secret-value"
+    assert record.secrets == {"Authorization": "GITHUB_MCP_TOKEN"}
+
+
+def test_headers_omit_unresolved_secret(tmp_hal0_home: str) -> None:
+    _install(
+        "github",
+        exposure=installed.ExposureConfig(hermes=True),
+        secrets={"Authorization": "GITHUB_MCP_TOKEN_UNSET"},
+    )
+    entries = hermes_join._desired_entries("hermes")
+    assert "Authorization" not in entries["github"]["headers"]

--- a/tests/mcp/test_installed.py
+++ b/tests/mcp/test_installed.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+from hal0.config.schema import ToolPolicy
 from hal0.errors import BadRequest, Conflict, NotFound
 from hal0.mcp import installed as registry
+from hal0.mcp.installed import ExposureConfig
 
 
 def _record(server_id: str = "filesystem", **overrides: object) -> registry.InstalledServer:
@@ -178,3 +180,85 @@ def test_patch_config_locked_rmw_applies(tmp_hal0_home: str) -> None:
     reloaded = registry.get_installed("filesystem")
     assert reloaded.enabled is False
     assert reloaded.env == {"FOO": "bar"}
+
+
+# ── ADR-0015: schema extension (command/args/url/secrets/tools/exposure) ────
+
+
+def test_new_fields_default_empty(tmp_hal0_home: str) -> None:
+    """A fresh record has zero callable tools and zero exposure by default."""
+    saved = registry.install(_record())
+    assert saved.command == ""
+    assert saved.args == []
+    assert saved.url == ""
+    assert saved.secrets == {}
+    assert saved.tool_policy == ToolPolicy()
+    assert saved.exposure == ExposureConfig()
+
+
+def test_pre_adr0015_record_still_validates(tmp_hal0_home: str) -> None:
+    """A pre-#305-extension on-disk shape (``tools`` as a bare int) still loads.
+
+    Simulates an old record written before this PR: no [secrets]/[tools]/
+    [exposure] tables, ``tools`` is the bare advertised-count int.
+    """
+    old_shape = {
+        "id": "legacy",
+        "name": "legacy",
+        "spec": "npm:legacy-mcp",
+        "transport": "stdio",
+        "tools": 7,
+        "enabled": True,
+    }
+    record = registry.InstalledServer.from_toml_dict(old_shape)
+    assert record.tools == 7
+    assert record.tool_policy == ToolPolicy()
+    assert record.exposure == ExposureConfig()
+
+
+def test_to_toml_dict_round_trips_tool_policy(tmp_hal0_home: str) -> None:
+    saved = registry.install(
+        _record(
+            "github",
+            tool_policy=ToolPolicy(allow=["search"], gated=["create_pr"], blocked=["delete_repo"]),
+        )
+    )
+    reloaded = registry.get_installed("github")
+    assert reloaded.tool_policy.allow == ["search"]
+    assert reloaded.tool_policy.gated == ["create_pr"]
+    assert reloaded.tool_policy.blocked == ["delete_repo"]
+    # The int tool *count* (a separate field, see InstalledServer docstring)
+    # survives the [tools]-table round-trip untouched.
+    assert reloaded.tools == saved.tools == 5
+
+
+def test_tool_policy_disjointness_enforced(tmp_hal0_home: str) -> None:
+    """ToolPolicy's own validator rejects a tool on two tiers — reused, not re-implemented."""
+    with pytest.raises(Exception, match="disjoint|overlap"):
+        _record("github", tool_policy=ToolPolicy(allow=["x"], gated=["x"]))
+
+
+def test_secrets_reference_must_be_env_shaped(tmp_hal0_home: str) -> None:
+    with pytest.raises(Exception, match="secrets"):
+        _record("github", secrets={"GITHUB_TOKEN": "not a valid key"})
+
+
+def test_secrets_reference_valid_name_accepted(tmp_hal0_home: str) -> None:
+    saved = registry.install(_record("github", secrets={"GITHUB_TOKEN": "GITHUB_MCP_TOKEN"}))
+    assert saved.secrets == {"GITHUB_TOKEN": "GITHUB_MCP_TOKEN"}
+
+
+def test_exposure_round_trips(tmp_hal0_home: str) -> None:
+    saved = registry.install(_record("github", exposure=ExposureConfig(hermes=True)))
+    reloaded = registry.get_installed("github")
+    assert reloaded.exposure.hermes is True
+    assert reloaded.exposure.brain is False
+
+
+def test_list_enabled_exposed_filters_correctly(tmp_hal0_home: str) -> None:
+    registry.install(_record("exposed", exposure=ExposureConfig(hermes=True), enabled=True))
+    registry.install(_record("disabled", exposure=ExposureConfig(hermes=True), enabled=False))
+    registry.install(_record("not-exposed", exposure=ExposureConfig(hermes=False), enabled=True))
+
+    hermes_ids = {r.id for r in registry.list_enabled_exposed(target="hermes")}
+    assert hermes_ids == {"exposed"}

--- a/tests/mcp/test_installed.py
+++ b/tests/mcp/test_installed.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from hal0.config.schema import ToolPolicy
@@ -262,3 +264,31 @@ def test_list_enabled_exposed_filters_correctly(tmp_hal0_home: str) -> None:
 
     hermes_ids = {r.id for r in registry.list_enabled_exposed(target="hermes")}
     assert hermes_ids == {"exposed"}
+
+
+def test_patch_config_traversal_id_creates_no_file_outside_the_registry(
+    tmp_hal0_home: str, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    """`patch_config` takes the record lock BEFORE `get_installed` validates.
+
+    The lock file is opened `"w"` — a truncating create — so an id that walked
+    out of the registry directory would let an API caller create (and, for a
+    `<name>.toml` target, truncate) a file anywhere the daemon can write.
+    `_registry_path` is the barrier; assert it holds from the entry point that
+    reaches it first, using a traversal spelled relative to the REAL registry
+    directory rather than a guessed number of `../`.
+    """
+    outside_dir = tmp_path_factory.mktemp("outside")
+    victim = outside_dir / "victim.toml"
+    victim.write_text("do not truncate me\n", encoding="utf-8")
+
+    # ".../outside0/victim" — strip the .toml the registry appends itself.
+    traversal = os.path.relpath(victim.with_suffix(""), registry._registry_dir())
+    assert traversal.startswith(".."), traversal
+
+    with pytest.raises(BadRequest) as exc:
+        registry.patch_config(traversal, enabled=False)
+    assert exc.value.code == "mcp.id_invalid"
+
+    assert victim.read_text(encoding="utf-8") == "do not truncate me\n"
+    assert not (outside_dir / "victim.toml.lock").exists()

--- a/tests/mcp/test_installed.py
+++ b/tests/mcp/test_installed.py
@@ -234,7 +234,7 @@ def test_to_toml_dict_round_trips_tool_policy(tmp_hal0_home: str) -> None:
 
 def test_tool_policy_disjointness_enforced(tmp_hal0_home: str) -> None:
     """ToolPolicy's own validator rejects a tool on two tiers — reused, not re-implemented."""
-    with pytest.raises(Exception, match="disjoint|overlap"):
+    with pytest.raises(Exception, match="disjoint|overlap"):  # noqa: RUF043
         _record("github", tool_policy=ToolPolicy(allow=["x"], gated=["x"]))
 
 
@@ -249,7 +249,7 @@ def test_secrets_reference_valid_name_accepted(tmp_hal0_home: str) -> None:
 
 
 def test_exposure_round_trips(tmp_hal0_home: str) -> None:
-    saved = registry.install(_record("github", exposure=ExposureConfig(hermes=True)))
+    registry.install(_record("github", exposure=ExposureConfig(hermes=True)))
     reloaded = registry.get_installed("github")
     assert reloaded.exposure.hermes is True
     assert reloaded.exposure.brain is False

--- a/tests/mcp/test_probe.py
+++ b/tests/mcp/test_probe.py
@@ -1,0 +1,123 @@
+"""Tests for :mod:`hal0.mcp.probe` — the generic user-server MCP prober.
+
+Stubs ``urlopen`` rather than hitting the network; each fake response is
+the JSON-RPC frame a real streamable-http MCP server would return for
+``initialize``/``tools/list``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.error import URLError
+
+import pytest
+
+from hal0.mcp import installed, probe
+
+
+def _record(**overrides: object) -> installed.InstalledServer:
+    defaults: dict[str, object] = {
+        "id": "github",
+        "name": "github",
+        "spec": "https://github.example.com/manifest.json",
+        "transport": "streamable-http",
+        "url": "https://github.example.com/mcp",
+    }
+    defaults.update(overrides)
+    return installed.InstalledServer(**defaults)
+
+
+class _FakeResponse:
+    def __init__(self, body: dict[str, Any], headers: dict[str, str] | None = None) -> None:
+        self._body = json.dumps(body).encode("utf-8")
+        self.headers = headers or {}
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+def test_probe_returns_tool_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = [
+        _FakeResponse({"jsonrpc": "2.0", "id": "1", "result": {}}),
+        _FakeResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": "2",
+                "result": {"tools": [{"name": "search_repositories"}, {"name": "get_file"}]},
+            }
+        ),
+    ]
+
+    def fake_urlopen(req: Any, timeout: float) -> _FakeResponse:
+        return responses.pop(0)
+
+    monkeypatch.setattr(probe, "urlopen", fake_urlopen)
+    result = probe.probe_installed_server_sync(_record())
+    assert result["ok"] is True
+    assert result["tools"] == ["search_repositories", "get_file"]
+    assert result["error"] is None
+
+
+def test_probe_reports_transport_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(req: Any, timeout: float) -> None:
+        raise URLError("connection refused")
+
+    monkeypatch.setattr(probe, "urlopen", fake_urlopen)
+    result = probe.probe_installed_server_sync(_record())
+    assert result["ok"] is False
+    assert "connection refused" in result["error"]
+    assert result["tools"] == []
+
+
+def test_probe_reports_jsonrpc_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = [
+        _FakeResponse({"jsonrpc": "2.0", "id": "1", "result": {}}),
+        _FakeResponse({"jsonrpc": "2.0", "id": "2", "error": {"message": "unauthorized"}}),
+    ]
+
+    def fake_urlopen(req: Any, timeout: float) -> _FakeResponse:
+        return responses.pop(0)
+
+    monkeypatch.setattr(probe, "urlopen", fake_urlopen)
+    result = probe.probe_installed_server_sync(_record())
+    assert result["ok"] is False
+    assert result["error"] == "unauthorized"
+
+
+def test_probe_rejects_stdio_transport() -> None:
+    record = _record(transport="stdio", url="", spec="npm:foo")
+    result = probe.probe_installed_server_sync(record)
+    assert result["ok"] is False
+    assert "stdio" in result["error"]
+
+
+def test_probe_rejects_missing_url() -> None:
+    record = _record(url="")
+    result = probe.probe_installed_server_sync(record)
+    assert result["ok"] is False
+    assert "url" in result["error"]
+
+
+def test_build_headers_resolves_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_MCP_TOKEN", "sekret")
+    record = _record(
+        env={"MCP_WORKSPACE": "/tmp/ws"},
+        secrets={"Authorization": "GITHUB_MCP_TOKEN"},
+    )
+    headers = probe.build_headers(record)
+    assert headers["Authorization"] == "sekret"
+    assert headers["MCP_WORKSPACE"] == "/tmp/ws"
+    assert headers["X-hal0-Agent"] == "hermes"
+
+
+def test_build_headers_omits_unresolved_secret() -> None:
+    record = _record(secrets={"Authorization": "NOT_SET_ANYWHERE"})
+    headers = probe.build_headers(record)
+    assert "Authorization" not in headers


### PR DESCRIPTION
Implements ADR-0015 (accepted in this branch): user-installed MCP servers that can
actually reach an agent, instead of a registry entry nothing consumes.

## What lands

- `InstalledServer` gains `secrets` (a reference into hal0's own `/etc/hal0/api.env`
  store, never a literal), `tool_policy` (the same `ToolPolicy` allow/gated/blocked
  scheme the bundled agents use — disjoint, empty by default), and `exposure`
  (`hermes`/`brain` honoured; `openwebui`/`opencode` reserved and rejected with
  `501 mcp.exposure_unsupported`).
- Flipping `exposure.hermes` on an enabled `streamable-http`/`sse` server joins it
  into Hermes's `config.yaml` and mirrors its tool policy into the
  `/etc/hal0/agents/hermes.toml` seed, so `classify()` governs it exactly like the
  two bundled servers. The join recomputes and prunes on every registry mutation and
  never touches an operator's own hand-added `mcp_servers` block.
- CLI: `hal0 mcp test <id>` (probe + per-tool allow/gated/blocked/unknown verdicts),
  `hal0 mcp allow|gate|block <id> <tool>`, `hal0 mcp expose <id> --hermes/--brain`,
  and `add`/`remove` as aliases of `install`/`uninstall`.
- REST: `POST /api/mcp/{id}/test`, `PATCH /api/mcp/{id}/tools`,
  `PATCH /api/mcp/{id}/exposure`. `GET /api/mcp/servers` now reports real
  reachability for installed `streamable-http`/`sse` servers instead of a hard-coded
  `"stopped"`.
- `hermes_join` is `HAL0_HOME`-aware rather than assuming hardcoded FHS paths.

A `stdio`-transport server's process supervisor is deferred (see
`docs/adr/0015-mcp-supervisor-and-exposure.md`): install and configure work, and
`exposure.hermes`/`.brain` reject with `409 mcp.exposure_needs_supervisor` until it
ships. (#305)

## Verification

`ruff check src tests` clean. Full α unit suite (12811 tests) green apart from three
failures that also fail on a clean `main` checkout
(`tests/providers/test_moonshine_server.py` ×2, needs `ffmpeg`, and
`tests/slots/test_pressure_eviction.py::test_pressure_evict_noop_when_probe_fails`).
Integration β not run locally (needs root + a live `hal0-lemonade.service`); CI covers it.

Includes a GP-15 fix found while validating: `hal0/api/routes/mcp.py` imported
`hal0.mcp.hermes_join` at module scope, and `hal0.api` imports every route module
eagerly, so `import hal0.api.routes.health` alone dragged a hermes-named module into
the core import graph. The import is now inside `_sync_hermes_join`, its only caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzkumtSWnm3AxixzHG38UG
